### PR TITLE
Create client function to setup server. [node_publish]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.13)
 
 # Project information
 project(omega_edit
-        VERSION 0.9.29
+        VERSION 0.9.30
         DESCRIPTION "Apache open source library for building editors"
         HOMEPAGE_URL "https://github.com/ctc-oss/omega-edit"
         LANGUAGES C CXX)

--- a/src/rpc/client/ts/package-lock.json
+++ b/src/rpc/client/ts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "omega-edit",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/rpc/client/ts/package.json
+++ b/src/rpc/client/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omega-edit",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "OmegaEdit gRPC Client TypeScript Types",
   "publisher": "ctc-oss",
   "repository": {

--- a/src/rpc/client/ts/src/server.d.ts
+++ b/src/rpc/client/ts/src/server.d.ts
@@ -23,4 +23,8 @@ declare module 'omega-edit/server' {
     omegaEditVersion: string
   ): Promise<number | undefined>
   export function stopServer(id: number | undefined): Promise<boolean>
+  export function setupServer(
+    rootPath: string,
+    omegaEditVersion: string
+  ): Promise<[string, string]>
 }

--- a/src/rpc/client/ts/src/server.ts
+++ b/src/rpc/client/ts/src/server.ts
@@ -23,9 +23,6 @@ import * as unzip from 'unzip-stream'
 import * as os from 'os'
 import * as child_process from 'child_process'
 
-// const xdgAppPaths = XDGAppPaths({ name: 'omega_edit' })
-const wait_port = require('wait-port')
-
 class Artifact {
   name: string
   archive: string
@@ -45,6 +42,9 @@ class Artifact {
   }
 }
 
+// const xdgAppPaths = XDGAppPaths({ name: 'omega_edit' })
+const wait_port = require('wait-port')
+
 async function unzipFile(zipFilePath: string, extractPath: string) {
   return await new Promise((resolve, reject) => {
     let stream = fs
@@ -60,17 +60,15 @@ async function unzipFile(zipFilePath: string, extractPath: string) {
   })
 }
 
-export async function startServer(
+export async function setupServer(
   rootPath: string,
   omegaEditVersion: string
-): Promise<number | undefined> {
+): Promise<[string, string]> {
   const artifact = new Artifact(
     'omega-edit-scala-server',
     omegaEditVersion,
     'omega-edit-grpc-server'
   )
-
-  // let rootPath = xdgAppPaths.data()
 
   if (!fs.existsSync(rootPath)) {
     fs.mkdirSync(rootPath, { recursive: true })
@@ -107,7 +105,16 @@ export async function startServer(
     )
   }
 
-  let server = child_process.spawn(artifact.scriptName, [], {
+  return [artifact.scriptName, scriptPath]
+}
+
+export async function startServer(
+  rootPath: string,
+  omegaEditVersion: string
+): Promise<number | undefined> {
+  const [scriptName, scriptPath] = await setupServer(rootPath, omegaEditVersion)
+
+  let server = child_process.spawn(scriptName, [], {
     cwd: `${scriptPath}/bin`,
     detached: true,
   })


### PR DESCRIPTION
@scholarsmate This should help be able to test running the client. with the setup server I can have the scriptName and scriptPath and then run it in daffodil-vscode and open a terminal. It seems doing this way might be the best way to get it to work between oses. Plan to release 0.9.30 when this is merged