### PR TITLE
remove all traces of string edits from the RPC

### DIFF
--- a/src/rpc/client/ts/package.json
+++ b/src/rpc/client/ts/package.json
@@ -32,23 +32,22 @@
     "@types/chai": "^4.3.1",
     "@types/mocha": "^10.0.0",
     "chai": "^4.3.6",
-    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "glob": "^8.0.3",
-    "grpc-tools": "^1.11.3",
-    "grpc_tools_node_protoc_ts": "^5.3.2",
+    "grpc-tools": "^1.12.4",
+    "grpc_tools_node_protoc_ts": "^5.3.3",
     "mocha": "^10.0.0",
-    "prettier": "^2.6.2",
+    "prettier": "^2.8.4",
     "run-script-os": "^1.1.6",
     "typedoc": "^0.23.16"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.8.9",
+    "@grpc/grpc-js": "^1.8.11",
     "@types/google-protobuf": "^3.15.5",
     "@types/node": "^18.8.4",
     "google-protobuf": "^3.21.2",
-    "pino": "^8.10.0",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.8.4",
+    "pino": "^8.11.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5",
     "wait-port": "^1.0.4"
   }
 }

--- a/src/rpc/client/ts/src/change.ts
+++ b/src/rpc/client/ts/src/change.ts
@@ -102,9 +102,11 @@ export function del(
   stats?: IEditStats
 ): Promise<number> {
   return new Promise<number>((resolve, reject) => {
-    let request = new ChangeRequest().setSessionId(session_id).setOffset(offset)
-    request.setKind(ChangeKind.CHANGE_DELETE)
-    request.setLength(len)
+    const request = new ChangeRequest()
+      .setSessionId(session_id)
+      .setKind(ChangeKind.CHANGE_DELETE)
+      .setOffset(offset)
+      .setLength(len)
     getLogger().debug({ fn: 'del', rqst: request.toObject() })
     getClient().submitChange(request, (err, r) => {
       if (err) {
@@ -149,25 +151,20 @@ export function del(
  * @param data bytes to insert at the given offset
  * @param stats optional edit stats to update
  * @return positive change serial number on success
- * @remarks If editing data that could have embedded nulls, do not rely on
- * setting the length to 0 and have this function compute the length using
- * strlen, because it will be wrong.  Passing length 0 is a convenience for
- * testing and should not be used in production code.  In production code,
- * explicitly pass in the length.
  */
 export function insert(
   session_id: string,
   offset: number,
-  data: string | Uint8Array,
+  data: Uint8Array,
   stats?: IEditStats
 ): Promise<number> {
   return new Promise<number>((resolve, reject) => {
-    let request = new ChangeRequest()
+    const request = new ChangeRequest()
       .setSessionId(session_id)
+      .setKind(ChangeKind.CHANGE_INSERT)
       .setOffset(offset)
+      .setData(data)
       .setLength(data.length)
-    request.setKind(ChangeKind.CHANGE_INSERT)
-    request.setData(typeof data === 'string' ? Buffer.from(data) : data)
     getLogger().debug({ fn: 'insert', rqst: request.toObject() })
     getClient().submitChange(request, (err, r) => {
       if (err) {
@@ -212,22 +209,20 @@ export function insert(
  * @param data new bytes to overwrite the old bytes with
  * @param stats optional edit stats to update
  * @return positive change serial number on success, zero otherwise
- * @remarks If editing data that could have embedded nulls, do not rely on
- * setting the length to 0 and have this function compute the length using
- * strlen, because it will be wrong.  Passing length 0 is a convenience for
- * testing and should not be used in production code.  In production code,
- * explicitly pass in the length.
  */
 export function overwrite(
   session_id: string,
   offset: number,
-  data: string | Uint8Array,
+  data: Uint8Array,
   stats?: IEditStats
 ): Promise<number> {
   return new Promise<number>((resolve, reject) => {
-    let request = new ChangeRequest().setSessionId(session_id).setOffset(offset)
-    request.setKind(ChangeKind.CHANGE_OVERWRITE)
-    request.setData(typeof data === 'string' ? Buffer.from(data) : data)
+    const request = new ChangeRequest()
+      .setSessionId(session_id)
+      .setKind(ChangeKind.CHANGE_OVERWRITE)
+      .setOffset(offset)
+      .setData(data)
+      .setLength(data.length)
     getLogger().debug({ fn: 'overwrite', rqst: request.toObject() })
     getClient().submitChange(request, (err, r) => {
       if (err) {
@@ -278,7 +273,7 @@ export function replace(
   session_id: string,
   offset: number,
   remove_bytes_count: number,
-  replacement: string | Uint8Array,
+  replacement: Uint8Array,
   stats?: IEditStats
 ): Promise<number> {
   // if no bytes are being removed, this is an insert

--- a/src/rpc/client/ts/tests/specs/encodeDecode.spec.ts
+++ b/src/rpc/client/ts/tests/specs/encodeDecode.spec.ts
@@ -18,17 +18,12 @@
  */
 
 import { expect } from 'chai'
-import { decode, encode } from 'fastestsmallesttextencoderdecoder'
 
 describe('Encode/Decode', () => {
   it('Should encode string into Uint8Array', () => {
-    expect(encode('abc123'))
-      .deep.equals(Buffer.from('abc123'))
-      .and.deep.equals(new Uint8Array([97, 98, 99, 49, 50, 51]))
-  })
-
-  it('Should decode Uint8Array into string', () => {
-    expect('abc123').to.equal(decode(new Uint8Array([97, 98, 99, 49, 50, 51])))
+    expect(Buffer.from('abc123')).deep.equals(
+      new Uint8Array([97, 98, 99, 49, 50, 51])
+    )
   })
 
   it('Should handle ASCII conversions', () => {

--- a/src/rpc/client/ts/tests/specs/profiler.spec.ts
+++ b/src/rpc/client/ts/tests/specs/profiler.spec.ts
@@ -55,7 +55,7 @@ describe('Profiling', () => {
 
     it('Should profile character data', async () => {
       const content = 'abaabbbaaaabbbbc'
-      const change_id = await overwrite(session_id, 0, content)
+      const change_id = await overwrite(session_id, 0, Buffer.from(content))
       expect(change_id).to.be.a('number').that.equals(1)
       const file_size = await getComputedFileSize(session_id)
       expect(file_size).equals(content.length)

--- a/src/rpc/client/ts/tests/specs/search.spec.ts
+++ b/src/rpc/client/ts/tests/specs/search.spec.ts
@@ -41,7 +41,6 @@ import {
   replace,
   undo,
 } from '../../src/change'
-import { encode } from 'fastestsmallesttextencoderdecoder'
 
 // prettier-ignore
 // @ts-ignore
@@ -62,7 +61,7 @@ describe('Searching', () => {
     const change_id = await overwrite(
       session_id,
       0,
-      'haystackneedleNEEDLENeEdLeneedhay'
+      Buffer.from('haystackneedleNEEDLENeEdLeneedhay')
     )
     expect(change_id).to.be.a('number').that.equals(1)
     const file_size = await getComputedFileSize(session_id)
@@ -484,7 +483,7 @@ describe('Searching', () => {
     const change_id = await overwrite(
       session_id,
       0,
-      'needle here needle there needleneedle everywhere'
+      Buffer.from('needle here needle there needleneedle everywhere')
     )
     expect(change_id).to.be.a('number').that.equals(1)
     let [replacementFound, nextOffset] = await replaceOneSession(
@@ -499,7 +498,7 @@ describe('Searching', () => {
     expect(nextOffset).to.equal(4)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item here needle there needleneedle everywhere'))
+    ).deep.equals(Buffer.from('Item here needle there needleneedle everywhere'))
     let ret = await replaceOneSession(
       session_id,
       'needle',
@@ -514,7 +513,7 @@ describe('Searching', () => {
     expect(nextOffset).to.equal(14)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item here Item there needleneedle everywhere'))
+    ).deep.equals(Buffer.from('Item here Item there needleneedle everywhere'))
     ret = await replaceOneSession(
       session_id,
       'needle',
@@ -529,7 +528,7 @@ describe('Searching', () => {
     expect(nextOffset).to.equal(25)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item here Item there Itemneedle everywhere'))
+    ).deep.equals(Buffer.from('Item here Item there Itemneedle everywhere'))
     ret = await replaceOneSession(
       session_id,
       'needle',
@@ -544,7 +543,7 @@ describe('Searching', () => {
     expect(nextOffset).to.equal(29)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item here Item there ItemItem everywhere'))
+    ).deep.equals(Buffer.from('Item here Item there ItemItem everywhere'))
     ret = await replaceOneSession(
       session_id,
       'needle',
@@ -565,7 +564,7 @@ describe('Searching', () => {
     expect(nextOffset).to.equal(6)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item-1 here Item there ItemItem everywhere'))
+    ).deep.equals(Buffer.from('Item-1 here Item there ItemItem everywhere'))
     ret = await replaceOneSession(
       session_id,
       'Item',
@@ -580,7 +579,7 @@ describe('Searching', () => {
     expect(nextOffset).to.equal(18)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item-1 here Item-1 there ItemItem everywhere'))
+    ).deep.equals(Buffer.from('Item-1 here Item-1 there ItemItem everywhere'))
     ret = await replaceOneSession(
       session_id,
       'Item',
@@ -595,7 +594,7 @@ describe('Searching', () => {
     expect(nextOffset).to.equal(31)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item-1 here Item-1 there Item-1Item everywhere'))
+    ).deep.equals(Buffer.from('Item-1 here Item-1 there Item-1Item everywhere'))
     ret = await replaceOneSession(
       session_id,
       'Item',
@@ -610,7 +609,9 @@ describe('Searching', () => {
     expect(nextOffset).to.equal(37)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item-1 here Item-1 there Item-1Item-1 everywhere'))
+    ).deep.equals(
+      Buffer.from('Item-1 here Item-1 there Item-1Item-1 everywhere')
+    )
     ret = await replaceOneSession(
       session_id,
       'Item',
@@ -630,7 +631,7 @@ describe('Searching', () => {
     const change_id = await overwrite(
       session_id,
       0,
-      'needle here needle there needleneedle everywhere',
+      Buffer.from('needle here needle there needleneedle everywhere'),
       stats
     )
     expect(change_id).to.be.a('number').that.equals(1)
@@ -658,7 +659,7 @@ describe('Searching', () => {
     expect(stats.error_count).to.equal(0)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item here Item there ItemItem everywhere'))
+    ).deep.equals(Buffer.from('Item here Item there ItemItem everywhere'))
     expect(await getChangeCount(session_id)).to.equal(9)
     expect(await getChangeTransactionCount(session_id)).to.equal(5)
     expect(await beginSessionTransaction(session_id)).to.equal(session_id)
@@ -697,7 +698,7 @@ describe('Searching', () => {
     expect(stats.error_count).to.equal(0)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item here needle there needleneedle everywhere'))
+    ).deep.equals(Buffer.from('Item here needle there needleneedle everywhere'))
     stats.reset()
     expect(
       await replaceSession(
@@ -713,7 +714,7 @@ describe('Searching', () => {
     ).to.equal(1)
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
-    ).deep.equals(encode('Item here noodle there needleneedle everywhere'))
+    ).deep.equals(Buffer.from('Item here noodle there needleneedle everywhere'))
     // expect a single overwrite
     expect(stats.delete_count).to.equal(0)
     expect(stats.insert_count).to.equal(0)
@@ -801,7 +802,7 @@ describe('Searching', () => {
     const change_id = await overwrite(
       session_id,
       0,
-      'Hey there is hay in my Needles'
+      Buffer.from('Hey there is hay in my Needles')
     )
     expect(change_id).to.equal(1)
     expect(await getComputedFileSize(session_id)).to.equal(30)
@@ -828,6 +829,6 @@ describe('Searching', () => {
     const file_size = await getComputedFileSize(session_id)
     const segment = await getSegment(session_id, 0, file_size)
     expect(segment.length).to.equal(file_size)
-    expect(segment).deep.equals(encode('Hey there are needles in my hay'))
+    expect(segment).deep.equals(Buffer.from('Hey there are needles in my hay'))
   })
 })

--- a/src/rpc/client/ts/tests/specs/stressTest.spec.ts
+++ b/src/rpc/client/ts/tests/specs/stressTest.spec.ts
@@ -38,7 +38,6 @@ import {
   destroyViewport,
   getViewportData,
 } from '../../src/viewport'
-import { decode, encode } from 'fastestsmallesttextencoderdecoder'
 import {
   EventSubscriptionRequest,
   SessionEventKind,
@@ -126,7 +125,7 @@ async function subscribeViewport(
             ', length: ' +
             viewportEvent.getLength() +
             ', data: "' +
-            decode(viewportEvent.getData()) +
+            viewportEvent.getData() +
             '", callbacks: ' +
             viewport_callbacks.get(viewport_id)
         )
@@ -157,7 +156,7 @@ describe('StressTest', () => {
   })
 
   it('Should handle fast inserting', async () => {
-    const data = encode(
+    const data = Buffer.from(
       'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:",<.>/?`~'.repeat(
         10
       )
@@ -194,7 +193,7 @@ describe('StressTest', () => {
   }).timeout(10000)
 
   it('Should handle fast appending', async () => {
-    const data = encode(
+    const data = Buffer.from(
       'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:",<.>/?`~'.repeat(
         10
       )
@@ -233,7 +232,7 @@ describe('StressTest', () => {
     async () => {
       expect(full_rotations).to.be.a('number').greaterThan(0)
 
-      const data = encode(
+      const data = Buffer.from(
         'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:",<.>/?`~'
       )
       await subscribeSession(session_id, ALL_EVENTS)
@@ -277,7 +276,7 @@ describe('StressTest', () => {
       await subscribeViewport(viewport_id, ALL_EVENTS)
       await subscribeViewport(viewport_2_id, ALL_EVENTS)
 
-      expect(decode(viewport_response.getData_asU8())).to.equal('~')
+      expect(viewport_response.getData_asU8()).to.deep.equal(Buffer.from('~'))
 
       let rotations = file_size * full_rotations
       const expected_num_changes = 1 + 3 * file_size * full_rotations
@@ -286,9 +285,9 @@ describe('StressTest', () => {
         log_info('\x1b[33m%s\x1b[0mrotations remaining: ' + rotations)
         let viewport_data = await getViewportData(viewport_id)
 
-        change_id = await insert(session_id, 0, ' ')
+        change_id = await insert(session_id, 0, Buffer.from(' '))
         expect(
-          await overwrite(session_id, 0, decode(viewport_data.getData_asU8()))
+          await overwrite(session_id, 0, viewport_data.getData_asU8())
         ).to.equal(1 + change_id)
 
         expect((await undo(session_id)) * -1).to.equal(await redo(session_id))

--- a/src/rpc/client/ts/yarn.lock
+++ b/src/rpc/client/ts/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@grpc/grpc-js@^1.8.9":
+"@grpc/grpc-js@^1.8.11":
   version "1.8.11"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.11.tgz#f113f7bc197e8d6f3d3f0c6b02925c7a5da1aec4"
   integrity sha512-f/xC+6Z2QKsRJ+VSSFlt4hA5KSRm+PKvMWV8kMPkMgGlFidR6PeIkXrOasIY2roe+WROM6GFQLlgDKfeEZo2YQ==
@@ -467,11 +467,6 @@ fast-redact@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.1.2.tgz#d58e69e9084ce9fa4c1a6fa98a3e1ecf5d7839aa"
   integrity sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==
 
-fastestsmallesttextencoderdecoder@^1.0.22:
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz#59b47e7b965f45258629cc6c127bf783281c5e93"
-  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
-
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -586,14 +581,14 @@ google-protobuf@^3.21.2:
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.2.tgz#4580a2bea8bbb291ee579d1fefb14d6fa3070ea4"
   integrity sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==
 
-grpc-tools@^1.11.3:
+grpc-tools@^1.12.4:
   version "1.12.4"
   resolved "https://registry.yarnpkg.com/grpc-tools/-/grpc-tools-1.12.4.tgz#a044c9e8157941033ea7a5f144c2dc9dc4501de4"
   integrity sha512-5+mLAJJma3BjnW/KQp6JBjUMgvu7Mu3dBvBPd1dcbNIb+qiR0817zDpgPjS7gRb+l/8EVNIa3cB02xI9JLToKg==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.5"
 
-grpc_tools_node_protoc_ts@^5.3.2:
+grpc_tools_node_protoc_ts@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/grpc_tools_node_protoc_ts/-/grpc_tools_node_protoc_ts-5.3.3.tgz#9a6c1c2f41563a1ab259c0177496d7dfed30dbfe"
   integrity sha512-M/YrklvVXMtuuj9kb42PxeouZhs7Ul+R4e/31XwrankUcKL8cQQP50Q9q+KEHGyHQaPt6VtKKsxMgLaKbCxeww==
@@ -969,7 +964,7 @@ pino-std-serializers@^6.0.0:
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz#307490fd426eefc95e06067e85d8558603e8e844"
   integrity sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==
 
-pino@^8.10.0:
+pino@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/pino/-/pino-8.11.0.tgz#2a91f454106b13e708a66c74ebc1c2ab7ab38498"
   integrity sha512-Z2eKSvlrl2rH8p5eveNUnTdd4AjJk8tAsLkHYZQKGHP4WTh2Gi1cOSOs3eWPqaj+niS3gj4UkoreoaWgF3ZWYg==
@@ -986,7 +981,7 @@ pino@^8.10.0:
     sonic-boom "^3.1.0"
     thread-stream "^2.0.0"
 
-prettier@^2.6.2:
+prettier@^2.8.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
   integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
@@ -1218,7 +1213,7 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-ts-node@^10.7.0:
+ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -1252,7 +1247,7 @@ typedoc@^0.23.16:
     minimatch "^7.1.3"
     shiki "^0.14.1"
 
-typescript@^4.8.4:
+typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==

--- a/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/SessionImpl.scala
+++ b/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/SessionImpl.scala
@@ -93,14 +93,8 @@ private[omega_edit] class SessionImpl(p: Pointer, i: FFI) extends Session {
   def insert(b: Array[Byte], offset: Long): Result =
     Edit(i.omega_edit_insert_bytes(p, offset, b, b.length.toLong))
 
-  def insert(s: String, offset: Long): Result =
-    Edit(i.omega_edit_insert(p, offset, s, 0))
-
   def overwrite(b: Array[Byte], offset: Long): Result =
     Edit(i.omega_edit_overwrite_bytes(p, offset, b, b.length.toLong))
-
-  def overwrite(s: String, offset: Long): Result =
-    Edit(i.omega_edit_overwrite(p, offset, s, 0))
 
   /** omega_edit_undo_last_change returns the *negative* serial number of the
     * change, so perform different matching for change id

--- a/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/api/Session.scala
+++ b/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/api/Session.scala
@@ -41,10 +41,8 @@ trait Session {
   def eventInterest: Int
   def eventInterest_=(eventInterest: Int): Unit
 
-  def insert(s: String, offset: Long): Result
   def insert(b: Array[Byte], offset: Long): Result
 
-  def overwrite(s: String, offset: Long): Result
   def overwrite(b: Array[Byte], offset: Long): Result
 
   def delete(offset: Long, len: Long): Result

--- a/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/ChangeImplSpec.scala
+++ b/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/ChangeImplSpec.scala
@@ -24,18 +24,26 @@ import org.scalatest.wordspec.AnyWordSpec
 class ChangeImplSpec extends AnyWordSpec with Matchers with TestSupport {
   "session edits" must {
     "provide" in emptySession { implicit s =>
-      changeFor(s.insert("abc", 0)) should matchPattern {
+      changeFor(s.insert("abc".getBytes(), 0)) should matchPattern {
         case Change(1, 0, 3, Change.Insert) =>
       }
     }
 
     "provide serial number" in emptySession { s =>
       s.isEmpty shouldBe true
-      s.insert("abc", 0) shouldBe Change.Changed(1)
+      s.insert("abc".getBytes(), 0) shouldBe Change.Changed(1)
       s.isEmpty shouldBe false
       s.size shouldBe 3
-      s.insert("123", 0) shouldBe Change.Changed(2)
+      s.getSegment(0, s.size) match {
+        case Some(s) => s.data shouldBe "abc".getBytes()
+        case _       => fail()
+      }
+      s.insert("123".getBytes, 0) shouldBe Change.Changed(2)
       s.size shouldBe 6
+      s.getSegment(0, s.size) match {
+        case Some(s) => s.data shouldBe "123abc".getBytes()
+        case _       => fail()
+      }
     }
   }
 }

--- a/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/SessionImplSpec.scala
+++ b/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/SessionImplSpec.scala
@@ -96,12 +96,12 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
 
   "a callback" should {
     "include the event" in emptySessionWithCallback { (s, cb) =>
-      s.insert("foo", 0) should matchPattern { case Changed(_) => }
+      s.insert("foo".getBytes(), 0) should matchPattern { case Changed(_) => }
       cb.event.value shouldBe SessionEvent.Edit
     }
 
     "include the change" in emptySessionWithCallback { (s, cb) =>
-      s.insert("bar", 0)
+      s.insert("bar".getBytes(), 0)
       cb.change.flatten.value.operation shouldBe Change.Insert
     }
   }
@@ -124,7 +124,7 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
       val dat = tmp.resolve(Paths.get("dat.txt"))
       val expected = UUID.randomUUID().toString
 
-      s.insert(expected, 0)
+      s.insert(expected.getBytes(), 0)
       s.save(dat) shouldBe Success(dat)
 
       fileContents(dat) shouldBe expected
@@ -135,7 +135,7 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
       dat.toFile.exists() shouldBe true
       val expected = UUID.randomUUID().toString
 
-      s.insert(expected, 0)
+      s.insert(expected.getBytes(), 0)
       s.save(dat, OverwriteStrategy.OverwriteExisting) shouldBe Success(dat)
 
       fileContents(dat) shouldBe expected
@@ -146,7 +146,7 @@ class SessionImplSpec extends AnyWordSpec with Matchers with SessionSupport {
       dat.toFile.exists() shouldBe true
 
       val expected = UUID.randomUUID().toString
-      s.insert(expected, 0)
+      s.insert(expected.getBytes(), 0)
 
       val r = s.save(dat, OverwriteStrategy.GenerateFilename)
       r.isSuccess shouldBe true

--- a/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/ViewportImplSpec.scala
+++ b/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/ViewportImplSpec.scala
@@ -84,13 +84,13 @@ class ViewportImplSpec extends AnyWordSpec with Matchers with TestSupport {
 
   "a callback" should {
     "be updated" in emptySession(viewWithCallback(0, 1, false, _) { (s, v) =>
-      s.insert("foo", 0)
+      s.insert("foo".getBytes(), 0)
       withClue(v) { v.data.map(_ shouldBe "f".getBytes()) }
     })
 
     "include the change type" in emptySession(viewWithCallback(0, 1, false, _) {
       (s, v) =>
-        s.insert("foo", 0)
+        s.insert("foo".getBytes(), 0)
         v.change shouldBe defined
         v.change.get.operation shouldBe Change.Insert
     })


### PR DESCRIPTION
This patch makes sure that we never edit using strings by mistake.