### PR TITLE
Fix notify changed viewports

### DIFF
--- a/src/include/omega_edit/viewport.h
+++ b/src/include/omega_edit/viewport.h
@@ -143,9 +143,10 @@ OMEGA_EDIT_EXPORT int omega_viewport_in_segment(const omega_viewport_t *viewport
  * @param viewport_ptr viewport for which to execute its on-change callback
  * @param viewport_event event kind that is taking place
  * @param event_ptr change responsible for the viewport change (if any)
+ * @return 1 if the viewport on-change callback was executed, 0 if the viewport on-change callback was not executed
  */
-OMEGA_EDIT_EXPORT void omega_viewport_notify(const omega_viewport_t *viewport_ptr,
-                                             omega_viewport_event_t viewport_event, const void *event_ptr);
+OMEGA_EDIT_EXPORT int omega_viewport_notify(const omega_viewport_t *viewport_ptr, omega_viewport_event_t viewport_event,
+                                            const void *event_ptr);
 
 #ifdef __cplusplus
 }

--- a/src/lib/session.cpp
+++ b/src/lib/session.cpp
@@ -143,10 +143,9 @@ int omega_session_notify_changed_viewports(const omega_session_t *session_ptr) {
     assert(session_ptr);
     int result = 0;
     for (const auto &viewport : session_ptr->viewports_) {
-        if (omega_viewport_has_changes(viewport.get())) {
-            omega_viewport_notify(viewport.get(), VIEWPORT_EVT_CHANGES, nullptr);
+        if (omega_viewport_has_changes(viewport.get()) &&
+            1 == omega_viewport_notify(viewport.get(), VIEWPORT_EVT_CHANGES, nullptr))
             ++result;
-        }
     }
     return result;
 }

--- a/src/lib/viewport.cpp
+++ b/src/lib/viewport.cpp
@@ -16,7 +16,6 @@
 #include "../include/omega_edit/segment.h"
 #include "../include/omega_edit/session.h"
 #include "impl_/internal_fun.hpp"
-#include "impl_/macros.h"
 #include "impl_/session_def.hpp"
 #include "impl_/viewport_def.hpp"
 #include <cassert>
@@ -127,13 +126,14 @@ int omega_viewport_in_segment(const omega_viewport_t *viewport_ptr, int64_t offs
                    : 0;
 }
 
-void omega_viewport_notify(const omega_viewport_t *viewport_ptr, omega_viewport_event_t viewport_event,
+int omega_viewport_notify(const omega_viewport_t *viewport_ptr, omega_viewport_event_t viewport_event,
                            const void *event_ptr) {
     assert(viewport_ptr);
     assert(viewport_ptr->session_ptr);
     if (viewport_ptr->event_handler && (viewport_event & viewport_ptr->event_interest_) &&
         !omega_session_viewport_event_callbacks_paused(viewport_ptr->session_ptr)) {
-        //LOG_ERROR("viewport: " << viewport_ptr << ", event: " << viewport_event << ", interest: " << viewport_ptr->event_interest_);
         (*viewport_ptr->event_handler)(viewport_ptr, viewport_event, event_ptr);
+        return 1;
     }
+    return 0;
 }

--- a/src/rpc/client/ts/src/logger.ts
+++ b/src/rpc/client/ts/src/logger.ts
@@ -20,19 +20,25 @@
 import pino from 'pino'
 import * as fs from 'fs'
 
+/**
+ * Logger type
+ * @typedef {pino.Logger} Logger
+ */
+export type Logger = pino.Logger
+
 // internal singleton logger instance
-let logger_: pino.Logger
+let logger_: Logger
 
 /**
- * Builds a pino logger
+ * Builds a logger
  * @param transports array of transports to log to
  * @param level log level
- * @returns pino logger
+ * @returns logger
  */
 function buildLogger(
   transports: any[],
   level: string = process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL || 'info'
-): pino.Logger {
+): Logger {
   const logger = pino({ level: level, transports: transports })
   logger.debug({
     fn: 'buildLogger',
@@ -44,23 +50,23 @@ function buildLogger(
 }
 
 /**
- * Creates a pino file logger
+ * Creates a file logger
  * @param logFilePath path to log file
  * @param level log level
- * @returns pino logger
+ * @returns logger
  */
 export function createSimpleFileLogger(
   logFilePath: string,
   level: string = process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL || 'info'
-): pino.Logger {
+): Logger {
   return pino({ level: level }, fs.createWriteStream(logFilePath))
 }
 
 /**
  * Gets the logger, creating it if necessary
- * @returns pino logger
+ * @returns logger
  */
-export function getLogger(): pino.Logger {
+export function getLogger(): Logger {
   if (!logger_) {
     setLogger(
       buildLogger([
@@ -79,7 +85,7 @@ export function getLogger(): pino.Logger {
  * Sets the logger
  * @param logger new logger instance
  */
-export function setLogger(logger: pino.Logger) {
+export function setLogger(logger: Logger) {
   logger_ = logger
   getLogger().info({ fn: 'setLogger', msg: 'logger set' })
 }

--- a/src/rpc/client/ts/tests/fixtures.ts
+++ b/src/rpc/client/ts/tests/fixtures.ts
@@ -50,7 +50,7 @@ function getPidFile(port: number): string {
  */
 export async function mochaGlobalSetup(): Promise<number | undefined> {
   const pidFile = getPidFile(testPort)
-  const logFile = path.join(rootPath, 'test.log')
+  const logFile = path.join(rootPath, 'client-tests.log')
   const level = process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL || 'info'
   const logger = createSimpleFileLogger(logFile, level)
 

--- a/src/rpc/client/ts/tests/specs/session.spec.ts
+++ b/src/rpc/client/ts/tests/specs/session.spec.ts
@@ -23,6 +23,7 @@ import {
   destroySession,
   getComputedFileSize,
   getSessionCount,
+  notifyChangedViewports,
   profileSession,
 } from '../../src/session'
 // @ts-ignore
@@ -84,6 +85,7 @@ describe('Sessions', () => {
       expect(serverHeartbeat.latency).to.be.greaterThanOrEqual(0)
       expect(serverHeartbeat.resp).to.equal(getClientVersion())
       expect(await profileSession(session_id)).to.deep.equal(expected_profile)
+      expect(await notifyChangedViewports(session_id)).to.equal(0)
       await destroySession(session_id)
       expect(await getSessionCount()).to.equal(0)
     }

--- a/src/rpc/protos/omega_edit.proto
+++ b/src/rpc/protos/omega_edit.proto
@@ -72,6 +72,7 @@ enum ChangeKind {
   CHANGE_OVERWRITE = 3;
 }
 
+// Make sure these match the session events defined in fwd_defs.h
 enum SessionEventKind {
   SESSION_EVT_UNDEFINED = 0;
   SESSION_EVT_CREATE = 1;
@@ -88,6 +89,7 @@ enum SessionEventKind {
   SESSION_EVT_DESTROY_VIEWPORT = 2048;
 }
 
+// Make sure these match the viewport events defined in fwd_defs.h
 enum ViewportEventKind {
   VIEWPORT_EVT_UNDEFINED = 0;
   VIEWPORT_EVT_CREATE = 1;
@@ -96,6 +98,7 @@ enum ViewportEventKind {
   VIEWPORT_EVT_CLEAR = 8;
   VIEWPORT_EVT_TRANSFORM = 16;
   VIEWPORT_EVT_MODIFY = 32;
+  VIEWPORT_EVT_CHANGES = 64;
 }
 
 enum CountKind {

--- a/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/api/SessionEvent.scala
+++ b/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/api/SessionEvent.scala
@@ -23,6 +23,7 @@ import enumeratum.values.IntEnum
   */
 sealed abstract class SessionEvent(val value: Int) extends IntEnumEntry
 object SessionEvent extends IntEnum[SessionEvent] {
+  // must match session events defined in omega_edit.proto
   case object Undefined extends SessionEvent(0)
   case object Create extends SessionEvent(1)
   case object Edit extends SessionEvent(2)

--- a/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/api/ViewportEvent.scala
+++ b/src/rpc/server/scala/api/src/main/scala/com/ctc/omega_edit/api/ViewportEvent.scala
@@ -22,6 +22,7 @@ import enumeratum.values._
   */
 sealed abstract class ViewportEvent(val value: Int) extends IntEnumEntry
 object ViewportEvent extends IntEnum[ViewportEvent] {
+  // must match viewport events defined in omega_edit.proto
   case object Undefined extends ViewportEvent(0)
   case object Create extends ViewportEvent(1)
   case object Edit extends ViewportEvent(2)
@@ -29,6 +30,7 @@ object ViewportEvent extends IntEnum[ViewportEvent] {
   case object Clear extends ViewportEvent(8)
   case object Transform extends ViewportEvent(16)
   case object Modify extends ViewportEvent(32)
+  case object Changes extends ViewportEvent(64)
 
   val values = findValues
 

--- a/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/ViewportImplSpec.scala
+++ b/src/rpc/server/scala/api/src/test/scala/com/ctc/omega_edit/ViewportImplSpec.scala
@@ -45,7 +45,7 @@ class ViewportImplSpec extends AnyWordSpec with Matchers with TestSupport {
     "offset data" in session("abc")(view(1, 1, false, _) { (s, v) =>
       s.size shouldBe 3
       v.hasChanges shouldBe true
-      s.notifyChangedViewports shouldBe 1
+      s.notifyChangedViewports shouldBe 0
       v.data shouldBe "b".getBytes()
       v.hasChanges shouldBe false
       s.notifyChangedViewports shouldBe 0

--- a/src/tests/omega_test.cpp
+++ b/src/tests/omega_test.cpp
@@ -778,7 +778,7 @@ TEST_CASE("Search", "[SearchTests]") {
     REQUIRE(NO_EVENTS == omega_viewport_get_event_interest(vpt));
     REQUIRE(0 == omega_viewport_get_following_byte_count(vpt));
     REQUIRE(0 != omega_viewport_has_changes(vpt));
-    REQUIRE(1 == omega_session_notify_changed_viewports(session_ptr));
+    REQUIRE(0 == omega_session_notify_changed_viewports(session_ptr)); // no event interest, so no notifications
     REQUIRE(ALL_EVENTS == omega_viewport_set_event_interest(vpt, ALL_EVENTS));
     REQUIRE(ALL_EVENTS == omega_viewport_get_event_interest(vpt));
     REQUIRE(vpt_change_cbk == omega_viewport_get_event_cbk(vpt));


### PR DESCRIPTION
Updated a test case that was able to trigger the `13 INTERNAL` error on notifying changed viewports.  The logs then showed that it was missing an enumeration value in the Scala and the `omega_edit.proto` file.  Those enumerations were added.  Additionally the notify event now returns the number of changed viewports _that had their callbacks called_ (they had a callback registered and they expressed interest) instead of just the number of viewports that have changes.