### PR TITLE
Fix omega-edit-native for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,14 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target omega_edit
 
-      - name: Move library file
+      - name: Move library file mac
+        if: startsWith(matrix.os, 'mac')
         run: mv build/lib/* lib
+        shell: bash
+
+      - name: Move library file windows
+        if: startsWith(matrix.os, 'win')
+        run: mv build/bin/omega_edit.dll lib
         shell: bash
 
       - name: Setup JDK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.13)
 
 # Project information
 project(omega_edit
-        VERSION 0.9.2
+        VERSION 0.9.3
         DESCRIPTION "Apache open source library for building editors"
         HOMEPAGE_URL "https://github.com/ctc-oss/omega-edit"
         LANGUAGES C CXX)

--- a/src/rpc/client/ts/package.json
+++ b/src/rpc/client/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omega-edit",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "OmegaEdit gRPC Client TypeScript Types",
   "publisher": "ctc-oss",
   "repository": {


### PR DESCRIPTION
Fix issue with windows generated .dll not being in the lib folder but the bin folder