### PR TITLE
relocate inline code into source files to ease FFI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ set(OMEGA_EDIT_SOURCE_FILES
         "src/include/omega_edit/fwd_defs.h"
         "src/include/omega_edit/byte.h"
         "src/include/omega_edit/scoped_ptr.hpp"
-        "src/include/omega_edit/stl_string_adaptor.hpp"
+        "src/include/omega_edit/stl_string_adaptor.hpp" "src/lib/stl_string_adapter.cpp"
         "src/include/omega_edit/change.h" "src/lib/change.cpp" "src/lib/impl_/change_def.hpp"
         "src/include/omega_edit/check.h" "src/lib/check.cpp"
         "src/include/omega_edit/edit.h" "src/lib/edit.cpp"

--- a/src/include/omega_edit/search.h
+++ b/src/include/omega_edit/search.h
@@ -60,12 +60,10 @@ omega_search_create_context_bytes(const omega_session_t *session_ptr, const omeg
  * @param case_insensitive zero for case sensitive matching and non-zero otherwise
  * @return search context
  */
-OMEGA_EDIT_EXPORT inline omega_search_context_t *
-omega_search_create_context(const omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,
-                            int64_t session_offset, int64_t session_length, int case_insensitive) {
-    return omega_search_create_context_bytes(session_ptr, (const omega_byte_t *) pattern, pattern_length,
-                                             session_offset, session_length, case_insensitive);
-}
+OMEGA_EDIT_EXPORT omega_search_context_t *omega_search_create_context(const omega_session_t *session_ptr,
+                                                                      const char *pattern, int64_t pattern_length,
+                                                                      int64_t session_offset, int64_t session_length,
+                                                                      int case_insensitive);
 
 /**
  * Given a search context, get the most recent search offset

--- a/src/include/omega_edit/stl_string_adaptor.hpp
+++ b/src/include/omega_edit/stl_string_adaptor.hpp
@@ -30,23 +30,14 @@
  * @param change_ptr change to get the data from
  * @return change data as a string
  */
-OMEGA_EDIT_EXPORT inline std::string omega_change_get_string(const omega_change_t *change_ptr) noexcept {
-    const auto change_bytes = omega_change_get_bytes(change_ptr);
-    if (change_bytes) {
-        return {reinterpret_cast<const char *>(change_bytes), static_cast<size_t>(omega_change_get_length(change_ptr))};
-    }
-    return {};
-}
+OMEGA_EDIT_EXPORT std::string omega_change_get_string(const omega_change_t *change_ptr) noexcept;
 
 /**
  * Given a viewport, return the viewport data as a string
  * @param viewport_ptr viewport to get the viewport data from
  * @return viewport data as a string
  */
-OMEGA_EDIT_EXPORT inline std::string omega_viewport_get_string(const omega_viewport_t *viewport_ptr) noexcept {
-    return {reinterpret_cast<const char *>(omega_viewport_get_data(viewport_ptr)),
-            static_cast<size_t>(omega_viewport_get_length(viewport_ptr))};
-}
+OMEGA_EDIT_EXPORT std::string omega_viewport_get_string(const omega_viewport_t *viewport_ptr) noexcept;
 
 /**
  * Insert a string at the given offset
@@ -55,10 +46,8 @@ OMEGA_EDIT_EXPORT inline std::string omega_viewport_get_string(const omega_viewp
  * @param str string to insert at the given offset
  * @return positive change serial number on success, zero otherwise
  */
-OMEGA_EDIT_EXPORT inline int64_t omega_edit_insert_string(omega_session_t *session_ptr, int64_t offset,
-                                                          const std::string &str) noexcept {
-    return omega_edit_insert(session_ptr, offset, str.c_str(), static_cast<int64_t>(str.length()));
-}
+OMEGA_EDIT_EXPORT int64_t omega_edit_insert_string(omega_session_t *session_ptr, int64_t offset,
+                                                   const std::string &str) noexcept;
 
 /**
  * Overwrite bytes at the given offset with the given new string
@@ -67,10 +56,8 @@ OMEGA_EDIT_EXPORT inline int64_t omega_edit_insert_string(omega_session_t *sessi
  * @param str new string to overwrite the old bytes with
  * @return positive change serial number on success, zero otherwise
  */
-OMEGA_EDIT_EXPORT inline int64_t omega_edit_overwrite_string(omega_session_t *session_ptr, int64_t offset,
-                                                             const std::string &str) noexcept {
-    return omega_edit_overwrite(session_ptr, offset, str.c_str(), static_cast<int64_t>(str.length()));
-}
+OMEGA_EDIT_EXPORT int64_t omega_edit_overwrite_string(omega_session_t *session_ptr, int64_t offset,
+                                                      const std::string &str) noexcept;
 
 /**
  * Create a search context
@@ -82,14 +69,11 @@ OMEGA_EDIT_EXPORT inline int64_t omega_edit_overwrite_string(omega_session_t *se
  * @param case_insensitive zero for case sensitive matching and non-zero otherwise
  * @return search context
  */
-OMEGA_EDIT_EXPORT inline omega_search_context_t *omega_search_create_context_string(const omega_session_t *session_ptr,
-                                                                                    const std::string &pattern,
-                                                                                    int64_t session_offset = 0,
-                                                                                    int64_t session_length = 0,
-                                                                                    int case_insensitive = 0) noexcept {
-    return omega_search_create_context(session_ptr, pattern.c_str(), static_cast<int64_t>(pattern.length()),
-                                       session_offset, session_length, case_insensitive);
-}
+OMEGA_EDIT_EXPORT omega_search_context_t *omega_search_create_context_string(const omega_session_t *session_ptr,
+                                                                             const std::string &pattern,
+                                                                             int64_t session_offset = 0,
+                                                                             int64_t session_length = 0,
+                                                                             int case_insensitive = 0) noexcept;
 
 #endif//__cplusplus
 

--- a/src/lib/search.cpp
+++ b/src/lib/search.cpp
@@ -66,6 +66,13 @@ omega_search_context_t *omega_search_create_context_bytes(const omega_session_t 
     return nullptr;
 }
 
+omega_search_context_t *
+omega_search_create_context(const omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,
+                            int64_t session_offset, int64_t session_length, int case_insensitive) {
+    return omega_search_create_context_bytes(session_ptr, (const omega_byte_t *) pattern, pattern_length,
+                                             session_offset, session_length, case_insensitive);
+}
+
 int64_t omega_search_context_get_offset(const omega_search_context_t *search_context_ptr) {
     assert(search_context_ptr);
     return search_context_ptr->match_offset;

--- a/src/lib/stl_string_adapter.cpp
+++ b/src/lib/stl_string_adapter.cpp
@@ -1,0 +1,43 @@
+/**********************************************************************************************************************
+* Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+*                                                                                                                    *
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+* with the License.  You may obtain a copy of the License at                                                         *
+*                                                                                                                    *
+*     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+*                                                                                                                    *
+* Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+* distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+* implied.  See the License for the specific language governing permissions and limitations under the License.       *
+*                                                                                                                    *
+**********************************************************************************************************************/
+
+#include "../include/omega_edit/stl_string_adaptor.hpp"
+
+std::string omega_change_get_string(const omega_change_t *change_ptr) noexcept {
+    const auto change_bytes = omega_change_get_bytes(change_ptr);
+    if (change_bytes) {
+        return {reinterpret_cast<const char *>(change_bytes), static_cast<size_t>(omega_change_get_length(change_ptr))};
+    }
+    return {};
+}
+
+std::string omega_viewport_get_string(const omega_viewport_t *viewport_ptr) noexcept {
+    return {reinterpret_cast<const char *>(omega_viewport_get_data(viewport_ptr)),
+            static_cast<size_t>(omega_viewport_get_length(viewport_ptr))};
+}
+
+int64_t omega_edit_insert_string(omega_session_t *session_ptr, int64_t offset, const std::string &str) noexcept {
+    return omega_edit_insert(session_ptr, offset, str.c_str(), static_cast<int64_t>(str.length()));
+}
+
+int64_t omega_edit_overwrite_string(omega_session_t *session_ptr, int64_t offset, const std::string &str) noexcept {
+    return omega_edit_overwrite(session_ptr, offset, str.c_str(), static_cast<int64_t>(str.length()));
+}
+
+omega_search_context_t *omega_search_create_context_string(const omega_session_t *session_ptr,
+                                                           const std::string &pattern, int64_t session_offset,
+                                                           int64_t session_length, int case_insensitive) noexcept {
+    return omega_search_create_context(session_ptr, pattern.c_str(), static_cast<int64_t>(pattern.length()),
+                                       session_offset, session_length, case_insensitive);
+}


### PR DESCRIPTION
Put inline code into source files so symbols appear in the library files for easing FFI.