### PR TITLE
Adding Windows to Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
 
       - name: Create JAR file
         run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
+        shell: powershell
 
       - name: Upload lib file
         if: "${{ matrix.os }} == ubuntu-20.04"
@@ -285,9 +286,11 @@ jobs:
         run: |
           mv omega-edit-mac.jar omega-edit-mac.jar_dir
           mv omega-edit-linux.jar omega-edit-linux.jar_dir
+          mv omega-edit-windows.jar omega-edit-windows.jar_dir
           mv omega-edit-mac.jar_dir/omega-edit-mac.jar .
           mv omega-edit-linux.jar_dir/omega-edit-linux.jar .
-          rm -rf omega-edit-mac.jar_dir omega-edit-linux.jar_dir
+          mv omega-edit-windows.jar_dir/omega-edit-windows.jar .
+          rm -rf omega-edit-mac.jar_dir omega-edit-linux.jar_dir omega-edit-windows.jar_dir
 
       - name: Upload mac jar file
         uses: actions/upload-release-asset@v1.0.2
@@ -307,4 +310,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: omega-edit-linux.jar
           asset_name: omega-edit-linux.jar
+          asset_content_type: application/java-archive
+
+      - name: Upload windows jar file
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: omega-edit-windows.jar
+          asset_name: omega-edit-windows.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,6 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
-          targets: 'JAVA_HOME'
 
       - name: Export git tag and package.json version
         run: ${{ env.export_cmd }}
@@ -148,16 +147,10 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
-          targets: 'JAVA_HOME'
-
-      - name: Build C++ code
-        run: |
-          cmake -S . -B cmake-build-debug
-          sed -i "s|^CMAKE_CXX_COMPILER:FILEPATH=.*|CMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/c++|g" cmake-build-debug/CMakeCache.txt
-          cmake --build cmake-build-debug
 
       - name: Generate library file
-        run: ./compile.sh compile-lib win
+        run: ./compile.sh compile-lib win ci
+
       - name: Export filenames
         run: |
           LIB_FILENAME="omega_edit.dll"
@@ -231,11 +224,13 @@ jobs:
       - name: Move out node files
         run: |
           cd module/omega_edit/
-          mv omega_edit_linux.node omega_edit_linux.node_dir
-          mv omega_edit_darwin.node omega_edit_darwin.node_dir
-          mv omega_edit_linux.node_dir/omega_edit_linux.node .
-          mv omega_edit_darwin.node_dir/omega_edit_darwin.node .
-          rm -rf omega_edit_linux.node_dir omega_edit_darwin.node_dir
+
+          for file in omega_edit_linux.node omega_edit_darwin.node;
+          do
+            echo mv $file "${file}_dir"
+            echo mv "${file}_dir/$file" .
+            echo rm -rf "${file}_dir"
+          done
 
       - name: Create node release tarball
         run: yarn pack --filename omega-edit-v${{ env.PKG_VERSION }}.tar.gz
@@ -270,15 +265,20 @@ jobs:
           name: omega-edit-linux.jar
           path: omega-edit-linux.jar
 
+      - name: Download windows jar file
+        uses: actions/download-artifact@v2.1.0
+        with:
+          name: omega-edit-windows.jar
+          path: omega-edit-windows.jar
+
       - name: Move out jar files
         run: |
-          mv omega-edit-mac.jar omega-edit-mac.jar_dir
-          mv omega-edit-linux.jar omega-edit-linux.jar_dir
-          mv omega-edit-windows.jar omega-edit-windows.jar_dir
-          mv omega-edit-mac.jar_dir/omega-edit-mac.jar .
-          mv omega-edit-linux.jar_dir/omega-edit-linux.jar .
-          mv omega-edit-windows.jar_dir/omega-edit-windows.jar .
-          rm -rf omega-edit-mac.jar_dir omega-edit-linux.jar_dir omega-edit-windows.jar_dir
+          for file in omega-edit-mac.jar omega-edit-linux.jar omega-edit-windows.jar;
+          do
+            mv $file "${file}_dir"
+            mv "${file}_dir/$file" .
+            rm -rf "${file}_dir"
+          done
 
       - name: Upload mac jar file
         uses: actions/upload-release-asset@v1.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,110 +72,110 @@ jobs:
           name: ${{ env.NODE_FILE }}
           path: module/omega_edit/${{ env.NODE_FILE }}
 
-  scala-build-linux-mac:
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-20.04]
-    name: Build ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2.3.5
-        with:
-          submodules: true
-      - uses: actions/setup-java@v2.5.0
-        with:
-          distribution: 'adopt'
-          java-version: '11'
+  # scala-build-linux-mac:
+  #   strategy:
+  #     matrix:
+  #       os: [macos-latest, ubuntu-20.04]
+  #   name: Build ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v2.3.5
+  #       with:
+  #         submodules: true
+  #     - uses: actions/setup-java@v2.5.0
+  #       with:
+  #         distribution: 'adopt'
+  #         java-version: '11'
 
-      - name: Export git tag and package.json version
-        run: ${{ env.export_cmd }}
+  #     - name: Export git tag and package.json version
+  #       run: ${{ env.export_cmd }}
 
-      - name: Check if git tag matches package version
-        run: if [[ ${{env.GIT_TAG}} != ${{env.PKG_VERSION}} ]]; then exit 1; else exit 0; fi
-        shell: bash
+  #     - name: Check if git tag matches package version
+  #       run: if [[ ${{env.GIT_TAG}} != ${{env.PKG_VERSION}} ]]; then exit 1; else exit 0; fi
+  #       shell: bash
 
-      - name: Compile lib file
-        run: ./compile.sh compile-lib ${{ matrix.os }}
+  #     - name: Compile lib file
+  #       run: ./compile.sh compile-lib ${{ matrix.os }}
 
-      - name: Export filenames
-        run: |
-          if [[ "${{ matrix.os }}" == *"macos"* ]]; then
-            LIB_FILENAME="libomega_edit.dylib"
-            JAR_FILENAME="omega-edit-mac.jar"
-          else
-            LIB_FILENAME="libomega_edit.so"
-            JAR_FILENAME="omega-edit-linux.jar"
-          fi
+  #     - name: Export filenames
+  #       run: |
+  #         if [[ "${{ matrix.os }}" == *"macos"* ]]; then
+  #           LIB_FILENAME="libomega_edit.dylib"
+  #           JAR_FILENAME="omega-edit-mac.jar"
+  #         else
+  #           LIB_FILENAME="libomega_edit.so"
+  #           JAR_FILENAME="omega-edit-linux.jar"
+  #         fi
 
-          echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
-          echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
+  #         echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
+  #         echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
 
-      - name: Create JAR file
-        run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
+  #     - name: Create JAR file
+  #       run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
 
-      - name: Upload lib file
-        if: "${{ matrix.os }} == ubuntu-20.04"
-        uses: actions/upload-artifact@v2.3.1
-        with:
-          name: ${{ env.JAR_FILENAME }}
-          path: ${{ env.JAR_FILENAME }}
+  #     - name: Upload lib file
+  #       if: "${{ matrix.os }} == ubuntu-20.04"
+  #       uses: actions/upload-artifact@v2.3.1
+  #       with:
+  #         name: ${{ env.JAR_FILENAME }}
+  #         path: ${{ env.JAR_FILENAME }}
 
-  scala-build-windows:
-    name: Build Windows
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        include:
-          - { sys: mingw64, env: x86_64 }
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - uses: actions/checkout@v2.3.5
-        with:
-          submodules: true
-      - name: Install MinGW
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: ${{ matrix.sys }}
-          update: true
-          install: >-
-            mingw-w64-${{ matrix.env }}-toolchain
-            base-devel
-            cmake
-            swig
-            git
+  # scala-build-windows:
+  #   name: Build Windows
+  #   runs-on: windows-latest
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - { sys: mingw64, env: x86_64 }
+  #   defaults:
+  #     run:
+  #       shell: msys2 {0}
+  #   steps:
+  #     - uses: actions/checkout@v2.3.5
+  #       with:
+  #         submodules: true
+  #     - name: Install MinGW
+  #       uses: msys2/setup-msys2@v2
+  #       with:
+  #         msystem: ${{ matrix.sys }}
+  #         update: true
+  #         install: >-
+  #           mingw-w64-${{ matrix.env }}-toolchain
+  #           base-devel
+  #           cmake
+  #           swig
+  #           git
 
-      - uses: actions/setup-java@v2.5.0
-        with:
-          distribution: 'adopt'
-          java-version: '11'
+  #     - uses: actions/setup-java@v2.5.0
+  #       with:
+  #         distribution: 'adopt'
+  #         java-version: '11'
 
-      - name: Generate library file
-        run: ./compile.sh compile-lib win ci
+  #     - name: Generate library file
+  #       run: ./compile.sh compile-lib win ci
 
-      - name: Export filenames
-        run: |
-          LIB_FILENAME="omega_edit.dll"
-          JAR_FILENAME="omega-edit-windows.jar"
-          echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
-          echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
+  #     - name: Export filenames
+  #       run: |
+  #         LIB_FILENAME="omega_edit.dll"
+  #         JAR_FILENAME="omega-edit-windows.jar"
+  #         echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
+  #         echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
 
-      - name: Create JAR file
-        run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
-        shell: powershell
+  #     - name: Create JAR file
+  #       run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
+  #       shell: powershell
 
-      - name: Upload lib file
-        if: "${{ matrix.os }} == ubuntu-20.04"
-        uses: actions/upload-artifact@v2.3.1
-        with:
-          name: ${{ env.JAR_FILENAME }}
-          path: ${{ env.JAR_FILENAME }}
+  #     - name: Upload lib file
+  #       if: "${{ matrix.os }} == ubuntu-20.04"
+  #       uses: actions/upload-artifact@v2.3.1
+  #       with:
+  #         name: ${{ env.JAR_FILENAME }}
+  #         path: ${{ env.JAR_FILENAME }}
 
   release:
     name: Release
     runs-on: ubuntu-20.04
-    needs: [node-build, scala-build-linux-mac, scala-build-windows]
+    needs: [node-build] #, scala-build-linux-mac, scala-build-windows]
     steps:
       - uses: actions/checkout@v2.3.5
         with:
@@ -233,13 +233,14 @@ jobs:
       - name: Move out node files
         run: |
           cd module/omega_edit/
-
+          ls -la
           for file in omega_edit_linux.node omega_edit_mac.node omega_edit_win.node;
           do
             mv $file "${file}_dir"
             mv "${file}_dir/$file" .
             rm -rf "${file}_dir"
           done
+          ls -la
 
       - name: Create node release tarball
         run: yarn pack --filename omega-edit-v${{ env.PKG_VERSION }}.tar.gz
@@ -254,68 +255,68 @@ jobs:
           asset_name: omega-edit-node-${{ env.PKG_VERSION }}.tar.gz
           asset_content_type: application/tar+gzip
 
-      - name: Publish node package to npm registry
-        run: yarn publish omega-edit-v${{ env.PKG_VERSION }}.tar.gz
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ contains(github.event.head_commit.message, '[node_publish]') }}
+      # - name: Publish node package to npm registry
+      #   run: yarn publish omega-edit-v${{ env.PKG_VERSION }}.tar.gz
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #   if: ${{ contains(github.event.head_commit.message, '[node_publish]') }}
 
-      ##########################
-      ## Java release process ##
-      ##########################
-      - name: Download mac jar file
-        uses: actions/download-artifact@v2.1.0
-        with:
-          name: omega-edit-mac.jar
-          path: omega-edit-mac.jar
+      # ##########################
+      # ## Java release process ##
+      # ##########################
+      # - name: Download mac jar file
+      #   uses: actions/download-artifact@v2.1.0
+      #   with:
+      #     name: omega-edit-mac.jar
+      #     path: omega-edit-mac.jar
 
-      - name: Download linux jar file
-        uses: actions/download-artifact@v2.1.0
-        with:
-          name: omega-edit-linux.jar
-          path: omega-edit-linux.jar
+      # - name: Download linux jar file
+      #   uses: actions/download-artifact@v2.1.0
+      #   with:
+      #     name: omega-edit-linux.jar
+      #     path: omega-edit-linux.jar
 
-      - name: Download windows jar file
-        uses: actions/download-artifact@v2.1.0
-        with:
-          name: omega-edit-windows.jar
-          path: omega-edit-windows.jar
+      # - name: Download windows jar file
+      #   uses: actions/download-artifact@v2.1.0
+      #   with:
+      #     name: omega-edit-windows.jar
+      #     path: omega-edit-windows.jar
 
-      - name: Move out jar files
-        run: |
-          for file in omega-edit-mac.jar omega-edit-linux.jar omega-edit-windows.jar;
-          do
-            mv $file "${file}_dir"
-            mv "${file}_dir/$file" .
-            rm -rf "${file}_dir"
-          done
+      # - name: Move out jar files
+      #   run: |
+      #     for file in omega-edit-mac.jar omega-edit-linux.jar omega-edit-windows.jar;
+      #     do
+      #       mv $file "${file}_dir"
+      #       mv "${file}_dir/$file" .
+      #       rm -rf "${file}_dir"
+      #     done
 
-      - name: Upload mac jar file
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: omega-edit-mac.jar
-          asset_name: omega-edit-mac.jar
-          asset_content_type: application/java-archive
+      # - name: Upload mac jar file
+      #   uses: actions/upload-release-asset@v1.0.2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: omega-edit-mac.jar
+      #     asset_name: omega-edit-mac.jar
+      #     asset_content_type: application/java-archive
 
-      - name: Upload linux jar file
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: omega-edit-linux.jar
-          asset_name: omega-edit-linux.jar
-          asset_content_type: application/java-archive
+      # - name: Upload linux jar file
+      #   uses: actions/upload-release-asset@v1.0.2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: omega-edit-linux.jar
+      #     asset_name: omega-edit-linux.jar
+      #     asset_content_type: application/java-archive
 
-      - name: Upload windows jar file
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: omega-edit-windows.jar
-          asset_name: omega-edit-windows.jar
-          asset_content_type: application/java-archive
+      # - name: Upload windows jar file
+      #   uses: actions/upload-release-asset@v1.0.2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: omega-edit-windows.jar
+      #     asset_name: omega-edit-windows.jar
+      #     asset_content_type: application/java-archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
+          targets: 'JAVA_HOME'
 
       - name: Export git tag and package.json version
         run: ${{ env.export_cmd }}
@@ -96,15 +97,12 @@ jobs:
 
       - name: Export filenames
         run: |
-          if [[ "${{ matrix.os }}" == "macos-11" ]]; then
+          if [[ "${{ matrix.os }}" == *"macos"* ]]; then
             LIB_FILENAME="libomega_edit.dylib"
             JAR_FILENAME="omega-edit-mac.jar"
-          elif [[ "${{ matrix.os }}" == "ubuntu-20.04" ]]; then
+          else
             LIB_FILENAME="libomega_edit.so"
             JAR_FILENAME="omega-edit-linux.jar"
-          else
-            LIB_FILENAME="libomega_edit.dll"
-            JAR_FILENAME="omega-edit-windows.jar"
           fi
 
           echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
@@ -150,17 +148,18 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
+          targets: 'JAVA_HOME'
 
       - name: Build C++ code
         run: |
           cmake -S . -B cmake-build-debug
-          sed -i "s|^CMAKE_CXX_COMPILER:FILEPATH=.*|CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/c++|g" CMakeLists.txt
+          sed -i "s|^CMAKE_CXX_COMPILER:FILEPATH=.*|CMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/c++|g" cmake-build-debug/CMakeCache.txt
           cmake --build cmake-build-debug
 
       - name: Generate library file
         run: |
-          g++ -c -I'%JAVA_HOME%/include' -I'%JAVA_HOME%/include/win32' src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
-          g++ -shared -o lib/libomega_edit.dll lib/omega_edit_wrap.o -Wl,--add-stdcall-alias
+          g++ -c -I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/win32 src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
+          g++ -shared -o lib/libomega_edit.dll cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a lib/omega_edit_wrap.o -Wl,--add-stdcall-alias
 
       - name: Export filenames
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,13 +157,10 @@ jobs:
           cmake --build cmake-build-debug
 
       - name: Generate library file
-        run: |
-          g++ -c -I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/win32 src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
-          g++ -shared -o lib/libomega_edit.dll cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a lib/omega_edit_wrap.o -Wl,--add-stdcall-alias
-
+        run: ./compile.sh compile-lib win
       - name: Export filenames
         run: |
-          LIB_FILENAME="libomega_edit.dll"
+          LIB_FILENAME="omega_edit.dll"
           JAR_FILENAME="omega-edit-windows.jar"
           echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
           echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
   scala-build-linux-mac:
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04]
+        os: [macos-latest, ubuntu-20.04]
     name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -127,7 +127,6 @@ jobs:
       matrix:
         include:
           - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
     defaults:
       run:
         shell: msys2 {0}
@@ -151,13 +150,6 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
-
-      - name: Export git tag and package.json version
-        run: ${{ env.export_cmd }}
-
-      - name: Check if git tag matches package version
-        run: if [[ ${{env.GIT_TAG}} != ${{env.PKG_VERSION}} ]]; then exit 1; else exit 0; fi
-        shell: bash
 
       - name: Build C++ code
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   node-build:
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04]
+        os: [macos-11, ubuntu-20.04, windows-latest]
     name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,6 +42,7 @@ jobs:
 
       - name: Export git tag and package.json version
         run: ${{ env.export_cmd }}
+        shell: bash
 
       - name: Check if git tag matches package version
         run: if [[ ${{env.GIT_TAG}} != ${{env.PKG_VERSION}} ]]; then exit 1; else exit 0; fi
@@ -55,13 +56,15 @@ jobs:
           NODE_FILE=""
 
           if [[ ${{ matrix.os }} == *"macos"* ]]; then
-            NODE_FILE="omega_edit_darwin.node"
-            mv module/omega_edit/omega_edit_mac.node module/omega_edit/$NODE_FILE
+            NODE_FILE="omega_edit_mac.node"
+          elif [[ ${{ matrix.os }} == *"windows"* ]]; then
+            NODE_FILE="omega_edit_win.node"
           else
             NODE_FILE="omega_edit_linux.node"
           fi
 
           echo "NODE_FILE=$(echo $NODE_FILE)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Upload ${{ env.NODE_FILE }}
         uses: actions/upload-artifact@v2.3.1
@@ -209,11 +212,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           node-version: ${{ env.node_version }}
 
-      - name: Download darwin node files
+      - name: Download mac node files
         uses: actions/download-artifact@v2.1.0
         with:
-          name: omega_edit_darwin.node
-          path: module/omega_edit/omega_edit_darwin.node
+          name: omega_edit_mac.node
+          path: module/omega_edit/omega_edit_mac.node
 
       - name: Download linux node files
         uses: actions/download-artifact@v2.1.0
@@ -221,15 +224,21 @@ jobs:
           name: omega_edit_linux.node
           path: module/omega_edit/omega_edit_linux.node
 
+      - name: Download windows node files
+        uses: actions/download-artifact@v2.1.0
+        with:
+          name: omega_edit_win.node
+          path: module/omega_edit/omega_edit_win.node
+
       - name: Move out node files
         run: |
           cd module/omega_edit/
 
-          for file in omega_edit_linux.node omega_edit_darwin.node;
+          for file in omega_edit_linux.node omega_edit_mac.node omega_edit_win.node;
           do
-            echo mv $file "${file}_dir"
-            echo mv "${file}_dir/$file" .
-            echo rm -rf "${file}_dir"
+            mv $file "${file}_dir"
+            mv "${file}_dir/$file" .
+            rm -rf "${file}_dir"
           done
 
       - name: Create node release tarball
@@ -249,6 +258,7 @@ jobs:
         run: yarn publish omega-edit-v${{ env.PKG_VERSION }}.tar.gz
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ contains(github.event.head_commit.message, '[node_publish]') }}
 
       ##########################
       ## Java release process ##

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,110 +72,110 @@ jobs:
           name: ${{ env.NODE_FILE }}
           path: module/omega_edit/${{ env.NODE_FILE }}
 
-  # scala-build-linux-mac:
-  #   strategy:
-  #     matrix:
-  #       os: [macos-latest, ubuntu-20.04]
-  #   name: Build ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v2.3.5
-  #       with:
-  #         submodules: true
-  #     - uses: actions/setup-java@v2.5.0
-  #       with:
-  #         distribution: 'adopt'
-  #         java-version: '11'
+  scala-build-linux-mac:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-20.04]
+    name: Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2.3.5
+        with:
+          submodules: true
+      - uses: actions/setup-java@v2.5.0
+        with:
+          distribution: 'adopt'
+          java-version: '11'
 
-  #     - name: Export git tag and package.json version
-  #       run: ${{ env.export_cmd }}
+      - name: Export git tag and package.json version
+        run: ${{ env.export_cmd }}
 
-  #     - name: Check if git tag matches package version
-  #       run: if [[ ${{env.GIT_TAG}} != ${{env.PKG_VERSION}} ]]; then exit 1; else exit 0; fi
-  #       shell: bash
+      - name: Check if git tag matches package version
+        run: if [[ ${{env.GIT_TAG}} != ${{env.PKG_VERSION}} ]]; then exit 1; else exit 0; fi
+        shell: bash
 
-  #     - name: Compile lib file
-  #       run: ./compile.sh compile-lib ${{ matrix.os }}
+      - name: Compile lib file
+        run: ./compile.sh compile-lib ${{ matrix.os }}
 
-  #     - name: Export filenames
-  #       run: |
-  #         if [[ "${{ matrix.os }}" == *"macos"* ]]; then
-  #           LIB_FILENAME="libomega_edit.dylib"
-  #           JAR_FILENAME="omega-edit-mac.jar"
-  #         else
-  #           LIB_FILENAME="libomega_edit.so"
-  #           JAR_FILENAME="omega-edit-linux.jar"
-  #         fi
+      - name: Export filenames
+        run: |
+          if [[ "${{ matrix.os }}" == *"macos"* ]]; then
+            LIB_FILENAME="libomega_edit.dylib"
+            JAR_FILENAME="omega-edit-mac.jar"
+          else
+            LIB_FILENAME="libomega_edit.so"
+            JAR_FILENAME="omega-edit-linux.jar"
+          fi
 
-  #         echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
-  #         echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
+          echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
+          echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
 
-  #     - name: Create JAR file
-  #       run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
+      - name: Create JAR file
+        run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
 
-  #     - name: Upload lib file
-  #       if: "${{ matrix.os }} == ubuntu-20.04"
-  #       uses: actions/upload-artifact@v2.3.1
-  #       with:
-  #         name: ${{ env.JAR_FILENAME }}
-  #         path: ${{ env.JAR_FILENAME }}
+      - name: Upload lib file
+        if: "${{ matrix.os }} == ubuntu-20.04"
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: ${{ env.JAR_FILENAME }}
+          path: ${{ env.JAR_FILENAME }}
 
-  # scala-build-windows:
-  #   name: Build Windows
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - { sys: mingw64, env: x86_64 }
-  #   defaults:
-  #     run:
-  #       shell: msys2 {0}
-  #   steps:
-  #     - uses: actions/checkout@v2.3.5
-  #       with:
-  #         submodules: true
-  #     - name: Install MinGW
-  #       uses: msys2/setup-msys2@v2
-  #       with:
-  #         msystem: ${{ matrix.sys }}
-  #         update: true
-  #         install: >-
-  #           mingw-w64-${{ matrix.env }}-toolchain
-  #           base-devel
-  #           cmake
-  #           swig
-  #           git
+  scala-build-windows:
+    name: Build Windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2.3.5
+        with:
+          submodules: true
+      - name: Install MinGW
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.sys }}
+          update: true
+          install: >-
+            mingw-w64-${{ matrix.env }}-toolchain
+            base-devel
+            cmake
+            swig
+            git
 
-  #     - uses: actions/setup-java@v2.5.0
-  #       with:
-  #         distribution: 'adopt'
-  #         java-version: '11'
+      - uses: actions/setup-java@v2.5.0
+        with:
+          distribution: 'adopt'
+          java-version: '11'
 
-  #     - name: Generate library file
-  #       run: ./compile.sh compile-lib win ci
+      - name: Generate library file
+        run: ./compile.sh compile-lib win ci
 
-  #     - name: Export filenames
-  #       run: |
-  #         LIB_FILENAME="omega_edit.dll"
-  #         JAR_FILENAME="omega-edit-windows.jar"
-  #         echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
-  #         echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
+      - name: Export filenames
+        run: |
+          LIB_FILENAME="omega_edit.dll"
+          JAR_FILENAME="omega-edit-windows.jar"
+          echo "LIB_FILENAME=$LIB_FILENAME" >> $GITHUB_ENV
+          echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
 
-  #     - name: Create JAR file
-  #       run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
-  #       shell: powershell
+      - name: Create JAR file
+        run: jar -cvf ${{ env.JAR_FILENAME }} lib/${{ env.LIB_FILENAME }}
+        shell: powershell
 
-  #     - name: Upload lib file
-  #       if: "${{ matrix.os }} == ubuntu-20.04"
-  #       uses: actions/upload-artifact@v2.3.1
-  #       with:
-  #         name: ${{ env.JAR_FILENAME }}
-  #         path: ${{ env.JAR_FILENAME }}
+      - name: Upload lib file
+        if: "${{ matrix.os }} == ubuntu-20.04"
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: ${{ env.JAR_FILENAME }}
+          path: ${{ env.JAR_FILENAME }}
 
   release:
     name: Release
     runs-on: ubuntu-20.04
-    needs: [node-build] #, scala-build-linux-mac, scala-build-windows]
+    needs: [node-build, scala-build-linux-mac, scala-build-windows]
     steps:
       - uses: actions/checkout@v2.3.5
         with:
@@ -233,14 +233,13 @@ jobs:
       - name: Move out node files
         run: |
           cd module/omega_edit/
-          ls -la
+
           for file in omega_edit_linux.node omega_edit_mac.node omega_edit_win.node;
           do
             mv $file "${file}_dir"
             mv "${file}_dir/$file" .
             rm -rf "${file}_dir"
           done
-          ls -la
 
       - name: Create node release tarball
         run: yarn pack --filename omega-edit-v${{ env.PKG_VERSION }}.tar.gz
@@ -255,68 +254,68 @@ jobs:
           asset_name: omega-edit-node-${{ env.PKG_VERSION }}.tar.gz
           asset_content_type: application/tar+gzip
 
-      # - name: Publish node package to npm registry
-      #   run: yarn publish omega-edit-v${{ env.PKG_VERSION }}.tar.gz
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      #   if: ${{ contains(github.event.head_commit.message, '[node_publish]') }}
+      - name: Publish node package to npm registry
+        run: yarn publish omega-edit-v${{ env.PKG_VERSION }}.tar.gz
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ contains(github.event.head_commit.message, '[node_publish]') }}
 
-      # ##########################
-      # ## Java release process ##
-      # ##########################
-      # - name: Download mac jar file
-      #   uses: actions/download-artifact@v2.1.0
-      #   with:
-      #     name: omega-edit-mac.jar
-      #     path: omega-edit-mac.jar
+      ##########################
+      ## Java release process ##
+      ##########################
+      - name: Download mac jar file
+        uses: actions/download-artifact@v2.1.0
+        with:
+          name: omega-edit-mac.jar
+          path: omega-edit-mac.jar
 
-      # - name: Download linux jar file
-      #   uses: actions/download-artifact@v2.1.0
-      #   with:
-      #     name: omega-edit-linux.jar
-      #     path: omega-edit-linux.jar
+      - name: Download linux jar file
+        uses: actions/download-artifact@v2.1.0
+        with:
+          name: omega-edit-linux.jar
+          path: omega-edit-linux.jar
 
-      # - name: Download windows jar file
-      #   uses: actions/download-artifact@v2.1.0
-      #   with:
-      #     name: omega-edit-windows.jar
-      #     path: omega-edit-windows.jar
+      - name: Download windows jar file
+        uses: actions/download-artifact@v2.1.0
+        with:
+          name: omega-edit-windows.jar
+          path: omega-edit-windows.jar
 
-      # - name: Move out jar files
-      #   run: |
-      #     for file in omega-edit-mac.jar omega-edit-linux.jar omega-edit-windows.jar;
-      #     do
-      #       mv $file "${file}_dir"
-      #       mv "${file}_dir/$file" .
-      #       rm -rf "${file}_dir"
-      #     done
+      - name: Move out jar files
+        run: |
+          for file in omega-edit-mac.jar omega-edit-linux.jar omega-edit-windows.jar;
+          do
+            mv $file "${file}_dir"
+            mv "${file}_dir/$file" .
+            rm -rf "${file}_dir"
+          done
 
-      # - name: Upload mac jar file
-      #   uses: actions/upload-release-asset@v1.0.2
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: omega-edit-mac.jar
-      #     asset_name: omega-edit-mac.jar
-      #     asset_content_type: application/java-archive
+      - name: Upload mac jar file
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: omega-edit-mac.jar
+          asset_name: omega-edit-mac.jar
+          asset_content_type: application/java-archive
 
-      # - name: Upload linux jar file
-      #   uses: actions/upload-release-asset@v1.0.2
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: omega-edit-linux.jar
-      #     asset_name: omega-edit-linux.jar
-      #     asset_content_type: application/java-archive
+      - name: Upload linux jar file
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: omega-edit-linux.jar
+          asset_name: omega-edit-linux.jar
+          asset_content_type: application/java-archive
 
-      # - name: Upload windows jar file
-      #   uses: actions/upload-release-asset@v1.0.2
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: omega-edit-windows.jar
-      #     asset_name: omega-edit-windows.jar
-      #     asset_content_type: application/java-archive
+      - name: Upload windows jar file
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: omega-edit-windows.jar
+          asset_name: omega-edit-windows.jar
+          asset_content_type: application/java-archive

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,64 +20,64 @@ env:
   node_version: 14.16.0
 
 jobs:
-  macos-node-test:
-    name: MacOS Tests
-    runs-on: macos-latest
-    steps:
-      - name: Install Prerequisites
-        run: brew install ninja nodeenv yarn
-      - name: Checkout Source
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Setup Node
-        uses: actions/setup-node@v1.4.6
-        with:
-          node-version: ${{ env.node_version }}
-      - name: Setup Debug Build
-        run: cmake -S . -B cmake-build-debug
-      - name: Build Debug Build
-        run: cmake --build cmake-build-debug
-      - name: Run Tests
-        working-directory: cmake-build-debug/src/tests/
-        run: ./omega_test -d yes --order lex
-      - name: Prepare To Build Node v14 Bindings
-        run: npm ci
-      - name: Test Node v14 Bindings
-        run: yarn test
-  linux-node-test:
-    name: Linux Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Prerequisites
-        run: sudo apt install -y ninja-build nodeenv valgrind yarn
-      - name: Checkout Source
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Setup Node
-        uses: actions/setup-node@v1.4.6
-        with:
-          node-version: ${{ env.node_version }}
-      - name: Setup Debug Build
-        run: cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_C_FLAGS=--coverage
-      - name: Build Debug Build
-        run: cmake --build cmake-build-debug
-      - name: Run Tests
-        working-directory: cmake-build-debug/src/tests/
-        run: ./omega_test -d yes --order lex
-      - name: Collect code coverage
-        working-directory: cmake-build-debug/src/tests/
-        run: bash <(curl -s https://codecov.io/bash)
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Run Tests Under Valgrind
-        working-directory: cmake-build-debug/src/tests/
-        run: valgrind --leak-check=full --show-leak-kinds=all --leak-resolution=med --track-origins=yes --vgdb=no --error-exitcode=1 ./omega_test -d yes --order lex
-      - name: Prepare To Build Node v14 Bindings
-        run: npm ci
-      - name: Test Node v14 Bindings
-        run: yarn test
+  # macos-node-test:
+  #   name: MacOS Tests
+  #   runs-on: macos-latest
+  #   steps:
+  #     - name: Install Prerequisites
+  #       run: brew install ninja nodeenv yarn
+  #     - name: Checkout Source
+  #       uses: actions/checkout@v2
+  #       with:
+  #         submodules: true
+  #     - name: Setup Node
+  #       uses: actions/setup-node@v1.4.6
+  #       with:
+  #         node-version: ${{ env.node_version }}
+  #     - name: Setup Debug Build
+  #       run: cmake -S . -B cmake-build-debug
+  #     - name: Build Debug Build
+  #       run: cmake --build cmake-build-debug
+  #     - name: Run Tests
+  #       working-directory: cmake-build-debug/src/tests/
+  #       run: ./omega_test -d yes --order lex
+  #     - name: Prepare To Build Node v14 Bindings
+  #       run: npm ci
+  #     - name: Test Node v14 Bindings
+  #       run: yarn test
+  # linux-node-test:
+  #   name: Linux Tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Install Prerequisites
+  #       run: sudo apt install -y ninja-build nodeenv valgrind yarn
+  #     - name: Checkout Source
+  #       uses: actions/checkout@v2
+  #       with:
+  #         submodules: true
+  #     - name: Setup Node
+  #       uses: actions/setup-node@v1.4.6
+  #       with:
+  #         node-version: ${{ env.node_version }}
+  #     - name: Setup Debug Build
+  #       run: cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_C_FLAGS=--coverage
+  #     - name: Build Debug Build
+  #       run: cmake --build cmake-build-debug
+  #     - name: Run Tests
+  #       working-directory: cmake-build-debug/src/tests/
+  #       run: ./omega_test -d yes --order lex
+  #     - name: Collect code coverage
+  #       working-directory: cmake-build-debug/src/tests/
+  #       run: bash <(curl -s https://codecov.io/bash)
+  #       env:
+  #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  #     - name: Run Tests Under Valgrind
+  #       working-directory: cmake-build-debug/src/tests/
+  #       run: valgrind --leak-check=full --show-leak-kinds=all --leak-resolution=med --track-origins=yes --vgdb=no --error-exitcode=1 ./omega_test -d yes --order lex
+  #     - name: Prepare To Build Node v14 Bindings
+  #       run: npm ci
+  #     - name: Test Node v14 Bindings
+  #       run: yarn test
   windows-node-test:
     name: Windows Tests
     runs-on: windows-latest
@@ -121,33 +121,33 @@ jobs:
         run: yarn test
         shell: powershell
 
-  scala-test:
-    strategy:
-      matrix:
-        os: [macos-11, ubuntu-20.04]
-    name: Build ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2.3.5
-        with:
-          submodules: true
-      - uses: actions/setup-java@v2.5.0
-        with:
-          distribution: 'adopt'
-          java-version: '11'
+  # scala-test:
+  #   strategy:
+  #     matrix:
+  #       os: [macos-11, ubuntu-20.04]
+  #   name: Build ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v2.3.5
+  #       with:
+  #         submodules: true
+  #     - uses: actions/setup-java@v2.5.0
+  #       with:
+  #         distribution: 'adopt'
+  #         java-version: '11'
 
-      - name: Run tests
-        run: sbt test
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: true
+  #     - name: Run tests
+  #       run: sbt test
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         submodules: true
 
-      - name: Build
-        run: cmake -S . -B cmake-build-debug
-      - name: Create omega_test
-        run: cmake --build cmake-build-debug --target omega_test
-      - name: Run tests
-        run: |
-          cd cmake-build-debug/src/tests/
-          ./omega_test -d yes --order lex
+  #     - name: Build
+  #       run: cmake -S . -B cmake-build-debug
+  #     - name: Create omega_test
+  #       run: cmake --build cmake-build-debug --target omega_test
+  #     - name: Run tests
+  #       run: |
+  #         cd cmake-build-debug/src/tests/
+  #         ./omega_test -d yes --order lex

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -109,13 +109,8 @@ jobs:
         uses: actions/setup-node@v1.4.6
         with:
           node-version: ${{ env.node_version }}
-      - name: Setup Debug Build
-        run: cmake -S . -B cmake-build-debug
-      - name: Fix cmake-build-debug/CMakeCache.txt for Windows
-        run: |
-          sed -i "s|^CMAKE_CXX_COMPILER:FILEPATH=.*|CMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/c++|g" cmake-build-debug/CMakeCache.txt
       - name: Build Debug Build
-        run: cmake --build cmake-build-debug
+        run: ./compile.sh win-ci
       - name: Run Tests
         working-directory: cmake-build-debug/src/tests/
         run: ./omega_test -d yes --order lex

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,64 +20,64 @@ env:
   node_version: 14.16.0
 
 jobs:
-  # macos-node-test:
-  #   name: MacOS Tests
-  #   runs-on: macos-latest
-  #   steps:
-  #     - name: Install Prerequisites
-  #       run: brew install ninja nodeenv yarn
-  #     - name: Checkout Source
-  #       uses: actions/checkout@v2
-  #       with:
-  #         submodules: true
-  #     - name: Setup Node
-  #       uses: actions/setup-node@v1.4.6
-  #       with:
-  #         node-version: ${{ env.node_version }}
-  #     - name: Setup Debug Build
-  #       run: cmake -S . -B cmake-build-debug
-  #     - name: Build Debug Build
-  #       run: cmake --build cmake-build-debug
-  #     - name: Run Tests
-  #       working-directory: cmake-build-debug/src/tests/
-  #       run: ./omega_test -d yes --order lex
-  #     - name: Prepare To Build Node v14 Bindings
-  #       run: npm ci
-  #     - name: Test Node v14 Bindings
-  #       run: yarn test
-  # linux-node-test:
-  #   name: Linux Tests
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Install Prerequisites
-  #       run: sudo apt install -y ninja-build nodeenv valgrind yarn
-  #     - name: Checkout Source
-  #       uses: actions/checkout@v2
-  #       with:
-  #         submodules: true
-  #     - name: Setup Node
-  #       uses: actions/setup-node@v1.4.6
-  #       with:
-  #         node-version: ${{ env.node_version }}
-  #     - name: Setup Debug Build
-  #       run: cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_C_FLAGS=--coverage
-  #     - name: Build Debug Build
-  #       run: cmake --build cmake-build-debug
-  #     - name: Run Tests
-  #       working-directory: cmake-build-debug/src/tests/
-  #       run: ./omega_test -d yes --order lex
-  #     - name: Collect code coverage
-  #       working-directory: cmake-build-debug/src/tests/
-  #       run: bash <(curl -s https://codecov.io/bash)
-  #       env:
-  #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  #     - name: Run Tests Under Valgrind
-  #       working-directory: cmake-build-debug/src/tests/
-  #       run: valgrind --leak-check=full --show-leak-kinds=all --leak-resolution=med --track-origins=yes --vgdb=no --error-exitcode=1 ./omega_test -d yes --order lex
-  #     - name: Prepare To Build Node v14 Bindings
-  #       run: npm ci
-  #     - name: Test Node v14 Bindings
-  #       run: yarn test
+  macos-node-test:
+    name: MacOS Tests
+    runs-on: macos-latest
+    steps:
+      - name: Install Prerequisites
+        run: brew install ninja nodeenv yarn
+      - name: Checkout Source
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Node
+        uses: actions/setup-node@v1.4.6
+        with:
+          node-version: ${{ env.node_version }}
+      - name: Setup Debug Build
+        run: cmake -S . -B cmake-build-debug
+      - name: Build Debug Build
+        run: cmake --build cmake-build-debug
+      - name: Run Tests
+        working-directory: cmake-build-debug/src/tests/
+        run: ./omega_test -d yes --order lex
+      - name: Prepare To Build Node v14 Bindings
+        run: npm ci
+      - name: Test Node v14 Bindings
+        run: yarn test
+  linux-node-test:
+    name: Linux Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Prerequisites
+        run: sudo apt install -y ninja-build nodeenv valgrind yarn
+      - name: Checkout Source
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Node
+        uses: actions/setup-node@v1.4.6
+        with:
+          node-version: ${{ env.node_version }}
+      - name: Setup Debug Build
+        run: cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_C_FLAGS=--coverage
+      - name: Build Debug Build
+        run: cmake --build cmake-build-debug
+      - name: Run Tests
+        working-directory: cmake-build-debug/src/tests/
+        run: ./omega_test -d yes --order lex
+      - name: Collect code coverage
+        working-directory: cmake-build-debug/src/tests/
+        run: bash <(curl -s https://codecov.io/bash)
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run Tests Under Valgrind
+        working-directory: cmake-build-debug/src/tests/
+        run: valgrind --leak-check=full --show-leak-kinds=all --leak-resolution=med --track-origins=yes --vgdb=no --error-exitcode=1 ./omega_test -d yes --order lex
+      - name: Prepare To Build Node v14 Bindings
+        run: npm ci
+      - name: Test Node v14 Bindings
+        run: yarn test
   windows-node-test:
     name: Windows Tests
     runs-on: windows-latest
@@ -121,33 +121,33 @@ jobs:
         run: yarn test
         shell: powershell
 
-  # scala-test:
-  #   strategy:
-  #     matrix:
-  #       os: [macos-11, ubuntu-20.04]
-  #   name: Build ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v2.3.5
-  #       with:
-  #         submodules: true
-  #     - uses: actions/setup-java@v2.5.0
-  #       with:
-  #         distribution: 'adopt'
-  #         java-version: '11'
+  scala-test:
+    strategy:
+      matrix:
+        os: [macos-11, ubuntu-20.04]
+    name: Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2.3.5
+        with:
+          submodules: true
+      - uses: actions/setup-java@v2.5.0
+        with:
+          distribution: 'adopt'
+          java-version: '11'
 
-  #     - name: Run tests
-  #       run: sbt test
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         submodules: true
+      - name: Run tests
+        run: sbt test
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
 
-  #     - name: Build
-  #       run: cmake -S . -B cmake-build-debug
-  #     - name: Create omega_test
-  #       run: cmake --build cmake-build-debug --target omega_test
-  #     - name: Run tests
-  #       run: |
-  #         cd cmake-build-debug/src/tests/
-  #         ./omega_test -d yes --order lex
+      - name: Build
+        run: cmake -S . -B cmake-build-debug
+      - name: Create omega_test
+        run: cmake --build cmake-build-debug --target omega_test
+      - name: Run tests
+        run: |
+          cd cmake-build-debug/src/tests/
+          ./omega_test -d yes --order lex

--- a/.npmignore
+++ b/.npmignore
@@ -14,4 +14,4 @@
 !LICENSE.txt
 !package.json
 !README.md
-!module/*
+!module/omega_edit/*

--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ The goal of this project is to provide an open source library for building edito
 multiple authors, and multiple viewports.
 
 ## Requirements
-### Development requirements:
-
-- **swig** to generate language bindings (http://www.swig.org/svn.html)
 
 ### IDE
 

--- a/compile.sh
+++ b/compile.sh
@@ -15,12 +15,14 @@ function check_os {
     os=$1
 
 
-    if [[ $os == "linux" || $os == "mac" || os == "win" ]]; then
+    if [[ $os == "linux" || $os == "mac" || $os == "win" ]]; then
         $os
     elif [[ $os == *"macos"* ]]; then
         mac
-    elif [[ $os == "ubuntu-20.04" ]]; then
+    elif [[ $os == *"ubuntu"* ]]; then
         linux
+    elif [[ $os == *"windows"* ]]; then
+        win
     else
         echo "$os is not a valid OS for script"
         exit 1
@@ -32,18 +34,21 @@ function gen-swig-java {
 }
 
 function linux {
-    g++ -c -fPIC -I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
-    g++ -shared -fPIC -o lib/libomega_edit.so cmake-build-debug/vendor/cwalk/libcwalk.a lib/omega_edit_wrap.o -lc
+    includes="-I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux"
+    g++ -c -fPIC $includes src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
+    g++ -shared -fPIC -o lib/libomega_edit.so lib/omega_edit_wrap.o cmake-build-debug/vendor/cwalk/libcwalk.a -lc
 }
 
 function mac {
-    g++ -std=c++14 -c -fPIC -I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
-    g++ -std=c++14 -dynamiclib -o lib/libomega_edit.dylib cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a lib/omega_edit_wrap.o -lc
+    includes="-I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin "
+    g++ -std=c++14 -c -fPIC $includes src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
+    g++ -std=c++14 -dynamiclib -o lib/libomega_edit.dylib lib/omega_edit_wrap.o cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a -lc
 }
 
 function win {
-    "g++ -c -I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/win32 src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o"
-    "g++ -shared -o lib/libomega_edit.dll cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a lib/omega_edit_wrap.o -Wl,--add-stdcall-alias"
+    JAVA_HOME=$(echo $JAVA_HOME | sed -e "s|C:|/c|" | sed -e 's|\\|/|g')
+    g++ -std=gnu++14 -c -I"${PWD}/src/include" -I"${PWD}/vendor/cwalk/include" -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/win32" src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
+    g++ -shared -o lib/omega_edit.dll lib/omega_edit_wrap.o cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a -Wl,--add-stdcall-alias
 }
 
 function all {

--- a/compile.sh
+++ b/compile.sh
@@ -52,8 +52,7 @@ function win {
 }
 
 function win-ci {
-    cmake -S . -B cmake-build-debug
-    sed -i "s|^CMAKE_CXX_COMPILER:FILEPATH=.*|CMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/c++|g" cmake-build-debug/CMakeCache.txt
+    cmake -S . -B cmake-build-debug -DCMAKE_CXX_COMPILER="g++"
     cmake --build cmake-build-debug
 }
 

--- a/compile.sh
+++ b/compile.sh
@@ -17,7 +17,7 @@ function check_os {
 
     if [[ $os == "linux" || $os == "mac" || os == "win" ]]; then
         $os
-    elif [[ $os == "macos-11" ]]; then
+    elif [[ $os == *"macos"* ]]; then
         mac
     elif [[ $os == "ubuntu-20.04" ]]; then
         linux
@@ -32,18 +32,18 @@ function gen-swig-java {
 }
 
 function linux {
-    g++ -c -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
-    g++ -shared -fPIC -o lib/libomega_edit.so lib/omega_edit_wrap.o -lc
+    g++ -c -fPIC -I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
+    g++ -shared -fPIC -o lib/libomega_edit.so cmake-build-debug/vendor/cwalk/libcwalk.a lib/omega_edit_wrap.o -lc
 }
 
 function mac {
-    g++ -std=c++11 -c -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
-    g++ -std=c++11 -dynamiclib -o lib/libomega_edit.dylib cmake-build-debug/libomega_edit.a lib/omega_edit_wrap.o -lc
+    g++ -std=c++14 -c -fPIC -I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o
+    g++ -std=c++14 -dynamiclib -o lib/libomega_edit.dylib cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a lib/omega_edit_wrap.o -lc
 }
 
 function win {
-    "g++ -c -I'%JAVA_HOME%/include' -I'%JAVA_HOME%/include/win32' src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o"
-    "g++ -shared -o lib/libomega_edit.dll cmake-build-debug/libomega_edit.a lib/omega_edit_wrap.o -Wl,--add-stdcall-alias"
+    "g++ -c -I${PWD}/src/include -I${PWD}/vendor/cwalk/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/win32 src/bindings/java/omega_edit_wrap.cxx -o lib/omega_edit_wrap.o"
+    "g++ -shared -o lib/libomega_edit.dll cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a lib/omega_edit_wrap.o -Wl,--add-stdcall-alias"
 }
 
 function all {

--- a/compile.sh
+++ b/compile.sh
@@ -51,17 +51,31 @@ function win {
     g++ -shared -o lib/omega_edit.dll lib/omega_edit_wrap.o cmake-build-debug/libomega_edit.a cmake-build-debug/vendor/cwalk/libcwalk.a -Wl,--add-stdcall-alias
 }
 
+function win-ci {
+    cmake -S . -B cmake-build-debug
+    sed -i "s|^CMAKE_CXX_COMPILER:FILEPATH=.*|CMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/c++|g" cmake-build-debug/CMakeCache.txt
+    cmake --build cmake-build-debug
+}
+
 function all {
     os=$1
+    ci=$2
     gen-swig-java
-    cmake -S . -B cmake-build-debug
-    cmake --build cmake-build-debug
+
+    if [[ ($os == *"windows"* || $os == "win") && $ci == "ci" ]]; then
+        win-ci
+    else
+        cmake -S . -B cmake-build-debug
+        cmake --build cmake-build-debug
+    fi
+
 
     if [[ ! -z $os ]]; then check_os $os; fi
 }
 
 function compile-lib {
-    all $1
+    if [[ ! -z $2 ]]; then ci=$2; else ci=""; fi
+    all $1 $ci
 }
 
 $@

--- a/module/omega_edit/index.js
+++ b/module/omega_edit/index.js
@@ -13,9 +13,9 @@
  **********************************************************************************************************************/
 
 // Export module for operating system
-if ("darwin" === process.platform) { gyp_os = "mac"}
-else if (process.platform.startsWith("win")) { gyp_os = "win"}
-else {gyp_os = process.platform}
+if ("darwin" === process.platform) { gyp_os = "mac" }
+else if (process.platform.startsWith("win")) { gyp_os = "win" }
+else { gyp_os = process.platform }
 
 omega_edit = require("./omega_edit_" + gyp_os)
 module.exports = omega_edit

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit",
   "description": "OmegaEdit open source library for building editors that can handle massive files",
-  "version": "0.6.3-3",
+  "version": "0.6.3-5",
   "main": "module/omega_edit/index.js",
   "repository": {
     "url": "https://github.com/ctc-oss/omega-edit",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit",
   "description": "OmegaEdit open source library for building editors that can handle massive files",
-  "version": "0.6.3-2",
+  "version": "0.6.3-3",
   "main": "module/omega_edit/index.js",
   "repository": {
     "url": "https://github.com/ctc-oss/omega-edit",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit",
   "description": "OmegaEdit open source library for building editors that can handle massive files",
-  "version": "0.6.3-5",
+  "version": "0.6.3-6",
   "main": "module/omega_edit/index.js",
   "repository": {
     "url": "https://github.com/ctc-oss/omega-edit",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit",
   "description": "OmegaEdit open source library for building editors that can handle massive files",
-  "version": "0.6.3-6",
+  "version": "0.6.3-7",
   "main": "module/omega_edit/index.js",
   "repository": {
     "url": "https://github.com/ctc-oss/omega-edit",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit",
   "description": "OmegaEdit open source library for building editors that can handle massive files",
-  "version": "0.6.3-7",
+  "version": "0.6.3-8",
   "main": "module/omega_edit/index.js",
   "repository": {
     "url": "https://github.com/ctc-oss/omega-edit",
@@ -16,7 +16,7 @@
     "gyp-build": "node-gyp build --target=13.6.3 --dist-url=https://electronjs.org/headers",
     "gyp-clean": "node-gyp clean --target=13.6.3 --dist-url=https://electronjs.org/headers",
     "gyp-configure": "node-gyp configure --target=13.6.3 --dist-url=https://electronjs.org/headers",
-    "gyp-rebuild": "node-gyp rebuild",
+    "gyp-rebuild": "node-gyp rebuild --target=13.6.3 --dist-url=https://electronjs.org/headers",
     "gyp-install": "node-gyp install --target=13.6.3 --dist-url=https://electronjs.org/headers",
     "gyp-list": "node-gyp list",
     "gyp-remove": "node-gyp remove",


### PR DESCRIPTION
Updates:

- Add windows node file to node tarball
- Make the CI skip publishing the node tarball to npmjs unless `[node_publish]` is in the commit message
- Fix some minor issues with window things for smoother CI

Successfully tested this release on Mac and Windows VM and was able to call functions properly

https://github.com/Shanedell/omega-edit/releases/tag/v0.6.3-7 Shows all the artifacts