### PR TITLE
Fix sync issue on session destroy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -205,7 +205,7 @@ jobs:
         working-directory: src/rpc/client/ts
 
       - name: Yarn Test 📋
-        run: yarn test # auto spins scala server up and down
+        run: yarn test || true # auto spins scala server up and down
         shell: bash
         working-directory: src/rpc/client/ts
         timeout-minutes: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,7 @@ jobs:
         working-directory: src/rpc/server/scala
 
       - name: Package Scala API 🎁
-        run: sbt installM2 || true # runs test so specifically running sbt test not needed
+        run: sbt installM2 # runs test so specifically running sbt test not needed
         working-directory: src/rpc/server/scala
         timeout-minutes: 30
 
@@ -183,13 +183,13 @@ jobs:
           if-no-files-found: error
 
       - name: Test Scala RPC server 📋
-        run: sbt serv/test || true
+        run: sbt serv/test
         working-directory: src/rpc/server/scala
         timeout-minutes: 30
 
       - name: Package & Run Scala RPC server 📋
         run: |
-          sbt pkgServer || true
+          sbt pkgServer
           cp -r serv/target/universal/omega-edit-grpc-server*.zip ../../client/ts
         shell: bash
         working-directory: src/rpc/server/scala

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -205,7 +205,7 @@ jobs:
         working-directory: src/rpc/client/ts
 
       - name: Yarn Test 📋
-        run: yarn test || true # auto spins scala server up and down
+        run: yarn test # auto spins scala server up and down
         shell: bash
         working-directory: src/rpc/client/ts
         timeout-minutes: 30

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
@@ -63,7 +63,7 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
 
   def destroySession(in: ObjectId): Future[ObjectId] =
     // Currently believe this works but Session.Destroy seems to cause errors in CI
-    (editors ? DestroyActor(in.id)).mapTo[Result].map {
+    (editors ? DestroyActor(in.id, timeout)).mapTo[Result].map {
       case Ok(_)  => in
       case Err(c) => throw grpcFailure(c)
     }

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
@@ -41,7 +41,7 @@ object Editors {
       id: Option[String],
       path: Option[Path]
   )
-  case class DestroyActor(id: String)
+  case class DestroyActor(id: String, timeout: Timeout)
   case object SessionCount
 
   ///
@@ -107,12 +107,12 @@ class Editors extends Actor with ActorLogging {
     case Find(id) =>
       sender() ! context.child(id)
 
-    case DestroyActor(id) =>
+    case DestroyActor(id, t) =>
       context.child(id) match {
         case None => sender() ! Err(Status.NOT_FOUND)
         case Some(s) =>
           val replyTo = sender()
-          gracefulStop(s, 2.seconds).onComplete(_ => replyTo ! Ok(id))(context.dispatcher)
+          gracefulStop(s, t.duration).onComplete(_ => replyTo ! Ok(id))(context.dispatcher)
       }
 
     case SessionCount =>

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
@@ -17,6 +17,7 @@
 package com.ctc.omega_edit.grpc
 
 import akka.actor.{Actor, ActorLogging, Props}
+import akka.pattern.gracefulStop
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
@@ -110,8 +111,8 @@ class Editors extends Actor with ActorLogging {
       context.child(id) match {
         case None => sender() ! Err(Status.NOT_FOUND)
         case Some(s) =>
-          context.system stop s
-          sender() ! Ok(id)
+          val replyTo = sender()
+          gracefulStop(s, 2.seconds).onComplete(_ => replyTo ! Ok(id))(context.dispatcher)
       }
 
     case SessionCount =>


### PR DESCRIPTION
Fixes an issue where session counts based on actor existence were out of sync.  Fixed by defering the return of a session kill call until the session actor is stopped, syncing up the chain.

Also adds a timeout on the kill request, which allows the timeout to be specified by the caller rather than being defaulted in the parent actor.