### PR TITLE
deps: upgrade catch2 from 3.8.1 -> 3.11.0

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -81,7 +81,7 @@ if (BUILD_TESTS)
             Catch2
             GIT_SHALLOW TRUE
             GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-            GIT_TAG v3.8.1
+            GIT_TAG v3.11.0
     )
     FetchContent_MakeAvailable(Catch2)
     # Restore the original BUILD_SHARED_LIBS value for the main project


### PR DESCRIPTION
Upgrade the Catch2 C/C++ testing framework from v3.8.1 to 3.11.0.