### PR TITLE
add support for segments and new RPC service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(OMEGA_EDIT_SOURCE_FILES
         "src/include/omega_edit/check.h" "src/lib/check.cpp"
         "src/include/omega_edit/edit.h" "src/lib/edit.cpp"
         "src/include/omega_edit/search.h" "src/lib/search.cpp"
+        "src/include/omega_edit/segment.h" "src/lib/segment.cpp" "src/lib/impl_/segment_def.hpp"
         "src/include/omega_edit/version.h" "src/lib/version.c"
         "src/include/omega_edit/visit.h" "src/lib/visit.cpp"
         "src/include/omega_edit/session.h" "src/lib/session.cpp" "src/lib/impl_/session_def.hpp"
@@ -73,8 +74,7 @@ set(OMEGA_EDIT_SOURCE_FILES
         "src/include/omega_edit/filesystem.h" "src/lib/filesystem.cpp"
         "src/lib/impl_/internal_fun.hpp" "src/lib/impl_/internal_fun.cpp"
         "src/lib/impl_/find.h" "src/lib/impl_/find.cpp"
-        "src/lib/impl_/data_def.hpp" "src/lib/impl_/data_segment_def.hpp"
-        "src/lib/impl_/model_def.hpp" "src/lib/impl_/model_segment_def.hpp"
+        "src/lib/impl_/data_def.hpp" "src/lib/impl_/model_def.hpp" "src/lib/impl_/model_segment_def.hpp"
         "src/lib/impl_/macros.h" "src/include/omega_edit/export.h"
         "src/lib/impl_/internal_fwd_defs.hpp")
 

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/FFI.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/FFI.scala
@@ -86,6 +86,8 @@ private[omega_edit] trait FFI {
   def omega_session_get_num_checkpoints(p: Pointer): Long
   def omega_session_get_num_undone_changes(p: Pointer): Long
   def omega_session_get_num_viewports(p: Pointer): Long
+  def omega_session_get_segment(session: Pointer, segment: Pointer, offset: Long): Int
+  def omega_session_get_segment_string(session: Pointer, offset: Long, length: Long): String
   def omega_session_set_event_interest(p: Pointer, eventInterest: Int): Int
 
   // viewport
@@ -145,6 +147,16 @@ private[omega_edit] trait FFI {
   def omega_search_context_get_length(p: Pointer): Long
   def omega_search_next_match(p: Pointer, advanceContext: Long): Int
   def omega_search_destroy_context(p: Pointer): Unit
+
+  // segment
+
+  def omega_segment_create(capacity: Long): Pointer
+  def omega_segment_get_capacity(p: Pointer): Long
+  def omega_segment_get_length(p: Pointer): Long
+  def omega_segment_get_offset(p: Pointer): Long
+  def omega_segment_get_offset_adjustment(p: Pointer): Long
+  def omega_segment_get_data(p: Pointer): String
+  def omega_segment_destroy(p: Pointer): Unit
 
   // find
 

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/SessionImpl.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/SessionImpl.scala
@@ -152,11 +152,25 @@ private[omega_edit] class SessionImpl(p: Pointer, i: FFI) extends Session {
             limit.map(numMatches < _).getOrElse(true) && i
               .omega_search_next_match(context, 1) > 0
           )(
-            i.omega_search_context_get_offset(context) -> (context, numMatches + 1)
+            i.omega_search_context_get_offset(
+              context
+            ) -> (context, numMatches + 1)
           )
         }
         .toList
     } finally i.omega_search_destroy_context(context)
+  }
+
+  def getSegment(offset: Long, length: Long): Option[Segment] = {
+    val sp = i.omega_segment_create(length)
+
+    try {
+      val result = i.omega_session_get_segment(p, sp, offset)
+
+      Option.when(result == 0)(
+        Segment(offset, i.omega_segment_get_data(sp).getBytes)
+      )
+    } finally i.omega_segment_destroy(sp)
   }
 }
 

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/api/Segment.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/api/Segment.scala
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-addSbtPlugin("com.github.battermann" % "sbt-json" % "0.5.0")
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")
+package com.ctc.omega_edit.api
+
+final case class Segment(offset: Long, data: Array[Byte])

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/api/Session.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/api/Session.scala
@@ -56,6 +56,8 @@ trait Session {
   def save(to: Path, overwrite: OverwriteStrategy): Try[Path]
 
   def search(pattern: String, offset: Long, length: Option[Long] = None, caseInsensitive: Boolean = false, limit: Option[Long] = None): List[Long]
+
+  def getSegment(offset: Long, length: Long): Option[Segment]
 }
 
 object Session {

--- a/src/bindings/scala/api/src/test/scala/com/ctc/omega_edit/SessionImplSpec.scala
+++ b/src/bindings/scala/api/src/test/scala/com/ctc/omega_edit/SessionImplSpec.scala
@@ -16,9 +16,9 @@
 
 package com.ctc.omega_edit
 
+import com.ctc.omega_edit.api._
 import com.ctc.omega_edit.api.Change.Changed
 import com.ctc.omega_edit.api.Session.OverwriteStrategy
-import com.ctc.omega_edit.api.{Change, OmegaEdit, SessionEvent}
 import com.ctc.omega_edit.support.SessionSupport
 import org.scalatest.OptionValues._
 import org.scalatest.matchers.should.Matchers
@@ -29,6 +29,13 @@ import java.util.UUID
 import scala.util.Success
 
 class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
+
+  val numbers = "123456789"
+  //        0         1
+  //        0123456789012345
+  //            |    ||    |
+  val as = "bbbbabbbbaabbbba"
+
   "a session" must {
     "be empty" in emptySession { s =>
       s.isEmpty shouldBe true
@@ -115,12 +122,6 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
   }
 
   "search" should {
-    val numbers = "123456789"
-    //        0         1
-    //        0123456789012345
-    //            |    ||    |
-    val as = "bbbbabbbbaabbbba"
-
     "find nothing if nothing is there" in session(numbers) { s =>
       s.search("abc", 0) shouldBe List.empty
     }
@@ -148,6 +149,16 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
 
     "respect limit" in session(as) { s =>
       s.search("a", 0, limit = Some(2)) shouldBe List(4, 9)
+    }
+  }
+
+  "segments" should {
+    "find stuff" in session(numbers) { s =>
+      s.getSegment(3, 4) match {
+        case Some(Segment(3, data)) =>
+          data should equal(numbers.substring(3, 3 + 4).getBytes())
+        case _ => fail()
+      }
     }
   }
 }

--- a/src/include/omega_edit.h
+++ b/src/include/omega_edit.h
@@ -24,6 +24,7 @@
  */
 
 #include "omega_edit/change.h"
+#include "omega_edit/segment.h"
 #include "omega_edit/edit.h"
 #include "omega_edit/license.h"
 #include "omega_edit/search.h"

--- a/src/include/omega_edit/fwd_defs.h
+++ b/src/include/omega_edit/fwd_defs.h
@@ -47,8 +47,9 @@ typedef enum {
     VIEWPORT_EVT_UPDATED = 32
 } omega_viewport_event_t;
 
-typedef struct omega_session_struct omega_session_t;
 typedef struct omega_change_struct omega_change_t;
+typedef struct omega_segment_struct omega_segment_t;
+typedef struct omega_session_struct omega_session_t;
 typedef struct omega_viewport_struct omega_viewport_t;
 
 #ifdef __cplusplus

--- a/src/include/omega_edit/segment.h
+++ b/src/include/omega_edit/segment.h
@@ -1,0 +1,83 @@
+/**********************************************************************************************************************
+* Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+*                                                                                                                    *
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+* with the License.  You may obtain a copy of the License at                                                         *
+*                                                                                                                    *
+*     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+*                                                                                                                    *
+* Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+* distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+* implied.  See the License for the specific language governing permissions and limitations under the License.       *
+*                                                                                                                    *
+**********************************************************************************************************************/
+
+#ifndef OMEGA_EDIT_SEGMENT_H
+#define OMEGA_EDIT_SEGMENT_H
+
+#include "byte.h"
+#include "export.h"
+#include "fwd_defs.h"
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdint>
+extern "C" {
+#else
+#include <stddef.h>
+#include <stdint.h>
+#endif
+
+/**
+ * Create a segment with the given capacity
+ * @param capacity desired capacity of the segment, must be greater then zero
+ * @return segment of the desired capacity
+ */
+OMEGA_EDIT_EXPORT omega_segment_t *omega_segment_create(int64_t capacity);
+
+/**
+ * Gets the capacity of the segment
+ * @param segment_ptr segment to get the capacity from
+ * @return given segment's capacity
+ */
+OMEGA_EDIT_EXPORT int64_t omega_segment_get_capacity(const omega_segment_t *segment_ptr);
+
+/**
+ * Gets the length of a populated segment
+ * @param segment_ptr populated segment to get the length from
+ * @return given segment's length
+ */
+OMEGA_EDIT_EXPORT int64_t omega_segment_get_length(const omega_segment_t *segment_ptr);
+
+/**
+ * Gets the offset of a populated segment
+ * @param segment_ptr populated segment to get the offset from
+ * @return given segment's offset, or a negative number if the segment is not populated
+ */
+OMEGA_EDIT_EXPORT int64_t omega_segment_get_offset(const omega_segment_t *segment_ptr);
+
+/**
+ * Gets the offset adjustment of a populated segment
+ * @param segment_ptr populated segment to get the offset adjustment from
+ * @return given segment's offset adjustment
+ */
+OMEGA_EDIT_EXPORT int64_t omega_segment_get_offset_adjustment(const omega_segment_t *segment_ptr);
+
+/**
+ * Gets the data in a populated segment (data in the segment is a copy, not a reference)
+ * @param segment_ptr populated segment to get the offset from
+ * @return given segment's data, or null if the segment is not populated
+ */
+OMEGA_EDIT_EXPORT omega_byte_t *omega_segment_get_data(omega_segment_t *segment_ptr);
+
+/**
+ * Destroy the given segment
+ * @param segment_ptr segment to destroy
+ */
+OMEGA_EDIT_EXPORT void omega_segment_destroy(omega_segment_t *segment_ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif//OMEGA_EDIT_SEGMENT_H

--- a/src/include/omega_edit/session.h
+++ b/src/include/omega_edit/session.h
@@ -43,6 +43,15 @@ OMEGA_EDIT_EXPORT const char *omega_session_get_file_path(const omega_session_t 
 OMEGA_EDIT_EXPORT void *omega_session_get_user_data_ptr(const omega_session_t *session_ptr);
 
 /**
+ *
+ * @param session_ptr
+ * @param data_segment_ptr
+ * @param offset
+ * @return zero on success, non-zero otherwise
+ */
+OMEGA_EDIT_EXPORT int omega_session_get_segment(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr, int64_t offset);
+
+/**
  * Given a session, return the number of active viewports
  * @param session_ptr session to get the number of active viewports for
  * @return number of active viewports

--- a/src/include/omega_edit/stl_string_adaptor.hpp
+++ b/src/include/omega_edit/stl_string_adaptor.hpp
@@ -72,6 +72,15 @@ OMEGA_EDIT_EXPORT inline int64_t omega_edit_overwrite_string(omega_session_t *se
     return omega_edit_overwrite(session_ptr, offset, str.c_str(), static_cast<int64_t>(str.length()));
 }
 
+OMEGA_EDIT_EXPORT inline std::string omega_session_get_segment_string(const omega_session_t *session_ptr, int64_t offset, int64_t length) noexcept {
+    auto segment_ptr = omega_segment_create(length);
+    auto rc =  omega_session_get_segment(session_ptr, segment_ptr, offset);
+    assert(0 == rc);
+    std::string result (reinterpret_cast<const char *>(omega_segment_get_data(segment_ptr)), static_cast<size_t>(omega_segment_get_length(segment_ptr)));
+    omega_segment_destroy(segment_ptr);
+    return result;
+}
+
 /**
  * Create a search context
  * @param session_ptr session to find patterns in

--- a/src/include/omega_edit/utility.h
+++ b/src/include/omega_edit/utility.h
@@ -114,6 +114,24 @@ OMEGA_EDIT_EXPORT int omega_util_apply_byte_transform_to_file(char const *in_pat
  */
 OMEGA_EDIT_EXPORT omega_byte_t omega_util_mask_byte(omega_byte_t byte, omega_byte_t mask, omega_mask_kind_t mask_kind);
 
+/**
+ * Compares sz bytes of two character strings
+ * @param s1 first character string
+ * @param s2 second character string
+ * @param sz number of bytes to compare
+ * @return zero if sz bytes of the two character strings match, non-zero otherwise
+ */
+OMEGA_EDIT_EXPORT int omega_util_strncmp(const char *s1, const char *s2, uint64_t sz);
+
+/**
+ * Compares sz bytes of two character strings, without regard to case (case insensitive)
+ * @param s1 first character string
+ * @param s2 second character string
+ * @param sz number of bytes to compare
+ * @return zero if sz bytes of the two character strings match, non-zero otherwise
+ */
+OMEGA_EDIT_EXPORT int omega_util_strnicmp(const char *s1, const char *s2, uint64_t sz);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/edit.cpp
+++ b/src/lib/edit.cpp
@@ -14,6 +14,7 @@
 
 #include "../include/omega_edit/edit.h"
 #include "../include/omega_edit/change.h"
+#include "../include/omega_edit/segment.h"
 #include "../include/omega_edit/session.h"
 #include "../include/omega_edit/viewport.h"
 #include "impl_/change_def.hpp"
@@ -357,7 +358,7 @@ omega_viewport_t *omega_edit_create_viewport(omega_session_t *session_ptr, int64
         viewport_ptr->data_segment.data.bytes_ptr = (7 < capacity) ? new omega_byte_t[capacity + 1] : nullptr;
         viewport_ptr->event_handler = cbk;
         viewport_ptr->user_data_ptr = user_data_ptr;
-        omega_data_segment_get_data(&viewport_ptr->data_segment)[0] = '\0';
+        omega_segment_get_data(&viewport_ptr->data_segment)[0] = '\0';
         session_ptr->viewports_.push_back(viewport_ptr);
         omega_viewport_notify(viewport_ptr.get(), VIEWPORT_EVT_CREATE, nullptr);
         return session_ptr->viewports_.back().get();

--- a/src/lib/impl_/internal_fun.cpp
+++ b/src/lib/impl_/internal_fun.cpp
@@ -13,6 +13,7 @@
  **********************************************************************************************************************/
 
 #include "internal_fun.hpp"
+#include "../../include/omega_edit/segment.h"
 #include "../../include/omega_edit/change.h"
 #include "change_def.hpp"
 #include "macros.h"
@@ -46,7 +47,7 @@ static int64_t read_segment_from_file_(FILE *from_file_ptr, int64_t offset, omeg
     return rc;
 }
 
-int populate_data_segment_(const omega_session_t *session_ptr, omega_data_segment_t *data_segment_ptr) noexcept {
+int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr) noexcept {
     assert(session_ptr);
     assert(session_ptr->models_.back());
     assert(data_segment_ptr);
@@ -69,7 +70,7 @@ int populate_data_segment_(const omega_session_t *session_ptr, omega_data_segmen
             // data segment offsets are likely not aligned, so we need to compute how much of the segment to move past
             // (the delta).
             auto delta = data_segment_offset - (*iter)->computed_offset;
-            auto data_segment_buffer = omega_data_segment_get_data(data_segment_ptr);
+            auto data_segment_buffer = omega_segment_get_data(data_segment_ptr);
             do {
                 // This is how much data remains to be filled
                 const auto remaining_capacity = data_segment_capacity - data_segment_ptr->length;

--- a/src/lib/impl_/internal_fun.hpp
+++ b/src/lib/impl_/internal_fun.hpp
@@ -21,7 +21,7 @@
 #include <iosfwd>
 
 // Data segment functions
-int populate_data_segment_(const omega_session_t *session_ptr, omega_data_segment_t *data_segment_ptr) noexcept;
+int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr) noexcept;
 
 // Model segment functions
 void print_model_segments_(const omega_model_t *model_ptr, std::ostream &out_stream) noexcept;

--- a/src/lib/impl_/segment_def.hpp
+++ b/src/lib/impl_/segment_def.hpp
@@ -12,8 +12,8 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#ifndef OMEGA_EDIT_DATA_SEGMENT_DEF_HPP
-#define OMEGA_EDIT_DATA_SEGMENT_DEF_HPP
+#ifndef OMEGA_EDIT_SEGMENT_DEF_HPP
+#define OMEGA_EDIT_SEGMENT_DEF_HPP
 
 #include "data_def.hpp"
 #include "internal_fwd_defs.hpp"
@@ -23,7 +23,7 @@
 /**
  * A segment of data
  */
-struct omega_data_segment_struct {
+struct omega_segment_struct {
     int64_t offset{};   ///< Data offset as changes have been made
     int64_t length{};   ///< Populated data length (in bytes)
     int64_t capacity{}; ///< Data capacity (in bytes)
@@ -32,8 +32,4 @@ struct omega_data_segment_struct {
     int64_t offset_adjustment{};
 };
 
-inline omega_byte_t *omega_data_segment_get_data(omega_data_segment_t *data_segment_ptr) {
-    return omega_data_get_data(&data_segment_ptr->data, std::abs(data_segment_ptr->capacity));
-}
-
-#endif//OMEGA_EDIT_DATA_SEGMENT_DEF_HPP
+#endif//OMEGA_EDIT_SEGMENT_DEF_HPP

--- a/src/lib/impl_/viewport_def.hpp
+++ b/src/lib/impl_/viewport_def.hpp
@@ -16,12 +16,12 @@
 #define OMEGA_EDIT_VIEWPORT_DEF_HPP
 
 #include "../../include/omega_edit/fwd_defs.h"
-#include "data_segment_def.hpp"
+#include "segment_def.hpp"
 #include "internal_fwd_defs.hpp"
 
 struct omega_viewport_struct {
     omega_session_t *session_ptr{};            ///< Session that owns this viewport instance
-    omega_data_segment_t data_segment{};       ///< Viewport data
+    omega_segment_t data_segment{};       ///< Viewport data
     omega_viewport_event_cbk_t event_handler{};///< User callback when the viewport changes
     void *user_data_ptr{};                     ///< Pointer to associated user-provided data
 };

--- a/src/lib/search.cpp
+++ b/src/lib/search.cpp
@@ -12,10 +12,11 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
+#include "../include/omega_edit/segment.h"
 #include "../include/omega_edit/search.h"
 #include "../include/omega_edit/session.h"
 #include "../include/omega_edit/utility.h"
-#include "impl_/data_segment_def.hpp"
+#include "impl_/segment_def.hpp"
 #include "impl_/find.h"
 #include "impl_/internal_fun.hpp"
 #include <cassert>
@@ -85,7 +86,7 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
     assert(search_context_ptr);
     assert(search_context_ptr->skip_table_ptr);
     assert(search_context_ptr->session_ptr);
-    omega_data_segment_t data_segment;
+    omega_segment_t data_segment;
     const auto session_length = (search_context_ptr->session_length)
                                         ? search_context_ptr->session_length
                                         : omega_session_get_computed_file_size(search_context_ptr->session_ptr);
@@ -101,7 +102,7 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
     do {
         data_segment.offset += skip;
         populate_data_segment_(search_context_ptr->session_ptr, &data_segment);
-        const auto segment_data_ptr = omega_data_segment_get_data(&data_segment);
+        const auto segment_data_ptr = omega_segment_get_data(&data_segment);
         if (search_context_ptr->case_insensitive) {
             omega_util_apply_byte_transform(segment_data_ptr, data_segment.length, to_lower_, nullptr);
         }

--- a/src/lib/segment.cpp
+++ b/src/lib/segment.cpp
@@ -1,0 +1,61 @@
+/**********************************************************************************************************************
+* Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+*                                                                                                                    *
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+* with the License.  You may obtain a copy of the License at                                                         *
+*                                                                                                                    *
+*     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+*                                                                                                                    *
+* Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+* distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+* implied.  See the License for the specific language governing permissions and limitations under the License.       *
+*                                                                                                                    *
+**********************************************************************************************************************/
+
+#include "../include/omega_edit/segment.h"
+#include "impl_/segment_def.hpp"
+#include <cassert>
+
+omega_segment_t *omega_segment_create(int64_t capacity) {
+    assert(0 < capacity);
+    auto *segment_ptr = new omega_segment_t();
+    segment_ptr->data.bytes_ptr = (7 < capacity) ? new omega_byte_t[capacity + 1] : nullptr;
+    segment_ptr->capacity = capacity;
+    segment_ptr->length = 0;
+    segment_ptr->offset = -1;
+    segment_ptr->offset_adjustment = 0;
+    omega_segment_get_data(segment_ptr)[capacity] = '\0';// null terminate, this does not exceed the upper limit
+    return segment_ptr;
+}
+
+int64_t omega_segment_get_capacity(const omega_segment_t *segment_ptr) {
+    assert(segment_ptr);
+    return segment_ptr->capacity;
+}
+
+int64_t omega_segment_get_length(const omega_segment_t *segment_ptr) {
+    assert(segment_ptr);
+    return segment_ptr->length;
+}
+
+int64_t omega_segment_get_offset(const omega_segment_t *segment_ptr) {
+    assert(segment_ptr);
+    return segment_ptr->offset;
+}
+
+int64_t omega_segment_get_offset_adjustment(const omega_segment_t *segment_ptr) {
+    assert(segment_ptr);
+    return segment_ptr->offset_adjustment;
+}
+
+omega_byte_t *omega_segment_get_data(omega_segment_t *segment_ptr) {
+    assert(segment_ptr);
+    return (0 <= segment_ptr->length) ? omega_data_get_data(&segment_ptr->data, std::abs(segment_ptr->capacity))
+                                      : nullptr;
+}
+
+void omega_segment_destroy(omega_segment_t *segment_ptr) {
+    assert(segment_ptr);
+    if (7 < omega_segment_get_capacity(segment_ptr)) { delete[] segment_ptr->data.bytes_ptr; }
+    delete segment_ptr;
+}

--- a/src/lib/session.cpp
+++ b/src/lib/session.cpp
@@ -14,8 +14,10 @@
 
 #include "../include/omega_edit/session.h"
 #include "impl_/change_def.hpp"
+#include "impl_/segment_def.hpp"
 #include "impl_/model_def.hpp"
 #include "impl_/session_def.hpp"
+#include "impl_/internal_fun.hpp"
 #include <cassert>
 
 enum class session_flags { pause_viewport_callbacks = 0x01 };
@@ -23,6 +25,14 @@ enum class session_flags { pause_viewport_callbacks = 0x01 };
 void *omega_session_get_user_data_ptr(const omega_session_t *session_ptr) {
     assert(session_ptr);
     return session_ptr->user_data_ptr;
+}
+
+int omega_session_get_segment(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr,
+                              int64_t offset) {
+    assert(session_ptr);
+    assert(data_segment_ptr);
+    data_segment_ptr->offset = offset;
+    return populate_data_segment_(session_ptr, data_segment_ptr);
 }
 
 int64_t omega_session_get_num_viewports(const omega_session_t *session_ptr) {
@@ -91,17 +101,17 @@ const omega_change_t *omega_session_get_change(const omega_session_t *session_pt
 
 int omega_session_viewport_on_change_callbacks_paused(const omega_session_t *session_ptr) {
     assert(session_ptr);
-    return (session_ptr->session_flags_ & (int8_t)session_flags::pause_viewport_callbacks) ? 1 : 0;
+    return (session_ptr->session_flags_ & (int8_t) session_flags::pause_viewport_callbacks) ? 1 : 0;
 }
 
 void omega_session_pause_viewport_event_callbacks(omega_session_t *session_ptr) {
     assert(session_ptr);
-    session_ptr->session_flags_ |= (int8_t)session_flags::pause_viewport_callbacks;
+    session_ptr->session_flags_ |= (int8_t) session_flags::pause_viewport_callbacks;
 }
 
 void omega_session_resume_viewport_event_callbacks(omega_session_t *session_ptr) {
     assert(session_ptr);
-    session_ptr->session_flags_ &= ~(int8_t)session_flags::pause_viewport_callbacks;
+    session_ptr->session_flags_ &= ~(int8_t) session_flags::pause_viewport_callbacks;
 }
 
 int64_t omega_session_get_num_checkpoints(const omega_session_t *session_ptr) {

--- a/src/lib/stl_string_adapter.cpp
+++ b/src/lib/stl_string_adapter.cpp
@@ -13,6 +13,7 @@
 **********************************************************************************************************************/
 
 #include "../include/omega_edit/stl_string_adaptor.hpp"
+#include <cassert>
 
 std::string omega_change_get_string(const omega_change_t *change_ptr) noexcept {
     const auto change_bytes = omega_change_get_bytes(change_ptr);
@@ -35,11 +36,13 @@ int64_t omega_edit_overwrite_string(omega_session_t *session_ptr, int64_t offset
     return omega_edit_overwrite(session_ptr, offset, str.c_str(), static_cast<int64_t>(str.length()));
 }
 
-std::string omega_session_get_segment_string(const omega_session_t *session_ptr, int64_t offset, int64_t length) noexcept {
+std::string omega_session_get_segment_string(const omega_session_t *session_ptr, int64_t offset,
+                                             int64_t length) noexcept {
     auto segment_ptr = omega_segment_create(length);
-    auto rc =  omega_session_get_segment(session_ptr, segment_ptr, offset);
+    auto rc = omega_session_get_segment(session_ptr, segment_ptr, offset);
     assert(0 == rc);
-    std::string result (reinterpret_cast<const char *>(omega_segment_get_data(segment_ptr)), static_cast<size_t>(omega_segment_get_length(segment_ptr)));
+    std::string result(reinterpret_cast<const char *>(omega_segment_get_data(segment_ptr)),
+                       static_cast<size_t>(omega_segment_get_length(segment_ptr)));
     omega_segment_destroy(segment_ptr);
     return result;
 }

--- a/src/lib/utility.c
+++ b/src/lib/utility.c
@@ -42,6 +42,7 @@
 #include "../include/omega_edit/utility.h"
 #include "impl_/macros.h"
 #include <assert.h>
+#include <ctype.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -259,4 +260,20 @@ omega_byte_t omega_util_mask_byte(omega_byte_t byte, omega_byte_t mask, omega_ma
         default:
             ABORT(LOG_ERROR("unhandled mask kind"););
     }
+}
+
+int omega_util_strncmp(const char *s1, const char *s2, uint64_t sz) {
+    int rc = 0;
+    for (uint64_t i = 0; i < sz; ++i) {
+        if (0 != (rc = s1[i] - s2[i])) break;
+    }
+    return rc;
+}
+
+int omega_util_strnicmp(const char *s1, const char *s2, uint64_t sz) {
+    int rc = 0;
+    for (uint64_t i = 0; i < sz; ++i) {
+        if (0 != (rc = tolower(s1[i]) - tolower(s2[i]))) break;
+    }
+    return rc;
 }

--- a/src/lib/viewport.cpp
+++ b/src/lib/viewport.cpp
@@ -13,6 +13,7 @@
  **********************************************************************************************************************/
 
 #include "../include/omega_edit/viewport.h"
+#include "../include/omega_edit/segment.h"
 #include "../include/omega_edit/edit.h"
 #include "../include/omega_edit/session.h"
 #include "../include/omega_edit/utility.h"
@@ -89,7 +90,7 @@ const omega_byte_t *omega_viewport_get_data(const omega_viewport_t *viewport_ptr
         if (populate_data_segment_(viewport_ptr->session_ptr, &mut_viewport_ptr->data_segment) != 0) { return nullptr; }
         assert(omega_viewport_get_length(viewport_ptr) == viewport_ptr->data_segment.length);
     }
-    return omega_data_segment_get_data(&mut_viewport_ptr->data_segment);
+    return omega_segment_get_data(&mut_viewport_ptr->data_segment);
 }
 
 int omega_viewport_has_changes(const omega_viewport_t *viewport_ptr) {

--- a/src/rpc/protos/omega_edit.proto
+++ b/src/rpc/protos/omega_edit.proto
@@ -43,6 +43,7 @@ service Editor {
 
   rpc GetCount(CountRequest) returns (CountResponse);
   rpc GetSessionCount(google.protobuf.Empty) returns (SessionCountResponse);
+  rpc GetSegment(SegmentRequest) returns (SegmentResponse);
 
   // Event streams
   rpc SubscribeToSessionEvents(ObjectId) returns (stream SessionEvent);
@@ -199,4 +200,16 @@ message ChangeDetailsResponse {
 message ComputedFileSizeResponse {
   string session_id = 1;
   int64 computed_file_size = 2;
+}
+
+message SegmentRequest {
+  string session_id = 1;
+  int64 offset = 2;
+  int64 length = 3;
+}
+
+message SegmentResponse {
+  string session_id = 1;
+  int64 offset = 2;
+  bytes data = 3;
 }

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
@@ -22,7 +22,6 @@ import akka.stream.scaladsl.Source
 import akka.util.Timeout
 import com.google.protobuf.ByteString
 import io.grpc.Status
-import com.ctc.omega_edit.api
 import com.ctc.omega_edit.api.{OmegaEdit, SessionCallback}
 
 import java.nio.file.Path

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Viewport.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Viewport.scala
@@ -54,7 +54,7 @@ object Viewport {
   case class Updated(id: String, data: String, change: Option[Change])
 }
 
-class Viewport(view: api.Viewport, events: EventStream, cb: ViewportCallback)
+class Viewport(view: api.Viewport, events: EventStream, @deprecated("unused", "") cb: ViewportCallback)
     extends Actor
     with ActorLogging {
   val viewportId: String = self.path.name

--- a/src/rpc/tests/server_test.cpp
+++ b/src/rpc/tests/server_test.cpp
@@ -46,6 +46,8 @@ using omega_edit::Editor;
 using omega_edit::ObjectId;
 using omega_edit::SaveSessionRequest;
 using omega_edit::SaveSessionResponse;
+using omega_edit::SegmentRequest;
+using omega_edit::SegmentResponse;
 using omega_edit::SessionCountResponse;
 using omega_edit::VersionResponse;
 using omega_edit::ViewportDataRequest;
@@ -636,6 +638,37 @@ public:
         }
     }
 
+    [[nodiscard]] std::string GetSegment(const std::string &session_id, int64_t offset, int64_t length) const {
+        assert(!session_id.empty());
+        SegmentRequest request;
+        SegmentResponse response;
+        ClientContext context;
+
+        request.set_session_id(session_id);
+        request.set_offset(offset);
+        request.set_length(length);
+        std::mutex mu;
+        std::condition_variable cv;
+        bool done = false;
+        Status status;
+        stub_->async()->GetSegment(&context, &request, &response, [&mu, &cv, &done, &status](Status s) {
+            status = std::move(s);
+            std::scoped_lock lock(mu);
+            done = true;
+            cv.notify_one();
+        });
+
+        std::unique_lock lock(mu);
+        cv.wait(lock, [&done] { return done; });
+
+        if (status.ok()) {
+            return response.data();
+        } else {
+            DBG(CLOG << LOCATION << status.error_code() << ": " << status.error_message() << std::endl;);
+            return "";
+        }
+    }
+
     [[nodiscard]] int64_t GetComputedFileSize(const std::string &session_id) const {
         assert(!session_id.empty());
         ObjectId request;
@@ -864,6 +897,14 @@ void run_tests(const std::string &target_str, int repetitions, bool log) {
             DBG(CLOG << LOCATION << "[Remaining: " << repetitions << "] Insert received: " << serial << std::endl;);
         }
 
+        auto segment = server_test_client.GetSegment(session_id, 0, 32);
+        if (log) {
+            const std::scoped_lock write_lock(write_mutex);
+            DBG(CLOG << LOCATION << "[Remaining: " << repetitions << "] GetSegment received length: " << segment.length() << ", data: " << segment << std::endl;);
+        }
+        assert(segment.length() == 15);
+        assert(segment == "Hello Weird!!!!");
+
         ChangeDetailsResponse change_details;
         auto rc = server_test_client.GetLastChange(session_id, change_details);
         assert(0 == rc);
@@ -989,6 +1030,14 @@ void run_tests(const std::string &target_str, int repetitions, bool log) {
             DBG(CLOG << LOCATION << "[Remaining: " << repetitions
                      << "] GetCount(CountKind::COUNT_CHECKPOINTS) received: " << count << std::endl;);
         }
+
+        segment = server_test_client.GetSegment(session_id, 0, 32);
+        if (log) {
+            const std::scoped_lock write_lock(write_mutex);
+            DBG(CLOG << LOCATION << "[Remaining: " << repetitions << "] GetSegment received length: " << segment.length() << ", data: " << segment << std::endl;);
+        }
+        assert(segment.length() == 12);
+        assert(segment == "Hello World!");
 
         reply = server_test_client.SaveSession(session_id, save_file.string(), false);
         if (log) {

--- a/src/tests/integration/omega_test.cpp
+++ b/src/tests/integration/omega_test.cpp
@@ -123,8 +123,10 @@ TEST_CASE("File Exists", "[UtilTests]") {
 
 TEST_CASE("File Touch", "[UtilTests]") {
     const char dir_sep = omega_util_directory_separator();
-    const auto exists = std::string("data") + dir_sep + "test1.dat";;
-    const auto dont_exist = std::string("data") + dir_sep + "IDonTExist.DaT";;
+    const auto exists = std::string("data") + dir_sep + "test1.dat";
+    ;
+    const auto dont_exist = std::string("data") + dir_sep + "IDonTExist.DaT";
+    ;
     REQUIRE(omega_util_file_exists(exists.c_str()));
     REQUIRE(!omega_util_file_exists(dont_exist.c_str()));
     auto expected = std::string("data") + dir_sep + "test1-1.dat";
@@ -677,6 +679,19 @@ static inline void vpt_change_cbk(const omega_viewport_t *viewport_ptr, omega_vi
     }
 }
 
+TEST_CASE("Compare", "[CompareTests]") {
+    REQUIRE(0 == omega_util_strncmp("needle", "needle", 6));
+    REQUIRE(0 != omega_util_strncmp("needle", "needlE", 6));
+    REQUIRE(0 == omega_util_strncmp("needle", "needlE", 5));
+    REQUIRE(0 != omega_util_strncmp("foo", "bar", 3));
+
+    REQUIRE(0 == omega_util_strnicmp("needle", "needle", 6));
+    REQUIRE(0 == omega_util_strnicmp("needle", "needlE", 6));
+    REQUIRE(0 == omega_util_strnicmp("needle", "needlE", 5));
+    REQUIRE(0 == omega_util_strnicmp("Needle", "nEedlE", 5));
+    REQUIRE(0 != omega_util_strnicmp("foo", "bar", 3));
+}
+
 TEST_CASE("Search", "[SearchTests]") {
     file_info_t file_info;
     file_info.num_changes = 0;
@@ -745,18 +760,39 @@ TEST_CASE("Search", "[SearchTests]") {
     REQUIRE(match_context);
     needles_found = 0;
     const std::string replace = "Noodles";
+    auto segment_peek = omega_segment_create(10);
+    REQUIRE(10 == omega_segment_get_capacity(segment_peek));
+    REQUIRE(0 == omega_segment_get_length(segment_peek));
+    REQUIRE(0 > omega_segment_get_offset(segment_peek));
+    REQUIRE(0 == omega_segment_get_offset_adjustment(segment_peek));
     auto pattern_length = omega_search_context_get_length(match_context);
     if (omega_search_next_match(match_context, 1)) {
         const auto advance_context = static_cast<int64_t>(replace.length());
         do {
             const auto pattern_offset = omega_search_context_get_offset(match_context);
+            omega_session_get_segment(session_ptr, segment_peek, pattern_offset);
+            clog << " needle before: " << omega_segment_get_data(segment_peek) << std::endl;
+            REQUIRE(pattern_offset == omega_segment_get_offset(segment_peek));
+            REQUIRE(0 == omega_util_strnicmp("needle", (const char *) omega_segment_get_data(segment_peek), 6));
+            REQUIRE(omega_session_get_segment_string(session_ptr, pattern_offset,
+                                                     omega_segment_get_capacity(segment_peek)) ==
+                    (const char *) omega_segment_get_data(segment_peek));
             omega_session_pause_viewport_event_callbacks(session_ptr);
             omega_edit_delete(session_ptr, pattern_offset, pattern_length);
             omega_session_resume_viewport_event_callbacks(session_ptr);
             omega_edit_insert_string(session_ptr, pattern_offset, replace);
+            omega_session_get_segment(session_ptr, segment_peek, pattern_offset);
+            clog << " needle after: " << omega_segment_get_data(segment_peek) << std::endl;
+            REQUIRE(0 == omega_util_strnicmp((const char *) replace.c_str(),
+                                             (const char *) omega_segment_get_data(segment_peek),
+                                             static_cast<uint64_t>(replace.length())));
+            REQUIRE(omega_session_get_segment_string(session_ptr, pattern_offset,
+                                                     omega_segment_get_capacity(segment_peek)) ==
+                    (const char *) omega_segment_get_data(segment_peek));
             ++needles_found;
         } while (omega_search_next_match(match_context, advance_context));
     }
+    omega_segment_destroy(segment_peek);
     REQUIRE(6 == needles_found);
     omega_search_destroy_context(match_context);
     // Single byte search
@@ -866,7 +902,7 @@ TEST_CASE("Session Save", "[SessionSaveTests]") {
     omega_util_remove_file("data/session_save.1.dat");
     omega_edit_save(session_ptr, "data/session_save.1.dat", 1, saved_filename);
     REQUIRE(omega_util_paths_equivalent("data/session_save.1.dat", saved_filename));
-    REQUIRE(3 == session_events_count);// SESSION_EVT_SAVE
+    REQUIRE(3 == session_events_count); // SESSION_EVT_SAVE
     REQUIRE(2 == viewport_events_count);// no additional viewport events
     omega_edit_destroy_session(session_ptr);
     session_events_count = 0;
@@ -884,13 +920,13 @@ TEST_CASE("Session Save", "[SessionSaveTests]") {
     REQUIRE(omega_util_paths_equivalent("data/session_save.1.dat", saved_filename));
     REQUIRE(0 == compare_files("data/session_save.expected.1.dat", "data/session_save.1.dat"));
     REQUIRE(0 == omega_session_get_num_changes(session_ptr));
-    REQUIRE(4 == session_events_count);// SESSION_EVT_CLEAR and SESSION_EVT_SAVE
+    REQUIRE(4 == session_events_count); // SESSION_EVT_CLEAR and SESSION_EVT_SAVE
     REQUIRE(2 == viewport_events_count);// no additional viewport events
     omega_edit_insert_string(session_ptr, omega_session_get_computed_file_size(session_ptr),
                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
     REQUIRE(1 == omega_session_get_num_changes(session_ptr));
     omega_util_remove_file("data/session_save.1-1.dat");
-    REQUIRE(5 == session_events_count);// SESSION_EVT_SAVE
+    REQUIRE(5 == session_events_count); // SESSION_EVT_SAVE
     REQUIRE(3 == viewport_events_count);// no additional viewport events
     omega_edit_save(session_ptr, "data/session_save.1.dat", 0, saved_filename);
     REQUIRE(6 == session_events_count);// SESSION_EVT_SAVE


### PR DESCRIPTION
Adds a new RPC endpoint GetSegment that can get a segment (a one-shot range of bytes) from an editing session.  Back-end library now exposes segments in the public API.