### PR TITLE
handle empty search pattern in TS client

### DIFF
--- a/src/rpc/client/ts/src/session.ts
+++ b/src/rpc/client/ts/src/session.ts
@@ -520,6 +520,11 @@ export function searchSession(
   limit: number = 0
 ): Promise<number[]> {
   return new Promise<number[]>((resolve, reject) => {
+    // make sure we have a pattern to search for
+    if (pattern.length === 0) {
+      getLogger().warn({ fn: 'searchSession', msg: 'empty pattern given' })
+      return resolve([])
+    }
     let request = new SearchRequest()
       .setSessionId(session_id)
       .setPattern(typeof pattern === 'string' ? Buffer.from(pattern) : pattern)


### PR DESCRIPTION
The Ωedit library `asserts` that the pattern length is positive and would die on empty patterns.  Handle this in the client.