### PR TITLE
build on older OS versions to support older OS versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   deploy-docs:
-    runs-on: macos-12
+    runs-on: macos-11
     steps:
       - name: Install Prerequisites 📚
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
   build-lib:
     strategy:
       matrix:
-        os: [ windows-2022, macos-12, ubuntu-20.04 ]
+        os: [ windows-2019, macos-11, ubuntu-20.04 ] # NOTE: build on older OS versions to support older OS versions
     name: Native build and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [create-release]
@@ -112,7 +112,7 @@ jobs:
   native-build-mac-win:
     strategy:
       matrix:
-        os: [macos-12, windows-2022]
+        os: [macos-11, windows-2019] # NOTE: build on older OS versions to support older OS versions
     name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [build-lib]
@@ -231,12 +231,12 @@ jobs:
       - name: Download macos Native JARs 🔻
         uses: actions/download-artifact@v3
         with:
-          name: macos-12-artifacts
+          name: macos-11-artifacts
 
       - name: Download windows Native JARs 🔻
         uses: actions/download-artifact@v3
         with:
-          name: windows-2022-artifacts
+          name: windows-2019-artifacts
 
       - name: Move windows and macos jars out 🚚
         env:
@@ -308,7 +308,7 @@ jobs:
 
   node-build:
     name: Node Release ✨
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04 # NOTE: build on older OS versions to support older OS versions
     needs: [scala-publish]
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
   build-native:
     strategy:
       matrix:
-        os: [ windows-2022, macos-12, ubuntu-20.04 ]
+        os: [ windows-2019, macos-11, ubuntu-20.04 ] # NOTE: build on older OS versions to support older OS versions
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     name: Native build and test on ${{ matrix.os }} 🦙
     runs-on: ${{ matrix.os }}
@@ -67,7 +67,7 @@ jobs:
     needs: [ build-native ]
     strategy:
       matrix:
-        os: [ macos-12, ubuntu-20.04 ] # TODO: add windows-2022 (currently it's timing out on Package Scala API)
+        os: [ macos-11, ubuntu-20.04 ] # TODO: add windows-2019 (currently it's timing out on Package Scala API)
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The idea here is that most of the time binaries built on an older version of the OS will continue to work on a newer version of the OS, but binaries built on a newer version of the OS are much less likely to work on an older version of the OS.