### PR TITLE
Add CI support for macos and linux arm64

### DIFF
--- a/.github/workflows/build-middleware-docker/action.yml
+++ b/.github/workflows/build-middleware-docker/action.yml
@@ -1,0 +1,85 @@
+# Copyright (c) 2021 Concurrent Technologies Corporation.
+#                                                                                                               
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at                                                    
+#                                                                                                               
+#     http://www.apache.org/licenses/LICENSE-2.0                                                                
+#                                                                                                               
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is       
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or              
+# implied.  See the License for the specific language governing permissions and limitations under the License.  
+
+---
+name: Build Middleware
+description: Reusable action for building middleware code using docker
+inputs:
+  os-name:
+    description: 'OS Name (runs-on value)'
+    required: true
+  docker-image:
+    description: 'Docker image to use'
+    required: true
+  library-filename:
+    description: 'Filename of library file (libomega_edit.so, libomega_edit.dylib or omega_edit.dll)'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Set up QEMU 🔧
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64
+
+    - name: Download library file 🔻
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.os-name }}-${{ inputs.library-filename }}
+        path: _install/${{ inputs.library-filename }}
+
+    - name: Move out library file 🛻
+      run: |
+        mv -v "_install/${{ inputs.library-filename }}" "_install/${{ inputs.library-filename }}_dir"
+        mv -v "_install/${{ inputs.library-filename }}_dir/${{ inputs.library-filename }}" "_install/${{ inputs.library-filename }}"
+        rm -rf "_install/${{ inputs.library-filename }}_dir"
+      shell: bash
+
+    - name: Start container 🐳
+      shell: bash
+      run: |
+        docker run \
+          --memory "8g" \
+          --cpus "2" \
+          -d \
+          --name omega-edit-${{ inputs.os-name }}-cont \
+          -v $PWD:/omega-edit \
+          -w /omega-edit \
+          ${{ inputs.docker-image }} \
+          bash -c "tail -f /dev/null"
+
+    - name: Package Scala Native 🎁
+      shell: bash
+      run: docker exec -w /omega-edit/server/scala omega-edit-${{ inputs.os-name }}-cont bash -c "sbt installM2"
+  
+    - name: Test Scala RPC server 📋
+      shell: bash
+      run: docker exec -w /omega-edit/server/scala omega-edit-${{ inputs.os-name }}-cont bash -c "sbt serv/test"
+
+    - name: Yarn Install 🏗️
+      run: docker exec omega-edit-${{ inputs.os-name }}-cont bash -c "yarn install"
+      shell: bash
+
+    - name: Yarn Package - Server 📦
+      run: docker exec omega-edit-${{ inputs.os-name }}-cont bash -c "yarn workspace @omega-edit/server package"
+      shell: bash
+
+    - name: Yarn Test - Client 🧑‍💼
+      run: docker exec omega-edit-${{ inputs.os-name }}-cont bash -c "yarn workspace @omega-edit/client test"
+      shell: bash
+
+    - name: Remove container and image 🧹
+      shell: bash
+      if: success() || failure()
+      run: |
+        docker kill omega-edit-${{ inputs.os-name }}-cont
+        docker rm -f omega-edit-${{ inputs.os-name }}-cont
+        docker rmi -f ${{ inputs.docker-image }}

--- a/.github/workflows/build-middleware/action.yml
+++ b/.github/workflows/build-middleware/action.yml
@@ -1,0 +1,144 @@
+# Copyright (c) 2021 Concurrent Technologies Corporation.
+#                                                                                                               
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at                                                    
+#                                                                                                               
+#     http://www.apache.org/licenses/LICENSE-2.0                                                                
+#                                                                                                               
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is       
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or              
+# implied.  See the License for the specific language governing permissions and limitations under the License.  
+
+---
+name: Build Middleware
+description: Reusable action to build omega-edit middleware
+inputs:
+  runner-os:
+    description: 'OS Name of Runner (macOS, Linux, Windows)'
+    required: true
+  os-name:
+    description: 'OS Name (runs-on value)'
+    required: true
+  github-token:
+    description: 'GitHub token retrieved from secrets'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v4
+
+    # NOTE: The macos-14 runner doesn't support JAVA 8, only 11+ can be used.
+    # macos-14 uses an M1 apple silicon chip, most likely being the reason it can't
+    # use JAVA 8.
+    - name: Setup Java 8 - non macos 14 ☕
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: temurin
+        java-version: 8
+        cache: sbt
+      if: ${{ !contains(inputs.os-name, 'macos-14') }}
+    
+    - name: Setup Java 11 - macos 14 ☕
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: temurin
+        java-version: 11
+        cache: sbt
+      if: contains(inputs.os-name, 'macos-14')
+
+    - name: Install SBT - macos-14 # if macos-13 is added this will done for it as well
+      shell: bash
+      run: brew install sbt
+      if: contains(inputs.os-name, 'macos-14')
+
+    - name: Make _install directory to store lib files 🔧
+      shell: bash
+      run: mkdir -p _install
+
+    - name: Download macOS library file 🔻
+      uses: actions/download-artifact@v4
+      if: inputs.runner-os == 'macOS'
+      with:
+        name: ${{ inputs.os-name }}-libomega_edit.dylib
+        path: _install/libomega_edit.dylib
+
+    - name: Download Linux library file 🔻
+      uses: actions/download-artifact@v4
+      if: inputs.runner-os == 'Linux'
+      with:
+        name: ${{ inputs.os-name }}-libomega_edit.so
+        path: _install/libomega_edit.so
+
+    - name: Download Windows library file 🔻
+      uses: actions/download-artifact@v4
+      if: inputs.runner-os == 'Windows'
+      with:
+        name: omega_edit.dll
+        path: _install/omega_edit.dll
+
+    - name: Move out library file 🛻
+      run: |
+        if [[ ${{ inputs.runner-os }} == 'Linux' ]]; then
+          LIB_FILENAME="libomega_edit.so"
+        elif [[ ${{ inputs.runner-os }} == 'macOS' ]]; then
+          LIB_FILENAME="libomega_edit.dylib"
+        else
+          LIB_FILENAME="omega_edit.dll"
+        fi
+
+        mv -v "_install/${LIB_FILENAME}" "_install/${LIB_FILENAME}_dir"
+        mv -v "_install/${LIB_FILENAME}_dir/$LIB_FILENAME" "_install/$LIB_FILENAME"
+        rm -rf "_install/${LIB_FILENAME}_dir"
+      shell: bash
+
+    - name: Check Scala headers ✔️
+      shell: bash
+      run: sbt headerCheckAll
+      working-directory: server/scala
+
+    - name: Package Scala API - Non windows 🎁
+      shell: bash
+      run: sbt installM2 # runs test so specifically running sbt test not needed  # TODO: Make sure tests run on windows
+      if: inputs.runner-os != 'Windows'
+      working-directory: server/scala
+      # timeout-minutes: 30
+  
+    - name: Package Scala Native - Windows 🎁
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      if: inputs.runner-os == 'Windows'  # TODO: Remove, current workaround so we can download all OS jars from tests for release
+      run: sbt native/publishM2
+      working-directory: server/scala
+
+    # - name: Archive M2 🔺
+    #   uses: actions/upload-artifact@v4
+    #   if: success() || failure()
+    #   with:
+    #     name: ${{ inputs.os-name }}-artifacts
+    #     path: ~/.m2/repository/com/ctc/*
+    #     if-no-files-found: error
+
+    - name: Test Scala RPC server 📋
+      shell: bash
+      run: sbt serv/test
+      if: inputs.runner-os != 'Windows' # TODO: Make sure tests run on windows
+      working-directory: server/scala
+      # timeout-minutes: 30
+
+    - name: Yarn Install 🏗️
+      run: yarn
+      shell: bash
+
+    - name: Yarn Package - Server 📦
+      if: inputs.runner-os != 'Windows' # TODO: Make sure tests run on windows
+      run: yarn workspace @omega-edit/server package
+      shell: bash
+      # timeout-minutes: 30
+
+    - name: Yarn Test - Client 🧑‍💼
+      if: inputs.runner-os != 'Windows' # TODO: Make sure tests run on windows
+      run: yarn workspace @omega-edit/client test
+      shell: bash
+      # timeout-minutes: 30

--- a/.github/workflows/build-native-docker/action.yml
+++ b/.github/workflows/build-native-docker/action.yml
@@ -1,0 +1,71 @@
+# Copyright (c) 2021 Concurrent Technologies Corporation.
+#                                                                                                               
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at                                                    
+#                                                                                                               
+#     http://www.apache.org/licenses/LICENSE-2.0                                                                
+#                                                                                                               
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is       
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or              
+# implied.  See the License for the specific language governing permissions and limitations under the License.  
+
+---
+name: Build Native
+description: Reusable action for building native code using docker
+inputs:
+  os-name:
+    description: 'OS Name (runs-on value)'
+    required: true
+  docker-image:
+    description: 'Docker image to use'
+    required: true
+  library-filename:
+    description: 'Filename of library file (libomega_edit.so, libomega_edit.dylib or omega_edit.dll)'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Set up QEMU 🔧
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64
+
+    - name: Start container 🐳
+      shell: bash
+      run: |
+        docker run \
+          --memory "12g" \
+          --cpus "3" \
+          -d \
+          --name omega-edit-${{ inputs.os-name }}-cont \
+          -v $PWD:/omega-edit \
+          -w /omega-edit \
+          ${{ inputs.docker-image }} \
+          bash -c "tail -f /dev/null"
+
+    - name: Perform cmake operators 🔧
+      shell: bash
+      run: docker exec omega-edit-${{ inputs.os-name }}-cont bash -c "(make clean || true) && make TYPE=Release all"
+
+    - name: Copy library file from docker container 🔻
+      shell: bash
+      run: |
+        rm -rf _install/lib/ || true
+        mkdir -p _install/lib || true
+        docker cp \
+          omega-edit-${{ inputs.os-name }}-cont:/omega-edit/lib/${{ inputs.library-filename }} \
+          ${{ inputs.library-filename }}
+
+    - name: Upload Native library 🔺
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.os-name }}-${{ inputs.library-filename }}
+        path: ${{ inputs.library-filename }}
+
+    - name: Remove container and image 🧹
+      shell: bash
+      if: success() || failure()
+      run: |
+        docker kill omega-edit-${{ inputs.os-name }}-cont
+        docker rm -f omega-edit-${{ inputs.os-name }}-cont
+        docker rmi -f ${{ inputs.docker-image }}

--- a/.github/workflows/build-native/action.yml
+++ b/.github/workflows/build-native/action.yml
@@ -1,0 +1,69 @@
+# Copyright (c) 2021 Concurrent Technologies Corporation.
+#                                                                                                               
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at                                                    
+#                                                                                                               
+#     http://www.apache.org/licenses/LICENSE-2.0                                                                
+#                                                                                                               
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is       
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or              
+# implied.  See the License for the specific language governing permissions and limitations under the License.  
+
+---
+name: Build Native
+description: Reusable action for building native code
+inputs:
+  runner-os:
+    description: 'OS Name of Runner (macOS, Linux, Windows)'
+    required: true
+  os-name:
+    description: 'OS Name (runs-on value)'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Enable Developer Command Prompt 💻
+      if: inputs.runner-os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Setup cmake 🔧
+      uses: lukka/get-cmake@latest
+
+    - name: Prepare, Build, Test, and Install Ωedit™- Non Windows 🔧
+      if: inputs.runner-os != 'Windows'
+      shell: bash
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON --install-prefix "${PWD}/_install"
+        cmake --build build --config Release
+        ctest -C Release --test-dir build/core --output-on-failure
+        cmake --install build/packages/core --prefix "${PWD}/_install" --config Release
+    
+    - name: Prepare, Build, Test, and Install Ωedit™ - Windows 🔧
+      if: inputs.runner-os == 'Windows'
+      shell: pwsh
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON --install-prefix "${PWD}/_install"
+        cmake --build build --config Release
+        ctest -C Release --test-dir build/core --output-on-failure
+        cmake --install build/packages/core --prefix "${PWD}/_install" --config Release
+
+    - name: Upload Native (.dylib) library - Macos 🔺
+      uses: actions/upload-artifact@v4
+      if: inputs.runner-os == 'macOS'
+      with:
+        name: ${{ inputs.os-name }}-libomega_edit.dylib
+        path: _install/lib/libomega_edit.dylib
+
+    - name: Upload Native (.so) library - Linux 🔺
+      uses: actions/upload-artifact@v4
+      if: inputs.runner-os == 'Linux'
+      with:
+        name: ${{ inputs.os-name }}-libomega_edit.so
+        path: _install/lib/libomega_edit.so
+
+    - name: Upload Native (.dll) library - Windows 🔺
+      uses: actions/upload-artifact@v4
+      if: inputs.runner-os == 'Windows'
+      with:
+        name: omega_edit.dll
+        path: _install/bin/omega_edit.dll

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   deploy-docs:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Install Prerequisites 📚
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,22 @@ jobs:
           checkName: "TypeScript code is properly formatted"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       
-      - name: Check tests - macOS ✅
+      - name: Check tests - macOS 12 ✅
         uses: fountainhead/action-wait-for-check@v1.1.0
-        id: macos-tests
+        id: macos12-tests
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Build middleware macos-11 🔧"
+          checkName: "Build middleware macos-12 🔧"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      
+      - name: Check tests - macOS 14 ✅
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: macos14-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "Build middleware macos-14 🔧"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check tests - Linux ✅
@@ -90,9 +99,26 @@ jobs:
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
           checkName: "Build middleware windows-2019 🔧"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        
+      - name: Check native build arm64 - Linux ✅
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: ubuntu-arm64-native
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
+          checkName: "Native build ubuntu-20.04 arm64 🦙"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Quality Gate ✅
-        if: steps.rat-check.outputs.conclusion != 'success' || steps.scala-format.outputs.conclusion != 'success' || steps.ts-format.outputs.conclusion != 'success' || steps.macos-tests.outputs.conclusion != 'success' || steps.ubuntu-tests.outputs.conclusion != 'success' || steps.windows-tests.outputs.conclusion != 'success'
+        if: |
+          steps.rat-check.outputs.conclusion != 'success' ||
+          steps.scala-format.outputs.conclusion != 'success' ||
+          steps.ts-format.outputs.conclusion != 'success' ||
+          steps.macos12-tests.outputs.conclusion != 'success' ||
+          steps.macos14-tests.outputs.conclusion != 'success' ||
+          steps.ubuntu-tests.outputs.conclusion != 'success' ||
+          steps.ubuntu-arm64-native.outputs.conclusion != 'success' ||
+          steps.windows-tests.outputs.conclusion != 'success'
         run: |
           echo "Rat Check Status: ${{ steps.rat-check.conclusion }}"
           echo "Scala Format Status: ${{ steps.scala-format.conclusion }}"
@@ -174,22 +200,40 @@ jobs:
       - name: Make _install directory to store lib files
         run: mkdir -p _install
 
-      - name: Download linux library file 🔻
+      - name: Download linux x86 library file 🔻
         uses: dawidd6/action-download-artifact@v3
         with:
           workflow: tests.yml
           branch: main
           workflow_conclusion: success
-          name: libomega_edit.so
+          name: ubuntu-20.04-x64-libomega_edit.so
           path: _install/libomega_edit_linux_amd64.so
       
-      - name: Download macos library file 🔻
+      - name: Download linux arm64 library file 🔻
         uses: dawidd6/action-download-artifact@v3
         with:
           workflow: tests.yml
           branch: main
           workflow_conclusion: success
-          name: libomega_edit.dylib
+          name: ubuntu-20.04-arm64-libomega_edit.so
+          path: _install/libomega_edit_linux_aarch64.so
+      
+      - name: Download macos-12 library file 🔻
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: tests.yml
+          branch: main
+          workflow_conclusion: success
+          name: macos-14-arm64-libomega_edit.dylib
+          path: _install/libomega_edit_macos_aarch64.dylib
+
+      - name: Download macos-14 library file 🔻
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: tests.yml
+          branch: main
+          workflow_conclusion: success
+          name: macos-12-x64-libomega_edit.dylib
           path: _install/libomega_edit_macos_x86_64.dylib
       
       - name: Download windows library file 🔻
@@ -203,22 +247,26 @@ jobs:
 
       - name: Move out library files 🛻
         run: |
-          for lib_filename in "libomega_edit_linux_amd64.so" "libomega_edit_macos_x86_64.dylib" "omega_edit_windows_64.dll"; do
-            downloaded_filename=$(echo $lib_filename | sed "s|_linux_amd64||g" | sed "s|_macos_x86_64||g" | sed "s|_windows_64||g")
+          for lib_filename in \
+            "libomega_edit_linux_amd64.so" \
+            "libomega_edit_linux_aarch64.so" \
+            "libomega_edit_macos_x86_64.dylib" \
+            "libomega_edit_macos_aarch64.dylib" \
+            "omega_edit_windows_64.dll"
+          do
+            downloaded_filename=$(echo $lib_filename \
+              | sed "s|_linux_amd64||g" \
+              | sed "s|_linux_aarch64||g" \
+              | sed "s|_macos_x86_64||g" \
+              | sed "s|_macos_aarch64||g" \
+              | sed "s|_windows_64||g"
+            )
             mv -v "${lib_filename}" "${lib_filename}_dir"
             mv -v "${lib_filename}_dir/$downloaded_filename" "$lib_filename"
             rm -rf "${lib_filename}_dir"
           done
         working-directory: _install
         shell: bash
-
-      - name: Download shared lib files for M1 mac 🔻
-        run: |
-          base_url=https://raw.githubusercontent.com/Shanedell/omega-edit-aarch/main
-
-          curl ${base_url}/libomega_edit_macos_aarch64.dylib --output libomega_edit_macos_aarch64.dylib
-          curl ${base_url}/libomega_edit_linux_aarch64.dylib --output libomega_edit_linux_aarch64.so
-        working-directory: _install
 
       ###########################
       ## Scala publish process ##

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,150 +20,85 @@ jobs:
   build-native:
     strategy:
       matrix:
-        os: [ windows-2019, macos-11, ubuntu-20.04 ] # NOTE: build on older OS versions to support older OS versions
+        # NOTE: build on older OS versions to support older OS versions
+        # macos-14 is m1 mac
+        # macos-13 not used as it doesn't by default have sbt installed.
+        # if macos-12 is updated to 13 SBT needs to be installed before
+        # trying to run it for every workflow using this os.
+        os: [ windows-2019, macos-12, ubuntu-20.04, macos-14 ]
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     name: Native build and test on ${{ matrix.os }} 🦙
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Enable Developer Command Prompt 💻
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
-      - name: Setup cmake 🔧
-        uses: lukka/get-cmake@latest
-
-      - name: Prepare, Build, Test, and Install Ωedit™ 🔧
+      - name: Convert runner arch to lower
+        shell: bash
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON --install-prefix "${PWD}/_install"
-          cmake --build build --config Release
-          ctest -C Release --test-dir build/core --output-on-failure
-          cmake --install build/packages/core --prefix "${PWD}/_install" --config Release
+          echo "runner_arch=$(echo $RUNNER_ARCH | awk '{print tolower($0)}')" >> $GITHUB_ENV
 
-      - name: Upload Native (.dylib) library - Macos 🔺
-        uses: actions/upload-artifact@v4
-        if: runner.os == 'macOS'
+      - name: Build Native ${{ matrix.os }}
+        uses: ./.github/workflows/build-native
         with:
-          name: libomega_edit.dylib
-          path: _install/lib/libomega_edit.dylib
+          runner-os: ${{ runner.os }}
+          os-name: ${{ matrix.os }}-${{ env.runner_arch }}
+  
+  build-native-linux-arm64:
+    name: Native build ubuntu-20.04 arm64 🦙
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
 
-      - name: Upload Native (.so) library - Linux 🔺
-        uses: actions/upload-artifact@v4
-        if: runner.os == 'Linux'
+      - name: Build Native Linux arm64
+        uses: ./.github/workflows/build-native-docker
         with:
-          name: libomega_edit.so
-          path: _install/lib/libomega_edit.so
-
-      - name: Upload Native (.dll) library - Windows 🔺
-        uses: actions/upload-artifact@v4
-        if: runner.os == 'Windows'
-        with:
-          name: omega_edit.dll
-          path: _install/bin/omega_edit.dll
+          os-name: ubuntu-20.04-arm64
+          docker-image: ghcr.io/ctc-oss/omega-edit-build-arm64:ubuntu-20.04
+          library-filename: libomega_edit.so
 
   build-middleware:
     needs: [ build-native ]
     strategy:
       matrix:
-        os: [ macos-11, ubuntu-20.04, windows-2019 ]
+        # NOTE: build on older OS versions to support older OS versions
+        # macos-14 is m1 mac
+        # macos-13 not used as it doesn't by default have sbt installed.
+        # if macos-12 is updated to 13 SBT needs to be installed before
+        # trying to run it for every workflow using this os.
+        os: [ windows-2019, macos-12, ubuntu-20.04, macos-14 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Build middleware ${{ matrix.os }} 🔧
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
-
-      - name: Setup Java ☕
-        uses: actions/setup-java@v4.0.0
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: sbt
-
-      - name: Make _install directory to store lib files 🔧
-        run: mkdir -p _install
-
-      - name: Download macOS library file 🔻
-        uses: actions/download-artifact@v4
-        if: runner.os == 'macOS'
-        with:
-          name: libomega_edit.dylib
-          path: _install/libomega_edit.dylib
-
-      - name: Download Linux library file 🔻
-        uses: actions/download-artifact@v4
-        if: runner.os == 'Linux'
-        with:
-          name: libomega_edit.so
-          path: _install/libomega_edit.so
-
-      - name: Download Windows library file 🔻
-        uses: actions/download-artifact@v4
-        if: runner.os == 'Windows'
-        with:
-          name: omega_edit.dll
-          path: _install/omega_edit.dll
-
-      - name: Move out library file 🛻
+      
+      - name: Convert runner arch to lower
+        shell: bash
         run: |
-          if [[ ${{ runner.os }} == 'Linux' ]]; then
-            LIB_FILENAME="libomega_edit.so"
-          elif [[ ${{ runner.os }} == 'macOS' ]]; then
-            LIB_FILENAME="libomega_edit.dylib"
-          else
-            LIB_FILENAME="omega_edit.dll"
-          fi
+          echo "runner_arch=$(echo $RUNNER_ARCH | awk '{print tolower($0)}')" >> $GITHUB_ENV
 
-          mv -v "_install/${LIB_FILENAME}" "_install/${LIB_FILENAME}_dir"
-          mv -v "_install/${LIB_FILENAME}_dir/$LIB_FILENAME" "_install/$LIB_FILENAME"
-          rm -rf "_install/${LIB_FILENAME}_dir"
-        shell: bash
-
-      - name: Check Scala headers ✔️
-        run: sbt headerCheckAll
-        working-directory: server/scala
-
-      - name: Package Scala API - Non windows 🎁
-        run: sbt installM2 # runs test so specifically running sbt test not needed  # TODO: Make sure tests run on windows
-        if: runner.os != 'Windows'
-        working-directory: server/scala
-        timeout-minutes: 30
-    
-      - name: Package Scala Native - Windows 🎁
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: runner.os == 'Windows'  # TODO: Remove, current workaround so we can download all OS jars from tests for release
-        run: sbt native/publishM2
-        working-directory: server/scala
-
-      - name: Archive M2 🔺
-        uses: actions/upload-artifact@v4
-        if: success() || failure()
+      - name: Build Middleware ${{ matrix.os }}
+        uses: ./.github/workflows/build-middleware
         with:
-          name: ${{ matrix.os }}-artifacts
-          path: ~/.m2/repository/com/ctc/*
-          if-no-files-found: error
+          runner-os: ${{ runner.os }}
+          os-name: ${{ matrix.os }}-${{ env.runner_arch }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test Scala RPC server 📋
-        run: sbt serv/test
-        if: runner.os != 'Windows' # TODO: Make sure tests run on windows
-        working-directory: server/scala
-        timeout-minutes: 30
-
-      - name: Yarn Install 🏗️
-        run: yarn
-        shell: bash
-
-      - name: Yarn Package - Server 📦
-        if: runner.os != 'Windows' # TODO: Make sure tests run on windows
-        run: yarn workspace @omega-edit/server package
-        shell: bash
-        timeout-minutes: 30
-
-      - name: Yarn Test - Client 🧑‍💼
-        if: runner.os != 'Windows' # TODO: Make sure tests run on windows
-        run: yarn workspace @omega-edit/client test
-        shell: bash
-        timeout-minutes: 30
+  # TODO: Currently this action fails on sbt installM2 due to a timeout on sbt test 'should listen to session event'
+  # build-middleware-linux-arm64:
+  #   needs: [ build-native-linux-arm64 ]
+  #   runs-on: ubuntu-20.04
+  #   name: Build middleware ubuntu-20.04 arm64 🔧
+  #   steps:
+  #     - name: Checkout 🛎️
+  #       uses: actions/checkout@v4
+      
+  #     - name: Build Middleware ${{ matrix.os }}
+  #       uses: ./.github/workflows/build-middleware-docker
+  #       with:
+  #         os-name: ubuntu-20.04-arm64
+  #         docker-image: ghcr.io/ctc-oss/omega-edit-build-arm64:ubuntu-20.04
+  #         library-filename: libomega_edit.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 # Copyright (c) 2021 Concurrent Technologies Corporation.
-#                                                                                                               
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at                                                    
-#                                                                                                               
-#     http://www.apache.org/licenses/LICENSE-2.0                                                                
-#                                                                                                               
-# Unless required by applicable law or agreed to in writing, software is distributed under the License is       
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or              
-# implied.  See the License for the specific language governing permissions and limitations under the License.  
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing permissions and limitations under the License.
 
 # generated files
 .DS_Store
@@ -17,6 +17,8 @@ _build*/
 _install
 _install*/
 build*/
+!.github/workflows/build-middleware*
+!.github/workflows/build-native*
 cmake-build*/
 core/src/include/omega-edit/features.h
 node_modules/
@@ -55,6 +57,8 @@ package-lock.json
 **/.vscode/settings.json
 
 .metals
+.bloop
+metals.sbt
 .scala-build
 project
 !server/scala/project

--- a/docker/Dockerfile.ubuntu20-cpp-env
+++ b/docker/Dockerfile.ubuntu20-cpp-env
@@ -77,12 +77,15 @@ RUN apt-get update \
   && apt-get install -y nodejs \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install yarn
+RUN npm i -g yarn
+
 # Verify the installation
 RUN node --version \
     && npm --version
 
-# Create a non-root user
-RUN useradd -ms /bin/bash developer \
-    && install -d -m 0755 -o developer -g developer /home/developer/project
-USER developer
-WORKDIR /home/developer/project
+# Create a non-root user - this breaks CI if trying to use it
+# RUN useradd -ms /bin/bash developer \
+#     && install -d -m 0755 -o developer -g developer /home/developer/project
+# USER developer
+# WORKDIR /home/developer/project


### PR DESCRIPTION
Add CI support for macos and linux arm64

- macos-14 uses an M1 mac so it creates an arm64 library file.
- used docker to create the ubuntu-20.04 arm64 image.
  - took some hacking around to get working, would have worked easier if macos-14 could have been the base os.
  - but since macos-14 is a VM running on an M1, it doesn't allow nested virtualization.

Closes #501

Currently the middleware is not built for the ubuntu arm64 because there is a single sbt test failing when using docker. Will need this merged to be able to test if the release process works.