### PR TITLE
Scala gRPC reference impl

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -88,3 +88,8 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: sbt howMuchCoverage
         working-directory: src/bindings/scala
+
+      - name: Build Scala gRPC Reference Impl
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sbt test
+        working-directory: src/rpc/server/scala

--- a/src/bindings/scala/README.md
+++ b/src/bindings/scala/README.md
@@ -39,7 +39,7 @@ Artifacts use Maven rather than Ivy to better support the use of the classifier 
 
 ### install from source tree
 
-Running `sbt install` from the root directory of this project will install the artifacts into the local Maven cache.
+Running `sbt +install` from the root directory of this project will install the artifacts into the local Maven cache.
 
 To use these artifacts from SBT you must add the M2 local resolver:
 

--- a/src/rpc/server/scala/.scalafmt.conf
+++ b/src/rpc/server/scala/.scalafmt.conf
@@ -1,0 +1,17 @@
+# Copyright 2021 Concurrent Technologies Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version = "2.3.2"
+maxColumn = 120
+rewrite.rules = [SortImports, RedundantBraces]

--- a/src/rpc/server/scala/README.md
+++ b/src/rpc/server/scala/README.md
@@ -1,0 +1,36 @@
+<!--
+  Copyright 2021 Concurrent Technologies Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+Ωedit Scala gRPC Server
+===
+
+Scala gRPC reference implementation using Akka.
+
+## Execution
+
+From the root project of Ωedit
+
+1. From within `src/bindings/scala` install the Ωedit bindings by running `sbt +install`
+2. From within `src/rpc/server/scala` launch the gRPC server by running `sbt run`
+
+## Reference
+- https://doc.akka.io/docs/akka-grpc
+
+## License
+
+This library is released under [Apache License, v2.0].
+
+[Apache License, v2.0]: https://www.apache.org/licenses/LICENSE-2.0

--- a/src/rpc/server/scala/build.sbt
+++ b/src/rpc/server/scala/build.sbt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BuildSupport._
+
+name := "example-grpc-server"
+scalaVersion := "2.13.6"
+
+git.useGitDescribe := true
+git.gitUncommittedChanges := false
+
+licenses := Seq(("Apache-2.0", apacheLicenseUrl))
+organizationName := "Concurrent Technologies Corporation"
+startYear := Some(2021)
+
+libraryDependencies ++= Seq(
+  "com.ctc" %% "omega-edit" % version.value,
+  "com.ctc" %% "omega-edit-native" % version.value classifier s"${arch.id}",
+  "org.scalatest" %% "scalatest" % "3.2.11" % Test
+)
+
+resolvers += Resolver.mavenLocal
+Compile / PB.protoSources += baseDirectory.value / "../../protos"
+
+enablePlugins(AkkaGrpcPlugin, GitVersioning, JavaAppPackaging, UniversalPlugin)

--- a/src/rpc/server/scala/project/BuildSupport.scala
+++ b/src/rpc/server/scala/project/BuildSupport.scala
@@ -1,0 +1,52 @@
+import sbt.URL
+
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+object BuildSupport {
+  case class Arch(id: String, _id: String)
+  val apacheLicenseUrl: URL = new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")
+
+  // some regexes for arch parsing
+  val Mac = """mac.+""".r
+  val Amd = """amd(\d+)""".r
+  val x86 = """x86_(\d+)""".r
+
+  lazy val arch: Arch = {
+    val os = System.getProperty("os.name").toLowerCase match {
+      case "linux"   => "linux"
+      case Mac()     => "macos"
+      case "windows" => "windows"
+    }
+
+    val arch = System.getProperty("os.arch").toLowerCase match {
+      case Amd(bits) => bits
+      case x86(bits) => bits
+      case arch      => throw new IllegalStateException(s"unknown arch: $arch")
+    }
+    Arch(s"$os-$arch", s"${os}_$arch")
+  }
+
+  def pair(name: String): (String, String) = name -> s"${arch._id}/$name"
+  lazy val mapping = {
+    val Mac = """mac.+""".r
+    System.getProperty("os.name").toLowerCase match {
+      case "linux"   => pair("libomega_edit.so")
+      case Mac()     => pair("libomega_edit.dylib")
+      case "windows" => pair("omega_edit.dll")
+    }
+  }
+}

--- a/src/rpc/server/scala/project/build.properties
+++ b/src/rpc/server/scala/project/build.properties
@@ -1,0 +1,15 @@
+# Copyright 2021 Concurrent Technologies Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sbt.version = 1.5.1

--- a/src/rpc/server/scala/project/plugins.sbt
+++ b/src/rpc/server/scala/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")

--- a/src/rpc/server/scala/src/main/resources/application.conf
+++ b/src/rpc/server/scala/src/main/resources/application.conf
@@ -1,0 +1,16 @@
+# Copyright 2021 Concurrent Technologies Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+akka.http.server.preview.enable-http2 = on
+akka.http.server.idle-timeout = infinite

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.grpc
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.grpc.GrpcServiceException
+import akka.http.scaladsl.Http
+import akka.pattern.ask
+import akka.stream.scaladsl.Source
+import akka.util.Timeout
+import com.ctc.omega_edit.api.OmegaEdit
+import com.ctc.omega_edit.grpc.EditorService._
+import com.ctc.omega_edit.grpc.Editors._
+import com.ctc.omega_edit.grpc.Session._
+import com.google.protobuf.empty.Empty
+import io.grpc.Status
+import omega_edit.ChangeKind.{CHANGE_DELETE, CHANGE_INSERT, CHANGE_OVERWRITE}
+import omega_edit._
+
+import java.nio.file.Paths
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+
+class EditorService(implicit val system: ActorSystem) extends Editor {
+  private implicit val timeout: Timeout = Timeout(1.second)
+  private val editors = system.actorOf(Editors.props())
+  import system.dispatcher
+
+  def getOmegaVersion(in: Empty): Future[VersionResponse] = {
+    val v = OmegaEdit.version()
+    Future.successful(VersionResponse(v.major, v.minor, v.patch))
+  }
+
+  def createSession(in: CreateSessionRequest): Future[CreateSessionResponse] =
+    (editors ? Create(in.sessionIdDesired, in.filePath.map(Paths.get(_)))).mapTo[Result].map {
+      case Ok(id) => CreateSessionResponse(id)
+      case Err(c) => throw grpcFailure(c)
+    }
+
+  def destroySession(in: ObjectId): Future[ObjectId] =
+    (editors ? Destroy(in.id)).mapTo[Result].map {
+      case Ok(_)  => in
+      case Err(c) => throw grpcFailure(c)
+    }
+
+  def saveSession(in: SaveSessionRequest): Future[SaveSessionResponse] =
+    (editors ? SessionOp(in.sessionId, Save(Paths.get(in.filePath)))).mapTo[Result].map {
+      case Ok(id) => SaveSessionResponse(id)
+      case Err(c) => throw grpcFailure(c)
+    }
+
+  def createViewport(in: CreateViewportRequest): Future[CreateViewportResponse] =
+    (editors ? SessionOp(in.sessionId, View(in.offset, in.capacity, in.viewportIdDesired))).mapTo[Result].map {
+      case Ok(id) => CreateViewportResponse(id)
+      case Err(c) => throw grpcFailure(c)
+    }
+
+  def destroyViewport(in: ObjectId): Future[ObjectId] =
+    in match {
+      case Viewport.Id(sid, vid) =>
+        (editors ? SessionOp(sid, DestroyView(vid))).mapTo[Result].map {
+          case Ok(_)  => in
+          case Err(c) => throw grpcFailure(c)
+        }
+      case _ => grpcFailFut(Status.INVALID_ARGUMENT, "malformed viewport id")
+    }
+
+  def getViewportData(in: ViewportDataRequest): Future[ViewportDataResponse] = ObjectId(in.viewportId) match {
+    case Viewport.Id(sid, vid) =>
+      (editors ? ViewportOp(sid, vid, Viewport.Get)).mapTo[Result].map {
+        case Err(c)           => throw grpcFailure(c)
+        case ok: Ok with Data => ViewportDataResponse(ok.id, ok.data.size(), ok.data)
+        case Ok(id)           => ViewportDataResponse(id)
+      }
+    case _ => grpcFailFut(Status.INVALID_ARGUMENT, "malformed viewport id")
+  }
+
+  def submitChange(in: ChangeRequest): Future[ChangeResponse] =
+    opForRequest(in) match {
+      case None => grpcFailFut(Status.INVALID_ARGUMENT, "undefined change kind")
+      case Some(op) =>
+        (editors ? SessionOp(in.sessionId, op)).mapTo[Result].map {
+          case Ok(id) => ChangeResponse(id)
+          case Err(c) => throw grpcFailure(c)
+        }
+    }
+
+  def getChangeDetails(in: SessionEvent): Future[ChangeDetailsResponse] = in.serial match {
+    case None => grpcFailFut(Status.INVALID_ARGUMENT, "change serial id required")
+    case Some(cid) =>
+      (editors ? SessionOp(in.sessionId, LookupChange(cid))).mapTo[Result].map {
+        case ok: Ok with ChangeDetails =>
+          ChangeDetailsResponse(in.sessionId, cid, offset = ok.change.offset, length = ok.change.length)
+        case Ok(_)  => ChangeDetailsResponse(in.sessionId)
+        case Err(c) => throw grpcFailure(c)
+      }
+  }
+
+  def getComputedFileSize(in: ObjectId): Future[ComputedFileSizeResponse] =
+    (editors ? SessionOp(in.id, GetSize)).mapTo[Result].map {
+      case ok: Ok with Size => ComputedFileSizeResponse(in.id, ok.computedSize)
+      case Err(c)           => throw grpcFailure(c)
+      case _                => throw grpcFailure(Status.UNKNOWN, "unable to compute size")
+    }
+
+  /**
+    * Event streams
+    */
+  def subscribeToSessionEvents(in: ObjectId): Source[SessionEvent, NotUsed] = {
+    val f = (editors ? SessionOp(in.id, Session.Watch)).mapTo[Result].map {
+      case ok: Ok with Session.Events =>
+        ok.stream.map(u => SessionEvent(u.id))
+      case _ => Source.failed(grpcFailure(Status.UNKNOWN))
+    }
+    Await.result(f, 1.second)
+  }
+
+  def subscribeToViewportEvents(in: ObjectId): Source[ViewportEvent, NotUsed] = in match {
+    case Viewport.Id(sid, vid) =>
+      val f = (editors ? ViewportOp(sid, vid, Viewport.Watch)).mapTo[Result].map {
+        case ok: Ok with Viewport.Events =>
+          ok.stream.map(u => ViewportEvent(u.id, serial = u.change.map(_.id)))
+        case _ => Source.failed(grpcFailure(Status.UNKNOWN))
+      }
+      Await.result(f, 1.second)
+    case _ => Source.failed(new GrpcServiceException(Status.INVALID_ARGUMENT.withDescription("malformed viewport id")))
+  }
+
+  def unsubscribeToSessionEvents(in: ObjectId): Future[ObjectId] = Future.successful(in)
+  def unsubscribeToViewportEvents(in: ObjectId): Future[ObjectId] = Future.successful(in)
+
+  //
+  // unimplementeds
+  //
+
+  def undoLastChange(in: ObjectId): Future[ChangeResponse] = grpcFailFut(Status.UNIMPLEMENTED)
+
+  def redoLastUndo(in: ObjectId): Future[ChangeResponse] = grpcFailFut(Status.UNIMPLEMENTED)
+
+  def clearChanges(in: ObjectId): Future[ObjectId] = grpcFailFut(Status.UNIMPLEMENTED)
+
+  def pauseViewportEvents(in: ObjectId): Future[ObjectId] = grpcFailFut(Status.UNIMPLEMENTED)
+
+  def resumeViewportEvents(in: ObjectId): Future[ObjectId] = grpcFailFut(Status.UNIMPLEMENTED)
+
+  def getLastChange(in: ObjectId): Future[ChangeDetailsResponse] = grpcFailFut(Status.UNIMPLEMENTED)
+
+  def getLastUndo(in: ObjectId): Future[ChangeDetailsResponse] = grpcFailFut(Status.UNIMPLEMENTED)
+}
+
+object EditorService {
+  def grpcFailure(status: Status, message: String = ""): GrpcServiceException =
+    new GrpcServiceException(if (message.nonEmpty) status.withDescription(message) else status)
+
+  def grpcFailFut[T](status: Status, message: String = ""): Future[T] =
+    Future.failed(grpcFailure(status, message))
+
+  def opForRequest(in: ChangeRequest): Option[Session.Op] = in.data.map(_.toStringUtf8).flatMap { data =>
+    in.kind match {
+      case CHANGE_INSERT    => Some(Session.Insert(data, in.offset))
+      case CHANGE_DELETE    => Some(Session.Delete(in.offset, in.length))
+      case CHANGE_OVERWRITE => Some(Session.Overwrite(data, in.offset))
+      case _                => None
+    }
+  }
+
+  def bind(iface: String = "127.0.0.1", port: Int = 9000)(implicit system: ActorSystem): Future[Http.ServerBinding] =
+    Http().newServerAt(iface, port).bind(EditorHandler(new EditorService))
+}

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.grpc
+
+import akka.actor.{Actor, ActorLogging, PoisonPill, Props}
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.Source
+import akka.util.Timeout
+import com.google.protobuf.ByteString
+import io.grpc.Status
+import com.ctc.omega_edit.api
+import com.ctc.omega_edit.api.{OmegaEdit, SessionCallback}
+import com.ctc.omega_edit.grpc.Session
+import com.ctc.omega_edit.grpc.Viewport
+
+import java.nio.file.Path
+import java.util.{Base64, UUID}
+import scala.concurrent.duration.DurationInt
+import scala.util.{Failure, Success}
+
+/**
+  * The Editors actor manages the backend Sessions
+  */
+object Editors {
+  def props() = Props(new Editors)
+
+  case class Find(id: String)
+  case class Create(id: Option[String], path: Option[Path])
+  case class Destroy(id: String)
+
+  ///
+
+  case class SessionOp(id: String, op: Session.Op)
+  case class ViewportOp(sid: String, vid: String, op: Viewport.Op)
+
+  sealed trait Result
+  case class Ok(id: String) extends Result
+  case class Err(reason: Status) extends Result
+
+  trait Data {
+    def data: ByteString
+  }
+
+  private def idFor(path: Option[Path]): String = path match {
+    case None    => UUID.randomUUID().toString.take(8)
+    case Some(p) => Base64.getEncoder.encodeToString(p.toString.getBytes)
+  }
+
+  private def sessionFor(path: Option[Path], cb: SessionCallback): api.Session = path match {
+    case None =>
+      val session = OmegaEdit.newSessionCb(None, cb)
+      session.insert(List.fill(Session.defaultSize)(" ").mkString, 0)
+      session
+    case path => OmegaEdit.newSessionCb(path, cb)
+  }
+}
+
+class Editors extends Actor with ActorLogging {
+  import Editors._
+  implicit val timeout = Timeout(1.second)
+
+  def receive: Receive = {
+    case Create(sid, path) =>
+      val id = sid.getOrElse(idFor(path))
+      context.child(id) match {
+        case Some(_) =>
+          sender() ! Err(Status.ALREADY_EXISTS)
+        case None =>
+          import context.system
+          val (input, stream) = Source.queue[Session.Updated](1, OverflowStrategy.dropHead).preMaterialize()
+          val cb = SessionCallback((_, _, _) => input.queue.offer(Session.Updated(id)))
+          context.actorOf(Session.props(sessionFor(path, cb), stream, cb), id)
+          sender() ! Ok(id)
+      }
+
+    case Find(id) =>
+      sender() ! context.child(id)
+
+    case Destroy(id) =>
+      context.child(id) match {
+        case None => sender() ! Err(Status.NOT_FOUND)
+        case Some(s) =>
+          s ! PoisonPill
+          sender() ! Ok(id)
+      }
+
+    case SessionOp(id, op) =>
+      context.child(id) match {
+        case None    => sender() ! Err(Status.NOT_FOUND.withDescription("session not found"))
+        case Some(s) => s forward op
+      }
+
+    case ViewportOp(sid, vid, op) =>
+      val replyTo = sender()
+      context.child(sid) match {
+        case None =>
+        case Some(s) =>
+          context
+            .actorSelection(s.path / vid)
+            .resolveOne()
+            .onComplete {
+              case Success(v) => v.tell(op, replyTo)
+              case Failure(_) => replyTo ! Err(Status.NOT_FOUND)
+            }(context.dispatcher)
+      }
+  }
+}

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.grpc
+
+import akka.NotUsed
+import akka.actor.{Actor, PoisonPill, Props}
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.Source
+import io.grpc.Status
+import com.ctc.omega_edit.grpc.Session._
+import com.ctc.omega_edit.grpc.Editors.{Err, Ok}
+import com.ctc.omega_edit.api
+import com.ctc.omega_edit.api.{Change, SessionCallback, ViewportCallback}
+
+import java.nio.file.Path
+
+object Session {
+  val defaultSize = 10000
+
+  type EventStream = Source[Session.Updated, NotUsed]
+  trait Events {
+    def stream: EventStream
+  }
+
+  trait Size {
+    def computedSize: Long
+  }
+
+  def props(session: api.Session, events: EventStream, cb: SessionCallback): Props =
+    Props(new Session(session, events, cb))
+
+  trait Op
+  case class Save(to: Path) extends Op
+  case class View(offset: Long, capacity: Long, id: Option[String]) extends Op
+  case class DestroyView(id: String) extends Op
+  case object Watch extends Op
+  case object GetSize extends Op
+
+  case class Push(data: String) extends Op
+  case class Delete(offset: Long, length: Long) extends Op
+  case class Insert(data: String, offset: Long) extends Op
+  case class Overwrite(data: String, offset: Long) extends Op
+
+  case class Updated(id: String)
+
+  case class LookupChange(id: Long) extends Op
+  trait ChangeDetails {
+    def change: Change
+  }
+}
+
+class Session(session: api.Session, events: EventStream, cb: SessionCallback) extends Actor {
+  val sessionId: String = self.path.name
+
+  def receive: Receive = {
+    case View(off, cap, id) =>
+      import context.system
+      val vid = id.getOrElse(Viewport.Id.uuid())
+      val fqid = s"$sessionId-$vid"
+
+      context.child(fqid) match {
+        case Some(_) => sender() ! Err(Status.ALREADY_EXISTS)
+        case None =>
+          val (input, stream) = Source.queue[Viewport.Updated](1, OverflowStrategy.dropHead).preMaterialize()
+          val cb = ViewportCallback((v, e, c) => input.queue.offer(Viewport.Updated(fqid, v.data, c)))
+          context.actorOf(Viewport.props(session.viewCb(off, cap, cb), stream, cb), vid)
+          sender() ! Ok(fqid)
+      }
+
+    case DestroyView(vid) =>
+      context.child(vid) match {
+        case None => sender() ! Err(Status.NOT_FOUND)
+        case Some(s) =>
+          s ! PoisonPill
+          sender() ! Ok(vid)
+      }
+
+    case Push(data) =>
+      session.insert(data, 0)
+      sender() ! Ok(sessionId)
+
+    case Insert(data, offset) =>
+      session.insert(data, offset)
+      sender() ! Ok(sessionId)
+
+    case Overwrite(data, offset) =>
+      session.overwrite(data, offset)
+      sender() ! Ok(sessionId)
+
+    case Delete(offset, length) =>
+      session.delete(offset, length)
+      sender() ! Ok(sessionId)
+
+    case LookupChange(id) =>
+      session.findChange(id) match {
+        case Some(c) =>
+          new Ok(s"$id") with ChangeDetails {
+            def change: Change = c
+          }
+        case None => sender() ! Err(Status.NOT_FOUND)
+      }
+
+    case Watch =>
+      sender() ! new Ok(sessionId) with Events {
+        def stream: EventStream = events
+      }
+
+    case GetSize =>
+      sender() ! new Ok(sessionId) with Size {
+        def computedSize: Long = session.size
+      }
+  }
+}

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Viewport.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Viewport.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.grpc
+
+import akka.NotUsed
+import akka.actor.{Actor, ActorLogging, Props}
+import akka.stream.scaladsl.Source
+import com.ctc.omega_edit.api
+import com.ctc.omega_edit.api.{Change, ViewportCallback}
+import com.ctc.omega_edit.grpc.Editors.{Data, Ok}
+import com.ctc.omega_edit.grpc.Viewport.{EventStream, Events, Get, Watch}
+import com.google.protobuf.ByteString
+import omega_edit.ObjectId
+
+import java.util.UUID
+
+object Viewport {
+  type EventStream = Source[Viewport.Updated, NotUsed]
+  trait Events {
+    def stream: EventStream
+  }
+
+  def props(view: api.Viewport, stream: EventStream, cb: ViewportCallback) =
+    Props(new Viewport(view, stream, cb))
+
+  case class Id(session: String, view: String)
+  object Id {
+    def unapply(oid: ObjectId): Option[(String, String)] =
+      oid.id.split("-") match {
+        case Array(s, v) => Some((s, v))
+        case _           => None
+      }
+
+    def uuid(): String = UUID.randomUUID().toString.take(8)
+  }
+
+  trait Op
+  case object Get extends Op
+  case object Watch extends Op
+  case class Updated(id: String, data: String, change: Option[Change])
+}
+
+class Viewport(view: api.Viewport, events: EventStream, cb: ViewportCallback) extends Actor with ActorLogging {
+  val viewportId: String = self.path.name
+
+  def receive: Receive = {
+    case Get =>
+      sender() ! new Ok(viewportId) with Data {
+        def data: ByteString = ByteString.copyFromUtf8(view.data)
+      }
+
+    case Watch =>
+      sender() ! new Ok(viewportId) with Events {
+        def stream: EventStream = events
+      }
+  }
+}

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/boot.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/boot.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.grpc
+
+import akka.actor.ActorSystem
+
+import scala.concurrent.ExecutionContext
+
+object boot extends App {
+  implicit val sys: ActorSystem = ActorSystem("omega-grpc")
+  implicit val ec: ExecutionContext = sys.dispatcher
+
+  EditorService.bind().foreach { binding =>
+    println(s"gRPC server bound to: ${binding.localAddress}")
+  }
+}

--- a/src/rpc/server/scala/src/test/scala/com/ctc/omega_edit/grpc/ExampleSpec.scala
+++ b/src/rpc/server/scala/src/test/scala/com/ctc/omega_edit/grpc/ExampleSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.grpc
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Sink
+import com.google.protobuf.ByteString
+import com.google.protobuf.empty.Empty
+import omega_edit._
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
+
+import java.util.UUID
+import scala.concurrent.Future
+
+/**
+  * This unit test is more for demonstration of the testability of the gRPC components than actual coverage
+  */
+class ExampleSpec extends AsyncWordSpecLike with Matchers with EditorServiceSupport {
+  "client" should useService { implicit service =>
+    "to get version" in service.getOmegaVersion(Empty()).map { v =>
+      v should matchPattern { case VersionResponse(_, _, _, _) => }
+    }
+
+    "to create session" in service.createSession(CreateSessionRequest()).map { v =>
+      v.sessionId shouldNot be(empty)
+    }
+
+    "to update session data" in newSession { sid =>
+      val testString = UUID.randomUUID().toString
+      for {
+        sizeBefore <- service.getComputedFileSize(ObjectId(sid)).map(_.computedFileSize)
+        changeResponse <- service.submitChange(
+          ChangeRequest(sid, ChangeKind.CHANGE_INSERT, data = Some(ByteString.copyFromUtf8(testString)))
+        )
+        sizeAfter <- service.getComputedFileSize(ObjectId(sid)).map(_.computedFileSize)
+      } yield {
+        sizeBefore shouldBe Session.defaultSize
+        changeResponse should matchPattern { case ChangeResponse(`sid`, _, _) => }
+        changeResponse should matchPattern { case ChangeResponse(`sid`, _, _) => }
+        sizeAfter shouldBe Session.defaultSize + testString.length
+      }
+    }
+
+    "listen to session events" in newSession { sid =>
+      import service.system
+      service.subscribeToSessionEvents(ObjectId(sid)).runWith(Sink.headOption).map {
+        case Some(e) => e should matchPattern { case SessionEvent(`sid`, _, _, _) => }
+        case None    => fail("no message received")
+      }
+    }
+  }
+}
+
+// fixture helper
+trait EditorServiceSupport {
+  def useService(test: EditorService => Unit): Unit =
+    test(new EditorService()(ActorSystem()))
+
+  def newSession(
+      test: String => Future[Assertion]
+  )(implicit service: EditorService): Future[Assertion] = {
+    import service.system.dispatcher
+    service.createSession(CreateSessionRequest()).map(_.sessionId).flatMap(test)
+  }
+}


### PR DESCRIPTION
Add Akka gRPC reference implementation from https://github.com/jw3/example-omega-vscode

- autogenerates gRPC implementation from OmegaEdit proto
- uses bindings API to provide backend for gRPC service
- sketches in some unit tests for examples of how it can be tested

There are a handful of later additions to the proto endpoints that are left unimplemented, not for any technical reason, just time constraints.

- `undoLastChange`
- `redoLastUndo`
- `clearChanges`
- `pauseViewportEvents`
- `resumeViewportEvents`
- `getLastChange`
- `getLastUndo`