### PR TITLE
Change osx platform string

### DIFF
--- a/src/bindings/scala/README.md
+++ b/src/bindings/scala/README.md
@@ -66,7 +66,7 @@ The classifier controls identifies the platform binaries to match the runtime.
 Platform identifiers are as follows
 
 - `linux-{32|64}`
-- `osx-{32|64}`
+- `macos-{32|64}`
 - `windows-{32|64}`
 
 ## callbacks

--- a/src/bindings/scala/project/BuildSupport.scala
+++ b/src/bindings/scala/project/BuildSupport.scala
@@ -47,7 +47,7 @@ object BuildSupport {
   lazy val arch: Arch = {
     val os = System.getProperty("os.name").toLowerCase match {
       case "linux"   => "linux"
-      case Mac()     => "osx"
+      case Mac()     => "macos"
       case "windows" => "windows"
     }
 


### PR DESCRIPTION
Changes our MacOS platform ID string from `osx` to `macos`

`omega-edit-native_2.12-ebb9b32e60325ca0e29fb5b0285f47e90c2485b2-macos-64.jar`

Missed in #190