### PR TITLE
do not enable debug for logger in production

### DIFF
--- a/src/rpc/server/scala/serv/src/main/resources/logback.xml
+++ b/src/rpc/server/scala/serv/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
  *                                                                                                                    *
  **********************************************************************************************************************
 -->
-<configuration debug="true">
+<configuration>
 
     <property name="LOG_PATH" value="logs" />
     <property name="LOG_ARCHIVE" value="${LOG_PATH}/archive" />


### PR DESCRIPTION
Debug statements for the logger itself is useful for testing and debug builds, but should be disabled for production.