### PR TITLE
cmake no longer generates gRPC TypeScript code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,13 @@ conan_config_set(NAME general.revisions_enabled VALUE 1)
 conan_cmake_configure(
         REQUIRES "boost/1.79.0" "catch2/2.13.9" "grpc/1.45.2@#4124668439356e3a496b04b0b2595223"
         OPTIONS boost:header_only=True
+        OPTIONS grpc:cpp_plugin=True
+        OPTIONS grpc:csharp_plugin=False
+        OPTIONS grpc:node_plugin=False
+        OPTIONS grpc:objective_c_plugin=False
+        OPTIONS grpc:php_plugin=False
+        OPTIONS grpc:python_plugin=False
+        OPTIONS grpc:ruby_plugin=False
         GENERATORS cmake cmake_find_package
         IMPORTS "bin, protoc* -> ./build_tools"
         IMPORTS "bin, grpc_*_plugin* -> ./build_tools"
@@ -160,11 +167,9 @@ if (BUILD_RPC)
     if (MSVC)
         set(protoc "build_tools/protoc.exe")
         set(grpc_cpp_plugin "build_tools/grpc_cpp_plugin.exe")
-        set(grpc_node_plugin "build_tools/grpc_node_plugin.exe")
     else ()
         set(protoc "build_tools/protoc")
         set(grpc_cpp_plugin "build_tools/grpc_cpp_plugin")
-        set(grpc_node_plugin "build_tools/grpc_node_plugin")
     endif ()
 
     # Proto file
@@ -179,9 +184,6 @@ if (BUILD_RPC)
     set(omega_grpc_cpp_srcs "${CMAKE_CURRENT_BINARY_DIR}/src/rpc/protos/cpp/omega_edit.grpc.pb.cc")
     set(omega_grpc_cpp_hdrs "${CMAKE_CURRENT_BINARY_DIR}/src/rpc/protos/cpp/omega_edit.grpc.pb.h")
 
-    set(omega_grpc_js_pb "${CMAKE_CURRENT_BINARY_DIR}/src/rpc/client/js/omega_edit_grpc_pb.js")
-    set(omega_js_pb "${CMAKE_CURRENT_BINARY_DIR}/src/rpc/client/js/omega_edit_pb.js")
-
     add_custom_command(
             OUTPUT "${omega_proto_cpp_srcs}" "${omega_proto_cpp_hdrs}" "${omega_grpc_cpp_srcs}" "${omega_grpc_cpp_hdrs}"
             COMMAND ${protoc}
@@ -195,28 +197,12 @@ if (BUILD_RPC)
             COMMENT "Running gRPC C++ protocol buffer compiler on ${omega_proto}"
             VERBATIM)
 
-    add_custom_command(
-            OUTPUT "${omega_grpc_js_pb}" "${omega_js_pb}"
-            COMMAND ${protoc}
-            ARGS --js_out=${CMAKE_CURRENT_BINARY_DIR}/src/rpc/client/js
-            --grpc_out=${CMAKE_CURRENT_BINARY_DIR}/src/rpc/client/js
-            --plugin=protoc-gen-grpc=${grpc_node_plugin}
-            -I ${omega_proto_path} -I ${CONAN_INCLUDE_DIRS_PROTOBUF}
-            ${omega_proto}
-            DEPENDS ${omega_proto}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMENT "Running gRPC JS protocol buffer compiler on ${omega_proto}"
-            VERBATIM)
-
     SET(RPC_SOURCE_FILES "${omega_proto_cpp_srcs}" "${omega_proto_cpp_hdrs}" "${omega_grpc_cpp_srcs}" "${omega_grpc_cpp_hdrs}")
     SET(WORKER_QUEUE_SOURCE_FILES "src/rpc/server/cpp/worker_queue/worker_queue.hpp" "src/rpc/server/cpp/worker_queue/worker_queue.cpp")
 
     add_executable(server "src/rpc/server/cpp/server.cpp" ${WORKER_QUEUE_SOURCE_FILES} ${RPC_SOURCE_FILES})
     target_include_directories(server PRIVATE "${CONAN_INCLUDE_DIRS_BOOST}" "${CMAKE_CURRENT_BINARY_DIR}/src/rpc/protos/cpp/" "${CONAN_INCLUDE_DIRS_GRPC}" "${CONAN_INCLUDE_DIRS_PROTOBUF}")
     target_link_libraries(server PRIVATE omega_edit::omega_edit ${FILESYSTEM_LIB} ${CONAN_LIBS_GRPC} ${CONAN_LIBS_PROTOBUF} ${CONAN_LIBS_C-ARES} ${CONAN_LIBS_ABSEIL} ${CONAN_LIBS_RE2} ${CONAN_LIBS_ZLIB})
-
-    add_custom_target(client SOURCES "${omega_grpc_js_pb}" "${omega_js_pb}")
-    add_dependencies(server client)
 endif ()
 
 #######################################################################################################################


### PR DESCRIPTION
JavaScript/TypeScript gRPC code generation is done using npm/yarn, so these sources do not need to be generated in cmake by the gRPC core package (which no longer bundles the JavaScript/TypeScript gRPC code generation plugins).