### PR TITLE
ci: use actions/setup-java v5.0.0 in build-middleware/action.yml

### DIFF
--- a/.github/workflows/build-middleware/action.yml
+++ b/.github/workflows/build-middleware/action.yml
@@ -32,7 +32,7 @@ runs:
     # macos-14 uses an M1 apple silicon chip, most likely being the reason it can't
     # use JAVA 8.
     - name: Setup Java 8 - non macos 14 ☕
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v5.0.0
       with:
         distribution: temurin
         java-version: 8
@@ -40,7 +40,7 @@ runs:
       if: ${{ !contains(inputs.os-name, 'macos-14') }}
     
     - name: Setup Java 11 - macos 14 ☕
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v5.0.0
       with:
         distribution: temurin
         java-version: 11


### PR DESCRIPTION
Use `actions/setup-java v5.0.0` across the board in the CI workflows.