### PR TITLE
Rename VIEWPORT_EVT_UPDATED to VIEWPORT_EVT_MODIFY

### DIFF
--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/FFI.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/FFI.scala
@@ -118,7 +118,7 @@ private[omega_edit] trait FFI {
   def omega_viewport_get_offset(p: Pointer): Long
   def omega_viewport_get_capacity(p: Pointer): Long
   def omega_viewport_set_event_interest(p: Pointer, eventInterest: Int): Int
-  def omega_viewport_update(
+  def omega_viewport_modify(
       p: Pointer,
       offset: Long,
       capacity: Long,

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/ViewportImpl.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/ViewportImpl.scala
@@ -51,7 +51,7 @@ private[omega_edit] class ViewportImpl(p: Pointer, i: FFI) extends Viewport {
     update(offset, capacity)
 
   def update(offset: Long, capacity: Long): Boolean =
-    i.omega_viewport_update(p, offset, capacity, 0) == 0
+    i.omega_viewport_modify(p, offset, capacity, 0) == 0
 
   override def toString: String = data
 }

--- a/src/examples/rotate.cpp
+++ b/src/examples/rotate.cpp
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
                 cerr << "Error deleting" << endl;
                 return -1;
             }
-            omega_viewport_update(viewport_ptr, omega_session_get_computed_file_size(session_ptr) - 1, 4, 0);
+            omega_viewport_modify(viewport_ptr, omega_session_get_computed_file_size(session_ptr) - 1, 4, 0);
         }
     }
     clog << "Saving " << omega_session_get_num_changes(session_ptr) << " changes to " << out_filename << " of size "

--- a/src/include/omega_edit/fwd_defs.h
+++ b/src/include/omega_edit/fwd_defs.h
@@ -48,7 +48,7 @@ typedef enum {
     VIEWPORT_EVT_UNDO = 1 << 2,     //< Occurs when an undo affects the viewport
     VIEWPORT_EVT_CLEAR = 1 << 3,    //< Occurs when a clear affects the viewport
     VIEWPORT_EVT_TRANSFORM = 1 << 4,//< Occurs when a transform affects the viewport
-    VIEWPORT_EVT_UPDATED = 1 << 5   //< Occurs when the viewport itself has been updated
+    VIEWPORT_EVT_MODIFY = 1 << 5    //< Occurs when the viewport itself has been modified
 } omega_viewport_event_t;
 
 #define ALL_EVENTS (~0)

--- a/src/include/omega_edit/viewport.h
+++ b/src/include/omega_edit/viewport.h
@@ -113,7 +113,7 @@ OMEGA_EDIT_EXPORT int32_t omega_viewport_set_event_interest(omega_viewport_t *vi
  * "float" as bytes are inserted or deleted before the start of this viewport
  * @return 0 on success, non-zero otherwise
  */
-OMEGA_EDIT_EXPORT int omega_viewport_update(omega_viewport_t *viewport_ptr, int64_t offset, int64_t capacity,
+OMEGA_EDIT_EXPORT int omega_viewport_modify(omega_viewport_t *viewport_ptr, int64_t offset, int64_t capacity,
                                             int is_floating);
 
 /**

--- a/src/lib/viewport.cpp
+++ b/src/lib/viewport.cpp
@@ -75,7 +75,7 @@ int omega_viewport_is_floating(const omega_viewport_t *viewport_ptr) {
     return viewport_ptr->data_segment.is_floating ? 1 : 0;
 }
 
-int omega_viewport_update(omega_viewport_t *viewport_ptr, int64_t offset, int64_t capacity, int is_floating) {
+int omega_viewport_modify(omega_viewport_t *viewport_ptr, int64_t offset, int64_t capacity, int is_floating) {
     assert(viewport_ptr);
     if (capacity > 0 && capacity <= OMEGA_VIEWPORT_CAPACITY_LIMIT) {
         // only change settings if they are different
@@ -87,7 +87,7 @@ int omega_viewport_update(omega_viewport_t *viewport_ptr, int64_t offset, int64_
             viewport_ptr->data_segment.offset_adjustment = 0;
             viewport_ptr->data_segment.capacity = -1 * capacity;// Negative capacity indicates dirty read
             omega_data_create(&viewport_ptr->data_segment.data, capacity);
-            omega_viewport_notify(viewport_ptr, VIEWPORT_EVT_UPDATED, nullptr);
+            omega_viewport_notify(viewport_ptr, VIEWPORT_EVT_MODIFY, nullptr);
         }
         return 0;
     }

--- a/src/rpc/protos/omega_edit.proto
+++ b/src/rpc/protos/omega_edit.proto
@@ -82,7 +82,7 @@ enum ViewportEventKind {
   VIEWPORT_EVT_UNDO = 4;
   VIEWPORT_EVT_CLEAR = 8;
   VIEWPORT_EVT_TRANSFORM = 16;
-  VIEWPORT_EVT_UPDATED = 32;
+  VIEWPORT_EVT_MODIFY = 32;
 }
 
 enum CountKind {

--- a/src/rpc/server/cpp/server.cpp
+++ b/src/rpc/server/cpp/server.cpp
@@ -341,8 +341,8 @@ static inline ViewportEventKind omega_viewport_event_to_rpc_event(omega_viewport
             return ViewportEventKind::VIEWPORT_EVT_CLEAR;
         case VIEWPORT_EVT_TRANSFORM:
             return ViewportEventKind::VIEWPORT_EVT_TRANSFORM;
-        case VIEWPORT_EVT_UPDATED:
-            return ViewportEventKind::VIEWPORT_EVT_UPDATED;
+        case VIEWPORT_EVT_MODIFY:
+            return ViewportEventKind::VIEWPORT_EVT_MODIFY;
         default:
             abort();
     }

--- a/src/tests/integration/omega_test.cpp
+++ b/src/tests/integration/omega_test.cpp
@@ -909,12 +909,12 @@ TEST_CASE("File Viewing", "[InitTests]") {
     view_mode.display_mode = display_mode_t::CHAR_MODE;
     omega_viewport_notify(viewport_ptr, VIEWPORT_EVT_UNDEFINED, nullptr);
     for (int64_t offset(0); offset < omega_session_get_computed_file_size(session_ptr); ++offset) {
-        REQUIRE(0 == omega_viewport_update(viewport_ptr, offset, 10 + (offset % 40), 0));
+        REQUIRE(0 == omega_viewport_modify(viewport_ptr, offset, 10 + (offset % 40), 0));
     }
 
     // Change the display mode from character mode to bit mode
     view_mode.display_mode = display_mode_t::BIT_MODE;
-    REQUIRE(0 == omega_viewport_update(viewport_ptr, 0, 20, 0));
+    REQUIRE(0 == omega_viewport_modify(viewport_ptr, 0, 20, 0));
     view_mode.display_mode = display_mode_t::BYTE_MODE;
     omega_viewport_notify(viewport_ptr, VIEWPORT_EVT_UNDEFINED, nullptr);
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 3, "++++"));


### PR DESCRIPTION
The purpose of this change is to try to make it more clear that the viewport _itself_ has been modified rather than the data in the viewport being updated by some means (e.g., edit, undo/redo, or transform).