### PR TITLE
fix and test shutdown API

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,7 +74,7 @@ if (BUILD_TESTS)
         Catch2
         GIT_SHALLOW TRUE
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.5.1
+        GIT_TAG v3.5.3
     )
     FetchContent_MakeAvailable(Catch2)
     list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/extras")

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -219,13 +219,13 @@ export async function stopProcessUsingPID(
       log.debug({
         ...logMetadata,
         stopped: true,
-        msg: 'Server already stopped',
+        msg: 'process already stopped',
       })
     } else {
       log.error({
         ...logMetadata,
         stopped: false,
-        err: { msg: 'Error stopping server', err },
+        err: { msg: String(err) },
       })
       return false
     }

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -96,20 +96,9 @@ describe('Server', () => {
     expect(pidIsRunning(pid as number)).to.be.false
   })
 
-  xit(`on port ${serverTestPort} should stop immediately via API`, async () => {
-    // stop the server immediately should stop the server immediately without waiting for sessions to end
-    expect(await stopServerImmediate()).to.equal(0)
-    // pause to allow server some time to stop
-    await delay(1000) // 1 second
-    expect(pidIsRunning(pid as number)).to.be.false
-  })
-
-  xit(`on port ${serverTestPort} should stop gracefully via API`, async () => {
+  it(`on port ${serverTestPort} should stop gracefully via API`, async () => {
     // stop the server gracefully
-    expect(await stopServerGraceful()).to.equal(0)
-
-    // pause to allow server some time to remain up
-    await delay(1000) // 1 second
+    await stopServerGraceful()
 
     // for graceful shutdown, the server should still be running until the session count drops to 0
     expect(pidIsRunning(pid as number)).to.be.true
@@ -121,8 +110,26 @@ describe('Server', () => {
     // destroy the session, dropping the count to 0, then the server should stop
     expect(await destroySession(session_id)).to.equal(session_id)
 
-    // pause to allow server some time to stop
-    await delay(1000) // 1 second
+    // pause for up to 2 seconds to allow server some time to stop
+    for (let i = 0; i < 20; ++i) {
+      await delay(100) // 0.1 second
+      if (!pidIsRunning(pid as number)) {
+        break
+      }
+    }
+    expect(pidIsRunning(pid as number)).to.be.false
+  })
+
+  it(`on port ${serverTestPort} should stop immediately via API`, async () => {
+    // stop the server immediately should stop the server immediately without waiting for sessions to end
+    await stopServerImmediate()
+    // pause for up to 2 seconds to allow server some time to stop
+    for (let i = 0; i < 20; ++i) {
+      await delay(100) // 0.1 second
+      if (!pidIsRunning(pid as number)) {
+        break
+      }
+    }
     expect(pidIsRunning(pid as number)).to.be.false
   })
 })


### PR DESCRIPTION
Enabling all client-side server lifecycle tests.

    ✔ on port 9011 should stop immediately via stopServiceOnPort using 'SIGTERM'
    ✔ on port 9011 should stop immediately via PID using 'SIGTERM'
    ✔ on port 9011 should stop immediately via stopServiceOnPort using 'SIGKILL'
    ✔ on port 9011 should stop immediately via PID using 'SIGKILL'
    ✔ on port 9011 should stop gracefully via API
    ✔ on port 9011 should stop immediately via API