### PR TITLE
add code to autofix unexpected data lengths from the server

### DIFF
--- a/src/rpc/client/ts/src/client.ts
+++ b/src/rpc/client/ts/src/client.ts
@@ -22,7 +22,7 @@ import * as grpc from '@grpc/grpc-js'
 import { getLogger } from './logger'
 
 // client instance
-let client: EditorClient | undefined = undefined
+let client_: EditorClient | undefined = undefined
 
 // subscription events
 export const NO_EVENTS = 0 // subscribe to no events
@@ -38,7 +38,7 @@ export function getClient(
   port: number = 9000,
   host: string = '127.0.0.1'
 ): EditorClient {
-  if (!client) {
+  if (!client_) {
     getLogger().debug({
       fn: 'getClient',
       port: port,
@@ -46,8 +46,8 @@ export function getClient(
       state: 'initializing',
     })
     const uri = process.env.OMEGA_EDIT_SERVER_URI || `${host}:${port}`
-    client = new EditorClient(uri, grpc.credentials.createInsecure())
-    waitForReady(client)
+    client_ = new EditorClient(uri, grpc.credentials.createInsecure())
+    waitForReady(client_)
       .catch((err) => {
         getLogger().error({
           cmd: 'getClient',
@@ -71,7 +71,7 @@ export function getClient(
         }
       })
   }
-  return client
+  return client_
 }
 
 /**

--- a/src/rpc/client/ts/tests/fixtures.ts
+++ b/src/rpc/client/ts/tests/fixtures.ts
@@ -17,9 +17,10 @@
  * limitations under the License.
  */
 
+import { createSimpleFileLogger, getLogger, setLogger } from '../src/logger'
 import { startServer, stopServer } from '../src/server'
 import { getClientVersion } from '../src/version'
-import { createSimpleFileLogger, getLogger, setLogger } from '../src/logger'
+import { setAutoFixViewportDataLength } from '../src/viewport'
 import * as fs from 'fs'
 
 // prettier-ignore
@@ -47,6 +48,7 @@ export async function mochaGlobalSetup(): Promise<number | undefined> {
   const logFile = path.join(rootPath, 'test.log')
   const level = process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL || 'info'
   const logger = createSimpleFileLogger(logFile, level)
+
   logger.info({
     fn: 'mochaGlobalSetup',
     msg: 'logger built',
@@ -60,6 +62,10 @@ export async function mochaGlobalSetup(): Promise<number | undefined> {
     port: testPort,
     pidfile: getPidFile(testPort),
   })
+
+  // don't fix viewport data length in tests
+  setAutoFixViewportDataLength(false)
+
   const pid = await startServer(rootPath, getClientVersion(), testPort)
   mochaGlobalTeardown()
   if (pid) {

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
@@ -144,7 +144,7 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
           case ok: Ok with Data =>
             ViewportDataResponse
               .apply(
-                ok.id,
+                viewportId = in.viewportId,
                 offset = ok.offset,
                 length = ok.data.size.toLong,
                 data = ok.data

--- a/src/rpc/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/ExampleSpec.scala
+++ b/src/rpc/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/ExampleSpec.scala
@@ -585,7 +585,7 @@ class ExampleSpec
           )
         )
         // get data to clear the "has changes" state for this viewport
-        _ <- service.getViewportData(
+        viewportDataResponse <- service.getViewportData(
           ViewportDataRequest(viewportResponse2.viewportId)
         )
         viewport2HasChanges <- service.viewportHasChanges(
@@ -623,6 +623,10 @@ class ExampleSpec
         numViewports1.kind shouldBe CountKind.COUNT_VIEWPORTS
         numViewports1.count shouldBe 0L
         viewportResponse1.viewportId shouldBe sid + ":viewport_1"
+        viewportDataResponse.data shouldBe ByteString.EMPTY
+        viewportDataResponse.offset shouldBe 10L
+        viewportDataResponse.length shouldBe 0L
+        viewportDataResponse.viewportId shouldBe viewportResponse2.viewportId
         viewport1HasChanges.response shouldBe true
         viewport2HasChanges.response shouldBe false
         numViewports2.sessionId shouldBe sid


### PR DESCRIPTION
In application code, we have seen instances where getViewportData will have data that is mysteriously padded with zeros equal to the data size, so if the size should be 100 bytes, the data will have 100 bytes, followed by 100 bytes of nulls.

The fix here is simply to truncate the data to the expected length when that scenario is detected.  This auto fix is disabled for testing because we've never seen this happen in the test cases.  In the application code, if this scenario is encountered, then use `setAutoFixViewportDataLength(true)` to enable the detection and auto fixing solution.