### PR TITLE
remove stale server pidfile (as needed)

### DIFF
--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -196,6 +196,8 @@ export async function startServer(
           `server pidFile ${pidFile} already exists and server shutdown using PID ${pidFromFile} failed`
         )
       }
+      // remove stale pidFile (as needed)
+      fs.unlinkSync(pidFile)
     }
   }
 


### PR DESCRIPTION
If a previous pidFile is there, and the server isn't running, it is possible that when starting up a new Data Editor, that a stale pidFile could be left behind.  This PR cleans that up.