### PR TITLE
efficiency tweak of the replace function in the TS client

### DIFF
--- a/src/rpc/client/ts/src/change.ts
+++ b/src/rpc/client/ts/src/change.ts
@@ -137,8 +137,6 @@ export function overwrite(
  * @param remove_bytes_count number of bytes to remove
  * @param replace replacement bytes
  * @return positive change serial number of the insert on success
- * @remarks if the bytes being replaced have the same length as the replacement
- * bytes, use overwrite for better efficiency
  */
 export function replace(
   session_id: string,
@@ -146,12 +144,14 @@ export function replace(
   remove_bytes_count: number,
   replace: string | Uint8Array
 ): Promise<number> {
-  return new Promise<number>(async (resolve) => {
-    await pauseViewportEvents(session_id)
-    await del(session_id, offset, remove_bytes_count)
-    await resumeViewportEvents(session_id)
-    return resolve(await insert(session_id, offset, replace))
-  })
+  return replace.length == remove_bytes_count
+    ? overwrite(session_id, offset, replace)
+    : new Promise<number>(async (resolve) => {
+        await pauseViewportEvents(session_id)
+        await del(session_id, offset, remove_bytes_count)
+        await resumeViewportEvents(session_id)
+        return resolve(await insert(session_id, offset, replace))
+      })
 }
 
 /**

--- a/src/rpc/client/ts/src/change.ts
+++ b/src/rpc/client/ts/src/change.ts
@@ -144,7 +144,7 @@ export function replace(
   remove_bytes_count: number,
   replace: string | Uint8Array
 ): Promise<number> {
-  return replace.length == remove_bytes_count
+  return replace.length === remove_bytes_count
     ? overwrite(session_id, offset, replace)
     : new Promise<number>(async (resolve) => {
         await pauseViewportEvents(session_id)

--- a/src/rpc/client/ts/src/server.ts
+++ b/src/rpc/client/ts/src/server.ts
@@ -114,7 +114,11 @@ export async function startServer(
   omegaEditVersion: string,
   packagePath: string
 ): Promise<number | undefined> {
-  const [scriptName, scriptPath] = await setupServer(rootPath, omegaEditVersion, packagePath)
+  const [scriptName, scriptPath] = await setupServer(
+    rootPath,
+    omegaEditVersion,
+    packagePath
+  )
 
   let server = child_process.spawn(scriptName, [], {
     cwd: `${scriptPath}/bin`,


### PR DESCRIPTION
On the case where the length of the replacement data equals the number of bytes to replace, use overwrite instead.