### PR TITLE
add additional callback queue capacity

### DIFF
--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
@@ -42,7 +42,9 @@ import scala.util.Failure
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class EditorService(implicit val system: ActorSystem) extends Editor {
-  private implicit val timeout: Timeout = Timeout(5000.milliseconds)
+  private implicit val timeout: Timeout = Timeout(
+    5000.milliseconds
+  ) // 5 seconds
   private val editors = system.actorOf(Editors.props())
   import system.dispatcher
 

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
@@ -72,7 +72,7 @@ object Editors {
 
 class Editors extends Actor with ActorLogging {
   import Editors._
-  implicit val timeout: Timeout = Timeout(5000.milliseconds)
+  implicit val timeout: Timeout = Timeout(5000.milliseconds) // 5 seconds
 
   def receive: Receive = {
     case Create(sid, path) =>
@@ -83,7 +83,7 @@ class Editors extends Actor with ActorLogging {
         case None =>
           import context.system
           val (input, stream) = Source
-            .queue[SessionEvent](5, OverflowStrategy.backpressure)
+            .queue[SessionEvent](16, OverflowStrategy.backpressure)
             .preMaterialize()
           val cb = SessionCallback { (session, event, change) =>
             input.queue.offer(

--- a/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
+++ b/src/rpc/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
@@ -172,7 +172,7 @@ class Session(
           sender() ! Err(Status.ALREADY_EXISTS)
         case None =>
           val (input, stream) = Source
-            .queue[ViewportEvent](5, OverflowStrategy.backpressure)
+            .queue[ViewportEvent](16, OverflowStrategy.backpressure)
             .preMaterialize() // preMaterialize the queue to obtain the input and stream objects
           val cb = ViewportCallback { (v, e, c) =>
             input.queue.offer(


### PR DESCRIPTION
Application layer code can issue many requests, for instance sending deletes, inserts, and a variety of counts which can quickly fill the callback queue.  This patch will bump the queue depth from 5 to 16.  Ideally this depth would be configurable.