### PR TITLE
Native SPI

### DIFF
--- a/src/bindings/scala/native/src/main/resources/META-INF/services/com.ctc.omega_edit.spi.BuildInfoService
+++ b/src/bindings/scala/native/src/main/resources/META-INF/services/com.ctc.omega_edit.spi.BuildInfoService
@@ -1,0 +1,15 @@
+# Copyright 2021 Concurrent Technologies Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+com.ctc.omega_edit.spi.NativeBuildInfoService

--- a/src/bindings/scala/native/src/main/scala/com/ctc/omega_edit/spi/NativeBuildInfoService.scala
+++ b/src/bindings/scala/native/src/main/scala/com/ctc/omega_edit/spi/NativeBuildInfoService.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.spi
+
+import com.ctc.omega_edit.native
+
+class NativeBuildInfoService extends BuildInfoService {
+  def info(): NativeBuildInfo = native.BuildInfo
+}

--- a/src/bindings/scala/project/BuildSupport.scala
+++ b/src/bindings/scala/project/BuildSupport.scala
@@ -20,7 +20,10 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 
 object BuildSupport {
-  case class Arch(id: String, _id: String)
+  case class Platform(os: String, bits: String) {
+    def id: String = s"$os-$bits"
+    def _id: String = s"${os}_$bits"
+  }
   val libdir: String = "../../../../lib"
   val apacheLicenseUrl: URL = new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")
 
@@ -44,11 +47,12 @@ object BuildSupport {
       }
     }).transform(node).head
 
-  lazy val arch: Arch = {
+  lazy val platform: Platform = {
     val os = System.getProperty("os.name").toLowerCase match {
       case "linux"   => "linux"
       case Mac()     => "macos"
       case "windows" => "windows"
+      case os        => throw new IllegalStateException(s"Unsupported OS: $os")
     }
 
     val arch = System.getProperty("os.arch").toLowerCase match {
@@ -56,10 +60,10 @@ object BuildSupport {
       case x86(bits) => bits
       case arch      => throw new IllegalStateException(s"unknown arch: $arch")
     }
-    Arch(s"$os-$arch", s"${os}_$arch")
+    Platform(os, arch)
   }
 
-  def pair(name: String): (String, String) = name -> s"${arch._id}/$name"
+  def pair(name: String): (String, String) = name -> s"${platform._id}/$name"
   lazy val mapping = {
     val Mac = """mac.+""".r
     System.getProperty("os.name").toLowerCase match {

--- a/src/bindings/scala/spi/src/main/scala-2.12/com/ctc/omega_edit/spi/PlatformInfoLoader.scala
+++ b/src/bindings/scala/spi/src/main/scala-2.12/com/ctc/omega_edit/spi/PlatformInfoLoader.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.spi
+
+import java.util.ServiceLoader
+
+object PlatformInfoLoader {
+  def load(): Option[NativeBuildInfo] = {
+    import scala.collection.JavaConverters._
+    val loader = ServiceLoader.load(classOf[BuildInfoService]).iterator()
+    loader.asScala.map(_.info()).find(NativeBuildInfo.matches)
+  }
+}

--- a/src/bindings/scala/spi/src/main/scala-2.13/com/ctc/omega_edit/spi/PlatformInfoLoader.scala
+++ b/src/bindings/scala/spi/src/main/scala-2.13/com/ctc/omega_edit/spi/PlatformInfoLoader.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.spi
+
+import com.ctc.omega_edit.spi.{BuildInfoService, NativeBuildInfo}
+
+import java.util.ServiceLoader
+
+object PlatformInfoLoader {
+  def load(): Option[NativeBuildInfo] = {
+    import scala.jdk.CollectionConverters._
+    val loader = ServiceLoader.load(classOf[BuildInfoService]).iterator()
+    loader.asScala.map(_.info()).find(NativeBuildInfo.matches)
+  }
+}

--- a/src/bindings/scala/spi/src/main/scala/com/ctc/omega_edit/spi/BuildInfoService.scala
+++ b/src/bindings/scala/spi/src/main/scala/com/ctc/omega_edit/spi/BuildInfoService.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.spi
+
+trait BuildInfoService {
+  def info(): NativeBuildInfo
+}

--- a/src/bindings/scala/spi/src/main/scala/com/ctc/omega_edit/spi/NativeBuildInfo.scala
+++ b/src/bindings/scala/spi/src/main/scala/com/ctc/omega_edit/spi/NativeBuildInfo.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.spi
+
+trait NativeBuildInfo {
+  def name: String
+  def version: String
+  def scalaVersion: String
+  def sbtVersion: String
+  def sharedLibraryOs: String
+  def sharedLibraryArch: String
+  def sharedLibraryName: String
+  def sharedLibraryPath: String
+}
+
+object NativeBuildInfo {
+  private val Mac = """mac.+""".r
+
+  def matches(info: NativeBuildInfo): Boolean = {
+    val thisOs = System.getProperty("os.name").toLowerCase match {
+      case "linux"   => Some("linux")
+      case Mac()     => Some("macos")
+      case "windows" => Some("windows")
+      case _         => None
+    }
+
+    val libOs = info.sharedLibraryOs
+    val libArch = info.sharedLibraryArch
+    (thisOs, System.getProperty("os.arch")) match {
+      case (Some(`libOs`), `libArch`) => true
+      case _                          => false
+    }
+  }
+}

--- a/src/bindings/scala/spi/src/main/scala/com/ctc/omega_edit/spi/NativeInfoNotFound.scala
+++ b/src/bindings/scala/spi/src/main/scala/com/ctc/omega_edit/spi/NativeInfoNotFound.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.spi
+
+case class NativeInfoNotFound(api: String) extends RuntimeException(s"Could not find BuildInfoService via SPI for $api")

--- a/src/bindings/scala/spi/src/main/scala/com/ctc/omega_edit/spi/VersionMismatch.scala
+++ b/src/bindings/scala/spi/src/main/scala/com/ctc/omega_edit/spi/VersionMismatch.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.spi
+
+case class VersionMismatch(api: String, native: String)
+    extends IllegalStateException(s"Native library mismatch: api: $api, native: $native")


### PR DESCRIPTION
Prevents API and native mismatch at compile time using BuildInfo and SPI

Needed for #203 to allow multiple native jars to exist in module
