### PR TITLE
Rework release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,80 @@ env:
     echo "PKG_VERSION=$PKG_VERSION" >> $GITHUB_ENV
 
 jobs:
+  quality-gate:
+    name: Quality Gate
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check ratCheck
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: rat-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "Rat Check"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      
+      - name: Check scala format
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: scala-format
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "Scala code is properly formatted"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      
+      - name: Check typescript format
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: ts-format
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "TypeScript code is properly formatted"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      
+      - name: Check tests - macos
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: macos-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "Build middleware macos-11 🔧"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check tests - ubuntu
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: ubuntu-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "Build middleware ubuntu-20.04 🔧"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      
+      - name: Check tests - windows
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: windows-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "Build middleware windows-2019 🔧"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Quality gate
+        if: steps.rat-check.outputs.conclusion != 'success' || steps.scala-format.outputs.conclusion != 'success' || steps.ts-format.outputs.conclusion != 'success' || steps.macos-tests.outputs.conclusion != 'success' || steps.ubuntu-tests.outputs.conclusion != 'success' || steps.windows-tests.outputs.conclusion != 'success'
+        run: |
+          echo "Rat Check Status: ${{ steps.rat-check.conclusion }}"
+          echo "Scala Format Status: ${{ steps.scala-format.conclusion }}"
+          echo "Typescript Format Status: ${{ steps.ts-format.conclusion }}"
+          echo "MacOS Test Status: ${{ steps.macos-tests.conclusion }}"
+          echo "Ubuntu Test Status: ${{ steps.ubuntu-tests.conclusion }}"
+          echo "Windows Test Status: ${{ steps.windows-tests.conclusion }}"
+          false
+
   create-release:
     name: Create Release ✨
+    needs: [quality-gate]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
@@ -63,127 +135,8 @@ jobs:
           name: upload_url
           path: upload_url
 
-  build-lib:
-    strategy:
-      matrix:
-        os: [ windows-2019, macos-11, ubuntu-20.04 ] # NOTE: build on older OS versions to support older OS versions
-    name: Native build and test on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    needs: [create-release]
-    steps:
-      - name: Enable Developer Command Prompt 💻
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3
-
-      - name: Setup cmake 🔧
-        uses: lukka/get-cmake@latest
-
-      - name: Prepare, Build, and Install Ωedit 🔧
-        run: |
-          cmake -S core -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON --install-prefix "${PWD}/_install"
-          cmake --build build --config Release
-          ctest -C Release --test-dir build --output-on-failure
-          cmake --install build/packaging --prefix "${PWD}/_install" --config Release
-
-      - name: Upload Native (.dylib) library - Macos 🔺
-        uses: actions/upload-artifact@v3
-        if: runner.os == 'macOS'
-        with:
-          name: libomega_edit.dylib
-          path: _install/lib/libomega_edit.dylib
-
-      - name: Upload Native (.so) library - Linux 🔺
-        uses: actions/upload-artifact@v3
-        if: runner.os == 'Linux'
-        with:
-          name: libomega_edit.so
-          path: _install/lib/libomega_edit.so
-
-      - name: Upload Native (.dll) library - Windows 🔺
-        uses: actions/upload-artifact@v3
-        if: runner.os == 'Windows'
-        with:
-          name: omega_edit.dll
-          path: _install/bin/omega_edit.dll
-
-  native-build-mac-win:
-    strategy:
-      matrix:
-        os: [macos-11, windows-2019] # NOTE: build on older OS versions to support older OS versions
-    name: Build ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    needs: [build-lib]
-    steps:
-      - name: Enable Developer Command Prompt 💻
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3
-
-      - name: Export git tag and package.json version 🚢
-        run: ${{ env.export_cmd }}
-        shell: bash
-
-      - name: Check if git tag matches package version ✅
-        run: if [[ ${{ env.GIT_TAG }} != ${{ env.PKG_VERSION }} ]]; then exit 1; else exit 0; fi
-        shell: bash
-
-      - name: Setup Java ☕
-        uses: actions/setup-java@v3.11.0
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: sbt
-
-      - name: Make _install/lib directory to store lib files
-        run: mkdir -p _install/lib
-
-      - name: Download macos library file 🔻
-        uses: actions/download-artifact@v3
-        if: runner.os == 'macOS'
-        with:
-          name: libomega_edit.dylib
-          path: _install/lib/libomega_edit.dylib
-
-      - name: Download windows library file 🔻
-        uses: actions/download-artifact@v3
-        if: runner.os == 'Windows'
-        with:
-          name: omega_edit.dll
-          path: _install/lib/omega_edit.dll
-
-      - name: Move out library file 🛻
-        run: |
-          if [[ ${{ runner.os }} == 'macOS' ]]; then
-            LIB_FILENAME="libomega_edit.dylib"
-          else
-            LIB_FILENAME="omega_edit.dll"
-          fi
-
-          mv -v "_install/lib/${LIB_FILENAME}" "_install/lib/${LIB_FILENAME}_dir"
-          mv -v "_install/lib/${LIB_FILENAME}_dir/$LIB_FILENAME" "_install/lib/$LIB_FILENAME"
-          rm -rf "_install/lib/${LIB_FILENAME}_dir"
-        shell: bash
-
-      - name: Package Scala Native 🎁
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: sbt native/publishM2
-        working-directory: server/scala
-
-      - name: Upload Native JARs 🔺
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.os }}-artifacts
-          path: ~/.m2/repository/com/ctc/omega-edit-native*
-          if-no-files-found: error
-
   scala-publish:
-    needs: [native-build-mac-win]
+    needs: [create-release]
     name: Scala Publish API, Native and Server✨
     runs-on: ubuntu-20.04
     steps:
@@ -211,39 +164,57 @@ jobs:
           java-version: 8
           cache: sbt
 
-      - name: Make _install/lib directory to store lib files
-        run: mkdir -p _install/lib
+      # - name: Make _install/lib directory to store lib files
+      #   run: mkdir -p _install/lib
 
-      - name: Download linux library file 🔻
-        uses: actions/download-artifact@v3
-        with:
-          name: libomega_edit.so
-          path: _install/lib/libomega_edit.so
+      # - name: Download linux library file 🔻
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: tests.yml
+      #     branch: main
+      #     workflow_conclusion: success
+      #     name: libomega_edit.so
+      #     path: _install/lib/libomega_edit.so
 
-      - name: Move out library file 🛻
-        run: |
-          LIB_FILENAME="libomega_edit.so"
-          mv -v "_install/lib/${LIB_FILENAME}" "_install/lib/${LIB_FILENAME}_dir"
-          mv -v "_install/lib/${LIB_FILENAME}_dir/$LIB_FILENAME" "_install/lib/$LIB_FILENAME"
-          rm -rf "_install/lib/${LIB_FILENAME}_dir"
-        shell: bash
+      # - name: Move out library file 🛻
+      #   run: |
+      #     LIB_FILENAME="libomega_edit.so"
+      #     mv -v "_install/lib/${LIB_FILENAME}" "_install/lib/${LIB_FILENAME}_dir"
+      #     mv -v "_install/lib/${LIB_FILENAME}_dir/$LIB_FILENAME" "_install/lib/$LIB_FILENAME"
+      #     rm -rf "_install/lib/${LIB_FILENAME}_dir"
+      #   shell: bash
 
       - name: Download macos Native JARs 🔻
-        uses: actions/download-artifact@v3
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: tests.yml
+          branch: main
+          workflow_conclusion: success
           name: macos-11-artifacts
 
-      - name: Download windows Native JARs 🔻
-        uses: actions/download-artifact@v3
+      - name: Download linux Native JARs 🔻
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: tests.yml
+          branch: main
+          workflow_conclusion: success
+          name: ubuntu-20.04-artifacts
+      
+      - name: Download windows Native JARs 🔻
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: tests.yml
+          branch: main
+          workflow_conclusion: success
           name: windows-2019-artifacts
 
-      - name: Move windows and macos jars out 🚚
+      - name: Move jars out 🚚
         env:
           folder: "omega-edit-native_2.13"
         run: |
           mv -v ${{ env.folder }}/${{ env.PKG_VERSION }}/${{ env.folder }}-${{ env.PKG_VERSION }}-windows-* .
           mv -v ${{ env.folder }}/${{ env.PKG_VERSION }}/${folder}-${{ env.PKG_VERSION }}-macos-* .
+          mv -v ${{ env.folder }}/${{ env.PKG_VERSION }}/${folder}-${{ env.PKG_VERSION }}-linux-* .
         
       - name: Download native JARs for M1 mac 🔻
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,9 +67,10 @@ jobs:
     needs: [ build-native ]
     strategy:
       matrix:
-        os: [ macos-11, ubuntu-20.04 ] # TODO: add windows-2019 (currently it's timing out on Package Scala API)
+        os: [ macos-11, ubuntu-20.04, windows-2019 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    name: Build middleware ${{ matrix.os }} 🔧
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -124,10 +125,18 @@ jobs:
         run: sbt headerCheckAll
         working-directory: server/scala
 
-      - name: Package Scala API 🎁
-        run: sbt installM2 # runs test so specifically running sbt test not needed
+      - name: Package Scala API - Non windows 🎁
+        run: sbt installM2 # runs test so specifically running sbt test not needed  # TODO: Make sure tests run on windows
+        if: runner.os != 'Windows'
         working-directory: server/scala
         timeout-minutes: 30
+    
+      - name: Package Scala Native - Windows 🎁
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: runner.os == 'Windows'  # TODO: Remove, current workaround so we can download all OS jars from tests for release
+        run: sbt native/publishM2
+        working-directory: server/scala
 
       - name: Archive M2 🔺
         uses: actions/upload-artifact@v3
@@ -139,18 +148,22 @@ jobs:
 
       - name: Test Scala RPC server 📋
         run: sbt serv/test
+        if: runner.os != 'Windows' # TODO: Make sure tests run on windows
         working-directory: server/scala
         timeout-minutes: 30
 
       - name: Yarn Install 🏗️
+        if: runner.os != 'Windows' # TODO: Make sure tests run on windows
         run: yarn
         shell: bash
 
       - name: Yarn Package - Server 📦
+        if: runner.os != 'Windows' # TODO: Make sure tests run on windows
         run: yarn workspace @omega-edit/server package
         shell: bash
 
       - name: Yarn Test - Client 🧑‍💼
+        if: runner.os != 'Windows' # TODO: Make sure tests run on windows
         run: yarn workspace @omega-edit/client test
         shell: bash
         timeout-minutes: 30


### PR DESCRIPTION
Rework release workflow

- Release workflow now checks all other CI workflows before running.
- Downloads all native jars from tests workflow.

@scholarsmate I will need to merge this before being able to fully test. Trying to a release on a branch/PR I believe will cause issues for the quality gate. But when ran on main it will be fine, I have seen the quality gate check that is being done here, work in another repo I have as well as a couple repos from Anchore. So that part is fine but the part in question will be the downloading of jars from different workflows.

When merged, I will do a dry run of `v0.9.66` that won't publish the node packages just in case. If it all works then I remake the release so that it can release the node packages.