### PR TITLE
upgrade catch2 to v3.7.0

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -79,7 +79,7 @@ if (BUILD_TESTS)
             Catch2
             GIT_SHALLOW TRUE
             GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-            GIT_TAG v3.5.4
+            GIT_TAG v3.7.0
     )
     FetchContent_MakeAvailable(Catch2)
     list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/extras")

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -88,9 +88,10 @@ async function executeServer(args: string[]): Promise<ChildProcess> {
 
   const serverProcess: ChildProcess = spawn(serverScript, args, {
     cwd: path.dirname(serverScript),
-    stdio: 'ignore',
     detached: true,
     shell: os.platform().startsWith('win'), // use shell on Windows because it can't execute scripts directly
+    stdio: ['ignore', 'ignore', 'ignore'],
+    windowsHide: true, // avoid showing a console window
   })
 
   serverProcess.on('error', (err: Error) => {


### PR DESCRIPTION
Upgrade the core testing framework to Catch2 version 3.7.0.