### PR TITLE
fix version to work for installed package

### DIFF
--- a/src/rpc/client/ts/tests/fixtures.ts
+++ b/src/rpc/client/ts/tests/fixtures.ts
@@ -18,7 +18,7 @@
  */
 
 import { startServer, stopServer } from '../src/server'
-import { ClientVersion } from '../src/version'
+import { getClientVersion } from '../src/version'
 import * as fs from 'fs'
 
 // prettier-ignore
@@ -33,7 +33,12 @@ function getPidFile(port: number): string {
 }
 
 export async function mochaGlobalSetup(): Promise<number | undefined> {
-  const pid = await startServer(rootPath, ClientVersion, rootPath, testPort)
+  const pid = await startServer(
+    rootPath,
+    getClientVersion(),
+    rootPath,
+    testPort
+  )
   mochaGlobalTeardown()
   if (pid) {
     fs.writeFileSync(getPidFile(testPort), pid.toString(), 'utf8')

--- a/src/rpc/client/ts/tests/specs/common.ts
+++ b/src/rpc/client/ts/tests/specs/common.ts
@@ -25,7 +25,7 @@ import {
   getSessionCount,
 } from '../../src/session'
 import { startServer, stopServer } from '../../src/server'
-import { ClientVersion } from '../../src/version'
+import { getClientVersion } from '../../src/version'
 import * as fs from 'fs'
 
 const path = require('path')
@@ -39,7 +39,7 @@ function getPidFile(port: number): string {
 export async function startTestServer(
   port: number
 ): Promise<number | undefined> {
-  const pid = await startServer(rootPath, ClientVersion, rootPath, port)
+  const pid = await startServer(rootPath, getClientVersion(), rootPath, port)
   stopTestServer(port)
   if (pid) {
     fs.writeFileSync(getPidFile(port), pid.toString(), 'utf8')

--- a/src/rpc/client/ts/tests/specs/version.spec.ts
+++ b/src/rpc/client/ts/tests/specs/version.spec.ts
@@ -18,7 +18,11 @@
  */
 
 import { expect } from 'chai'
-import { ClientVersion, getVersion } from '../../src/version'
+import {
+  ClientVersion,
+  getClientVersion,
+  getServerVersion,
+} from '../../src/version'
 import { getClient, waitForReady } from '../../src/client'
 
 // prettier-ignore
@@ -26,14 +30,15 @@ import { getClient, waitForReady } from '../../src/client'
 import { startTestServer, stopTestServer } from './common'
 
 describe('Version', () => {
-  const expected_version = ClientVersion
   const port = 9010
 
   beforeEach('Ensure the client is ready', async () => {
     expect(await waitForReady(getClient(port)))
   })
 
-  it('Should return version ' + expected_version, async () => {
-    expect(await getVersion()).to.equal(expected_version)
+  it('Server version should return version ' + ClientVersion, async () => {
+    expect(await getServerVersion())
+      .to.equal(getClientVersion())
+      .to.equal(ClientVersion)
   })
 })


### PR DESCRIPTION
Discovering the client version worked in the source tree, but not once it was installed.  This patch should fix that.