### PR TITLE
Add session heartbeat timeout + reaper

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -81,7 +81,7 @@ if (BUILD_TESTS)
             Catch2
             GIT_SHALLOW TRUE
             GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-            GIT_TAG v3.11.0
+            GIT_TAG v3.12.0
     )
     FetchContent_MakeAvailable(Catch2)
     # Restore the original BUILD_SHARED_LIBS value for the main project

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,6 +27,7 @@
   "author": "CTC-OSS",
   "license": "Apache-2.0",
   "scripts": {
+    "pretest": "yarn build && node scripts/ensure-server-prepackaged.js",
     "clean": "rimraf dist",
     "generate-version": "node scripts/generate-version.js",
     "copy-proto": "node scripts/copy-proto-files.js",

--- a/packages/client/scripts/ensure-server-prepackaged.js
+++ b/packages/client/scripts/ensure-server-prepackaged.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2021 Concurrent Technologies Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..')
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+function tryStat(filePath) {
+  try {
+    return fs.statSync(filePath)
+  } catch {
+    return null
+  }
+}
+
+function latestMtimeUnder(dirPath) {
+  const stat = tryStat(dirPath)
+  if (!stat) return 0
+  if (!stat.isDirectory()) return stat.mtimeMs
+
+  let latest = stat.mtimeMs
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true })
+  for (const entry of entries) {
+    const child = path.join(dirPath, entry.name)
+    if (entry.isDirectory()) {
+      latest = Math.max(latest, latestMtimeUnder(child))
+    } else if (entry.isFile()) {
+      const s = tryStat(child)
+      if (s) latest = Math.max(latest, s.mtimeMs)
+    }
+  }
+  return latest
+}
+
+function loadJson(filePath) {
+  try {
+    return JSON.parse(readText(filePath))
+  } catch {
+    return null
+  }
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true })
+}
+
+function main() {
+  const versionFile = path.join(repoRoot, 'VERSION')
+  const expectedVersion = readText(versionFile).trim()
+
+  const serverOutDir = path.join(repoRoot, 'packages', 'server', 'out')
+  const serverOutBin = path.join(serverOutDir, 'bin', 'omega-edit-grpc-server')
+  const serverOutBat = path.join(
+    serverOutDir,
+    'bin',
+    'omega-edit-grpc-server.bat'
+  )
+  const serverOutEntry = tryStat(serverOutBin) ? serverOutBin : serverOutBat
+
+  const markerFile = path.join(serverOutDir, '.prepackage-stamp.json')
+  const marker = loadJson(markerFile)
+
+  const inputs = [
+    versionFile,
+    path.join(repoRoot, 'proto', 'omega_edit.proto'),
+    path.join(repoRoot, 'server', 'scala', 'build.sbt'),
+    path.join(repoRoot, 'server', 'scala', 'project'),
+    path.join(repoRoot, 'server', 'scala', 'api', 'src', 'main'),
+    path.join(repoRoot, 'server', 'scala', 'spi', 'src', 'main'),
+    path.join(repoRoot, 'server', 'scala', 'native', 'src', 'main'),
+    path.join(repoRoot, 'server', 'scala', 'serv', 'src', 'main'),
+  ]
+
+  const latestInputMtime = inputs.reduce(
+    (acc, p) => Math.max(acc, latestMtimeUnder(p)),
+    0
+  )
+
+  const outStat = serverOutEntry ? tryStat(serverOutEntry) : null
+  const outMtime = outStat ? outStat.mtimeMs : 0
+
+  const isUpToDate =
+    marker &&
+    marker.version === expectedVersion &&
+    outMtime !== 0 &&
+    outMtime >= latestInputMtime
+
+  if (isUpToDate) {
+    process.stdout.write(
+      `@omega-edit/client: server prepackage up-to-date (v${expectedVersion})\n`
+    )
+    return
+  }
+
+  process.stdout.write(
+    `@omega-edit/client: refreshing server prepackage (expected v${expectedVersion})\n`
+  )
+
+  const result = spawnSync(
+    process.platform === 'win32' ? 'yarn.cmd' : 'yarn',
+    ['workspace', '@omega-edit/server', 'prepackage'],
+    { cwd: repoRoot, stdio: 'inherit' }
+  )
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+
+  const refreshedOutStat = serverOutEntry ? tryStat(serverOutEntry) : null
+  ensureDir(serverOutDir)
+  fs.writeFileSync(
+    markerFile,
+    JSON.stringify(
+      {
+        version: expectedVersion,
+        latestInputMtime,
+        refreshedAt: new Date().toISOString(),
+        outMtime: refreshedOutStat ? refreshedOutStat.mtimeMs : null,
+      },
+      null,
+      2
+    ) + '\n'
+  )
+}
+
+main()

--- a/packages/client/tests/fixtures.ts
+++ b/packages/client/tests/fixtures.ts
@@ -27,7 +27,7 @@ import {
   stopServiceOnPort,
 } from '@omega-edit/client'
 import * as fs from 'fs'
-import { testHost, testPort } from './specs/common'
+import { initChai, testHost, testPort } from './specs/common'
 
 const path = require('path')
 const rootPath = path.resolve(__dirname, '..')
@@ -47,6 +47,7 @@ function getPidFile(rootPath: string, port: number): string {
  * @remarks used by mocha
  */
 export async function mochaGlobalSetup(): Promise<number | undefined> {
+  await initChai()
   const pidFile = getPidFile(rootPath, testPort)
   const logFile = path.join(rootPath, 'client-tests.log')
   const level = process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL || 'info'

--- a/packages/client/tests/specs/common.ts
+++ b/packages/client/tests/specs/common.ts
@@ -17,7 +17,15 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
+let chaiInitialized = false
+
+export let expect!: Chai.ExpectStatic
+
+export async function initChai(): Promise<void> {
+  if (chaiInitialized) return
+  ;({ expect } = await import('chai'))
+  chaiInitialized = true
+}
 import {
   createSession,
   destroySession,

--- a/packages/client/tests/specs/editing.spec.ts
+++ b/packages/client/tests/specs/editing.spec.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
 import {
   ALL_EVENTS,
   ChangeKind,
@@ -43,6 +42,7 @@ import {
   checkCallbackCount,
   createTestSession,
   destroyTestSession,
+  expect,
   session_callbacks,
   subscribeSession,
   testPort,

--- a/packages/client/tests/specs/emojiFilenames.spec.ts
+++ b/packages/client/tests/specs/emojiFilenames.spec.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
+import { expect, testPort } from './common'
 import {
   createSession,
   destroySession,
@@ -29,7 +29,6 @@ import {
   IOFlags,
   saveSession,
 } from '@omega-edit/client'
-import { testPort } from './common'
 import * as fs from 'fs'
 import * as path from 'path'
 

--- a/packages/client/tests/specs/encodeDecode.spec.ts
+++ b/packages/client/tests/specs/encodeDecode.spec.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
+import { expect } from './common'
 
 describe('Encode/Decode', () => {
   it('Should encode string into Uint8Array', () => {

--- a/packages/client/tests/specs/events.spec.ts
+++ b/packages/client/tests/specs/events.spec.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
+import { expect } from './common'
 import { ALL_EVENTS, NO_EVENTS, ViewportEventKind } from '@omega-edit/client'
 
 describe('Events', () => {

--- a/packages/client/tests/specs/profiler.spec.ts
+++ b/packages/client/tests/specs/profiler.spec.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
 import {
   getComputedFileSize,
   numAscii,
@@ -25,7 +24,12 @@ import {
   PROFILE_DOS_EOL,
   profileSession,
 } from '@omega-edit/client'
-import { createTestSession, destroyTestSession, testPort } from './common'
+import {
+  createTestSession,
+  destroyTestSession,
+  expect,
+  testPort,
+} from './common'
 
 describe('Profiling', () => {
   let session_id = ''

--- a/packages/client/tests/specs/search.spec.ts
+++ b/packages/client/tests/specs/search.spec.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
 import {
   beginSessionTransaction,
   clear,
@@ -39,7 +38,12 @@ import {
   searchSession,
   undo,
 } from '@omega-edit/client'
-import { createTestSession, destroyTestSession, testPort } from './common'
+import {
+  createTestSession,
+  destroyTestSession,
+  expect,
+  testPort,
+} from './common'
 
 describe('Searching', () => {
   let session_id = ''

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
+import { expect, testPort } from './common'
 import {
   countCharacters,
   createSession,
@@ -38,7 +38,6 @@ import {
   saveSession,
   SaveStatus,
 } from '@omega-edit/client'
-import { testPort } from './common'
 import * as fs from 'fs'
 import * as path from 'path'
 

--- a/packages/client/tests/specs/stressTest.spec.ts
+++ b/packages/client/tests/specs/stressTest.spec.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
 import {
   ALL_EVENTS,
   clear,
@@ -41,6 +40,7 @@ import {
   checkCallbackCount,
   createTestSession,
   destroyTestSession,
+  expect,
   log_info,
   session_callbacks,
   subscribeSession,

--- a/packages/client/tests/specs/undoRedo.spec.ts
+++ b/packages/client/tests/specs/undoRedo.spec.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
 import {
   ChangeKind,
   clear,
@@ -38,7 +37,12 @@ import {
   undo,
 } from '@omega-edit/client'
 import { unlinkSync } from 'fs'
-import { createTestSession, destroyTestSession, testPort } from './common'
+import {
+  createTestSession,
+  destroyTestSession,
+  expect,
+  testPort,
+} from './common'
 
 describe('Undo/Redo', () => {
   let session_id = ''

--- a/packages/client/tests/specs/version.spec.ts
+++ b/packages/client/tests/specs/version.spec.ts
@@ -17,14 +17,13 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
+import { expect, testPort } from './common'
 import {
   ClientVersion,
   getClient,
   getClientVersion,
   getServerInfo,
 } from '@omega-edit/client'
-import { testPort } from './common'
 
 describe('Version', () => {
   beforeEach('Ensure the client is ready', async () => {

--- a/packages/client/tests/specs/viewport.spec.ts
+++ b/packages/client/tests/specs/viewport.spec.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
 import {
   ALL_EVENTS,
   createViewport,
@@ -42,6 +41,7 @@ import {
   checkCallbackCount,
   createTestSession,
   destroyTestSession,
+  expect,
   log_info,
   subscribeViewport,
   testPort,

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -16,32 +16,12 @@
  */
 
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "esModuleInterop": true,
-    "module": "commonjs",
-    "target": "es6",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "outDir": "out",
-    "lib": ["es6", "es2021", "es2017"],
-    "sourceMap": true,
-    "rootDir": "src",
-    "baseUrl": ".",
-    "paths": {
-      "@omega-edit/client": ["out/index"],
-      "@omega-edit/client/*": ["out/*"]
-    },
-    "strict": true /* enable all strict type-checking options */,
-    /* Additional Checks */
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-    "noImplicitAny": false,
-    "removeComments": false,
-    "noUnusedLocals": true,
-    "noImplicitThis": true,
-    "inlineSourceMap": false,
-    "preserveConstEnums": true,
-    "strictNullChecks": true,
-    "noUnusedParameters": true,
-    "declaration": true
+    "noEmit": true
   },
-  "exclude": ["node_modules", "tests", "**/*.d.ts", "scripts"]
+  "exclude": ["node_modules", "tests", "**/*.d.ts", "scripts", "dist", "out"]
 }

--- a/server/scala/project/BuildSupport.scala
+++ b/server/scala/project/BuildSupport.scala
@@ -53,11 +53,7 @@ object BuildSupport {
 
   // get full path as relative can cause issues
   val libdir: String =
-    new java.io.File(normalizeLibDirFromEnv(rawLibDir))
-      .toPath
-      .toAbsolutePath
-      .normalize
-      .toString
+    new java.io.File(normalizeLibDirFromEnv(rawLibDir)).toPath.toAbsolutePath.normalize.toString
   val apacheLicenseUrl: URL = new URL(
     "https://www.apache.org/licenses/LICENSE-2.0.txt"
   )

--- a/server/scala/project/BuildSupport.scala
+++ b/server/scala/project/BuildSupport.scala
@@ -45,9 +45,19 @@ object BuildSupport {
   }
 
   private val defaultLibSubdir = if (isWindows) "bin" else "lib"
-  private val rawLibDir = sys.env.getOrElse("OE_LIB_DIR", s"../../_install/$defaultLibSubdir")
+  private val rawLibDir =
+    sys.env.getOrElse(
+      "OE_LIB_DIR",
+      s"../../_install/$defaultLibSubdir"
+    )
+
+  // get full path as relative can cause issues
   val libdir: String =
-    new java.io.File(normalizeLibDirFromEnv(rawLibDir)).toPath.toAbsolutePath.normalize.toString // get full path as relative can cause issues
+    new java.io.File(normalizeLibDirFromEnv(rawLibDir))
+      .toPath
+      .toAbsolutePath
+      .normalize
+      .toString
   val apacheLicenseUrl: URL = new URL(
     "https://www.apache.org/licenses/LICENSE-2.0.txt"
   )

--- a/server/scala/project/BuildSupport.scala
+++ b/server/scala/project/BuildSupport.scala
@@ -211,12 +211,9 @@ object BuildSupport {
 
   lazy val mapping: List[(String, String)] = {
     val libFileList =
-      new java.io.File(libdir).listFiles
-        .filter(_.isFile)
-        // only want the lib files with a single period, for the filename like .dylib, .so, .dll.
-        .filter(
-          _.getName.filter(_ == '.').size == 1
-        )
+      Option(new java.io.File(libdir).listFiles())
+        .getOrElse(Array.empty)
+        .filter(isSharedLibFile)
         .toList
 
     getMappings(

--- a/server/scala/serv/src/main/resources/application.conf
+++ b/server/scala/serv/src/main/resources/application.conf
@@ -24,3 +24,23 @@ pekko {
     idle-timeout = infinite
   }
 }
+
+# Session orphan cleanup / auto-shutdown.
+#
+# Heartbeat messages include a set of `session_ids` currently held by the client.
+# When enabled, the server tracks when each session was last reported via heartbeat
+# (and also touches a session at creation time). Sessions that go idle beyond
+# `session-timeout` are destroyed.
+#
+# NOTE: By default, stale-session cleanup is enabled (60s). Auto-shutdown is
+# still opt-in via `shutdown-when-no-sessions`.
+omega-edit.grpc.heartbeat {
+  # How long a session can go without a heartbeat mentioning it.
+  session-timeout = 60s
+
+  # How often to scan for stale sessions.
+  cleanup-interval = 10s
+
+  # If true, terminate the server when there are zero remaining sessions.
+  shutdown-when-no-sessions = false
+}

--- a/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
+++ b/server/scala/serv/src/main/scala/com/ctc/omega_edit/grpc/EditorService.scala
@@ -26,7 +26,7 @@ import com.google.protobuf.empty.Empty
 import io.grpc.Status
 import omega_edit._
 import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem, Cancellable}
 import org.apache.pekko.grpc.GrpcServiceException
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.pattern.ask
@@ -35,13 +35,57 @@ import org.apache.pekko.util.Timeout
 
 import java.lang.management.ManagementFactory
 import java.nio.file.Paths
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
+
+import scala.jdk.CollectionConverters._
 
 class EditorService(implicit val system: ActorSystem) extends Editor {
   private implicit val timeout: Timeout = Timeout(20.seconds)
+  private implicit val ec: ExecutionContext = system.dispatcher
+
+  private val config = system.settings.config
+
+  private val sessionTimeoutMillis: Long =
+    if (config.hasPath("omega-edit.grpc.heartbeat.session-timeout")) {
+      config.getDuration("omega-edit.grpc.heartbeat.session-timeout").toMillis
+    } else {
+      0L
+    }
+
+  private val cleanupIntervalMillis: Long =
+    if (config.hasPath("omega-edit.grpc.heartbeat.cleanup-interval")) {
+      config.getDuration("omega-edit.grpc.heartbeat.cleanup-interval").toMillis
+    } else {
+      10000L
+    }
+
+  private val shutdownWhenNoSessions: Boolean =
+    if (config.hasPath("omega-edit.grpc.heartbeat.shutdown-when-no-sessions")) {
+      config.getBoolean("omega-edit.grpc.heartbeat.shutdown-when-no-sessions")
+    } else {
+      false
+    }
+
+  private val requireHadSessionBeforeShutdown: Boolean = true
+
+  private val sessionLastSeenMillis = new ConcurrentHashMap[String, java.lang.Long]()
+  private val hadAnySession = new AtomicBoolean(false)
+  private val shutdownStarted = new AtomicBoolean(false)
+  private val lastReapAtMillis = new AtomicLong(0L)
+  private val reaper: Option[Cancellable] = startSessionReaper()
+
+  private def touchIfKnown(sessionId: String): Unit =
+    if (sessionLastSeenMillis.containsKey(sessionId)) touchSession(sessionId)
+
+  private def touchFromId(id: String): Unit = {
+    // Session ids are UUIDs; viewport ids are formatted as "<sessionId>:<viewportId>".
+    val sid = id.split(':').headOption.getOrElse(id)
+    touchIfKnown(sid)
+  }
 
   lazy val jvmVersion: String = System.getProperty("java.version")
   lazy val jvmVendor: String = System.getProperty("java.vendor")
@@ -89,6 +133,8 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         .mapTo[Result]
         .map {
           case ok: Ok with CheckpointDirectory =>
+            hadAnySession.set(true)
+            touchSession(ok.id)
             filePath match {
               // If a file path is provided, add the file size to the response
               case Some(_) =>
@@ -114,9 +160,11 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
       case Ok(id) =>
         (editors ? DestroyActor(id, timeout)).mapTo[Result].map {
           case Ok(_) =>
+            sessionLastSeenMillis.remove(id)
             // If after session is destroyed, the number of sessions is 0 and the server is to shutdown gracefully,
             // stop server after destroying the last session
             checkIsGracefulShutdown()
+            maybeAutoShutdownIfIdle()
             in
           case Err(c) => throw grpcFailure(c)
         }
@@ -150,7 +198,8 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         }
       )
 
-  def stopServer(kind: ServerControlKind): Future[ServerControlResponse] =
+  def stopServer(kind: ServerControlKind): Future[ServerControlResponse] = {
+    reaper.foreach(_.cancel())
     system
       .terminate()
       .transform {
@@ -173,7 +222,10 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
           Success(response)
       }(ExecutionContext.global)
 
-  def saveSession(in: SaveSessionRequest): Future[SaveSessionResponse] =
+  }
+
+  def saveSession(in: SaveSessionRequest): Future[SaveSessionResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(
       in.sessionId,
       Save(
@@ -191,8 +243,10 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         )
       case Err(c) => throw grpcFailure(c)
     }
+  }
 
-  def createViewport(in: CreateViewportRequest): Future[ViewportDataResponse] =
+  def createViewport(in: CreateViewportRequest): Future[ViewportDataResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(
       in.sessionId,
       View(in.offset, in.capacity, in.isFloating, in.viewportIdDesired)
@@ -201,8 +255,10 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         case Ok(id) => getViewportData(ViewportDataRequest(id))
         case Err(c) => Future.failed(grpcFailure(c))
       }
+  }
 
-  def getViewportData(in: ViewportDataRequest): Future[ViewportDataResponse] =
+  def getViewportData(in: ViewportDataRequest): Future[ViewportDataResponse] = {
+    touchFromId(in.viewportId)
     ObjectId(in.viewportId) match {
       case Viewport.Id(sid, vid) =>
         (editors ? ViewportOp(sid, vid, Viewport.Get)).mapTo[Result].map {
@@ -228,10 +284,12 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
           s"malformed viewport id '${in.viewportId}'"
         )
     }
+  }
 
   def modifyViewport(
       in: ModifyViewportRequest
-  ): Future[ViewportDataResponse] =
+  ): Future[ViewportDataResponse] = {
+    touchFromId(in.viewportId)
     ObjectId(in.viewportId) match {
       case Viewport.Id(sid, vid) =>
         (editors ? ViewportOp(
@@ -265,8 +323,10 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
           s"malformed viewport id '${in.viewportId}'"
         )
     }
+  }
 
-  def destroyViewport(in: ObjectId): Future[ObjectId] =
+  def destroyViewport(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     in match {
       case Viewport.Id(sid, vid) =>
         (editors ? ViewportOp(sid, vid, Viewport.Destroy)).mapTo[Result].map {
@@ -276,8 +336,10 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
       case _ =>
         grpcFailFut(Status.INVALID_ARGUMENT, s"malformed viewport id '$in'")
     }
+  }
 
-  def viewportHasChanges(in: ObjectId): Future[BooleanResponse] =
+  def viewportHasChanges(in: ObjectId): Future[BooleanResponse] = {
+    touchFromId(in.id)
     in match {
       case Viewport.Id(sid, vid) =>
         (editors ? ViewportOp(sid, vid, Viewport.HasChanges))
@@ -294,8 +356,10 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
       case _ =>
         grpcFailFut(Status.INVALID_ARGUMENT, s"malformed viewport id '$in'")
     }
+  }
 
-  def notifyChangedViewports(in: ObjectId): Future[IntResponse] =
+  def notifyChangedViewports(in: ObjectId): Future[IntResponse] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, NotifyChangedViewports)).mapTo[Result].map {
       case ok: Ok with Count => IntResponse(ok.count)
       case Ok(id) =>
@@ -305,8 +369,10 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         )
       case Err(c) => throw grpcFailure(c)
     }
+  }
 
-  def submitChange(in: ChangeRequest): Future[ChangeResponse] =
+  def submitChange(in: ChangeRequest): Future[ChangeResponse] = {
+    touchIfKnown(in.sessionId)
     in match {
       case Session.Op(op) =>
         (editors ? SessionOp(in.sessionId, op)).mapTo[Result].flatMap {
@@ -319,8 +385,10 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
       case _ =>
         grpcFailFut(Status.INVALID_ARGUMENT, "undefined change kind")
     }
+  }
 
-  def getChangeDetails(in: SessionEvent): Future[ChangeDetailsResponse] =
+  def getChangeDetails(in: SessionEvent): Future[ChangeDetailsResponse] = {
+    touchIfKnown(in.sessionId)
     in.serial match {
       case None =>
         grpcFailFut(Status.INVALID_ARGUMENT, "change serial id required")
@@ -337,13 +405,16 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
             case Err(c) => throw grpcFailure(c)
           }
     }
+  }
 
-  def getComputedFileSize(in: ObjectId): Future[ComputedFileSizeResponse] =
+  def getComputedFileSize(in: ObjectId): Future[ComputedFileSizeResponse] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, GetSize)).mapTo[Result].map {
       case ok: Ok with Count => ComputedFileSizeResponse(in.id, ok.count)
       case Err(c)            => throw grpcFailure(c)
       case _                 => throw grpcFailure(Status.UNKNOWN, "unable to compute size")
     }
+  }
 
   def getSessionCount(in: Empty): Future[SessionCountResponse] =
     (editors ? SessionCount)
@@ -351,6 +422,8 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
       .map(count => SessionCountResponse(count.toLong))
 
   def getCount(in: CountRequest): Future[CountResponse] = {
+
+    touchIfKnown(in.sessionId)
 
     // create a list of futures for each CountKind value in the request
     val futures = in.kind.map {
@@ -394,6 +467,9 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
   }
 
   def getHeartbeat(in: HeartbeatRequest): Future[HeartbeatResponse] = {
+    in.sessionIds.foreach { sid =>
+      if (sessionLastSeenMillis.containsKey(sid)) touchSession(sid)
+    }
     val memory = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage()
     val numSessions = Await.result((editors ? SessionCount).mapTo[Int].map(_.toInt), 1.second)
     val res = HeartbeatResponse(
@@ -414,6 +490,7 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
   def subscribeToSessionEvents(
       in: EventSubscriptionRequest
   ): Source[SessionEvent, NotUsed] = {
+    touchFromId(in.id)
     val f = (editors ? SessionOp(in.id, Session.Watch(in.interest)))
       .mapTo[Result]
       .map {
@@ -428,6 +505,7 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
   ): Source[ViewportEvent, NotUsed] =
     ObjectId(in.id) match {
       case Viewport.Id(sid, vid) =>
+        touchFromId(in.id)
         val f =
           (editors ? ViewportOp(sid, vid, Viewport.Watch(in.interest)))
             .mapTo[Result]
@@ -446,15 +524,18 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         )
     }
 
-  def unsubscribeToSessionEvents(in: ObjectId): Future[ObjectId] =
+  def unsubscribeToSessionEvents(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.Unwatch)).mapTo[Result].map {
       case Ok(id) => ObjectId(id)
       case Err(c) => throw grpcFailure(c)
     }
+  }
 
   def unsubscribeToViewportEvents(in: ObjectId): Future[ObjectId] =
     ObjectId(in.id) match {
       case Viewport.Id(sid, vid) =>
+        touchFromId(in.id)
         (editors ? ViewportOp(sid, vid, Viewport.Unwatch)).mapTo[Result].map {
           case Ok(_)  => in
           case Err(c) => throw grpcFailure(c)
@@ -467,39 +548,52 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         )
     }
 
-  def getByteFrequencyProfile(in: SegmentRequest): Future[ByteFrequencyProfileResponse] =
+  def getByteFrequencyProfile(in: SegmentRequest): Future[ByteFrequencyProfileResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(in.sessionId, Session.Profile(in)))
       .mapTo[ByteFrequencyProfileResponse] // No `Ok` wrapper
+  }
 
-  def getCharacterCounts(in: omega_edit.TextRequest): Future[CharacterCountResponse] =
+  def getCharacterCounts(in: omega_edit.TextRequest): Future[CharacterCountResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(in.sessionId, Session.CharCount(in)))
       .mapTo[CharacterCountResponse] // No `Ok` wrapper
+  }
 
-  def searchSession(in: SearchRequest): Future[SearchResponse] =
+  def searchSession(in: SearchRequest): Future[SearchResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(in.sessionId, Session.Search(in)))
       .mapTo[SearchResponse] // No `Ok` wrapper
+  }
 
-  def undoLastChange(in: ObjectId): Future[ChangeResponse] =
+  def undoLastChange(in: ObjectId): Future[ChangeResponse] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.UndoLast())).mapTo[Result].map {
       case ok: Ok with Serial => ChangeResponse(ok.id, ok.serial)
       case Err(c)             => throw grpcFailure(c)
       case _                  => throw grpcFailure(Status.UNKNOWN, s"unable to compute $in")
     }
+  }
 
-  def redoLastUndo(in: ObjectId): Future[ChangeResponse] =
+  def redoLastUndo(in: ObjectId): Future[ChangeResponse] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.RedoUndo())).mapTo[Result].map {
       case ok: Ok with Serial => ChangeResponse(ok.id, ok.serial)
       case Err(c)             => throw grpcFailure(c)
       case _                  => throw grpcFailure(Status.UNKNOWN, s"unable to compute $in")
     }
+  }
 
-  def clearChanges(in: ObjectId): Future[ObjectId] =
+  def clearChanges(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.ClearChanges())).mapTo[Result].map {
       case Ok(id) => ObjectId(id)
       case Err(c) => throw grpcFailure(c)
     }
+  }
 
-  def getLastChange(in: ObjectId): Future[ChangeDetailsResponse] =
+  def getLastChange(in: ObjectId): Future[ChangeDetailsResponse] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.GetLastChange()))
       .mapTo[Result]
       .map {
@@ -509,55 +603,71 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         case o =>
           throw grpcFailure(Status.UNKNOWN, s"unable to compute $in: $o")
       }
+  }
 
-  def getLastUndo(in: ObjectId): Future[ChangeDetailsResponse] =
+  def getLastUndo(in: ObjectId): Future[ChangeDetailsResponse] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.GetLastUndo())).mapTo[Result].map {
       case ok: Ok with ChangeDetails => ok.toChangeResponse(ok.id)
       case Err(c)                    => throw grpcFailure(c)
       case _                         => throw grpcFailure(Status.UNKNOWN, s"unable to compute $in")
     }
+  }
 
-  def pauseSessionChanges(in: ObjectId): Future[ObjectId] =
+  def pauseSessionChanges(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.PauseSession())).mapTo[Result].map {
       case Ok(id) => ObjectId(id)
       case Err(c) => throw grpcFailure(c)
     }
+  }
 
-  def resumeSessionChanges(in: ObjectId): Future[ObjectId] =
+  def resumeSessionChanges(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.ResumeSession())).mapTo[Result].map {
       case Ok(id) => ObjectId(id)
       case Err(c) => throw grpcFailure(c)
     }
+  }
 
-  def pauseViewportEvents(in: ObjectId): Future[ObjectId] =
+  def pauseViewportEvents(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.PauseViewportEvents()))
       .mapTo[Result]
       .map {
         case Ok(id) => ObjectId(id)
         case Err(c) => throw grpcFailure(c)
       }
+  }
 
-  def resumeViewportEvents(in: ObjectId): Future[ObjectId] =
+  def resumeViewportEvents(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.ResumeViewportEvents()))
       .mapTo[Result]
       .map {
         case Ok(id) => ObjectId(id)
         case Err(c) => throw grpcFailure(c)
       }
+  }
 
-  def sessionBeginTransaction(in: ObjectId): Future[ObjectId] =
+  def sessionBeginTransaction(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.BeginTransaction())).mapTo[Result].map {
       case Ok(id) => ObjectId(id)
       case Err(c) => throw grpcFailure(c)
     }
+  }
 
-  def sessionEndTransaction(in: ObjectId): Future[ObjectId] =
+  def sessionEndTransaction(in: ObjectId): Future[ObjectId] = {
+    touchFromId(in.id)
     (editors ? SessionOp(in.id, Session.EndTransaction())).mapTo[Result].map {
       case Ok(id) => ObjectId(id)
       case Err(c) => throw grpcFailure(c)
     }
+  }
 
-  def getSegment(in: SegmentRequest): Future[SegmentResponse] =
+  def getSegment(in: SegmentRequest): Future[SegmentResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(in.sessionId, Session.Segment(in)))
       .mapTo[Option[api.Segment]] // No `Ok` wrapper
       .flatMap {
@@ -571,6 +681,7 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
             SegmentResponse.of(in.sessionId, offset, ByteString.copyFrom(data))
           )
       }
+  }
 
   def serverControl(in: ServerControlRequest): Future[ServerControlResponse] =
     in.kind match {
@@ -587,29 +698,93 @@ class EditorService(implicit val system: ActorSystem) extends Editor {
         )
     }
 
-  def getByteOrderMark(in: SegmentRequest): Future[ByteOrderMarkResponse] =
+  def getByteOrderMark(in: SegmentRequest): Future[ByteOrderMarkResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(in.sessionId, Session.ByteOrderMark(in)))
       .mapTo[ByteOrderMarkResponse] // No `Ok` wrapper
+  }
 
-  def getContentType(in: SegmentRequest): Future[ContentTypeResponse] =
+  def getContentType(in: SegmentRequest): Future[ContentTypeResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(in.sessionId, Session.ContentType(in)))
       .mapTo[ContentTypeResponse] // No `Ok` wrapper
+  }
 
-  def getLanguage(in: TextRequest): Future[LanguageResponse] =
+  def getLanguage(in: TextRequest): Future[LanguageResponse] = {
+    touchIfKnown(in.sessionId)
     (editors ? SessionOp(in.sessionId, Session.Language(in)))
       .mapTo[LanguageResponse] // No `Ok` wrapper
+  }
+
+  private def touchSession(sessionId: String): Unit =
+    sessionLastSeenMillis.put(sessionId, System.currentTimeMillis())
+
+  private def maybeAutoShutdownIfIdle(): Unit = {
+    if (!shutdownWhenNoSessions) return
+    if (requireHadSessionBeforeShutdown && !hadAnySession.get()) return
+    if (shutdownStarted.get()) return
+
+    checkNoSessionsRunning().foreach { isZero =>
+      if (isZero && shutdownStarted.compareAndSet(false, true)) {
+        stopServer(ServerControlKind.SERVER_CONTROL_GRACEFUL_SHUTDOWN)
+        ()
+      }
+    }
+  }
+
+  private def startSessionReaper(): Option[Cancellable] = {
+    if (sessionTimeoutMillis <= 0L) return None
+
+    val intervalMillis = math.max(50L, cleanupIntervalMillis)
+    val cancellable =
+      system.scheduler.scheduleAtFixedRate(
+        initialDelay = intervalMillis.millis,
+        interval = intervalMillis.millis
+      )(() => reapStaleSessions())
+
+    system.registerOnTermination(() => cancellable.cancel())
+    Some(cancellable)
+  }
+
+  private def reapStaleSessions(): Unit = {
+    val now = System.currentTimeMillis()
+
+    // Avoid running too frequently if interval is tiny
+    val last = lastReapAtMillis.get()
+    if (last != 0L && now - last < cleanupIntervalMillis) return
+    lastReapAtMillis.set(now)
+
+    val timeoutMillis = sessionTimeoutMillis
+    if (timeoutMillis <= 0L) return
+
+    val stale = sessionLastSeenMillis.asScala.collect {
+      case (sid, lastSeen) if now - lastSeen.longValue() > timeoutMillis => sid
+    }.toList
+
+    stale.foreach { sid =>
+      // Remove first to prevent duplicate work if a second sweep runs
+      val removed = sessionLastSeenMillis.remove(sid)
+      if (removed != null) {
+        destroySession(ObjectId(sid))
+          .recover { case _ => ObjectId(sid) }
+          .foreach(_ => maybeAutoShutdownIfIdle())
+      }
+    }
+  }
 }
 
 object EditorService {
   def bind(iface: String, port: Int)(implicit
       system: ActorSystem
-  ): Future[Http.ServerBinding] =
+  ): Future[Http.ServerBinding] = {
+    implicit val ec: ExecutionContext = system.dispatcher
     Http()
       .newServerAt(iface, port)
       .bind(EditorHandler(new EditorService))
       .andThen { case Failure(_) =>
         system.terminate()
       }
+  }
 
   def getServerPID(): Int =
     ManagementFactory.getRuntimeMXBean().getName().split('@')(0).toInt

--- a/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/HeartbeatTimeoutSpec.scala
+++ b/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/HeartbeatTimeoutSpec.scala
@@ -32,8 +32,8 @@ class HeartbeatTimeoutSpec extends AsyncWordSpecLike with Matchers {
     val cfg = ConfigFactory
       .parseString(
         """
-          |omega-edit.grpc.heartbeat.session-timeout = 200ms
-          |omega-edit.grpc.heartbeat.cleanup-interval = 50ms
+          |omega-edit.grpc.heartbeat.session-timeout = 1s
+          |omega-edit.grpc.heartbeat.cleanup-interval = 100ms
           |omega-edit.grpc.heartbeat.shutdown-when-no-sessions = false
           |""".stripMargin
       )
@@ -54,7 +54,7 @@ class HeartbeatTimeoutSpec extends AsyncWordSpecLike with Matchers {
 
       for {
         _ <- service.createSession(CreateSessionRequest.defaultInstance)
-        _ <- pekkoAfter(600.millis, service.system.scheduler)(Future.successful(()))
+        _ <- pekkoAfter(2.seconds, service.system.scheduler)(Future.successful(()))
         count1 <- service.getSessionCount(Empty())
         _ = count1.count shouldBe 0L
       } yield succeed
@@ -66,7 +66,7 @@ class HeartbeatTimeoutSpec extends AsyncWordSpecLike with Matchers {
       for {
         created <- service.createSession(CreateSessionRequest.defaultInstance)
         sid = created.sessionId
-        _ <- pekkoAfter(150.millis, service.system.scheduler)(Future.successful(()))
+        _ <- pekkoAfter(500.millis, service.system.scheduler)(Future.successful(()))
         _ <- service.getHeartbeat(
           HeartbeatRequest(
             hostname = "test",
@@ -75,10 +75,10 @@ class HeartbeatTimeoutSpec extends AsyncWordSpecLike with Matchers {
             sessionIds = Seq(sid)
           )
         )
-        _ <- pekkoAfter(150.millis, service.system.scheduler)(Future.successful(()))
+        _ <- pekkoAfter(500.millis, service.system.scheduler)(Future.successful(()))
         count1 <- service.getSessionCount(Empty())
         _ = count1.count shouldBe 1L
-        _ <- pekkoAfter(600.millis, service.system.scheduler)(Future.successful(()))
+        _ <- pekkoAfter(2.seconds, service.system.scheduler)(Future.successful(()))
         count2 <- service.getSessionCount(Empty())
         _ = count2.count shouldBe 0L
       } yield succeed

--- a/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/HeartbeatTimeoutSpec.scala
+++ b/server/scala/serv/src/test/scala/com/ctc/omega_edit/grpc/HeartbeatTimeoutSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ctc.omega_edit.grpc
+
+import com.google.protobuf.empty.Empty
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.pattern.{after => pekkoAfter}
+import omega_edit._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class HeartbeatTimeoutSpec extends AsyncWordSpecLike with Matchers {
+  private def withService[T](test: EditorService => Future[T]): Future[T] = {
+    val cfg = ConfigFactory
+      .parseString(
+        """
+          |omega-edit.grpc.heartbeat.session-timeout = 200ms
+          |omega-edit.grpc.heartbeat.cleanup-interval = 50ms
+          |omega-edit.grpc.heartbeat.shutdown-when-no-sessions = false
+          |""".stripMargin
+      )
+      .withFallback(ConfigFactory.load())
+
+    implicit val system: ActorSystem = ActorSystem("HeartbeatTimeoutSpec", cfg)
+    val service = new EditorService()
+
+    test(service).andThen { case _ =>
+      system.terminate()
+      ()
+    }(system.dispatcher)
+  }
+
+  "heartbeat reaper" should {
+    "destroy sessions that stop being heartbeated" in withService { service =>
+      import service.system.dispatcher
+
+      for {
+        _ <- service.createSession(CreateSessionRequest.defaultInstance)
+        _ <- pekkoAfter(600.millis, service.system.scheduler)(Future.successful(()))
+        count1 <- service.getSessionCount(Empty())
+        _ = count1.count shouldBe 0L
+      } yield succeed
+    }
+
+    "keep sessions alive when heartbeats arrive" in withService { service =>
+      import service.system.dispatcher
+
+      for {
+        created <- service.createSession(CreateSessionRequest.defaultInstance)
+        sid = created.sessionId
+        _ <- pekkoAfter(150.millis, service.system.scheduler)(Future.successful(()))
+        _ <- service.getHeartbeat(
+          HeartbeatRequest(
+            hostname = "test",
+            processId = 123,
+            heartbeatInterval = 100,
+            sessionIds = Seq(sid)
+          )
+        )
+        _ <- pekkoAfter(150.millis, service.system.scheduler)(Future.successful(()))
+        count1 <- service.getSessionCount(Empty())
+        _ = count1.count shouldBe 1L
+        _ <- pekkoAfter(600.millis, service.system.scheduler)(Future.successful(()))
+        count2 <- service.getSessionCount(Empty())
+        _ = count2.count shouldBe 0L
+      } yield succeed
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,10 +2054,10 @@ pino-webpack-plugin@^2.0.0:
   dependencies:
     memfs "^3.4.12"
 
-pino@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-10.2.0.tgz#01d7f0fdabdb7bb31102a55770b6fe2dd3f139e8"
-  integrity sha512-NFnZqUliT+OHkRXVSf8vdOr13N1wv31hRryVjqbreVh/SDCNaI6mnRDDq89HVRCbem1SAl7yj04OANeqP0nT6A==
+pino@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-10.3.0.tgz#965ae842e9b7e6e7e9f002bac33c831b16912529"
+  integrity sha512-0GNPNzHXBKw6U/InGe79A3Crzyk9bcSyObF9/Gfo9DLEf5qj5RF50RSjsu0W1rZ6ZqRGdzDFCRBQvi9/rSGPtA==
   dependencies:
     "@pinojs/redact" "^0.4.0"
     atomic-sleep "^1.0.0"


### PR DESCRIPTION
## What
- Adds last-seen tracking for gRPC sessions and a periodic reaper to drop sessions that stop heartbeating or stop making session RPCs.
- Optional server auto-shutdown when no sessions remain (guarded; default off).
- Adds config knobs under `omega-edit.grpc.heartbeat.*` with a default 60s timeout.

## Tests
- Scala spec coverage for session reaping + keepalive behavior.
- TypeScript lifecycle tests for reap + keepalive via normal session RPCs (no heartbeat).

## Tooling / reliability
- Ensures `packages/server/out` is refreshed when stale before client tests (fixes native version mismatch failures).
- Adds runtime native/library version validation in Scala FFI to fail fast on mismatches.
- Fixes TS config deprecation diagnostics and updates tests to work with ESM-only `chai`.
