### PR TITLE
fix clear

### DIFF
--- a/src/lib/edit.cpp
+++ b/src/lib/edit.cpp
@@ -570,6 +570,7 @@ int omega_edit_clear_changes(omega_session_t *session_ptr) {
     }
     initialize_model_segments_(session_ptr->models_.front()->model_segments, length);
     free_session_changes_(session_ptr);
+    free_session_changes_undone_(session_ptr);
     for (const auto &viewport_ptr : session_ptr->viewports_) {
         viewport_ptr->data_segment.capacity = -1 * std::abs(viewport_ptr->data_segment.capacity);// indicate dirty read
         omega_viewport_notify(viewport_ptr.get(), VIEWPORT_EVT_CLEAR, nullptr);

--- a/src/rpc/client/ts/tests/specs/undoRedo.spec.ts
+++ b/src/rpc/client/ts/tests/specs/undoRedo.spec.ts
@@ -199,8 +199,14 @@ describe('Undo/Redo', () => {
 
     // test clearing changes from a session
     expect(await getChangeCount(session_id)).to.equal(3)
+    expect(await getUndoCount(session_id)).to.equal(0)
+    change_id = await undo(session_id)
+    expect(change_id).to.equal(-3)
+    expect(await getChangeCount(session_id)).to.equal(2)
+    expect(await getUndoCount(session_id)).to.equal(1)
     const cleared_session_id = await clear(session_id)
     expect(cleared_session_id).to.equal(session_id)
     expect(await getChangeCount(session_id)).to.equal(0)
+    expect(await getUndoCount(session_id)).to.equal(0)
   })
 })

--- a/src/tests/omega_test.cpp
+++ b/src/tests/omega_test.cpp
@@ -676,8 +676,12 @@ TEST_CASE("Check initialization", "[InitTests]") {
             REQUIRE(71 == omega_session_get_computed_file_size(session_ptr));
             REQUIRE(0 == omega_edit_save(session_ptr, "data/test1.dat.out", 1, nullptr));
             REQUIRE(6 == omega_session_get_num_changes(session_ptr));
+            REQUIRE(-6 == omega_edit_undo_last_change(session_ptr));
+            REQUIRE(5 == omega_session_get_num_changes(session_ptr));
+            REQUIRE(2 == omega_session_get_num_undone_changes(session_ptr));
             REQUIRE(0 == omega_edit_clear_changes(session_ptr));
             REQUIRE(0 == omega_session_get_num_changes(session_ptr));
+            REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
             REQUIRE(0 == omega_edit_save(session_ptr, "data/test1.reset.dat", 1, nullptr));
             REQUIRE(0 == compare_files("data/test1.dat", "data/test1.reset.dat"));
             omega_edit_destroy_session(session_ptr);


### PR DESCRIPTION
When session edits are cleared, the redo stack must also be cleared.