### PR TITLE
Multiple updates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   deploy-docs:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Install Prerequisites 📚
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   create-release:
     name: Create Release ✨
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
   native-build-mac-win:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-12, windows-2022]
     name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [create-release]
@@ -142,7 +142,7 @@ jobs:
   api-native-publish:
     needs: [native-build-mac-win]
     name: Publish Scala API and Native packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -181,18 +181,26 @@ jobs:
       - name: Download macos Native JARs 🔻
         uses: actions/download-artifact@v3
         with:
-          name: macos-latest-artifacts
+          name: macos-12-artifacts
 
       - name: Download windows Native JARs 🔻
         uses: actions/download-artifact@v3
         with:
-          name: windows-latest-artifacts
+          name: windows-2022-artifacts
 
       - name: Move windows and macos jars out 🚚
         run: |
-          for folder in "omega-edit-native_2.13"; do
+          for folder in $(echo "omega-edit-native_2.13"); do
             mv -v ${folder}/${{ env.PKG_VERSION }}/${folder}-${{ env.PKG_VERSION }}-windows-* .
             mv -v ${folder}/${{ env.PKG_VERSION }}/${folder}-${{ env.PKG_VERSION }}-macos-* .
+          done
+        
+      - name: Download native JARs for M1 mac 🔻
+        run: |
+          for folder in $(echo "omega-edit-native_2.13"); do
+            curl \
+              https://raw.githubusercontent.com/Shanedell/omega-edit-m1/main/${folder}-${{ env.PKG_VERSION }}-macos-aarch64.jar \
+              --output ${folder}-${{ env.PKG_VERSION }}-macos-aarch64.jar
           done
 
       - name: Package Scala Native 🎁
@@ -212,7 +220,7 @@ jobs:
 
   scala-release:
     name: Scala Release ✨
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [api-native-publish]
     steps:
       - name: Checkout 🛎️
@@ -278,7 +286,7 @@ jobs:
 
   node-build:
     name: Node Release ✨
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [scala-release]
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   scala-steward:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Scala Steward 🔔
     steps:
       - name: Scala Steward 🔔

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
   build-native:
     strategy:
       matrix:
-        os: [ windows-latest, macos-latest, ubuntu-latest ]
+        os: [ windows-2022, macos-12, ubuntu-20.04 ]
     name: Native build and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,7 +85,7 @@ jobs:
     needs: [ build-native ]
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest] #, windows-latest ] # TODO: Add in later
+        os: [ macos-12, ubuntu-20.04] #, windows-2022 ] # TODO: Add in later
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout 🛎️

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.13)
 
 # Project information
 project(omega_edit
-        VERSION 0.9.28
+        VERSION 0.9.29
         DESCRIPTION "Apache open source library for building editors"
         HOMEPAGE_URL "https://github.com/ctc-oss/omega-edit"
         LANGUAGES C CXX)

--- a/src/rpc/client/ts/package-lock.json
+++ b/src/rpc/client/ts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "omega-edit",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/rpc/client/ts/package.json
+++ b/src/rpc/client/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omega-edit",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "description": "OmegaEdit gRPC Client TypeScript Types",
   "publisher": "ctc-oss",
   "repository": {

--- a/src/rpc/server/scala/build.sbt
+++ b/src/rpc/server/scala/build.sbt
@@ -32,12 +32,20 @@ lazy val ghb_resolver = (
 lazy val bashExtras = s"""declare new_classpath=\"$$app_classpath\"
 declare windows_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-windows-${arch.arch}.jar"
 declare linux_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-linux-${arch.arch}.jar"
-declare macos_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-macos-${arch.arch}.jar"
+declare macos_x86_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-macos-x86_64.jar"
+declare macos_aarch_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-macos-aarch64.jar"
 if [[ $$OSTYPE == "darwin"* ]]; then
-  new_classpath=$$(echo $$new_classpath |\\
-    sed -e "s/$${linux_jar_file}/$${macos_jar_file}/" | \\
-    sed -e "s/$${windows_jar_file}/$${macos_jar_file}/"\\
-  )
+  if [[ $$(uname -m) == "x86_64" ]]; then
+    new_classpath=$$(echo $$new_classpath |\\
+      sed -e "s/$${linux_jar_file}/$${macos_jar_file}/" | \\
+      sed -e "s/$${windows_jar_file}/$${macos_jar_file}/"\\
+    )
+  else
+    new_classpath=$$(echo $$new_classpath |\\
+      sed -e "s/$${linux_jar_file}/$${macos_aarch_jar_file}/" | \\
+      sed -e "s/$${windows_jar_file}/$${macos_aarch_jar_file}/"\\
+    )
+  fi
 else
   new_classpath=$$(echo $$new_classpath |\\
     sed -e "s/$${macos_jar_file}/$${linux_jar_file}/" | \\
@@ -166,7 +174,7 @@ lazy val spi = project
   .in(file("spi"))
   .settings(commonSettings)
   .settings(
-    name := "omega-edit-spi"
+    name := "omega-edit-spi",
   )
   .enablePlugins(GitVersioning)
 

--- a/src/rpc/server/scala/project/BuildSupport.scala
+++ b/src/rpc/server/scala/project/BuildSupport.scala
@@ -68,12 +68,16 @@ object BuildSupport {
       case os      => throw new IllegalStateException(s"Unsupported OS: $os")
     }
 
-    val arch = System.getProperty("os.arch").toLowerCase match {
-      case Amd(bits)   => bits
-      case x86(bits)   => bits
-      case aarch(bits) => bits
-      case arch        => throw new IllegalStateException(s"unknown arch: $arch")
-    }
+    val arch =
+      if (os == "macos") System.getProperty("os.arch").toLowerCase
+      else
+        System.getProperty("os.arch").toLowerCase match {
+          case Amd(bits)   => bits
+          case x86(bits)   => bits
+          case aarch(bits) => bits
+          case arch        => throw new IllegalStateException(s"unknown arch: $arch")
+        }
+
     Platform(os, arch)
   }
 
@@ -84,12 +88,16 @@ object BuildSupport {
       case Win()   => "windows"
     }
 
-    val arch = System.getProperty("os.arch").toLowerCase match {
-      case Amd(bits)   => bits
-      case x86(bits)   => bits
-      case aarch(bits) => bits
-      case arch        => throw new IllegalStateException(s"unknown arch: $arch")
-    }
+    val arch =
+      if (os == "macos") System.getProperty("os.arch").toLowerCase
+      else
+        System.getProperty("os.arch").toLowerCase match {
+          case Amd(bits)   => bits
+          case x86(bits)   => bits
+          case aarch(bits) => bits
+          case arch        => throw new IllegalStateException(s"unknown arch: $arch")
+        }
+
     Arch(s"$os-$arch", s"${os}_$arch", s"$os", s"$arch")
   }
 


### PR DESCRIPTION
Multiple updates:

- Update CI workflows to use specific versions for windows, macos and linux oses to run on.
- Should add BuildSupport to have option for macos using x86_64 and aarch64.
- Update release workflow to download a JAR file for SPI and native for mac m1.
- Update version to v0.9.29.

Closes #473 
