### PR TITLE
do not fail fast on CI matrix jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       matrix:
         os: [ windows-2022, macos-12, ubuntu-20.04 ]
-    name: Native build and test on ${{ matrix.os }}
+      fail-fast: false  # don't immediately fail all other jobs if a single job fails
+    name: Native build and test on ${{ matrix.os }} 🦙
     runs-on: ${{ matrix.os }}
     steps:
       - name: Enable Developer Command Prompt 💻
@@ -67,6 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-12, ubuntu-20.04 ] # TODO: add windows-2022 (currently it's timing out on Package Scala API)
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout 🛎️
@@ -79,7 +81,7 @@ jobs:
           java-version: 8
           cache: sbt
 
-      - name: Make _install/lib directory to store lib files
+      - name: Make _install/lib directory to store lib files 🔧
         run: mkdir -p _install/lib
 
       - name: Download macos library file 🔻
@@ -140,15 +142,15 @@ jobs:
         working-directory: server/scala
         timeout-minutes: 30
 
-      - name: Yarn Install
+      - name: Yarn Install 🏗️
         run: yarn
         shell: bash
 
-      - name: Yarn Package - Server
+      - name: Yarn Package - Server 📦
         run: yarn workspace @omega-edit/server package
         shell: bash
 
-      - name: Yarn Test - Client
+      - name: Yarn Test - Client 🧑‍💼
         run: yarn workspace @omega-edit/client test
         shell: bash
         timeout-minutes: 30


### PR DESCRIPTION
Disable fail-fast on matrix jobs so we can see if all the other platforms would pass or fail.