### PR TITLE
update grpc to 1.8.12 for bug fix

### DIFF
--- a/src/rpc/client/ts/package.json
+++ b/src/rpc/client/ts/package.json
@@ -41,7 +41,7 @@
     "typedoc": "^0.23.16"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.8.11",
+    "@grpc/grpc-js": "^1.8.12",
     "@types/google-protobuf": "^3.15.5",
     "@types/node": "^18.8.4",
     "google-protobuf": "^3.21.2",

--- a/src/rpc/client/ts/yarn.lock
+++ b/src/rpc/client/ts/yarn.lock
@@ -10,9 +10,9 @@
     "@jridgewell/trace-mapping" "0.3.9"
 
 "@grpc/grpc-js@^1.8.11":
-  version "1.8.11"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.11.tgz#f113f7bc197e8d6f3d3f0c6b02925c7a5da1aec4"
-  integrity sha512-f/xC+6Z2QKsRJ+VSSFlt4hA5KSRm+PKvMWV8kMPkMgGlFidR6PeIkXrOasIY2roe+WROM6GFQLlgDKfeEZo2YQ==
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.12.tgz#bc0120859e8b153db764b473cc019ddf6bb2b414"
+  integrity sha512-MbUMvpVvakeKhdYux6gbSIPJaFMLNSY8jw4PqLI+FFztGrQRrYYAnHlR94+ncBQQewkpXQaW449m3tpH/B/ZnQ==
   dependencies:
     "@grpc/proto-loader" "^0.7.0"
     "@types/node" ">=12.12.47"


### PR DESCRIPTION
This update fixes an order of operations bug in gRPC.js.