### PR TITLE
feat(core): add embed mode and scripted edit replay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,19 @@ project(omega_edit
         HOMEPAGE_URL "https://github.com/ctc-oss/omega-edit"
         LANGUAGES C CXX)
 
+option(OMEGA_EDIT_EMBED_MODE "Configure a lean embeddable build with tests, docs, examples, and packaging disabled" OFF)
+
+if (OMEGA_EDIT_EMBED_MODE)
+    set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(BUILD_DOCS OFF CACHE BOOL "" FORCE)
+    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(BUILD_COVERAGE OFF CACHE BOOL "" FORCE)
+endif()
+
 # Include the core CMakeLists.txt
 add_subdirectory(core)
 
 # Packaging rules
-add_subdirectory(packages/core)
+if (NOT OMEGA_EDIT_EMBED_MODE)
+    add_subdirectory(packages/core)
+endif()

--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ Here is how to build a debug version of a shared library, with no documentation 
 cmake -S . -B _build -DCMAKE_BUILD_TYPE=Debug -DBUILD_DOCS=NO -DBUILD_EXAMPLES=NO -DBUILD_SHARED_LIBS=YES
 ```
 
+#### Embedding the core library in another CMake project:
+
+If you want to consume Ωedit as a subproject, enable embed mode to automatically disable tests,
+documentation, examples, coverage instrumentation, and packaging:
+
+```bash
+cmake -S . -B _build -DOMEGA_EDIT_EMBED_MODE=ON
+```
+
 ### Build the configured build:
 
 This will build the core library, and any example programs or documentation if configured.  Note that the config type

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,11 +9,20 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or              
 # implied.  See the License for the specific language governing permissions and limitations under the License.  
 
+# Duplicated at the repo root on purpose so `core/` can also be consumed directly as a subproject.
+option(OMEGA_EDIT_EMBED_MODE "Configure a lean embeddable build with tests, docs, and examples disabled" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static ones" ON)
 option(BUILD_TESTS "build tests" ON)
 option(BUILD_DOCS "build documentation" ON)
 option(BUILD_EXAMPLES "build examples" ON)
 option(BUILD_COVERAGE "build with code coverage instrumentation (GCC/Clang)" OFF)
+
+if (OMEGA_EDIT_EMBED_MODE)
+    set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(BUILD_DOCS OFF CACHE BOOL "" FORCE)
+    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(BUILD_COVERAGE OFF CACHE BOOL "" FORCE)
+endif ()
 
 ## Let omega_edit_SHARED_LIBS override BUILD_SHARED_LIBS
 if (DEFINED omega_edit_SHARED_LIBS)
@@ -35,7 +44,9 @@ endif ()
 
 # Common configurations
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON")
+if (NOT OMEGA_EDIT_EMBED_MODE)
+    set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON")
+endif ()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/core/src/examples/apply_script.cpp
+++ b/core/src/examples/apply_script.cpp
@@ -1,0 +1,67 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+ * implied.  See the License for the specific language governing permissions and limitations under the License.       *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+/*
+ * This application demonstrates a production-oriented embedding path: build a simple in-memory edit
+ * script, replay it into a session, and save the result to disk.
+ */
+
+#include <iostream>
+#include <omega_edit.h>
+#include <omega_edit/scoped_ptr.hpp>
+#include <omega_edit/stl_string_adaptor.hpp>
+
+using namespace std;
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        cerr << "USAGE: " << argv[0] << " output-file" << endl;
+        return -1;
+    }
+
+    auto session_ptr = omega_scoped_ptr<omega_session_t>(
+            omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr), omega_edit_destroy_session);
+    if (!session_ptr) {
+        cerr << "failed to create session" << endl;
+        return -1;
+    }
+
+    static const omega_byte_t hello_world[] = "hello world";
+    static const omega_byte_t omega_edit[] = "OmegaEdit";
+    static const omega_byte_t hello_upper[] = "HELLO";
+    static const omega_byte_t comma_space[] = ", ";
+
+    const omega_edit_script_op_t ops[] = {
+            {0, 0, OMEGA_EDIT_SCRIPT_INSERT, hello_world, 11},
+            {6, 5, OMEGA_EDIT_SCRIPT_REPLACE, omega_edit, 9},
+            {0, 5, OMEGA_EDIT_SCRIPT_OVERWRITE, hello_upper, 5},
+            {5, 1, OMEGA_EDIT_SCRIPT_DELETE, nullptr, 0},
+            {5, 0, OMEGA_EDIT_SCRIPT_INSERT, comma_space, 2},
+    };
+
+    if (0 != omega_edit_apply_script(session_ptr.get(), ops, sizeof(ops) / sizeof(ops[0]))) {
+        cerr << "failed to apply script" << endl;
+        return -1;
+    }
+
+    if (0 != omega_edit_save(session_ptr.get(), argv[1], omega_io_flags_t::IO_FLG_OVERWRITE, nullptr)) {
+        cerr << "failed to save output file" << endl;
+        return -1;
+    }
+
+    cout << omega_session_get_segment_string(
+                    session_ptr.get(), 0, omega_session_get_computed_file_size(session_ptr.get()))
+         << endl;
+    return 0;
+}

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -132,6 +132,34 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
 int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path);
 
 /**
+ * Batch script operation kinds for sequential edit replay.
+ */
+typedef enum {
+    OMEGA_EDIT_SCRIPT_DELETE = 1,
+    OMEGA_EDIT_SCRIPT_INSERT = 2,
+    OMEGA_EDIT_SCRIPT_OVERWRITE = 3,
+    OMEGA_EDIT_SCRIPT_REPLACE = 4
+} omega_edit_script_op_kind_t;
+
+/**
+ * A single edit script operation.
+ *
+ * Semantics by kind:
+ * - DELETE: remove `length` bytes at `offset`; `bytes` and `bytes_length` are ignored
+ * - INSERT: insert `bytes_length` bytes from `bytes` at `offset`; `length` should be 0
+ * - OVERWRITE: overwrite `length` bytes at `offset` with `bytes_length` bytes from `bytes`
+ *   (`length` and `bytes_length` should match when both are non-zero)
+ * - REPLACE: replace `length` bytes at `offset` with `bytes_length` bytes from `bytes`
+ */
+typedef struct {
+    int64_t offset;
+    int64_t length;
+    omega_edit_script_op_kind_t kind;
+    const omega_byte_t *bytes;
+    int64_t bytes_length;
+} omega_edit_script_op_t;
+
+/**
  * Delete a number of bytes at the given offset
  * @param session_ptr session to make the change in
  * @param offset location offset to make the change
@@ -194,6 +222,48 @@ int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset,
  * and should not be used in production code.  In production code, explicitly pass in the length.
  */
 int64_t omega_edit_overwrite(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length);
+
+/**
+ * Replace a span of bytes at the given offset with a new byte sequence.
+ *
+ * If the delete and insert lengths match, this is lowered to a single overwrite. Otherwise it is
+ * applied as a delete followed by an insert in one logical transaction. If the insert step fails
+ * after a successful delete, the helper attempts to undo the delete before returning failure.
+ *
+ * @param session_ptr session to make the change in
+ * @param offset location offset to make the change
+ * @param delete_length number of original bytes to remove
+ * @param bytes replacement bytes, or null if `insert_length` is zero
+ * @param insert_length number of replacement bytes to insert
+ * @return positive change serial number on success, zero otherwise
+ */
+int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
+                                 const omega_byte_t *bytes, int64_t insert_length);
+
+/**
+ * Replace a span of bytes at the given offset with a new C string.
+ * @param session_ptr session to make the change in
+ * @param offset location offset to make the change
+ * @param delete_length number of original bytes to remove
+ * @param cstr replacement C string, or null if `insert_length` is zero
+ * @param insert_length length of the replacement string (if 0, strlen will be used)
+ * @return positive change serial number on success, zero otherwise
+ */
+int64_t omega_edit_replace(omega_session_t *session_ptr, int64_t offset, int64_t delete_length, const char *cstr,
+                           int64_t insert_length);
+
+/**
+ * Apply an array of edit script operations sequentially to the given session.
+ *
+ * Operations are applied in the order given. The function does not roll back already-applied
+ * operations if a later operation fails; it simply stops and returns non-zero.
+ *
+ * @param session_ptr session to edit
+ * @param ops array of edit operations
+ * @param op_count number of operations in the array
+ * @return zero on success and non-zero otherwise
+ */
+int omega_edit_apply_script(omega_session_t *session_ptr, const omega_edit_script_op_t *ops, size_t op_count);
 
 /**
  * Checkpoint and apply the given mask of the given mask type to the bytes starting at the given offset up to the given

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -185,6 +185,82 @@ namespace {
         return change_ptr;
     }
 
+    inline auto restore_viewport_callbacks_(omega_session_t *session_ptr, bool callbacks_were_paused,
+                                            bool notify_changed_viewports) -> void {
+        if (!session_ptr || callbacks_were_paused) { return; }
+        omega_session_resume_viewport_event_callbacks(session_ptr);
+        if (notify_changed_viewports) { omega_session_notify_changed_viewports(session_ptr); }
+    }
+
+    auto replace_bytes_impl_(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
+                             const omega_byte_t *bytes, int64_t insert_length) -> int64_t {
+        if (!session_ptr) { return -1; }
+        if (delete_length < 0 || insert_length < 0 || offset < 0) { return 0; }
+        if (!bytes && insert_length > 0) { return -1; }
+        if (delete_length == 0 && insert_length == 0) { return 0; }
+        if (delete_length == 0) { return omega_edit_insert_bytes(session_ptr, offset, bytes, insert_length); }
+        if (insert_length == 0) { return omega_edit_delete(session_ptr, offset, delete_length); }
+        if (delete_length == insert_length) { return omega_edit_overwrite_bytes(session_ptr, offset, bytes, insert_length); }
+
+        const auto callbacks_were_paused = omega_session_viewport_event_callbacks_paused(session_ptr) != 0;
+        if (!callbacks_were_paused) { omega_session_pause_viewport_event_callbacks(session_ptr); }
+
+        const auto transaction_state = omega_session_get_transaction_state(session_ptr);
+        const auto started_transaction = (transaction_state == 0) && (0 == omega_session_begin_transaction(session_ptr));
+        if ((transaction_state == 0) && !started_transaction) {
+            restore_viewport_callbacks_(session_ptr, callbacks_were_paused, false);
+            return -1;
+        }
+
+        int64_t last_serial = 0;
+        bool changed = false;
+        bool success = false;
+
+        do {
+            const auto delete_serial = omega_edit_delete(session_ptr, offset, delete_length);
+            if (delete_serial <= 0) { break; }
+            last_serial = delete_serial;
+            changed = true;
+
+            const auto insert_serial = omega_edit_insert_bytes(session_ptr, offset, bytes, insert_length);
+            if (insert_serial <= 0) {
+                if (0 >= omega_edit_undo_last_change(session_ptr)) { break; }
+                changed = false;
+                break;
+            }
+            last_serial = insert_serial;
+            changed = true;
+            success = true;
+        } while (false);
+
+        if (started_transaction) { omega_session_end_transaction(session_ptr); }
+        restore_viewport_callbacks_(session_ptr, callbacks_were_paused, changed);
+        return success ? last_serial : 0;
+    }
+
+    auto apply_script_op_(omega_session_t *session_ptr, const omega_edit_script_op_t &op) -> int64_t {
+        switch (op.kind) {
+            case OMEGA_EDIT_SCRIPT_DELETE:
+                return (op.length > 0) ? omega_edit_delete(session_ptr, op.offset, op.length) : 0;
+            case OMEGA_EDIT_SCRIPT_INSERT:
+                return (op.bytes_length > 0)
+                       ? omega_edit_insert_bytes(session_ptr, op.offset, op.bytes, op.bytes_length)
+                       : 0;
+            case OMEGA_EDIT_SCRIPT_OVERWRITE: {
+                if (op.length < 0 || op.bytes_length < 0) { return -1; }
+                if ((op.length > 0) && (op.bytes_length > 0) && (op.length != op.bytes_length)) { return -1; }
+                const auto overwrite_length = op.bytes_length > 0 ? op.bytes_length : op.length;
+                return (overwrite_length > 0)
+                       ? omega_edit_overwrite_bytes(session_ptr, op.offset, op.bytes, overwrite_length)
+                       : 0;
+            }
+            case OMEGA_EDIT_SCRIPT_REPLACE:
+                return replace_bytes_impl_(session_ptr, op.offset, op.length, op.bytes, op.bytes_length);
+            default:
+                return -1;
+        }
+    }
+
     inline void update_viewport_offset_adjustment_(omega_viewport_t *viewport_ptr,
                                                    const omega_change_t *change_ptr) {
         assert(0 < change_ptr->length);
@@ -761,6 +837,56 @@ int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset,
 
 int64_t omega_edit_overwrite(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length) {
     return omega_edit_overwrite_bytes(session_ptr, offset, (const omega_byte_t *) cstr, length);
+}
+
+int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
+                                 const omega_byte_t *bytes, int64_t insert_length) {
+    return replace_bytes_impl_(session_ptr, offset, delete_length, bytes, insert_length);
+}
+
+int64_t omega_edit_replace(omega_session_t *session_ptr, int64_t offset, int64_t delete_length, const char *cstr,
+                           int64_t insert_length) {
+    return omega_edit_replace_bytes(session_ptr, offset, delete_length, (const omega_byte_t *) cstr, insert_length);
+}
+
+int omega_edit_apply_script(omega_session_t *session_ptr, const omega_edit_script_op_t *ops, size_t op_count) {
+    if (!session_ptr) { return -1; }
+    if (!ops && op_count > 0) { return -1; }
+    if (op_count == 0) { return 0; }
+
+    const auto callbacks_were_paused = omega_session_viewport_event_callbacks_paused(session_ptr) != 0;
+    if (!callbacks_were_paused) { omega_session_pause_viewport_event_callbacks(session_ptr); }
+
+    const auto transaction_state = omega_session_get_transaction_state(session_ptr);
+    const auto started_transaction = (transaction_state == 0) && (0 == omega_session_begin_transaction(session_ptr));
+    if ((transaction_state == 0) && !started_transaction) {
+        restore_viewport_callbacks_(session_ptr, callbacks_were_paused, false);
+        return -1;
+    }
+
+    bool changed = false;
+    int rc = 0;
+    for (size_t i = 0; i < op_count; ++i) {
+        const auto serial = apply_script_op_(session_ptr, ops[i]);
+        if (serial < 0) {
+            rc = -1;
+            break;
+        }
+        if (serial == 0 &&
+            (ops[i].kind == OMEGA_EDIT_SCRIPT_DELETE ||
+             ops[i].kind == OMEGA_EDIT_SCRIPT_INSERT ||
+             ops[i].kind == OMEGA_EDIT_SCRIPT_OVERWRITE ||
+             ops[i].kind == OMEGA_EDIT_SCRIPT_REPLACE) &&
+            (ops[i].length > 0 || ops[i].bytes_length > 0)) {
+            rc = -1;
+            break;
+        }
+        if (serial > 0) { changed = true; }
+    }
+
+    if (started_transaction) { omega_session_end_transaction(session_ptr); }
+    restore_viewport_callbacks_(session_ptr, callbacks_were_paused, changed);
+    return rc;
 }
 
 int omega_edit_apply_transform(omega_session_t *session_ptr, omega_util_byte_transform_t transform, void *user_data_ptr,

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -61,6 +61,54 @@ TEST_CASE("Bit Manipulation", "[BitManip]") {
     REQUIRE(~(1 << 31) == 2147483647);
 }
 
+TEST_CASE("Replace Helper", "[EditScript]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "alpha beta gamma"));
+    REQUIRE(0 < omega_edit_replace(session_ptr, 6, 4, "OMEGA", 5));
+    REQUIRE("alpha OMEGA gamma" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(2 == omega_session_get_num_change_transactions(session_ptr));
+
+    REQUIRE(0 < omega_edit_replace(session_ptr, 0, 5, "ALPHA", 5));
+    REQUIRE("ALPHA OMEGA gamma" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(3 == omega_session_get_num_change_transactions(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Apply Script", "[EditScript]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    static const omega_byte_t hello_world[] = "hello world";
+    static const omega_byte_t omega_edit[] = "OmegaEdit";
+    static const omega_byte_t hello_upper[] = "HELLO";
+    static const omega_byte_t comma_space[] = ", ";
+
+    const omega_edit_script_op_t ops[] = {
+            {0, 0, OMEGA_EDIT_SCRIPT_INSERT, hello_world, 11},
+            {6, 5, OMEGA_EDIT_SCRIPT_REPLACE, omega_edit, 9},
+            {0, 5, OMEGA_EDIT_SCRIPT_OVERWRITE, hello_upper, 5},
+            {5, 1, OMEGA_EDIT_SCRIPT_DELETE, nullptr, 0},
+            {5, 0, OMEGA_EDIT_SCRIPT_INSERT, comma_space, 2},
+    };
+
+    REQUIRE(0 == omega_edit_apply_script(session_ptr, ops, sizeof(ops) / sizeof(ops[0])));
+    REQUIRE("HELLO, OmegaEdit" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(1 == omega_session_get_num_change_transactions(session_ptr));
+
+    const omega_edit_script_op_t bad_ops[] = {
+            {0, 3, static_cast<omega_edit_script_op_kind_t>(999), nullptr, 0},
+    };
+    REQUIRE(0 != omega_edit_apply_script(session_ptr, bad_ops, sizeof(bad_ops) / sizeof(bad_ops[0])));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Model Tests", "[ModelTests]") {
     file_info_t file_info;
     file_info.num_changes = 0;


### PR DESCRIPTION
## Summary
- add OMEGA_EDIT_EMBED_MODE to make subproject/embedded builds lean and predictable
- add native omega_edit_replace[_bytes] helpers for variable-width replacement
- add omega_edit_apply_script(...) for sequential replay of edit op arrays
- add a production-oriented pply_script core example and tests for the new APIs

Fixes #1349
Fixes #1351
Fixes #1353
Fixes #1354

## Details
This smooths the core C integration surface for downstream embedders like OmegaMatch.

Embed mode now disables tests, docs, examples, coverage, and root packaging so dd_subdirectory(...) consumers can opt into a quieter dependency build without forcing project-wide extras.

The new scripted replay surface keeps the existing edit engine model intact while removing a bunch of repetitive adapter code downstream:
- omega_edit_replace_bytes(...)
- omega_edit_replace(...)
- omega_edit_apply_script(...)
- omega_edit_script_op_t
- omega_edit_script_op_kind_t

## Validation
- configured and built a normal Debug Windows build with tests/examples enabled
- configured and built an embed-mode check with -DOMEGA_EDIT_EMBED_MODE=ON
- ctest --test-dir extern/omega-edit/_build/codex/core --build-config Debug --output-on-failure
- ran core/Debug/apply_script.exe successfully and verified output

## Follow-up
Once this lands, I can come back to OmegaMatch and simplify its temporary OmegaEdit integration glue around replay and embedding.