### PR TITLE
scala: Check file exists on session create

### DIFF
--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/ChangeImpl.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/ChangeImpl.scala
@@ -20,6 +20,8 @@ import com.ctc.omega_edit.api.Change
 import jnr.ffi.Pointer
 
 private[omega_edit] class ChangeImpl(p: Pointer, i: FFI) extends Change {
+  require(p != null, "native change pointer was null")
+
   val id: Long = i.omega_change_get_serial(p)
 
   val offset: Long = i.omega_change_get_offset(p)

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/SessionImpl.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/SessionImpl.scala
@@ -21,6 +21,8 @@ import com.ctc.omega_edit.api.{Change, Session, Viewport, ViewportCallback}
 import jnr.ffi.Pointer
 
 private[omega_edit] class SessionImpl(p: Pointer, i: FFI) extends Session {
+  require(p != null, "native session pointer was null")
+
   def isEmpty: Boolean =
     size == 0
 

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/ViewportImpl.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/ViewportImpl.scala
@@ -20,6 +20,8 @@ import com.ctc.omega_edit.api.Viewport
 import jnr.ffi.Pointer
 
 private[omega_edit] class ViewportImpl(p: Pointer, i: FFI) extends Viewport {
+  require(p != null, "native viewport pointer was null")
+
   def data: String =
     i.omega_viewport_get_data(p)
 

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/api/OmegaEdit.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/api/OmegaEdit.scala
@@ -27,15 +27,16 @@ import scala.util.Try
   * Provides Session instances and version information.
   */
 object OmegaEdit extends OmegaEdit {
-  def newSession(path: Option[Path]): Session = new SessionImpl(
-    ffi.omega_edit_create_session(path.map(_.toString).orNull, null, null),
-    ffi
-  )
+  def newSession(path: Option[Path]): Session =
+    newSessionCb(path, null)
 
-  def newSessionCb(path: Option[Path], cb: SessionCallback): Session = new SessionImpl(
-    ffi.omega_edit_create_session(path.map(_.toString).orNull, cb, null),
-    ffi
-  )
+  def newSessionCb(path: Option[Path], cb: SessionCallback): Session = {
+    require(path.forall(_.toFile.exists()), "specified path does not exist")
+    new SessionImpl(
+      ffi.omega_edit_create_session(path.map(_.toString).orNull, cb, null),
+      ffi
+    )
+  }
 
   def version(): Version =
     Version(ffi.omega_version_major(), ffi.omega_version_minor(), ffi.omega_version_patch())

--- a/src/bindings/scala/api/src/test/scala/com/ctc/omega_edit/SessionImplSpec.scala
+++ b/src/bindings/scala/api/src/test/scala/com/ctc/omega_edit/SessionImplSpec.scala
@@ -17,11 +17,13 @@
 package com.ctc.omega_edit
 
 import com.ctc.omega_edit.api.Change.Changed
-import com.ctc.omega_edit.api.{Change, SessionEvent}
+import com.ctc.omega_edit.api.{Change, OmegaEdit, SessionEvent}
 import com.ctc.omega_edit.support.SessionSupport
 import org.scalatest.OptionValues._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Paths
 
 class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
   "a session" must {
@@ -38,6 +40,10 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
     "have string" in session("abc") { s =>
       s.isEmpty shouldBe false
       s.size shouldBe 3
+    }
+
+    "throw if file doesnt exist" in {
+      assertThrows[IllegalArgumentException](OmegaEdit.newSession(Some(Paths.get("/does-not-exist"))))
     }
   }
 

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
@@ -60,13 +60,8 @@ object Editors {
     case Some(p) => Base64.getEncoder.encodeToString(p.toString.getBytes)
   }
 
-  private def sessionFor(path: Option[Path], cb: SessionCallback): api.Session = path match {
-    case None =>
-      val session = OmegaEdit.newSessionCb(None, cb)
-      session.insert(List.fill(Session.defaultSize)(" ").mkString, 0)
-      session
-    case path => OmegaEdit.newSessionCb(path, cb)
-  }
+  private def sessionFor(path: Option[Path], cb: SessionCallback): api.Session =
+    OmegaEdit.newSessionCb(path, cb)
 }
 
 class Editors extends Actor with ActorLogging {

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
@@ -29,8 +29,6 @@ import com.ctc.omega_edit.api.{Change, SessionCallback, ViewportCallback}
 import java.nio.file.Path
 
 object Session {
-  val defaultSize = 10000
-
   type EventStream = Source[Session.Updated, NotUsed]
   trait Events {
     def stream: EventStream

--- a/src/rpc/server/scala/src/test/scala/com/ctc/omega_edit/grpc/ExampleSpec.scala
+++ b/src/rpc/server/scala/src/test/scala/com/ctc/omega_edit/grpc/ExampleSpec.scala
@@ -50,10 +50,10 @@ class ExampleSpec extends AsyncWordSpecLike with Matchers with EditorServiceSupp
         )
         sizeAfter <- service.getComputedFileSize(ObjectId(sid)).map(_.computedFileSize)
       } yield {
-        sizeBefore shouldBe Session.defaultSize
+        sizeBefore shouldBe 0
         changeResponse should matchPattern { case ChangeResponse(`sid`, _, _) => }
         changeResponse should matchPattern { case ChangeResponse(`sid`, _, _) => }
-        sizeAfter shouldBe Session.defaultSize + testString.length
+        sizeAfter shouldBe testString.length
       }
     }
 


### PR DESCRIPTION
The native create session call returns null when the specified file does not exist, using the session object then results in native segfault.

Guard against that specific file not found failure by checking for file exists, also add checks on the impl classes to require non-null pointers to fail fast in the case where the calling logic allows a null to get through.

Removes logic from the gRPC example that pre allocates empty space in the session.  That logic was added as a result of misunderstanding the api bug.

closes #227