### PR TITLE
Linux aarch64 support

### DIFF
--- a/.github/release.sbt
+++ b/.github/release.sbt
@@ -33,19 +33,20 @@ lazy val ghb_resolver = (
 // mostly used for getting all 3 jars working inside of one package
 lazy val bashExtras = s"""declare new_classpath=\"$$app_classpath\"
 declare windows_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-windows-${arch.arch}.jar"
-declare linux_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-linux-${arch.arch}.jar"
+declare linux_x84_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-linux-x86_64.jar"
+declare linux_aarch_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-linux-aarch64.jar"
 declare macos_x86_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-macos-x86_64.jar"
 declare macos_aarch_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-macos-aarch64.jar"
 if [[ $$OSTYPE == "darwin"* ]]; then
   if [[ $$(uname -m) == "x86_64" ]]; then
     new_classpath=$$(echo $$new_classpath |\\
-      sed -e "s/$${linux_jar_file}//" | \\
+      sed -e "s/$${linux_aarch_jar_file}//" | \\
       sed -e "s/$${windows_jar_file}//" | \\
       sed -e "s/$${macos_aarch_jar_file}//"\\
     )
   else
     new_classpath=$$(echo $$new_classpath |\\
-      sed -e "s/$${linux_jar_file}//" | \\
+      sed -e "s/$${linux_x86_jar_file}//" | \\
       sed -e "s/$${windows_jar_file}//" | \\
       sed -e "s/$${macos_x86_jar_file}//"\\
     )
@@ -166,6 +167,9 @@ lazy val native = project
       ),
       Artifact("omega-edit-native", "macos-aarch64") -> file(
         s"../../../../omega-edit-native_${scalaBinaryVersion.value}-${version.value}-macos-aarch64.jar"
+      ),
+      Artifact("omega-edit-native", "linux-aarch64") -> file(
+        s"../../../../omega-edit-native_${scalaBinaryVersion.value}-${version.value}-linux-aarch64.jar"
       )
     )
   )
@@ -180,7 +184,8 @@ lazy val serv = project
     libraryDependencies ++= {
       Seq(
         "com.ctc" %% "omega-edit" % omegaVersion,
-        "com.ctc" %% "omega-edit-native" % omegaVersion classifier s"${arch.id}",
+        "com.ctc" %% "omega-edit-native" % omegaVersion classifier s"linux-x86_64",
+        "com.ctc" %% "omega-edit-native" % omegaVersion classifier s"linux-aarch64",
         "com.ctc" %% "omega-edit-native" % omegaVersion classifier s"macos-x86_64",
         "com.ctc" %% "omega-edit-native" % omegaVersion classifier s"macos-aarch64",
         "com.ctc" %% "omega-edit-native" % omegaVersion classifier s"windows-${arch.arch}",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,8 +199,11 @@ jobs:
         run: |
           for folder in $(echo "omega-edit-native_2.13"); do
             curl \
-              https://raw.githubusercontent.com/Shanedell/omega-edit-m1/main/${folder}-${{ env.PKG_VERSION }}-macos-aarch64.jar \
+              https://raw.githubusercontent.com/Shanedell/omega-edit-aarch/main/${folder}-${{ env.PKG_VERSION }}-macos-aarch64.jar \
               --output ${folder}-${{ env.PKG_VERSION }}-macos-aarch64.jar
+            curl \
+              https://raw.githubusercontent.com/Shanedell/omega-edit-aarch/main/${folder}-${{ env.PKG_VERSION }}-linux-aarch64.jar \
+              --output ${folder}-${{ env.PKG_VERSION }}-linux-aarch64.jar
           done
 
       - name: Package Scala Native 🎁

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ lib/*
 
 .metals
 project
+!src/rpc/server/scala/project/BuildSupport.scala

--- a/docker/Dockerfile.centos8-cpp-env
+++ b/docker/Dockerfile.centos8-cpp-env
@@ -35,10 +35,22 @@ RUN yum -y update && yum -y install dnf-plugins-core && yum config-manager --set
   ninja-build \
   valgrind \
   wget \
+  java-1.8.0-openjdk \
  && yum clean all
 
 RUN pip3 install \
-    breathe \
-    conan \
-    sphinx_rtd_theme \
-    sphinx-sitemap
+  breathe \
+  conan \
+  sphinx_rtd_theme \
+  sphinx-sitemap
+
+# Install nodejs and yarn
+RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - \
+  && yum install -y nodejs \
+  && npm install -g yarn
+
+# Install sbt
+RUN rm -f /etc/yum.repos.d/bintray-rpm.repo \
+  && curl -L https://www.scala-sbt.org/sbt-rpm.repo > sbt-rpm.repo \
+  && mv sbt-rpm.repo /etc/yum.repos.d/ \
+  && yum install -y sbt

--- a/docker/Dockerfile.ubuntu20-cpp-env
+++ b/docker/Dockerfile.ubuntu20-cpp-env
@@ -14,7 +14,9 @@
 
 FROM ubuntu:20.04
 
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y install tzdata
+ENV DEBIAN_FRONTEND="noninteractive" 
+
+RUN apt-get update && apt-get -y install tzdata
 RUN apt-get update && apt-get -y install \
   build-essential \
   gcc \
@@ -39,9 +41,28 @@ RUN apt-get update && apt-get -y install \
   graphviz \
   valgrind \
   wget \
+  curl \
+  openjdk-8-jdk \
+  openjdk-8-jre \
+  scala \
+  && apt-get clean
+
+# install sbt
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list \
+  && echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list \
+  && curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" \
+    | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import \
+  && chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg \
+  && apt-get update \
+  && apt-get install -y sbt \
   && apt-get clean
 
 RUN pip3 install \
-    conan \
-    sphinx_rtd_theme \
-    sphinx-sitemap
+  conan \
+  sphinx_rtd_theme \
+  sphinx-sitemap
+
+# Install nodejs and yarn
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+  && apt-get install -y nodejs \
+  && npm install -g yarn

--- a/src/rpc/server/scala/build.sbt
+++ b/src/rpc/server/scala/build.sbt
@@ -31,19 +31,20 @@ lazy val ghb_resolver = (
 // getting all 3 jars working inside of one package
 lazy val bashExtras = s"""declare new_classpath=\"$$app_classpath\"
 declare windows_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-windows-${arch.arch}.jar"
-declare linux_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-linux-${arch.arch}.jar"
+declare linux_x84_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-linux-x86_64.jar"
+declare linux_aarch_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-linux-aarch64.jar"
 declare macos_x86_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-macos-x86_64.jar"
 declare macos_aarch_jar_file="com.ctc.omega-edit-native_2.13-${omegaVersion}-macos-aarch64.jar"
 if [[ $$OSTYPE == "darwin"* ]]; then
   if [[ $$(uname -m) == "x86_64" ]]; then
     new_classpath=$$(echo $$new_classpath |\\
-      sed -e "s/$${linux_jar_file}//" | \\
+      sed -e "s/$${linux_aarch_jar_file}//" | \\
       sed -e "s/$${windows_jar_file}//" | \\
       sed -e "s/$${macos_aarch_jar_file}//"\\
     )
   else
     new_classpath=$$(echo $$new_classpath |\\
-      sed -e "s/$${linux_jar_file}//" | \\
+      sed -e "s/$${linux_x86_jar_file}//" | \\
       sed -e "s/$${windows_jar_file}//" | \\
       sed -e "s/$${macos_x86_jar_file}//"\\
     )

--- a/src/rpc/server/scala/project/BuildSupport.scala
+++ b/src/rpc/server/scala/project/BuildSupport.scala
@@ -38,6 +38,7 @@ object BuildSupport {
   val Amd: Regex = """amd(\d+)""".r
   val x86: Regex = """x86_(\d+)""".r
   val aarch: Regex = """aarch(\d+)""".r
+  val arm: Regex = """arm(\d+)""".r
 
   // https://stackoverflow.com/a/51416386
   def filterScopedDependenciesFromPom(node: XmlNode): XmlNode =
@@ -69,7 +70,7 @@ object BuildSupport {
     }
 
     val arch =
-      if (os == "macos") System.getProperty("os.arch").toLowerCase
+      if (os == "macos" || os == "linux") System.getProperty("os.arch").toLowerCase
       else
         System.getProperty("os.arch").toLowerCase match {
           case Amd(bits)   => bits
@@ -89,7 +90,7 @@ object BuildSupport {
     }
 
     val arch =
-      if (os == "macos") System.getProperty("os.arch").toLowerCase
+      if (os == "macos" || os == "linux") System.getProperty("os.arch").toLowerCase
       else
         System.getProperty("os.arch").toLowerCase match {
           case Amd(bits)   => bits


### PR DESCRIPTION
Linux aarch64 support:

- Update Dockerfiles to be able to fully build the code.
- Update release to download linux aarch64 jar file.
- Update scala sbt files to include both linux x86 and aarch64 jars.
- Update BuildSupport to create linux jar file with proper arch name.