### PR TITLE
reduce test verbosity conditionally

### DIFF
--- a/src/rpc/client/ts/tests/specs/common.ts
+++ b/src/rpc/client/ts/tests/specs/common.ts
@@ -61,18 +61,19 @@ export async function check_callback_count(
 ) {
   // disable the check unless the OMEGA_EDIT_ENABLE_CLIENT_CALLBACK_COUNT_CHECKS
   // environment variable is defined and is non-zero
-  const do_check: boolean = process.env.OMEGA_EDIT_ENABLE_CLIENT_CALLBACK_COUNT_CHECKS
+  const do_check: boolean = process.env
+    .OMEGA_EDIT_ENABLE_CLIENT_CALLBACK_COUNT_CHECKS
     ? process.env.OMEGA_EDIT_ENABLE_CLIENT_CALLBACK_COUNT_CHECKS !== '0'
-    : false 
+    : false
   if (!do_check) return
   if (millisecond_delay !== undefined && millisecond_delay > 0) {
     await delay(millisecond_delay)
   }
-  console.log(callback_map)
+  log_info(callback_map)
   if (0 < expected_count) {
     expect(callback_map.has(key)).to.be.true
     const value = callback_map.get(key)
-    console.log(
+    log_info(
       'check_callback_count key: ' +
         key +
         ', value: ' +
@@ -84,4 +85,17 @@ export async function check_callback_count(
   } else {
     expect(callback_map.has(key)).to.be.false
   }
+}
+
+export function log_info(message?: any, ...optionalParams: any[]) {
+  const do_log: boolean = process.env.OMEGA_EDIT_ENABLE_INFO_LOGS
+    ? process.env.OMEGA_EDIT_ENABLE_INFO_LOGS !== '0'
+    : false
+  if (do_log) {
+    console.log(message, optionalParams)
+  }
+}
+
+export function log_error(message?: any, ...optionalParams: any[]) {
+  console.log(message, optionalParams)
 }

--- a/src/rpc/client/ts/tests/specs/editing.spec.ts
+++ b/src/rpc/client/ts/tests/specs/editing.spec.ts
@@ -31,7 +31,7 @@ import {
 } from '../../src/omega_edit_pb'
 import { decode, encode } from 'fastestsmallesttextencoderdecoder'
 // @ts-ignore
-import { check_callback_count, cleanup, custom_setup } from './common'
+import { check_callback_count, cleanup, custom_setup, log_info } from './common'
 import { ALL_EVENTS, getClient } from '../../src/settings'
 
 let session_callbacks = new Map()
@@ -53,7 +53,7 @@ async function subscribeSession(
       )
       const event = sessionEvent.getSessionEventKind()
       if (SessionEventKind.SESSION_EVT_EDIT == event) {
-        console.log(
+        log_info(
           'session: ' +
             session_id +
             ', event: ' +
@@ -64,7 +64,7 @@ async function subscribeSession(
             session_callbacks.get(session_id)
         )
       } else {
-        console.log(
+        log_info(
           'session: ' +
             session_id +
             ', event: ' +

--- a/src/rpc/client/ts/tests/specs/stressTest.spec.ts
+++ b/src/rpc/client/ts/tests/specs/stressTest.spec.ts
@@ -40,7 +40,13 @@ import {
 } from '../../src/viewport'
 import { decode, encode } from 'fastestsmallesttextencoderdecoder'
 // @ts-ignore
-import { check_callback_count, cleanup, custom_setup, delay } from './common'
+import {
+  check_callback_count,
+  cleanup,
+  custom_setup,
+  delay,
+  log_info,
+} from './common'
 import {
   EventSubscriptionRequest,
   SessionEventKind,
@@ -67,7 +73,7 @@ async function subscribeSession(
       )
       const event = sessionEvent.getSessionEventKind()
       if (SessionEventKind.SESSION_EVT_EDIT == event) {
-        console.log(
+        log_info(
           'session: ' +
             session_id +
             ', event: ' +
@@ -78,7 +84,7 @@ async function subscribeSession(
             session_callbacks.get(session_id)
         )
       } else {
-        console.log(
+        log_info(
           'session: ' +
             session_id +
             ', event: ' +
@@ -112,7 +118,7 @@ async function subscribeViewport(
       )
       const event = viewportEvent.getViewportEventKind()
       if (ViewportEventKind.VIEWPORT_EVT_EDIT == event) {
-        console.log(
+        log_info(
           'viewport_id: ' +
             viewport_id +
             ', event: ' +
@@ -129,7 +135,7 @@ async function subscribeViewport(
             viewport_callbacks.get(viewport_id)
         )
       } else {
-        console.log(
+        log_info(
           'viewport: ' +
             viewport_id +
             ', event: ' +
@@ -176,8 +182,8 @@ describe('StressTest', () => {
     expect(await getSegment(session_id, 0, data.length)).deep.equals(
       data.reverse()
     )
-    console.log(session_callbacks)
-    console.log(viewport_callbacks)
+    log_info(session_callbacks)
+    log_info(viewport_callbacks)
     await delay(100)
     await check_callback_count(session_callbacks, session_id, data.length)
     await check_callback_count(viewport_callbacks, viewport_id, data.length)
@@ -186,8 +192,8 @@ describe('StressTest', () => {
       await del(session_id, 0, 1)
     }
     expect(await getComputedFileSize(session_id)).to.equal(0)
-    console.log(session_callbacks)
-    console.log(viewport_callbacks)
+    log_info(session_callbacks)
+    log_info(viewport_callbacks)
     await delay(100)
     await check_callback_count(session_callbacks, session_id, data.length * 2)
     await check_callback_count(viewport_callbacks, viewport_id, data.length * 2)
@@ -220,8 +226,8 @@ describe('StressTest', () => {
       await del(session_id, data.length - i - 1, 1)
     }
     expect(await getComputedFileSize(session_id)).to.equal(0)
-    console.log(session_callbacks)
-    console.log(viewport_callbacks)
+    log_info(session_callbacks)
+    log_info(viewport_callbacks)
     await delay(100)
     await check_callback_count(session_callbacks, session_id, data.length * 2)
     await check_callback_count(viewport_callbacks, viewport_id, data.length * 2)
@@ -246,9 +252,8 @@ describe('StressTest', () => {
 
       await pauseSessionChanges(session_id)
 
-      console.log(
-        '\x1b[33m%s\x1b[0m',
-        'Expect to see an "Error:" here, we are intentionally causing it'
+      log_info(
+        '\x1b[33m%s\x1b[0mExpect to see an "Error:" here, we are intentionally causing it'
       ) // yellow text
       await insert(session_id, 0, data).catch((e) => {
         expect(e)
@@ -284,7 +289,7 @@ describe('StressTest', () => {
       const expected_num_changes = 1 + 3 * file_size * full_rotations
 
       while (rotations--) {
-        console.log('\x1b[33m%s\x1b[0m', 'rotations remaining: ' + rotations)
+        log_info('\x1b[33m%s\x1b[0mrotations remaining: ' + rotations)
         viewport_data = await getViewportData(viewport_id)
 
         change_id = await insert(session_id, 0, ' ')
@@ -331,8 +336,8 @@ describe('StressTest', () => {
         460 * full_rotations
       )
 
-      console.info('\x1b[32m%s\x1b[0m', session_callbacks)
-      console.info('\x1b[32m%s\x1b[0m', viewport_callbacks)
+      log_info('\x1b[32m%s\x1b[0m', session_callbacks)
+      log_info('\x1b[32m%s\x1b[0m', viewport_callbacks)
     }
   ).timeout(10000 * full_rotations)
 })

--- a/src/rpc/client/ts/tests/specs/viewport.spec.ts
+++ b/src/rpc/client/ts/tests/specs/viewport.spec.ts
@@ -34,7 +34,13 @@ import {
   ViewportEventKind,
 } from '../../src/omega_edit_pb'
 // @ts-ignore
-import { check_callback_count, cleanup, custom_setup, delay } from './common'
+import {
+  check_callback_count,
+  cleanup,
+  custom_setup,
+  delay,
+  log_info,
+} from './common'
 
 let viewport_callbacks = new Map()
 
@@ -57,7 +63,7 @@ async function subscribeViewport(
       )
       const event = viewportEvent.getViewportEventKind()
       if (ViewportEventKind.VIEWPORT_EVT_EDIT == event) {
-        console.log(
+        log_info(
           'viewport_id: ' +
             viewport_id +
             ', event: ' +
@@ -74,7 +80,7 @@ async function subscribeViewport(
             viewport_callbacks.get(viewport_id)
         )
       } else {
-        console.log(
+        log_info(
           'viewport: ' +
             viewport_id +
             ', event: ' +
@@ -126,7 +132,7 @@ describe('Viewports', () => {
     expect(viewport_2_id).to.be.a('string').with.length(73) // viewport_id is the session ID, colon, then a random UUID
     expect(await subscribeViewport(viewport_2_id)).to.equal(viewport_2_id)
     expect(await getViewportCount(session_id)).to.equal(2)
-    console.log(viewport_callbacks)
+    log_info(viewport_callbacks)
     await check_callback_count(viewport_callbacks, viewport_2_id, 0, 500)
 
     let change_id = await insert(session_id, 0, '0123456789ABC')
@@ -193,14 +199,14 @@ describe('Viewports', () => {
     expect(await getViewportCount(session_id)).to.equal(2)
     const destroyed_viewport_id = await destroyViewport(viewport_2_id)
     expect(destroyed_viewport_id).to.equal(viewport_2_id)
-    console.log('destroyed viewport: ' + destroyed_viewport_id)
+    log_info('destroyed viewport: ' + destroyed_viewport_id)
     expect(await getViewportCount(session_id)).to.equal(1)
-    console.log('num changes: ' + (await getChangeCount(session_id)))
+    log_info('num changes: ' + (await getChangeCount(session_id)))
     expect(await getChangeCount(session_id)).to.equal(4)
-    console.log(viewport_callbacks)
+    log_info(viewport_callbacks)
     await check_callback_count(viewport_callbacks, viewport_1_id, 1, 500)
     await check_callback_count(viewport_callbacks, viewport_2_id, 3)
-    console.log(viewport_callbacks)
+    log_info(viewport_callbacks)
   }).timeout(5000)
 
   it('Should handle floating viewports', async () => {


### PR DESCRIPTION
Conditionally dial down the verbosity of the TypeScript client test logging to reduce the noise in the CI workflow logs.

fixes #433