### PR TITLE
trigger test CI workflow on PR and workflow dispatch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   build-native:


### PR DESCRIPTION
Trigger the test CI workflow on the following events:

1. Any push to any branch (push with branches: ["**"])
2. When a pull request is opened, synchronized, or reopened (pull_request with types: [opened, synchronize, reopened])
3. When manually triggered via the GitHub Actions UI (workflow_dispatch)