### PR TITLE
enhanced support for viewport scrolling

### DIFF
--- a/.run/omega_edit.run.xml
+++ b/.run/omega_edit.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="omega_edit" type="CMakeRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Project" TARGET_NAME="omega_edit" CONFIG_NAME="Debug">
+  <configuration default="false" name="omega_edit" type="CMakeRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="omega_edit" TARGET_NAME="omega_edit" CONFIG_NAME="Debug">
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
     </method>

--- a/src/include/omega_edit/viewport.h
+++ b/src/include/omega_edit/viewport.h
@@ -81,6 +81,13 @@ OMEGA_EDIT_EXPORT int64_t omega_viewport_get_offset(const omega_viewport_t *view
 OMEGA_EDIT_EXPORT int omega_viewport_is_floating(const omega_viewport_t *viewport_ptr);
 
 /**
+ * Given a viewport, return the number of bytes that exist after the viewport
+ * @param viewport_ptr viewport to get the number of bytes that exist after the viewport from
+ * @return number of bytes that exist after the viewport
+ */
+OMEGA_EDIT_EXPORT int64_t omega_viewport_get_following_byte_count(const omega_viewport_t *viewport_ptr);
+
+/**
  * Given a viewport, return the viewport user data
  * @param viewport_ptr viewport to get the user data from
  * @return viewport user data

--- a/src/lib/edit.cpp
+++ b/src/lib/edit.cpp
@@ -106,11 +106,16 @@ static inline const_omega_change_ptr_t ovr_(int64_t serial, int64_t offset, cons
 static inline void update_viewport_offset_adjustment_(omega_viewport_t *viewport_ptr,
                                                       const omega_change_t *change_ptr) {
     assert(0 < change_ptr->length);
+    const auto offset = omega_viewport_get_offset(viewport_ptr);
     // If the viewport is floating and a change happens before or at the start of the given viewport...
-    if (omega_viewport_is_floating(viewport_ptr) && change_ptr->offset <= omega_viewport_get_offset(viewport_ptr)) {
+    if (omega_viewport_is_floating(viewport_ptr) && change_ptr->offset <= offset) {
         // ...and the change is a delete, or insert, update the offset adjustment accordingly
         if (change_kind_t::CHANGE_DELETE == omega_change_get_kind(change_ptr)) {
             viewport_ptr->data_segment.offset_adjustment -= change_ptr->length;
+            // If the offset adjustment is now negative, adjust it to zero
+            if (offset < -viewport_ptr->data_segment.offset_adjustment) {
+                viewport_ptr->data_segment.offset_adjustment = -offset;
+            }
         } else if (change_kind_t::CHANGE_INSERT == omega_change_get_kind(change_ptr)) {
             viewport_ptr->data_segment.offset_adjustment += change_ptr->length;
         }

--- a/src/lib/viewport.cpp
+++ b/src/lib/viewport.cpp
@@ -76,6 +76,12 @@ int omega_viewport_is_floating(const omega_viewport_t *viewport_ptr) {
     return viewport_ptr->data_segment.is_floating ? 1 : 0;
 }
 
+int64_t omega_viewport_get_following_byte_count(const omega_viewport_t *viewport_ptr) {
+    assert(viewport_ptr);
+    return omega_session_get_computed_file_size(omega_viewport_get_session(viewport_ptr)) -
+            (omega_viewport_get_offset(viewport_ptr) + omega_viewport_get_length(viewport_ptr));
+}
+
 int omega_viewport_modify(omega_viewport_t *viewport_ptr, int64_t offset, int64_t capacity, int is_floating) {
     assert(viewport_ptr);
     if (capacity > 0 && capacity <= OMEGA_VIEWPORT_CAPACITY_LIMIT) {

--- a/src/rpc/client/ts/src/viewport.ts
+++ b/src/rpc/client/ts/src/viewport.ts
@@ -19,6 +19,7 @@ import {
   CountKind,
   CountRequest,
   CreateViewportRequest,
+  ModifyViewportRequest,
   ObjectId,
   ViewportDataRequest,
   ViewportDataResponse,
@@ -29,7 +30,7 @@ import { getClient } from './client'
 let autoFixViewportDataLength_ = false
 
 /**
- * Set whether or not to automatically fix viewport data length
+ * Set whether to automatically fix viewport data length
  * @param shouldAutoFix true if the client should automatically fix viewport data length, false otherwise
  */
 export function setAutoFixViewportDataLength(shouldAutoFix: boolean): void {
@@ -56,9 +57,9 @@ export function createViewport(
   session_id: string,
   offset: number,
   capacity: number,
-  is_floating: boolean
-): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
+  is_floating: boolean = false
+): Promise<ViewportDataResponse> {
+  return new Promise<ViewportDataResponse>((resolve, reject) => {
     let request = new CreateViewportRequest()
       .setSessionId(session_id)
       .setOffset(offset)
@@ -82,7 +83,39 @@ export function createViewport(
         return reject(`createViewport error: ${err.message}`)
       }
       getLogger().debug({ fn: 'createViewport', resp: r.toObject() })
-      return resolve(r.getViewportId())
+      return resolve(r)
+    })
+  })
+}
+
+export function modifyViewport(
+  viewport_id: string,
+  offset: number,
+  capacity: number,
+  is_floating: boolean = false
+): Promise<ViewportDataResponse> {
+  return new Promise<ViewportDataResponse>((resolve, reject) => {
+    const request = new ModifyViewportRequest()
+      .setViewportId(viewport_id)
+      .setOffset(offset)
+      .setCapacity(capacity)
+      .setIsFloating(is_floating)
+    getLogger().debug({ fn: 'modifyViewport', rqst: request.toObject() })
+    getClient().modifyViewport(request, (err, r) => {
+      if (err) {
+        getLogger().error({
+          fn: 'modifyViewport',
+          err: {
+            msg: err.message,
+            details: err.details,
+            code: err.code,
+            stack: err.stack,
+          },
+        })
+        return reject(`modifyViewport error: ${err.message}`)
+      }
+      getLogger().debug({ fn: 'modifyViewport', resp: r.toObject() })
+      return resolve(r)
     })
   })
 }

--- a/src/rpc/client/ts/tests/specs/session.spec.ts
+++ b/src/rpc/client/ts/tests/specs/session.spec.ts
@@ -28,11 +28,7 @@ import {
 // @ts-ignore
 import { testPort } from './common'
 import * as fs from 'fs'
-import {
-  createViewport,
-  getViewportCount,
-  getViewportData,
-} from '../../src/viewport'
+import { createViewport, getViewportCount } from '../../src/viewport'
 import { getClient, waitForReady } from '../../src/client'
 import { getServerHeartbeat } from '../../src/server'
 import { getClientVersion } from '../../src/version'
@@ -75,10 +71,15 @@ describe('Sessions', () => {
       expect(session_id).to.equal(expected_session_id)
       expect(await getSessionCount()).to.equal(1)
       expect(fileData.length).to.equal(await getComputedFileSize(session_id))
-      const vpt_id = await createViewport(undefined, session_id, 0, 1000, false)
+      const vpt_response = await createViewport(
+        undefined,
+        session_id,
+        0,
+        1000,
+        false
+      )
       expect(await getViewportCount(session_id)).to.equal(1)
-      const dataResponse = await getViewportData(vpt_id)
-      expect(dataResponse.getData_asU8()).to.deep.equal(fileBuffer)
+      expect(vpt_response.getData_asU8()).to.deep.equal(fileBuffer)
       const serverHeartbeat = await getServerHeartbeat()
       expect(serverHeartbeat.latency).to.be.greaterThanOrEqual(0)
       expect(serverHeartbeat.resp).to.equal(getClientVersion())

--- a/src/rpc/client/ts/tests/specs/stressTest.spec.ts
+++ b/src/rpc/client/ts/tests/specs/stressTest.spec.ts
@@ -162,13 +162,14 @@ describe('StressTest', () => {
         10
       )
     )
-    const viewport_id = await createViewport(
+    const viewport_response = await createViewport(
       undefined,
       session_id,
       0,
       data.length,
       false
     )
+    const viewport_id = viewport_response.getViewportId()
     await subscribeViewport(viewport_id)
     await subscribeSession(session_id, ALL_EVENTS)
     for (let i = 0; i < data.length; ++i) {
@@ -198,13 +199,14 @@ describe('StressTest', () => {
         10
       )
     )
-    const viewport_id = await createViewport(
+    const viewport_response = await createViewport(
       undefined,
       session_id,
       0,
       data.length,
       false
     )
+    const viewport_id = viewport_response.getViewportId()
     await subscribeViewport(viewport_id)
     await subscribeSession(session_id, ALL_EVENTS)
     for (let i = 0; i < data.length; ++i) {
@@ -256,32 +258,33 @@ describe('StressTest', () => {
       await resumeSessionChanges(session_id)
       expect(await getComputedFileSize(session_id)).to.equal(data.length)
 
-      const viewport_id = await createViewport(
+      const viewport_response = await createViewport(
         'last_byte_vpt',
         session_id,
         file_size - 1,
         1,
         false
       )
-      const viewport_2_id = await createViewport(
+      const viewport_id = viewport_response.getViewportId()
+      const viewport_2_response = await createViewport(
         'all_data_vpt',
         session_id,
         0,
         file_size,
         false
       )
+      const viewport_2_id = viewport_2_response.getViewportId()
       await subscribeViewport(viewport_id, ALL_EVENTS)
       await subscribeViewport(viewport_2_id, ALL_EVENTS)
-      let viewport_data = await getViewportData(viewport_id)
 
-      expect(decode(viewport_data.getData_asU8())).to.equal('~')
+      expect(decode(viewport_response.getData_asU8())).to.equal('~')
 
       let rotations = file_size * full_rotations
       const expected_num_changes = 1 + 3 * file_size * full_rotations
 
       while (rotations--) {
         log_info('\x1b[33m%s\x1b[0mrotations remaining: ' + rotations)
-        viewport_data = await getViewportData(viewport_id)
+        let viewport_data = await getViewportData(viewport_id)
 
         change_id = await insert(session_id, 0, ' ')
         expect(
@@ -298,7 +301,7 @@ describe('StressTest', () => {
         .to.equal(await getChangeCount(session_id))
         .and.to.equal(expected_num_changes)
 
-      viewport_data = await getViewportData(viewport_2_id)
+      let viewport_data = await getViewportData(viewport_2_id)
 
       expect(viewport_data.getData_asU8()).to.deep.equal(data)
       expect(await getComputedFileSize(session_id)).to.equal(file_size)

--- a/src/rpc/protos/omega_edit.proto
+++ b/src/rpc/protos/omega_edit.proto
@@ -36,7 +36,8 @@ service Editor {
   rpc SessionBeginTransaction(ObjectId) returns (ObjectId);
   rpc SessionEndTransaction(ObjectId) returns (ObjectId);
   rpc NotifyChangedViewports(ObjectId) returns (IntResponse);
-  rpc CreateViewport(CreateViewportRequest) returns (CreateViewportResponse);
+  rpc CreateViewport(CreateViewportRequest) returns (ViewportDataResponse);
+  rpc ModifyViewport(ModifyViewportRequest) returns (ViewportDataResponse);
   rpc ViewportHasChanges(ObjectId) returns (BooleanResponse);
   rpc GetViewportData(ViewportDataRequest) returns (ViewportDataResponse);
   rpc DestroyViewport(ObjectId) returns (ObjectId);
@@ -153,9 +154,11 @@ message CreateViewportRequest {
   optional string viewport_id_desired = 5;
 }
 
-message CreateViewportResponse {
-  string session_id = 1;
-  string viewport_id = 2;
+message ModifyViewportRequest {
+  string viewport_id = 1;
+  int64 offset = 2;
+  int64 capacity = 3;
+  bool is_floating = 4;
 }
 
 message ViewportDataRequest {
@@ -167,6 +170,7 @@ message ViewportDataResponse {
   int64 offset = 2;
   int64 length = 3;
   bytes data = 4;
+  int64 following_byte_count = 5;
 }
 
 message CreateSessionRequest {

--- a/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/FFI.scala
+++ b/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/FFI.scala
@@ -103,11 +103,6 @@ private[omega_edit] trait FFI {
       segment: Pointer,
       offset: Long
   ): Int
-  def omega_session_get_segment_string(
-      session: Pointer,
-      offset: Long,
-      length: Long
-  ): String
   def omega_session_set_event_interest(p: Pointer, eventInterest: Int): Int
   def omega_session_pause_changes(p: Pointer): Unit
   def omega_session_resume_changes(p: Pointer): Unit
@@ -134,7 +129,9 @@ private[omega_edit] trait FFI {
   def omega_viewport_get_length(p: Pointer): Long
   def omega_viewport_get_offset(p: Pointer): Long
   def omega_viewport_get_capacity(p: Pointer): Long
+  def omega_viewport_get_following_byte_count(p: Pointer): Long
   def omega_viewport_is_floating(p: Pointer): Boolean
+  def omega_viewport_get_session(p: Pointer): Pointer
   def omega_viewport_set_event_interest(p: Pointer, eventInterest: Int): Int
   def omega_viewport_modify(
       p: Pointer,

--- a/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/ViewportImpl.scala
+++ b/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/ViewportImpl.scala
@@ -24,9 +24,17 @@ private[omega_edit] class ViewportImpl(p: Pointer, i: FFI) extends Viewport {
   require(p != null, "native viewport pointer was null")
 
   def data: Array[Byte] = {
+    val len = length.toInt
     val data = i.omega_viewport_get_data(p)
-    val out = Array.ofDim[Byte](length.toInt)
-    data.get(0, out, 0, length.toInt)
+
+    // if the length is 0, or less, return an empty array
+    if (len < 1) {
+      return Array.emptyByteArray
+    }
+
+    // create a new array to copy the data into it
+    val out = Array.ofDim[Byte](len)
+    data.get(0, out, 0, len)
     out
   }
 
@@ -48,15 +56,18 @@ private[omega_edit] class ViewportImpl(p: Pointer, i: FFI) extends Viewport {
   def capacity: Long =
     i.omega_viewport_get_capacity(p)
 
+  def followingByteCount: Long =
+    i.omega_viewport_get_following_byte_count(p)
+
   def move(offset: Long): Boolean =
-    update(offset, capacity)
+    modify(offset, capacity, isFloating)
 
   def resize(capacity: Long): Boolean =
-    update(offset, capacity)
+    modify(offset, capacity, isFloating)
 
-  def update(offset: Long, capacity: Long): Boolean =
-    i.omega_viewport_modify(p, offset, capacity, 0) == 0
-
+  def modify(offset: Long, capacity: Long, isFloating: Boolean): Boolean = {
+    i.omega_viewport_modify(p, offset, capacity, if (isFloating) 1 else 0) == 0
+  }
   override def toString: String =
     data.mkString // TODO: probably render instead as hex
 

--- a/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/api/Viewport.scala
+++ b/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/api/Viewport.scala
@@ -28,11 +28,12 @@ trait Viewport {
 
   def offset: Long
   def capacity: Long
+  def followingByteCount: Long
   def isFloating: Boolean
   def hasChanges: Boolean
 
   def move(offset: Long): Boolean
   def resize(capacity: Long): Boolean
-  def update(offset: Long, capacity: Long): Boolean
+  def modify(offset: Long, capacity: Long, isFloating: Boolean): Boolean
   def destroy(): Unit
 }

--- a/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/ViewportImplSpec.scala
+++ b/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/ViewportImplSpec.scala
@@ -25,9 +25,19 @@ class ViewportImplSpec extends AnyWordSpec with Matchers with TestSupport {
   "views" should {
     "limit data" in session("abc")(view(0, 1, false, _) { (s, v) =>
       s.size shouldBe 3
+      v.offset shouldBe 0
+      v.capacity shouldBe 1
       v.isFloating shouldBe false
       v.hasChanges shouldBe true
       v.data shouldBe "a".getBytes()
+      v.hasChanges shouldBe false
+      s.notifyChangedViewports shouldBe 0
+      v.modify(1, 2, true)
+      v.offset shouldBe 1
+      v.capacity shouldBe 2
+      v.isFloating shouldBe true
+      v.hasChanges shouldBe true
+      v.data shouldBe "bc".getBytes()
       v.hasChanges shouldBe false
       s.notifyChangedViewports shouldBe 0
     })
@@ -65,7 +75,7 @@ class ViewportImplSpec extends AnyWordSpec with Matchers with TestSupport {
       v.hasChanges shouldBe true
       v.data shouldBe "a".getBytes()
       v.hasChanges shouldBe false
-      v.update(1, 2)
+      v.modify(1, 2, false)
       v.hasChanges shouldBe true
       v.data shouldBe "bc".getBytes()
       v.hasChanges shouldBe false

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
@@ -53,9 +53,10 @@ object Editors {
   case class Ok(id: String) extends Result
   case class Err(reason: Status) extends Result
 
-  trait Data {
+  trait ViewportData {
     def data: ByteString
     def offset: Long
+    def followingByteCount: Long
   }
 
   trait BooleanResult {

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Viewport.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Viewport.scala
@@ -20,7 +20,7 @@ import akka.NotUsed
 import akka.actor.{Actor, ActorLogging, Props}
 import akka.stream.scaladsl.Source
 import com.ctc.omega_edit.api
-import com.ctc.omega_edit.grpc.Editors.{BooleanResult, Data, Ok}
+import com.ctc.omega_edit.grpc.Editors.{BooleanResult, Ok, ViewportData}
 import com.ctc.omega_edit.grpc.Viewport.{
   Destroy,
   EventStream,
@@ -28,6 +28,7 @@ import com.ctc.omega_edit.grpc.Viewport.{
   Get,
   HasChanges,
   Unwatch,
+  Modify,
   Watch
 }
 import com.google.protobuf.ByteString
@@ -57,12 +58,14 @@ object Viewport {
   }
 
   trait Op
+  case class Modify(offset: Long, capacity: Long, isFloating: Boolean)
+      extends Op
   case object Get extends Op
   case object HasChanges extends Op
   case object Destroy extends Op
   case class Watch(eventInterest: Option[Int]) extends Op
-
   case object Unwatch extends Op
+
 }
 
 class Viewport(
@@ -72,12 +75,23 @@ class Viewport(
     with ActorLogging {
   val viewportId: String = self.path.name
 
+  private def generateViewportData(
+      viewport: api.Viewport,
+      id: String
+  ): Ok with ViewportData = new Ok(id) with ViewportData {
+    def data: ByteString = ByteString.copyFrom(viewport.data)
+    def offset: Long = viewport.offset
+    def followingByteCount: Long = viewport.followingByteCount
+  }
+
   def receive: Receive = {
+
+    case Modify(offset, capacity, isFloating) =>
+      view.modify(offset, capacity, isFloating)
+      sender() ! generateViewportData(view, viewportId)
+
     case Get =>
-      sender() ! new Ok(viewportId) with Data {
-        def data: ByteString = ByteString.copyFrom(view.data)
-        def offset: Long = view.offset
-      }
+      sender() ! generateViewportData(view, viewportId)
 
     case HasChanges =>
       sender() ! new Ok(viewportId) with BooleanResult {

--- a/src/rpc/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/ExampleSpec.scala
+++ b/src/rpc/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/ExampleSpec.scala
@@ -626,8 +626,9 @@ class ExampleSpec
         viewportDataResponse.data shouldBe ByteString.EMPTY
         viewportDataResponse.offset shouldBe 10L
         viewportDataResponse.length shouldBe 0L
+        viewportDataResponse.followingByteCount shouldBe -10L
         viewportDataResponse.viewportId shouldBe viewportResponse2.viewportId
-        viewport1HasChanges.response shouldBe true
+        viewport1HasChanges.response shouldBe false
         viewport2HasChanges.response shouldBe false
         numViewports2.sessionId shouldBe sid
         numViewports2.kind shouldBe CountKind.COUNT_VIEWPORTS


### PR DESCRIPTION
With this patch, whenever data is fetched for a viewport, the number of bytes that exist after the viewport is known.  If positive, it means that the viewport can be scrolled forward up to that number of bytes.  If negative, then the viewport is off the edge of the file and needs to be pulled back that number of bytes.  If zero, then the viewport is exactly at the end of the file.  This is meant to help with integrating viewport scrolling into applications.

Additionally, viewport creation responses will include the viewport data for the initial viewport population.

closes #548.