### PR TITLE
handle save overwriting file being edited

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.13)
 
 # Project information
 project(omega_edit
-        VERSION 0.8.1
+        VERSION 0.8.3
         DESCRIPTION "Apache open source library for building editors"
         HOMEPAGE_URL "https://github.com/ctc-oss/omega-edit"
         LANGUAGES C CXX)

--- a/src/include/omega_edit/edit.h
+++ b/src/include/omega_edit/edit.h
@@ -32,13 +32,11 @@ extern "C" {
 /** On session change callback.  This under-defined function will be called when an associated session changes. */
 // TODO: Session change events can now be session creation, checkpoints, session clearing, transformations, session
 //  saving, in addition to changes, so we might want to consider adding a session change event type to the callback
-typedef void (*omega_session_event_cbk_t)(const omega_session_t *, omega_session_event_t session_event,
-                                          const omega_change_t *);
+typedef void (*omega_session_event_cbk_t)(const omega_session_t *, omega_session_event_t, const omega_change_t *);
 
 /** On viewport change callback.  This under-defined function will be called when an associated viewport changes. */
 // TODO: Like session changes, there are events other than standard changes that could change the state of a viewport
-typedef void (*omega_viewport_event_cbk_t)(const omega_viewport_t *, omega_viewport_event_t viewport_event,
-                                           const omega_change_t *);
+typedef void (*omega_viewport_event_cbk_t)(const omega_viewport_t *, omega_viewport_event_t, const omega_change_t *);
 
 /**
  * Create a file editing session from a file path
@@ -111,7 +109,7 @@ OMEGA_EDIT_EXPORT int64_t omega_edit_redo_last_undo(omega_session_t *session_ptr
  * this parameter is non-null, the saved file path will be copied here (must be able to accommodate FILENAME_MAX bytes)
  * @return 0 on success, non-zero otherwise
  */
-OMEGA_EDIT_EXPORT int omega_edit_save(const omega_session_t *session_ptr, const char *file_path, int overwrite,
+OMEGA_EDIT_EXPORT int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int overwrite,
                                       char *saved_file_path);
 
 /**

--- a/src/include/omega_edit/filesystem.h
+++ b/src/include/omega_edit/filesystem.h
@@ -82,6 +82,14 @@ OMEGA_EDIT_EXPORT int omega_util_remove_directory(char const *path);
 OMEGA_EDIT_EXPORT int64_t omega_util_file_size(char const *path);
 
 /**
+ * Given two file paths, determine if they are equivalent
+ * @param path1 first path
+ * @param path2 second path
+ * @return non-zero if the paths are equivalent and zero otherwise
+ */
+OMEGA_EDIT_EXPORT int omega_util_paths_equivalent(char const *path1, char const *path2);
+
+/**
  * Given a file name, return the associated basename (filename without the directory) and if a matching suffix is given, the returned basename will have the suffix removed
  * @param path file path
  * @param buffer pointer to memory to hold the base name (allocated to at least FILENAME_MAX) or could be NULL, in which case an internal static buffer will be used

--- a/src/lib/filesystem.cpp
+++ b/src/lib/filesystem.cpp
@@ -32,6 +32,8 @@ int omega_util_remove_directory(char const *path) { return (fs::remove(path)) ? 
 
 int64_t omega_util_file_size(char const *path) { return static_cast<int64_t>(fs::file_size(path)); }
 
+int omega_util_paths_equivalent(char const *path1, char const *path2) { return fs::equivalent(path1, path2) ? 1 : 0; }
+
 const char *omega_util_get_current_dir(char *buffer) {
     static char buff[FILENAME_MAX];//create string buffer to hold path
     if (!buffer) { buffer = buff; }

--- a/src/rpc/client/ts/package.json
+++ b/src/rpc/client/ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "omega-edit",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "OmegaEdit gRPC Client TypeScript Types",
     "publisher": "ctc-oss",
     "repository": {

--- a/src/tests/integration/data/session_save.expected.1.dat
+++ b/src/tests/integration/data/session_save.expected.1.dat
@@ -1,0 +1,1 @@
+0123456789abcdefghijklmnopqrstuvwxyz

--- a/src/tests/integration/data/session_save.expected.2.dat
+++ b/src/tests/integration/data/session_save.expected.2.dat
@@ -1,0 +1,1 @@
+0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ


### PR DESCRIPTION
Special care needs to be taken when overwriting the file being edited.  What this update does is when this happens during a save session call, it saves the file off to the side (in a temporary file), closes the file being edited, moves the file saved to the side to the original file, reopens the file and hands it back over to the session, then clears the session.  This means that if the session file is being overwritten, that the edit history will be cleared (no more undo/redo), and a SESSION_EVT_CLEAR is fired, notifying the caller of the edit history clearing event.  In other words, if the edited file gets overwritten, the session is reset with that saved file, and the editing state is no different than if we were editing the saved file for the first time.