### PR TITLE
nuke ~/.m2, what does this even do for us?

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,8 +52,11 @@ kill -9 "$( lsof -i:9000 | sed -n '2p' | awk '{print $2}' )" >/dev/null 2>&1 || 
 # Build and test the Scala server
 pushd src/rpc/server/scala
 sbt test
+rm -rf ~/.m2/
 sbt pkgServer
+rm -rf ~/.m2/
 sbt serv/test
+rm -rf ~/.m2/
 popd
 
 # Build and test the TypeScript client


### PR DESCRIPTION
From time to time, this breaks ./build.sh due to a double publish.  I don't really know what advantage it gives us other than taking up space and breaking things.  There is probably a more graceful way to handle it.  I'll look into that later, but for now, this works.