### PR TITLE
Include file size in session creation response if a file name was given

### DIFF
--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -120,6 +120,8 @@ describe('Sessions', () => {
       expect(session_id).to.equal(expected_session_id)
       expect(session.hasContentType()).to.be.true
       expect(session.getContentType()).to.equal('text/html')
+      expect(session.hasFileSize()).to.be.true
+      expect(session.getFileSize()).to.equal(fileData.length)
       expect(await getSessionCount()).to.equal(1)
       expect(fileData.length).to.equal(await getComputedFileSize(session_id))
       const vpt_response = await createViewport(
@@ -227,6 +229,8 @@ describe('Sessions', () => {
     const session2 = await createSession()
     const session_id2 = session2.getSessionId()
     expect(session_id1).to.not.equal(session_id2)
+    expect(session1.hasContentType()).to.be.false
+    expect(session1.hasFileSize()).to.be.false
 
     let change_id = await insert(session_id1, 0, Buffer.from('a'))
     expect(change_id).to.equal(1)

--- a/proto/omega_edit.proto
+++ b/proto/omega_edit.proto
@@ -198,6 +198,7 @@ message CreateSessionResponse {
   string session_id = 1;
   string checkpoint_directory = 2;
   optional string content_type = 3;
+  optional int64 file_size = 4;
 }
 
 message SaveSessionRequest {

--- a/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
+++ b/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
@@ -71,7 +71,7 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
   def createSession(in: CreateSessionRequest): Future[CreateSessionResponse] =
     if (isGracefulShutdown) {
       // If server is to shutdown gracefully, don't create new sessions
-      Future.successful(CreateSessionResponse("", "", None))
+      Future.successful(CreateSessionResponse("", "", None, None))
     } else {
       val filePath = in.filePath.map(Paths.get(_))
       val chkptDir = in.checkpointDirectory.map(Paths.get(_))
@@ -82,8 +82,13 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
             filePath match {
               // If a file path is provided, detect file type, otherwise return None
               case Some(path) =>
-                CreateSessionResponse(ok.id, ok.checkpointDirectory.toString, detectFileType(path.toString))
-              case None => CreateSessionResponse(ok.id, ok.checkpointDirectory.toString, None)
+                CreateSessionResponse(
+                  ok.id,
+                  ok.checkpointDirectory.toString,
+                  detectFileType(path.toString),
+                  Option(ok.fileSize)
+                )
+              case None => CreateSessionResponse(ok.id, ok.checkpointDirectory.toString, None, None)
             }
           case Ok(id) =>
             throw grpcFailure(Status.INTERNAL, s"didn't receive checkpoint directory for session '$id'")

--- a/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
+++ b/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Editors.scala
@@ -114,7 +114,7 @@ class Editors extends Actor with ActorLogging {
             ),
             id
           )
-          sender() ! CheckpointDirectory.ok(id, session.checkpointDirectory)
+          sender() ! CheckpointDirectory.ok(id, session.checkpointDirectory, session.size)
       }
 
     case Find(id) =>

--- a/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
+++ b/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/Session.scala
@@ -130,12 +130,14 @@ object Session {
 
   trait CheckpointDirectory {
     def checkpointDirectory: Path
+    def fileSize: Long
   }
 
   object CheckpointDirectory {
-    def ok(sessionId: String, checkpointDirectory0: Path): Ok with CheckpointDirectory =
+    def ok(sessionId: String, checkpointDirectory0: Path, size: Long): Ok with CheckpointDirectory =
       new Ok(sessionId) with CheckpointDirectory {
         val checkpointDirectory: Path = checkpointDirectory0
+        val fileSize: Long = size
       }
   }
 


### PR DESCRIPTION
It is useful to immediately know the file size in addition to its type when a session is created.