### PR TITLE
Pass actual data size to Scala FFI.

### DIFF
--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/FFI.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/FFI.scala
@@ -174,7 +174,7 @@ private[omega_edit] trait FFI {
   def omega_segment_get_length(p: Pointer): Long
   def omega_segment_get_offset(p: Pointer): Long
   def omega_segment_get_offset_adjustment(p: Pointer): Long
-  def omega_segment_get_data(p: Pointer): String
+  def omega_segment_get_data(p: Pointer): Pointer
   def omega_segment_destroy(p: Pointer): Unit
 
   // find

--- a/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/SessionImpl.scala
+++ b/src/bindings/scala/api/src/main/scala/com/ctc/omega_edit/SessionImpl.scala
@@ -77,13 +77,13 @@ private[omega_edit] class SessionImpl(p: Pointer, i: FFI) extends Session {
     Edit(i.omega_edit_delete(p, offset, len))
 
   def insert(b: Array[Byte], offset: Long): Result =
-    Edit(i.omega_edit_insert_bytes(p, offset, b, 0))
-
+    Edit(i.omega_edit_insert_bytes(p, offset, b, b.length.toLong))
+    
   def insert(s: String, offset: Long): Result =
     Edit(i.omega_edit_insert(p, offset, s, 0))
 
   def overwrite(b: Array[Byte], offset: Long): Result =
-    Edit(i.omega_edit_overwrite_bytes(p, offset, b, 0))
+    Edit(i.omega_edit_overwrite_bytes(p, offset, b, b.length.toLong))
 
   def overwrite(s: String, offset: Long): Result =
     Edit(i.omega_edit_overwrite(p, offset, s, 0))
@@ -208,9 +208,12 @@ private[omega_edit] class SessionImpl(p: Pointer, i: FFI) extends Session {
     try {
       val result = i.omega_session_get_segment(p, sp, offset)
 
-      Option.when(result == 0)(
-        Segment(offset, i.omega_segment_get_data(sp).getBytes)
-      )
+      Option.when(result == 0) {
+        val data = i.omega_segment_get_data(sp)
+        val out = Array.ofDim[Byte](length.toInt)
+        data.get(0, out, 0, length.toInt)
+        Segment(offset, out)
+      }
     } finally i.omega_segment_destroy(sp)
   }
 }

--- a/src/bindings/scala/api/src/test/scala/com/ctc/omega_edit/SessionImplSpec.scala
+++ b/src/bindings/scala/api/src/test/scala/com/ctc/omega_edit/SessionImplSpec.scala
@@ -35,6 +35,7 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
   //        0123456789012345
   //            |    ||    |
   val as = "bbbbabbbbaabbbba"
+  val binary = Array[Byte](1, 2, 3, 4, 0, 5, 6)
 
   "a session" must {
     "be empty" in emptySession { s =>
@@ -45,6 +46,11 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
     "have bytes" in session(Array[Byte]('a', 'b', 'c')) { s =>
       s.isEmpty shouldBe false
       s.size shouldBe 3
+    }
+
+    "handle binary" in session(binary) { s =>
+      s.size shouldBe binary.length
+      s.getSegment(0, binary.length.toLong).map(_.data shouldBe binary)
     }
 
     "have string" in session("abc") { s =>

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
@@ -60,9 +60,9 @@ object Session {
         case ChangeKind.CHANGE_DELETE =>
           Some(Session.Delete(in.offset, in.length))
         case ChangeKind.CHANGE_INSERT =>
-          Some(Session.Insert(EditorService.getData(in), in.offset))
+          in.data.map(Session.Insert(_, in.offset))
         case ChangeKind.CHANGE_OVERWRITE =>
-          Some(Session.Overwrite(EditorService.getData(in), in.offset))
+          in.data.map(Session.Overwrite(_, in.offset))
         case _ => None
       }
 
@@ -84,8 +84,8 @@ object Session {
   case object GetNumSearchContexts extends Op
 
   case class Delete(offset: Long, length: Long) extends Op
-  case class Insert(data: String, offset: Long) extends Op
-  case class Overwrite(data: String, offset: Long) extends Op
+  case class Insert(data: ByteString, offset: Long) extends Op
+  case class Overwrite(data: ByteString, offset: Long) extends Op
 
   case class LookupChange(id: Long) extends Op
 
@@ -194,7 +194,7 @@ class Session(
       }
 
     case Insert(data, offset) =>
-      session.insert(data, offset) match {
+      session.insert(data.toByteArray(), offset) match {
         case Change.Changed(serial) =>
           sender() ! Serial.ok(sessionId, serial)
         case Change.Paused => sender() ! Serial.paused(sessionId)
@@ -202,7 +202,7 @@ class Session(
       }
 
     case Overwrite(data, offset) =>
-      session.overwrite(data, offset) match {
+      session.overwrite(data.toByteArray(), offset) match {
         case Change.Changed(serial) =>
           sender() ! Serial.ok(sessionId, serial)
         case Change.Paused => sender() ! Serial.paused(sessionId)

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
@@ -194,7 +194,7 @@ class Session(
       }
 
     case Insert(data, offset) =>
-      session.insert(data.toByteArray(), offset) match {
+      session.insert(data, offset) match {
         case Change.Changed(serial) =>
           sender() ! Serial.ok(sessionId, serial)
         case Change.Paused => sender() ! Serial.paused(sessionId)

--- a/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
+++ b/src/rpc/server/scala/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
@@ -194,7 +194,7 @@ class Session(
       }
 
     case Insert(data, offset) =>
-      session.insert(data, offset) match {
+      session.insert(data.toByteArray(), offset) match {
         case Change.Changed(serial) =>
           sender() ! Serial.ok(sessionId, serial)
         case Change.Paused => sender() ! Serial.paused(sessionId)


### PR DESCRIPTION
Avoids null-terminated string behavior if 0 is passed.
Also ensure binary data is passed around instead of Java/Scala String.

Part of #320.