### PR TITLE
Fix copyright date

### DIFF
--- a/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/Bug976Spec.scala
+++ b/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/Bug976Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Concurrent Technologies Corporation
+ * Copyright 2021 Concurrent Technologies Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
New unit test in #1007 added incorrect copyright date in the header.