### PR TITLE
Await gRPC server termination.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,9 @@ kill $server_pid
 
 if [ $test_scala_server -ne 0 ]; then
   pushd src/rpc/server/scala
-  sbt run
+  sbt stage
+  ./target/universal/stage/bin/omega-edit-grpc-server --port 9000 &
+  server_pid=$!
   popd
   pushd src/rpc/client/ts/
   npm install
@@ -85,7 +87,7 @@ if [ $test_scala_server -ne 0 ]; then
   npm run lint
   npm test
   popd
-  # TODO: kill the Scala RPC server
+  kill $server_pid
 fi
 
 rm -rf build-tests-integration-$type

--- a/src/rpc/server/scala/build.sbt
+++ b/src/rpc/server/scala/build.sbt
@@ -22,7 +22,7 @@ lazy val packageData = Json
   .as[JsObject]
 lazy val omegaVersion = packageData("version").as[String]
 
-name := "example-grpc-server"
+name := "omega-edit-grpc-server"
 scalaVersion := "2.13.8"
 
 lazy val ghb_repo_owner = "ctc-oss"
@@ -46,9 +46,12 @@ startYear := Some(2021)
 publishConfiguration := publishConfiguration.value.withOverwrite(true)
 publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true)
 
+fork := true
+
 libraryDependencies ++= Seq(
   "com.ctc" %% "omega-edit" % omegaVersion,
   "com.ctc" %% "omega-edit-native" % omegaVersion classifier s"${arch.id}",
+  "com.monovore" %% "decline" % "2.3.0",
   "org.scalatest" %% "scalatest" % "3.2.12" % Test
 )
 
@@ -64,4 +67,4 @@ externalResolvers ++= Seq(
 
 Compile / PB.protoSources += baseDirectory.value / "../../protos"
 
-enablePlugins(AkkaGrpcPlugin, GitVersioning, JavaAppPackaging, UniversalPlugin)
+enablePlugins(AkkaGrpcPlugin, GitVersioning, JavaServerAppPackaging, UniversalPlugin)

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/boot.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/boot.scala
@@ -17,14 +17,39 @@
 package com.ctc.omega_edit.grpc
 
 import akka.actor.ActorSystem
+import com.monovore.decline._
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.concurrent.Await
 
-object boot extends App {
-  implicit val sys: ActorSystem = ActorSystem("omega-grpc")
+object boot
+    extends CommandApp(
+      name = "omega-edit-grpc-server",
+      header = "",
+      main = Opts
+        .option[Int]("port", short = "p", metavar = "port_num", help = "Set the gRPC port to listen on. Default: 9000")
+        .withDefault(9000)
+        .map(new boot(_).run())
+    )
+
+class boot(port: Int) {
+  implicit val sys: ActorSystem = ActorSystem("omega-grpc-server")
   implicit val ec: ExecutionContext = sys.dispatcher
 
-  EditorService.bind().foreach { binding =>
-    println(s"gRPC server bound to: ${binding.localAddress}")
+  def run() = {
+    val done =
+      for {
+        binding <- EditorService.bind(port = port)
+
+        _ = println(s"gRPC server bound to: ${binding.localAddress}")
+
+        done <- binding.addToCoordinatedShutdown(1.second).whenTerminated
+
+        _ = println(s"exiting...")
+      } yield done
+
+    Await.result(done, atMost = Duration.Inf)
+    ()
   }
 }


### PR DESCRIPTION
Fixes #320.

- Renamed Scala gRPC server to "omega-edit-grpc-server".
- Command line arg support, "--port" defaults to 9000.
- build.sh pushes Scala gRP server into bg for testing.