### PR TITLE
Node Modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.13)
 
 # Project information
 project(omega_edit
-        VERSION 0.9.6
+        VERSION 0.9.7
         DESCRIPTION "Apache open source library for building editors"
         HOMEPAGE_URL "https://github.com/ctc-oss/omega-edit"
         LANGUAGES C CXX)

--- a/src/rpc/client/ts/.gitignore
+++ b/src/rpc/client/ts/.gitignore
@@ -1,15 +1,16 @@
 # Copyright (c) 2021 Concurrent Technologies Corporation.
-#                                                                                                               
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at                                                    
-#                                                                                                               
-#     http://www.apache.org/licenses/LICENSE-2.0                                                                
-#                                                                                                               
-# Unless required by applicable law or agreed to in writing, software is distributed under the License is       
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or              
-# implied.  See the License for the specific language governing permissions and limitations under the License.  
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing permissions and limitations under the License.
 
 omega_edit_*.js
 omega_edit_*.ts
 **/*.js
 **/*.js.map
+package

--- a/src/rpc/client/ts/.npmignore
+++ b/src/rpc/client/ts/.npmignore
@@ -1,16 +1,18 @@
 # Copyright (c) 2021 Concurrent Technologies Corporation.
-#                                                                                                               
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at                                                    
-#                                                                                                               
-#     http://www.apache.org/licenses/LICENSE-2.0                                                                
-#                                                                                                               
-# Unless required by applicable law or agreed to in writing, software is distributed under the License is       
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or              
-# implied.  See the License for the specific language governing permissions and limitations under the License.  
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing permissions and limitations under the License.
 
 **/*
 *
+node_modules
 !*.js
+!*.ts
 !package.json
 !README.md

--- a/src/rpc/client/ts/compile-proto.sh
+++ b/src/rpc/client/ts/compile-proto.sh
@@ -14,14 +14,14 @@
 for arg in $@; do
     if [[ $arg == "--out" ]]; then
         OUT_DIR="$PWD/out"
+        TS_OUT_DIR="$PWD/out"
     fi
 done
 
 if [[ $# < 1 ]]; then
     OUT_DIR="$PWD/src"
+    TS_OUT_DIR="$PWD/src"
 fi
-
-TS_OUT_DIR="$PWD/src"
 
 IN_DIR="../../protos"
 PROTOC="$(yarn bin)/grpc_tools_node_protoc"

--- a/src/rpc/client/ts/package.json
+++ b/src/rpc/client/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omega-edit",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "OmegaEdit gRPC Client TypeScript Types",
   "publisher": "ctc-oss",
   "repository": {
@@ -15,12 +15,12 @@
   "scripts": {
     "compile-src": "./compile-proto.sh",
     "prepackage": "run-script-os",
-    "prepackage:default": "./compile-proto.sh && tsc -p ./ && ./compile-proto.sh --out && cp .npmignore package.json README.md out",
-    "prepackage:windows": "./compile-proto.sh && tsc -p ./ && ./compile-proto.sh --out && copy .npmignore package.json README.md out",
+    "prepackage:default": "./compile-proto.sh && tsc -p ./ && ./compile-proto.sh --out && cp .npmignore package.json README.md out && cp -r src/*.d.ts out",
+    "prepackage:windows": "./compile-proto.sh && tsc -p ./ && ./compile-proto.sh --out && copy .npmignore package.json README.md out && copy -r src/*.d.ts out",
     "package": "cd out && yarn pack && cd ../",
     "postpackage": "run-script-os",
-    "postpackage:default": "rm -rf out/.npmignore out/package.json out/README.md && mv out/omega-edit* .",
-    "postpackage:windows": "del /q out/.npmignore out/package.json out/README.md && move out/omega-edit* .",
+    "postpackage:default": "rm -rf out/*.d.ts out/.npmignore out/package.json out/README.md && mv out/omega-edit* .",
+    "postpackage:windows": "del /q out/*.d.ts out/.npmignore out/package.json out/README.md && move out/omega-edit* .",
     "test": "mocha --require ts-node/register ./tests/specs/*.spec.ts",
     "lint": "yarn run prettier src -c"
   },

--- a/src/rpc/client/ts/src/change.d.ts
+++ b/src/rpc/client/ts/src/change.d.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Concurrent Technologies Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeDetailsResponse } from './omega_edit_pb'
+
+declare module 'omega-edit/change' {
+  export const insert: (
+    session_id: string,
+    offset: number,
+    data: string | Uint8Array
+  ) => Promise<number>
+
+  export const del: (
+    session_id: string,
+    offset: number,
+    data: string,
+    len: number
+  ) => Promise<number>
+
+  export const overwrite: (
+    session_id: string,
+    offset: number,
+    data: string | Uint8Array
+  ) => Promise<number>
+
+  export const undo: (session_id: string) => Promise<number>
+
+  export const redo: (session_id: string) => Promise<number>
+
+  export const clear: (session_id: string) => Promise<string>
+
+  export const getLastChange: (
+    session_id: string
+  ) => Promise<ChangeDetailsResponse>
+
+  export const getLastUndo: (
+    session_id: string
+  ) => Promise<ChangeDetailsResponse>
+
+  export const getChangeCount: (session_id: string) => Promise<number>
+
+  export const getUndoCount: (session_id: string) => Promise<number>
+}

--- a/src/rpc/client/ts/src/change.ts
+++ b/src/rpc/client/ts/src/change.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { client } from './settings'
 import {
   ChangeDetailsResponse,
   ChangeKind,
@@ -26,9 +25,10 @@ import {
   CountRequest,
   ObjectId,
 } from './omega_edit_pb'
-import { TextEncoder } from 'node:util'
+import { getClient } from './settings'
+const client = getClient()
 
-export function ins(
+export function insert(
   session_id: string,
   offset: number,
   data: string | Uint8Array
@@ -36,13 +36,11 @@ export function ins(
   return new Promise<number>((resolve, reject) => {
     let request = new ChangeRequest().setSessionId(session_id).setOffset(offset)
     request.setKind(ChangeKind.CHANGE_INSERT)
-    request.setData(
-      typeof data == 'string' ? new TextEncoder().encode(data) : data
-    )
+    request.setData(typeof data == 'string' ? Buffer.from(data) : data)
     client.submitChange(request, (err, r) => {
       if (err) {
         console.log(err.message)
-        return reject('ins error: ' + err.message)
+        return reject('insert error: ' + err.message)
       }
       return resolve(r.getSerial())
     })
@@ -52,12 +50,14 @@ export function ins(
 export function del(
   session_id: string,
   offset: number,
+  data: string,
   len: number
 ): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     let request = new ChangeRequest().setSessionId(session_id).setOffset(offset)
     request.setKind(ChangeKind.CHANGE_DELETE)
     request.setLength(len)
+    request.setData(typeof data == 'string' ? Buffer.from(data) : data)
     client.submitChange(request, (err, r) => {
       if (err) {
         console.log(err.message)
@@ -68,7 +68,7 @@ export function del(
   })
 }
 
-export function ovr(
+export function overwrite(
   session_id: string,
   offset: number,
   data: string | Uint8Array
@@ -76,13 +76,11 @@ export function ovr(
   return new Promise<number>((resolve, reject) => {
     let request = new ChangeRequest().setSessionId(session_id).setOffset(offset)
     request.setKind(ChangeKind.CHANGE_OVERWRITE)
-    request.setData(
-      typeof data == 'string' ? new TextEncoder().encode(data) : data
-    )
+    request.setData(typeof data == 'string' ? Buffer.from(data, 'utf8') : data)
     client.submitChange(request, (err, r) => {
       if (err) {
         console.log(err.message)
-        return reject('ovr error: ' + err.message)
+        return reject('overwrite error: ' + err.message)
       }
       return resolve(r.getSerial())
     })
@@ -113,12 +111,12 @@ export function redo(session_id: string): Promise<number> {
   })
 }
 
-export function clr(session_id: string): Promise<string> {
+export function clear(session_id: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     client.clearChanges(new ObjectId().setId(session_id), (err, r) => {
       if (err) {
         console.log(err.message)
-        return reject('clr error: ' + err.message)
+        return reject('clear error: ' + err.message)
       }
       return resolve(r.getId())
     })

--- a/src/rpc/client/ts/src/session.d.ts
+++ b/src/rpc/client/ts/src/session.d.ts
@@ -17,24 +17,36 @@
  * limitations under the License.
  */
 
-import { Empty } from 'google-protobuf/google/protobuf/empty_pb'
-import { getClient } from './settings'
-const client = getClient()
+declare module 'omega-edit/session' {
+  export function createSession(
+    path: string | undefined,
+    sessionIdDesired: string | undefined
+  ): Promise<string>
 
-export function getVersion(): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    client.getVersion(new Empty(), (err, v) => {
-      if (err) {
-        console.log(err.message)
-        return reject('getVersion error: ' + err.message)
-      }
+  export function destroySession(id: string): Promise<string>
 
-      if (!v) {
-        console.log('undefined version')
-        return reject('undefined version')
-      }
+  export function saveSession(
+    sessionId: string,
+    filePath: string,
+    overwrite: boolean
+  ): Promise<string>
 
-      return resolve(`v${v.getMajor()}.${v.getMinor()}.${v.getPatch()}`)
-    })
-  })
+  export function getComputedFileSize(sessionId: string): Promise<number>
+
+  export function getSegment(
+    sessionId: string,
+    offset: number,
+    len: number
+  ): Promise<Uint8Array>
+
+  export function getSessionCount(): Promise<number>
+
+  export function searchSession(
+    sessionId: string,
+    pattern: string | Uint8Array,
+    isCaseInsensitive: boolean,
+    offset: number,
+    length: number,
+    limit: number | undefined
+  ): Promise<number[]>
 }

--- a/src/rpc/client/ts/src/session.ts
+++ b/src/rpc/client/ts/src/session.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { client } from './settings'
 import {
   CreateSessionRequest,
   ObjectId,
@@ -26,7 +25,8 @@ import {
   SegmentRequest,
 } from './omega_edit_pb'
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb'
-import { TextEncoder } from 'node:util'
+import { getClient } from './settings'
+const client = getClient()
 
 export function createSession(
   path: string | undefined,
@@ -138,9 +138,7 @@ export function searchSession(
   return new Promise<number[]>((resolve, reject) => {
     let request = new SearchRequest()
       .setSessionId(sessionId)
-      .setPattern(
-        typeof pattern == 'string' ? new TextEncoder().encode(pattern) : pattern
-      )
+      .setPattern(typeof pattern == 'string' ? Buffer.from(pattern) : pattern)
       .setIsCaseInsensitive(isCaseInsensitive)
       .setOffset(offset)
       .setLength(length)

--- a/src/rpc/client/ts/src/settings.d.ts
+++ b/src/rpc/client/ts/src/settings.d.ts
@@ -17,24 +17,8 @@
  * limitations under the License.
  */
 
-import { Empty } from 'google-protobuf/google/protobuf/empty_pb'
-import { getClient } from './settings'
-const client = getClient()
+import { EditorClient } from './omega_edit_grpc_pb'
 
-export function getVersion(): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    client.getVersion(new Empty(), (err, v) => {
-      if (err) {
-        console.log(err.message)
-        return reject('getVersion error: ' + err.message)
-      }
-
-      if (!v) {
-        console.log('undefined version')
-        return reject('undefined version')
-      }
-
-      return resolve(`v${v.getMajor()}.${v.getMinor()}.${v.getPatch()}`)
-    })
-  })
+declare module 'omega-edit/settings' {
+  export function getClient(): EditorClient
 }

--- a/src/rpc/client/ts/src/settings.ts
+++ b/src/rpc/client/ts/src/settings.ts
@@ -20,6 +20,10 @@
 import { EditorClient } from './omega_edit_grpc_pb'
 import * as grpc from '@grpc/grpc-js'
 
-export const uri = '127.0.0.1:9000'
+const uri = '127.0.0.1:9000'
 let creds = grpc.credentials.createInsecure()
-export const client = new EditorClient(uri, creds)
+const client = new EditorClient(uri, creds)
+
+export function getClient(): EditorClient {
+  return client
+}

--- a/src/rpc/client/ts/src/version.d.ts
+++ b/src/rpc/client/ts/src/version.d.ts
@@ -17,24 +17,6 @@
  * limitations under the License.
  */
 
-import { Empty } from 'google-protobuf/google/protobuf/empty_pb'
-import { getClient } from './settings'
-const client = getClient()
-
-export function getVersion(): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    client.getVersion(new Empty(), (err, v) => {
-      if (err) {
-        console.log(err.message)
-        return reject('getVersion error: ' + err.message)
-      }
-
-      if (!v) {
-        console.log('undefined version')
-        return reject('undefined version')
-      }
-
-      return resolve(`v${v.getMajor()}.${v.getMinor()}.${v.getPatch()}`)
-    })
-  })
+declare module 'omega-edit/version' {
+  export function getVersion(): Promise<string>
 }

--- a/src/rpc/client/ts/src/viewport.d.ts
+++ b/src/rpc/client/ts/src/viewport.d.ts
@@ -17,24 +17,14 @@
  * limitations under the License.
  */
 
-import { Empty } from 'google-protobuf/google/protobuf/empty_pb'
-import { getClient } from './settings'
-const client = getClient()
-
-export function getVersion(): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    client.getVersion(new Empty(), (err, v) => {
-      if (err) {
-        console.log(err.message)
-        return reject('getVersion error: ' + err.message)
-      }
-
-      if (!v) {
-        console.log('undefined version')
-        return reject('undefined version')
-      }
-
-      return resolve(`v${v.getMajor()}.${v.getMinor()}.${v.getPatch()}`)
-    })
-  })
+declare module 'omega-edit/viewport' {
+  export function createViewport(
+    desired_viewport_id: string | undefined,
+    session_id: string,
+    offset: number,
+    capacity: number
+  ): Promise<string>
+  export function destroyViewport(id: string): Promise<string>
+  export function getViewportCount(sesssion_id: string): Promise<number>
+  export function getViewportData(viewport_id: string): Promise<Uint8Array>
 }

--- a/src/rpc/client/ts/src/viewport.ts
+++ b/src/rpc/client/ts/src/viewport.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { client } from './settings'
 import {
   CountKind,
   CountRequest,
@@ -23,6 +22,8 @@ import {
   ObjectId,
   ViewportDataRequest,
 } from './omega_edit_pb'
+import { getClient } from './settings'
+const client = getClient()
 
 export function createViewport(
   desired_viewport_id: string | undefined,

--- a/src/rpc/client/ts/tests/specs/client.spec.ts
+++ b/src/rpc/client/ts/tests/specs/client.spec.ts
@@ -29,14 +29,14 @@ import {
   searchSession,
 } from '../../src/session'
 import {
-  clr,
+  clear,
   del,
   getChangeCount,
   getLastChange,
   getLastUndo,
   getUndoCount,
-  ins,
-  ovr,
+  insert,
+  overwrite,
   redo,
   undo,
 } from '../../src/change'
@@ -47,7 +47,6 @@ import {
   getViewportData,
 } from '../../src/viewport'
 import { unlinkSync } from 'node:fs'
-import { TextEncoder, TextDecoder } from 'node:util'
 import { ChangeKind } from '../../src/omega_edit_pb'
 
 describe('Version', () => {
@@ -78,49 +77,47 @@ describe('Editing', () => {
     //console.log("destroyed session: "+session_id)
   })
 
-  describe('Insert', () => {
-    it('Should insert a string', async () => {
+  describe('insertert', () => {
+    it('Should insertert a string', async () => {
       expect(0).to.equal(await getComputedFileSize(session_id))
-      const data = new TextEncoder().encode('abcghijklmnopqrstuvwxyz')
-      let change_id = await ins(session_id, 0, data)
+      const data = Buffer.from('abcghijklmnopqrstuvwxyz', 'utf-8')
+      let change_id = await insert(session_id, 0, data)
       expect(change_id).to.be.a('number').that.equals(1)
-      change_id = await ins(session_id, 3, new TextEncoder().encode('def'))
+      change_id = await insert(session_id, 3, Buffer.from('def', 'utf8'))
       expect(change_id).to.be.a('number').that.equals(2)
       let file_size = await getComputedFileSize(session_id)
       expect(data.length + 3).equals(file_size)
       let segment = await getSegment(session_id, 0, file_size)
-      expect(
-        new TextEncoder().encode('abcdefghijklmnopqrstuvwxyz')
-      ).deep.equals(segment)
+      expect(Buffer.from('abcdefghijklmnopqrstuvwxyz')).deep.equals(segment)
     })
   })
 
   describe('Delete', () => {
     it('Should delete some data', async () => {
       expect(0).to.equal(await getComputedFileSize(session_id))
-      const data = new TextEncoder().encode('abcdefghijklmnopqrstuvwxyz')
-      let change_id = await ins(session_id, 0, data)
+      const data = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+      let change_id = await insert(session_id, 0, data)
       expect(change_id).to.be.a('number').that.equals(1)
       let segment = await getSegment(session_id, 0, data.length)
       expect(data).deep.equals(segment)
       let file_size = await getComputedFileSize(session_id)
       expect(data.length).equals(file_size)
-      let del_change_id = await del(session_id, 13, 10) // deleting: nopqrstuvw (len: 10)
+      let del_change_id = await del(session_id, 13, '', 10) // deleting: nopqrstuvw (len: 10)
       expect(del_change_id)
         .to.be.a('number')
         .that.equals(change_id + 1)
       file_size = await getComputedFileSize(session_id)
       expect(data.length - 10).equals(file_size)
       segment = await getSegment(session_id, 0, file_size)
-      expect(segment).deep.equals(new TextEncoder().encode('abcdefghijklmxyz'))
+      expect(segment).deep.equals(Buffer.from('abcdefghijklmxyz'))
     })
   })
 
   describe('Overwrite', () => {
     it('Should overwrite some data', async () => {
       expect(0).to.equal(await getComputedFileSize(session_id))
-      const data = new TextEncoder().encode('abcdefghijklmnopqrstuvwxyz')
-      let change_id = await ins(session_id, 0, data)
+      const data = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+      let change_id = await insert(session_id, 0, data)
       expect(change_id).to.be.a('number').that.equals(1)
       let segment = await getSegment(session_id, 0, data.length)
       expect(data).deep.equals(segment)
@@ -133,60 +130,54 @@ describe('Editing', () => {
       expect(1).to.equal(last_change.getSerial())
       expect(26).to.equal(last_change.getLength())
       expect(session_id).to.equal(last_change.getSessionId())
-      let ovr_change_id = await ovr(
+      let overwrite_change_id = await overwrite(
         session_id,
         13,
-        new TextEncoder().encode('NO123456VW')
+        Buffer.from('NO123456VW')
       ) // overwriting: nopqrstuvw (len: 10)
-      expect(ovr_change_id).to.be.a('number').that.equals(2)
+      expect(overwrite_change_id).to.be.a('number').that.equals(2)
       file_size = await getComputedFileSize(session_id)
       expect(data.length).equals(file_size)
       last_change = await getLastChange(session_id)
-      expect('NO123456VW').deep.equals(
-        new TextDecoder().decode(last_change.getData_asU8())
-      )
+      expect('NO123456VW').deep.equals(last_change.getData_asU8().toString())
       expect(13).to.equal(last_change.getOffset())
       expect(ChangeKind.CHANGE_OVERWRITE).to.equal(last_change.getKind())
       expect(2).to.equal(last_change.getSerial())
       expect(10).to.equal(last_change.getLength())
       expect(session_id).to.equal(last_change.getSessionId())
-      ovr_change_id = await ovr(session_id, 15, 'PQRSTU') // overwriting: 123456 (len: 6), using a string
-      expect(ovr_change_id).to.be.a('number').that.equals(3)
+      overwrite_change_id = await overwrite(session_id, 15, 'PQRSTU') // overwriting: 123456 (len: 6), using a string
+      expect(overwrite_change_id).to.be.a('number').that.equals(3)
       file_size = await getComputedFileSize(session_id)
       expect(data.length).equals(file_size)
       segment = await getSegment(session_id, 0, file_size)
-      expect(segment).deep.equals(
-        new TextEncoder().encode('abcdefghijklmNOPQRSTUVWxyz')
-      )
+      expect(segment).deep.equals(Buffer.from('abcdefghijklmNOPQRSTUVWxyz'))
     })
   })
 
   describe('Undo/Redo', () => {
     it('Should undo and redo changes', async () => {
-      expect('0123456789').equals(
-        new TextDecoder().decode(new TextEncoder().encode('0123456789'))
-      )
+      expect('0123456789').equals(Buffer.from('0123456789').toString())
       expect(0).to.equal(await getChangeCount(session_id))
 
-      let change_id = await ins(session_id, 0, new TextEncoder().encode('9'))
+      let change_id = await insert(session_id, 0, Buffer.from('9'))
       expect(1).to.equal(change_id)
       expect(1).to.equal(await getChangeCount(session_id))
       let file_size = await getComputedFileSize(session_id)
       expect(1).to.equal(file_size)
 
-      change_id = await ins(session_id, 0, new TextEncoder().encode('78'))
+      change_id = await insert(session_id, 0, Buffer.from('78'))
       expect(2).to.equal(change_id)
       expect(2).to.equal(await getChangeCount(session_id))
       file_size = await getComputedFileSize(session_id)
       expect(3).to.equal(file_size)
 
-      change_id = await ins(session_id, 0, '456') // test sending in a string
+      change_id = await insert(session_id, 0, '456') // test sending in a string
       expect(3).to.equal(change_id)
       expect(3).to.equal(await getChangeCount(session_id))
       file_size = await getComputedFileSize(session_id)
       expect(6).to.equal(file_size)
 
-      change_id = await ins(session_id, 0, '0123')
+      change_id = await insert(session_id, 0, '0123')
       expect(4).to.equal(change_id)
       expect(4).to.equal(await getChangeCount(session_id))
       file_size = await getComputedFileSize(session_id)
@@ -195,15 +186,15 @@ describe('Editing', () => {
       file_size = await getComputedFileSize(session_id)
       expect(10).to.equal(file_size)
       let segment = await getSegment(session_id, 0, file_size)
-      expect(segment).deep.equals(new TextEncoder().encode('0123456789'))
-      expect(new TextDecoder().decode(segment)).equals('0123456789')
+      expect(segment).deep.equals(Buffer.from('0123456789'))
+      expect(segment.toString()).equals('0123456789')
       expect(0).to.equal(await getUndoCount(session_id))
 
       change_id = await undo(session_id)
       expect(-4).to.equal(change_id)
       file_size = await getComputedFileSize(session_id)
       expect(6).to.equal(file_size)
-      expect(new TextEncoder().encode('456789')).deep.equals(
+      expect(Buffer.from('456789')).deep.equals(
         await getSegment(session_id, 0, file_size)
       )
       expect(3).to.equal(await getChangeCount(session_id))
@@ -213,14 +204,14 @@ describe('Editing', () => {
       expect(-3).to.equal(change_id)
       file_size = await getComputedFileSize(session_id)
       expect(3).to.equal(file_size)
-      expect(new TextEncoder().encode('789')).deep.equals(
+      expect(Buffer.from('789')).deep.equals(
         await getSegment(session_id, 0, file_size)
       )
       expect(2).to.equal(await getChangeCount(session_id))
       expect(2).to.equal(await getUndoCount(session_id))
 
       let last_undo = await getLastUndo(session_id)
-      expect('456').to.equal(new TextDecoder().decode(last_undo.getData_asU8()))
+      expect('456').to.equal(last_undo.getData_asU8().toString())
       expect(0).to.equal(last_undo.getOffset())
       expect(ChangeKind.CHANGE_INSERT).to.equal(last_undo.getKind())
       expect(-3).to.equal(last_undo.getSerial())
@@ -231,7 +222,7 @@ describe('Editing', () => {
       expect(-2).to.equal(change_id)
       file_size = await getComputedFileSize(session_id)
       expect(1).to.equal(file_size)
-      expect(new TextEncoder().encode('9')).deep.equals(
+      expect(Buffer.from('9')).deep.equals(
         await getSegment(session_id, 0, file_size)
       )
       expect(1).to.equal(await getChangeCount(session_id))
@@ -258,7 +249,7 @@ describe('Editing', () => {
       expect(1).to.equal(change_id)
       file_size = await getComputedFileSize(session_id)
       expect(1).to.equal(file_size)
-      expect(new TextEncoder().encode('9')).deep.equals(
+      expect(Buffer.from('9')).deep.equals(
         await getSegment(session_id, 0, file_size)
       )
       expect(1).to.equal(await getChangeCount(session_id))
@@ -268,20 +259,20 @@ describe('Editing', () => {
       expect(2).to.equal(change_id)
       file_size = await getComputedFileSize(session_id)
       expect(3).to.equal(file_size)
-      expect(new TextEncoder().encode('789')).deep.equals(
+      expect(Buffer.from('789')).deep.equals(
         await getSegment(session_id, 0, file_size)
       )
       expect(2).to.equal(await getChangeCount(session_id))
       expect(2).to.equal(await getUndoCount(session_id))
 
-      change_id = await ins(session_id, 0, new TextEncoder().encode('0123456'))
+      change_id = await insert(session_id, 0, Buffer.from('0123456'))
       expect(3).to.equal(change_id)
       expect(3).to.equal(await getChangeCount(session_id))
       expect(0).to.equal(await getUndoCount(session_id))
       file_size = await getComputedFileSize(session_id)
       expect(10).to.equal(file_size)
       segment = await getSegment(session_id, 0, file_size)
-      expect(segment).deep.equals(new TextEncoder().encode('0123456789'))
+      expect(segment).deep.equals(Buffer.from('0123456789'))
 
       // Try redo when there is noting left to redo (expect change_id to be zero)
       change_id = await redo(session_id)
@@ -306,7 +297,7 @@ describe('Editing', () => {
       file_size = await getComputedFileSize(session_id_2)
       expect(10).to.equal(file_size)
       segment = await getSegment(session_id_2, 0, file_size)
-      expect(segment).deep.equals(new TextEncoder().encode('0123456789'))
+      expect(segment).deep.equals(Buffer.from('0123456789'))
       let destroyed_session = await destroySession(session_id_2)
       expect(destroyed_session).to.equal(session_id_2)
       expect(1).to.equal(await getSessionCount())
@@ -316,7 +307,7 @@ describe('Editing', () => {
 
       // test clearing changes from a session
       expect(3).to.equal(await getChangeCount(session_id))
-      let cleared_session_id = await clr(session_id)
+      let cleared_session_id = await clear(session_id)
       expect(session_id).to.equal(cleared_session_id)
       expect(0).to.equal(await getChangeCount(session_id))
     })
@@ -324,10 +315,10 @@ describe('Editing', () => {
 
   describe('Search', () => {
     it('Should search sessions', async () => {
-      let change_id = await ovr(
+      let change_id = await overwrite(
         session_id,
         0,
-        new TextEncoder().encode('haystackneedleNEEDLENeEdLeneedhay')
+        Buffer.from('haystackneedleNEEDLENeEdLeneedhay')
       )
       expect(1).to.equal(change_id)
       let file_size = await getComputedFileSize(session_id)
@@ -342,7 +333,7 @@ describe('Editing', () => {
       expect([8]).deep.equals(needles)
       needles = await searchSession(
         session_id,
-        new TextEncoder().encode('needle'),
+        Buffer.from('needle'),
         true,
         3,
         file_size - 3,
@@ -351,7 +342,7 @@ describe('Editing', () => {
       expect([8, 14, 20]).deep.equals(needles)
       needles = await searchSession(
         session_id,
-        new TextEncoder().encode('needle'),
+        Buffer.from('needle'),
         true,
         3,
         file_size - 3,
@@ -360,7 +351,7 @@ describe('Editing', () => {
       expect([8, 14, 20]).deep.equals(needles)
       needles = await searchSession(
         session_id,
-        new TextEncoder().encode('needle'),
+        Buffer.from('needle'),
         true,
         3,
         file_size - 3,
@@ -407,7 +398,7 @@ describe('Editing', () => {
       expect([]).deep.equals(needles)
 
       // try searching an empty session
-      await clr(session_id)
+      await clear(session_id)
       expect(0).to.equal(await getChangeCount(session_id))
       needles = await searchSession(session_id, 'needle', true, 0, 0, undefined)
       expect([]).deep.equals(needles)
@@ -422,32 +413,32 @@ describe('Editing', () => {
       viewport_id = await createViewport(undefined, session_id, 10, 10)
       expect(viewport_id).to.be.a('string').with.length(36) // viewport_id is a random UUID
       expect(2).to.equal(await getViewportCount(session_id))
-      let change_id = await ins(session_id, 0, '0123456789ABC')
+      let change_id = await insert(session_id, 0, '0123456789ABC')
       expect(1).to.equal(change_id)
       let file_size = await getComputedFileSize(session_id)
       expect(13).to.equal(file_size)
       let viewport_data = await getViewportData('test_vpt_1')
-      expect('0123456789').to.equal(new TextDecoder().decode(viewport_data))
+      expect('0123456789').to.equal(viewport_data.toString())
       viewport_data = await getViewportData(viewport_id)
-      expect('ABC').to.equal(new TextDecoder().decode(viewport_data))
-      change_id = await del(session_id, 0, 1)
+      expect('ABC').to.equal(viewport_data.toString())
+      change_id = await del(session_id, 0, '', 1)
       expect(2).to.equal(change_id)
       file_size = await getComputedFileSize(session_id)
       expect(12).to.equal(file_size)
       viewport_data = await getViewportData('test_vpt_1')
-      expect('123456789A').to.equal(new TextDecoder().decode(viewport_data))
+      expect('123456789A').to.equal(viewport_data.toString())
       viewport_data = await getViewportData(viewport_id)
-      expect('BC').to.equal(new TextDecoder().decode(viewport_data))
-      change_id = await ovr(session_id, 8, '!@#')
+      expect('BC').to.equal(viewport_data.toString())
+      change_id = await overwrite(session_id, 8, '!@#')
       expect(3).to.equal(change_id)
       file_size = await getComputedFileSize(session_id)
       expect(12).to.equal(file_size)
       let segment = await getSegment(session_id, 0, file_size)
-      expect(segment).deep.equals(new TextEncoder().encode('12345678!@#C'))
+      expect(segment).deep.equals(Buffer.from('12345678!@#C'))
       viewport_data = await getViewportData('test_vpt_1')
-      expect('12345678!@').to.equal(new TextDecoder().decode(viewport_data))
+      expect('12345678!@').to.equal(viewport_data.toString())
       viewport_data = await getViewportData(viewport_id)
-      expect('#C').to.equal(new TextDecoder().decode(viewport_data))
+      expect('#C').to.equal(viewport_data.toString())
       let deleted_viewport_id = await destroyViewport(viewport_id)
       expect(viewport_id).to.equal(deleted_viewport_id)
       expect(1).to.equal(await getViewportCount(session_id))

--- a/src/rpc/client/ts/tsconfig.json
+++ b/src/rpc/client/ts/tsconfig.json
@@ -44,6 +44,7 @@
 	},
 	"exclude": [
 		"node_modules",
-		"tests"
+		"tests",
+		".d.ts"
 	]
 }


### PR DESCRIPTION
Updates:

- Remove TextEncoder and TextDecoder.
- Create TypeScript modules for allowing easier access when something is importing the different file methods.
- Bump version to 0.9.7
- Change some names of methods so external users would better understand what they do
  - clr-->clear
  - ins-->insert
  - ovr-->overwrite
- Added setting of data to del. Without it the viewports didn't update in daffodil-vscode
