### PR TITLE
workflow updates

### DIFF
--- a/.github/workflows/build-middleware-docker/action.yml
+++ b/.github/workflows/build-middleware-docker/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Docker image to use'
     required: true
   library-filename:
-    description: 'Filename of library file (libomega_edit.so, libomega_edit.dylib or omega_edit.dll)'
+    description: 'Filename of library file (e.g., libomega_edit.so, libomega_edit.dylib, omega_edit.dll)'
     required: true
 runs:
   using: "composite"
@@ -30,18 +30,19 @@ runs:
       with:
         platforms: arm64
 
-    - name: Download library file 🔻
+    - name: Download Library File (${{ inputs.os-name }}-${{ inputs.library-filename }}) 🔻
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.os-name }}-${{ inputs.library-filename }}
-        path: _install/${{ inputs.library-filename }}
+        path: _artifacts/
 
-    - name: Move out library file 🛻
-      run: |
-        mv -v "_install/${{ inputs.library-filename }}" "_install/${{ inputs.library-filename }}_dir"
-        mv -v "_install/${{ inputs.library-filename }}_dir/${{ inputs.library-filename }}" "_install/${{ inputs.library-filename }}"
-        rm -rf "_install/${{ inputs.library-filename }}_dir"
+    - name: Install Library File (${{ inputs.library-filename }}) 🛻
       shell: bash
+      run: |
+        mkdir -p _install/
+        cp "_artifacts/${{ inputs.library-filename }}" _install/
+        ls -Rl _install/
+        echo "OE_LIB_DIR=$(pwd)/_install" >> $GITHUB_ENV
 
     - name: Start container 🐳
       shell: bash

--- a/.github/workflows/build-middleware/action.yml
+++ b/.github/workflows/build-middleware/action.yml
@@ -56,41 +56,30 @@ runs:
       shell: bash
       run: mkdir -p _install
 
-    - name: Download macOS library file 🔻
-      uses: actions/download-artifact@v4
-      if: inputs.runner-os == 'macOS'
-      with:
-        name: ${{ inputs.os-name }}-libomega_edit.dylib
-        path: _install/libomega_edit.dylib
-
-    - name: Download Linux library file 🔻
-      uses: actions/download-artifact@v4
-      if: inputs.runner-os == 'Linux'
-      with:
-        name: ${{ inputs.os-name }}-libomega_edit.so
-        path: _install/libomega_edit.so
-
-    - name: Download Windows library file 🔻
-      uses: actions/download-artifact@v4
-      if: inputs.runner-os == 'Windows'
-      with:
-        name: omega_edit.dll
-        path: _install/omega_edit.dll
-
-    - name: Move out library file 🛻
+    - name: Set Library Name For ${{ inputs.runner-os }} 📖
+      shell: bash
       run: |
-        if [[ ${{ inputs.runner-os }} == 'Linux' ]]; then
-          LIB_FILENAME="libomega_edit.so"
-        elif [[ ${{ inputs.runner-os }} == 'macOS' ]]; then
-          LIB_FILENAME="libomega_edit.dylib"
+        if [ "${{ inputs.runner-os }}" == "Windows" ]; then
+          echo "libname=omega_edit.dll" >> $GITHUB_ENV
+        elif [ "${{ inputs.runner-os }}" == "macOS" ]; then
+          echo "libname=libomega_edit.dylib" >> $GITHUB_ENV
         else
-          LIB_FILENAME="omega_edit.dll"
+          echo "libname=libomega_edit.so" >> $GITHUB_ENV
         fi
 
-        mv -v "_install/${LIB_FILENAME}" "_install/${LIB_FILENAME}_dir"
-        mv -v "_install/${LIB_FILENAME}_dir/$LIB_FILENAME" "_install/$LIB_FILENAME"
-        rm -rf "_install/${LIB_FILENAME}_dir"
+    - name: Download Library File (${{ env.libname }}) 🔻
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.os-name }}-${{ env.libname }}
+        path: _artifacts/
+
+    - name: Install Library File (${{ env.libname }}) 🛻
       shell: bash
+      run: |
+        mkdir -p _install/
+        cp "_artifacts/${{ env.libname }}" _install/
+        ls -Rl _install/
+        echo "OE_LIB_DIR=$(pwd)/_install" >> $GITHUB_ENV
 
     - name: Check Scala headers ✔️
       shell: bash

--- a/.github/workflows/build-native-docker/action.yml
+++ b/.github/workflows/build-native-docker/action.yml
@@ -56,7 +56,7 @@ runs:
           omega-edit-${{ inputs.os-name }}-cont:/omega-edit/lib/${{ inputs.library-filename }} \
           ${{ inputs.library-filename }}
 
-    - name: Upload Native library 🔺
+    - name: Upload Native Library (${{ inputs.os-name }}-${{ inputs.library-filename }}) 🔺
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.os-name }}-${{ inputs.library-filename }}

--- a/.github/workflows/build-native/action.yml
+++ b/.github/workflows/build-native/action.yml
@@ -29,41 +29,45 @@ runs:
     - name: Setup cmake 🔧
       uses: lukka/get-cmake@latest
 
-    - name: Prepare, Build, Test, and Install Ωedit™- Non Windows 🔧
-      if: inputs.runner-os != 'Windows'
+    - name: Set install path 🔧
       shell: bash
       run: |
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON --install-prefix "${PWD}/_install"
-        cmake --build build --config Release
-        ctest -C Release --test-dir build/core --output-on-failure
-        cmake --install build/packages/core --prefix "${PWD}/_install" --config Release
-    
-    - name: Prepare, Build, Test, and Install Ωedit™ - Windows 🔧
-      if: inputs.runner-os == 'Windows'
-      shell: pwsh
+          mkdir -p _install
+          echo "install_path=$(pwd)/_install" >> $GITHUB_ENV
+          echo "install_rel_path=_install" >> $GITHUB_ENV
+
+    - name: Prepare, Build, Test, and Install Ωedit™ native library 🦙
+      shell: bash
       run: |
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON --install-prefix "${PWD}/_install"
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON --install-prefix "${{ env.install_path }}"
         cmake --build build --config Release
         ctest -C Release --test-dir build/core --output-on-failure
-        cmake --install build/packages/core --prefix "${PWD}/_install" --config Release
+        cmake --install build/packages/core --prefix "${{ env.install_path }}" --config Release
 
-    - name: Upload Native (.dylib) library - Macos 🔺
-      uses: actions/upload-artifact@v4
-      if: inputs.runner-os == 'macOS'
-      with:
-        name: ${{ inputs.os-name }}-libomega_edit.dylib
-        path: _install/lib/libomega_edit.dylib
+    - name: Find Library For ${{ inputs.runner-os }} 📖
+      shell: bash
+      run: |
+        if [ "${{ inputs.runner-os }}" == "Windows" ]; then
+          libname=omega_edit.dll
+        elif [ "${{ inputs.runner-os }}" == "macOS" ]; then
+          libname=libomega_edit.dylib
+        else
+          libname=libomega_edit.so
+        fi
+        libpath=$(find -L "${{ env.install_rel_path }}" -type f -name "${libname}" | head -n 1)
+        if ! [ -s "${libpath}" ]; then
+          echo "ERROR: Library ${libname} not found in ${{ env.install_rel_path }}" >&2
+          find -L "${{ env.install_rel_path }}" -type f
+          exit 1
+        fi
+        ls -l "${libpath}"
+        echo "libname=${libname}" >> $GITHUB_ENV
+        echo "libpath=${libpath}" >> $GITHUB_ENV
 
-    - name: Upload Native (.so) library - Linux 🔺
+    - name: Upload Native Library (${{ inputs.os-name }}-${{ env.libname }}) 🔺
       uses: actions/upload-artifact@v4
-      if: inputs.runner-os == 'Linux'
       with:
-        name: ${{ inputs.os-name }}-libomega_edit.so
-        path: _install/lib/libomega_edit.so
-
-    - name: Upload Native (.dll) library - Windows 🔺
-      uses: actions/upload-artifact@v4
-      if: inputs.runner-os == 'Windows'
-      with:
-        name: omega_edit.dll
-        path: _install/bin/omega_edit.dll
+        name: ${{ inputs.os-name }}-${{ env.libname }}
+        path: ${{ env.libpath }}
+        retention-days: 5
+        if-no-files-found: error

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   deploy-docs:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: Install Prerequisites 📚
         run: |
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Prepare and Build Docs 🔧
+      - name: Prepare and Build Documentation 🔧
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_DOCS=ON -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF
           cmake --build build --target sphinx --config Release

--- a/.github/workflows/ratCheck.yml
+++ b/.github/workflows/ratCheck.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   check:
-    name: Rat Check
+    name: Rat Check 🐀
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -29,15 +29,15 @@ jobs:
       SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m
     
     steps:
-      - name: Setup Java
+      - name: Setup Java ☕
         uses: actions/setup-java@v4.2.1
         with:
           distribution: temurin
           java-version: 8
 
-      - name: Check out Repository
+      - name: Check out Repository 🛎️
         uses: actions/checkout@v4
 
-      - name: Run Rat Check
+      - name: Run Rat Check 🐀
         run: $SBT ratCheck || (cat target/rat.txt; exit 1)
         working-directory: server/scala

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
 
   scala-publish:
     needs: [create-release]
-    name: Scala Publish API, Native and Server✨
+    name: Scala Publish API, Native and Server ✨
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
@@ -242,7 +242,7 @@ jobs:
           workflow: tests.yml
           branch: main
           workflow_conclusion: success
-          name: omega_edit.dll
+          name: windows-2019-x64-omega_edit.dll
           path: _install/omega_edit_windows_64.dll
 
       - name: Move out library files 🛻

--- a/.github/workflows/ts-format.yml
+++ b/.github/workflows/ts-format.yml
@@ -24,19 +24,19 @@ jobs:
     name: TypeScript code is properly formatted
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout current branch (full)
+      - name: Checkout current branch (full) 🛎️
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
       
-      - name: Setup Node
+      - name: Setup Node 📐
         uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: 16
 
-      - name: yarn lint - all workspaces
+      - name: yarn lint - all workspaces 🧶
         run: |
           yarn
           yarn lint

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -32,8 +32,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT MINGW)
     set(FILESYSTEM_LIB stdc++fs)
 endif ()
 
-include(CheckFunctionExists)
+if(WIN32)
+    # Shared library prefix for Windows does not include "lib" by convention
+    set(CMAKE_SHARED_LIBRARY_PREFIX "")
+endif()
+
 # Check platform features
+include(CheckFunctionExists)
 check_function_exists(fseeko HAVE_FSEEKO)
 check_function_exists(ftello HAVE_FTELLO)
 check_function_exists(fopen_s HAVE_FOPEN_S)

--- a/core/src/examples/transform.c
+++ b/core/src/examples/transform.c
@@ -19,11 +19,11 @@
 #include <omega_edit.h>
 #include <stdio.h>
 
-static inline omega_byte_t to_lower(omega_byte_t byte, __attribute__((unused)) void *_unused) {
+static inline omega_byte_t to_lower(omega_byte_t byte, ATTRIBUTE_UNUSED void *_unused) {
     return (omega_byte_t) tolower(byte);
 }
 
-static inline omega_byte_t to_upper(omega_byte_t byte, __attribute__((unused)) void *_unused) {
+static inline omega_byte_t to_upper(omega_byte_t byte, ATTRIBUTE_UNUSED void *_unused) {
     return (omega_byte_t) toupper(byte);
 }
 

--- a/core/src/include/omega_edit/config.h
+++ b/core/src/include/omega_edit/config.h
@@ -84,6 +84,12 @@ static inline int safe_open_(const char *filename, int oflag, int pmode) {
     _sopen_s(&fd, filename, oflag | _O_BINARY, _SH_DENYWR, pmode);
     return fd;
 }
+
+// Define ATTRIBUTE_UNUSED for MSVC
+#ifndef ATTRIBUTE_UNUSED
+#define ATTRIBUTE_UNUSED
+#endif
+
 #else
 
 // For other compilers/platforms, fall back to open
@@ -91,6 +97,11 @@ static inline int safe_open_(const char *filename, int oflag, int pmode) {
     // Note: The mode only applies if O_CREAT is part of oflag
     return open(filename, oflag, pmode);
 }
+
+// Define ATTRIBUTE_UNUSED for other compilers/platforms
+#ifndef ATTRIBUTE_UNUSED
+#define ATTRIBUTE_UNUSED __attribute__((unused))
+#endif
 
 #endif
 

--- a/mingw64-toolchain.cmake
+++ b/mingw64-toolchain.cmake
@@ -9,29 +9,15 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied.  See the License for the specific language governing permissions and limitations under the License.
 
----
-name: Scala Formatting
+# Set the system name
+set(CMAKE_SYSTEM_NAME Windows)
 
-permissions: {}
+# Specify the cross-compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
 
-on:
-  push:
-    branches:
-      - '**'
+# Set the root path for MinGW (adjust as necessary)
+set(MINGW_ROOT "${HOME}/mingw64")
 
-jobs:
-  build:
-    name: Scala Code Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Current Branch (full) 🛎️
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check Scala Format ✅
-        uses: jrouly/scalafmt-native-action@v3
-        with:
-          # NOTE: make sure this version matches the version in .scalafmt.conf
-          version: '3.7.17'
-          arguments: '--list --mode diff-ref=origin/main'
+# Add the MinGW bin directory to the system PATH
+set(CMAKE_FIND_ROOT_PATH "${MINGW_ROOT}" "${MINGW_ROOT}/bin")

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -26,7 +26,7 @@
     "install-client-local": "yarn add file://$INIT_CWD/omega-edit-node-client-v${npm_package_version}.tgz",
     "pretest": "yarn package && yarn install-client-local",
     "test:client": "mocha --exit --timeout 100000 --slow 50000 --require ts-node/register --require tests/fixtures.ts --exclude ./tests/specs/server.spec.ts ./tests/specs/*.spec.ts",
-    "test:lifecycle": "mocha --exit --timeout 100000 --slow 50000 --require ts-node/register ./tests/specs/server.spec.ts",
+    "test:lifecycle": "mocha --exit --timeout 50000 --slow 25000 --require ts-node/register ./tests/specs/server.spec.ts",
     "test": "(yarn test:client && yarn test:lifecycle) || (yarn posttest && exit 1)",
     "posttest": "yarn remove @omega-edit/client",
     "lint": "prettier --check package.json webpack.config.js src tests && eslint .",

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,15 +51,15 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@grpc/grpc-js@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.10.1.tgz#be450560c990c08274bc19d514e181ea205ccaa8"
-  integrity sha512-55ONqFytZExfOIjF1RjXPcVmT/jJqFzbbDqxK9jmRV4nxiYWtL9hENSW1Jfx0SdZfrvoqd44YJ/GJTqfRrawSQ==
+"@grpc/grpc-js@1.10.3":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.10.3.tgz#13d7ace7d34190e6adad6de1f5d4e50bc255a78c"
+  integrity sha512-qiO9MNgYnwbvZ8MK0YLWbnGrNX3zTcj6/Ef7UHu5ZofER3e2nF3Y35GaPo9qNJJ/UJQKa4KL+z/F4Q8Q+uCdUQ==
   dependencies:
-    "@grpc/proto-loader" "^0.7.8"
-    "@types/node" ">=12.12.47"
+    "@grpc/proto-loader" "^0.7.10"
+    "@js-sdsl/ordered-map" "^4.4.2"
 
-"@grpc/proto-loader@^0.7.8":
+"@grpc/proto-loader@^0.7.10":
   version "0.7.10"
   resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.10.tgz#6bf26742b1b54d0a473067743da5d3189d06d720"
   integrity sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==
@@ -143,6 +143,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
 "@mapbox/node-pre-gyp@^1.0.5":
   version "1.0.11"
@@ -306,7 +311,7 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.11.28":
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@^20.11.28":
   version "20.11.28"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.28.tgz#4fd5b2daff2e580c12316e457473d68f15ee6f66"
   integrity sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==


### PR DESCRIPTION
This PR aims to simplify and improve the CI and so that the MSVC build and ming64w (gcc/g++ cross-compiler suite) produce the same library filename so that the compiler suites can be interchangeable.

It shouldn't be out of the question for it to work using MSYS, MSVC, and ming64w (pick your poison) on Windows -- as long as it builds a .dll with the required symbols, the JVM shouldn't care what compiler was used to make the library.