### PR TITLE
Unix Domain Socket RPC option

### DIFF
--- a/src/rpc/server/scala/build.sbt
+++ b/src/rpc/server/scala/build.sbt
@@ -19,6 +19,7 @@ lazy val packageData = Json
   .as[JsObject]
 lazy val omegaVersion = packageData("version").as[String]
 
+lazy val AkkaVersion = "2.6.19" // don't upgrade 2.7.x due to license change
 lazy val ghb_repo_owner = "ctc-oss"
 lazy val ghb_repo = "omega-edit"
 lazy val ghb_resolver = (
@@ -111,7 +112,7 @@ lazy val api = project
       Seq(
         "com.beachape" %% "enumeratum" % "1.7.0",
         "com.github.jnr" % "jnr-ffi" % "2.2.12",
-        "org.scalatest" %% "scalatest" % "3.2.13" % Test
+        "org.scalatest" %% "scalatest" % "3.2.14" % Test
       )
     },
     scalacOptions ~= adjustScalacOptionsForScalatest,
@@ -178,8 +179,11 @@ lazy val serv = project
     name := "omega-edit-grpc-server",
     libraryDependencies ++= {
       Seq(
-        "com.monovore" %% "decline" % "2.3.0",
-        "org.scalatest" %% "scalatest" % "3.2.13" % Test
+        "com.lightbend.akka" %% "akka-stream-alpakka-unix-domain-socket" % "4.0.0", // don't upgrade to 5.x due to license change in Akka 2.7.x
+        "com.monovore" %% "decline" % "2.3.1",
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+        "org.scalatest" %% "scalatest" % "3.2.14" % Test
       )
     },
     excludeDependencies ++= Seq(

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
@@ -35,11 +35,10 @@ import io.grpc.Status
 import omega_edit._
 
 import java.nio.file.Paths
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
-
-import scala.util.{Failure}
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Failure
 
 class EditorService(implicit val system: ActorSystem) extends Editor {
   private implicit val timeout: Timeout = Timeout(5000.milliseconds)
@@ -366,4 +365,13 @@ object EditorService {
     Http().newServerAt(iface, port).bind(EditorHandler(new EditorService)).andThen {
       case Failure(_) => system.terminate()
     }
+  /* TODO: get this to work.
+  def bind(path: Path)(
+      implicit
+      system: ActorSystem
+  ): Future[UnixDomainSocket.ServerBinding] =
+      UnixDomainSocket().bindAndHandle(EditorHandler(new EditorService), path).andThen {
+          case Failure(_) => system.terminate()
+      }
+ */
 }


### PR DESCRIPTION
Provides an option to use Unix Domain Sockets as an alternative to TCP/IP.

closes #445