### PR TITLE
Fix VS Code extension build and test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,49 @@ on:
   workflow_dispatch:
 
 jobs:
+  vscode-extension:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025]
+        vscode-version: ['1.110.0', stable]
+      fail-fast: false
+    name: VS Code extension checks on ${{ matrix.os }} with VS Code ${{ matrix.vscode-version }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: examples/vscode-extension/package-lock.json
+
+      - name: Install VS Code extension example dependencies
+        run: npm ci
+        working-directory: examples/vscode-extension
+
+      - name: Build and run fast VS Code extension checks
+        run: npm run lint && npm run compile && npm run test:unit
+        working-directory: examples/vscode-extension
+        env:
+          VSCODE_VERSION: ${{ matrix.vscode-version }}
+
+      - name: Run VS Code extension integration tests on Linux
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:integration
+        working-directory: examples/vscode-extension
+        env:
+          VSCODE_VERSION: ${{ matrix.vscode-version }}
+
+      - name: Run VS Code extension integration tests on Windows
+        if: runner.os == 'Windows'
+        run: npm run test:integration
+        working-directory: examples/vscode-extension
+        env:
+          VSCODE_VERSION: ${{ matrix.vscode-version }}
+
   build-native:
     strategy:
       matrix:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,4 +1,20 @@
 {
   "version": "0.2.0",
-  "configurations": []
+  "configurations": [
+    {
+      "name": "Run OmegaEdit VS Code Example",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--disable-extensions",
+        "--disable-workspace-trust",
+        "--skip-welcome",
+        "--extensionDevelopmentPath=${workspaceFolder}/examples/vscode-extension"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/examples/vscode-extension/out/**/*.js"
+      ],
+      "preLaunchTask": "compile:vscode-extension"
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "compile:vscode-extension",
+      "type": "shell",
+      "command": "npm run compile",
+      "options": {
+        "cwd": "${workspaceFolder}/examples/vscode-extension"
+      },
+      "group": "build",
+      "problemMatcher": [
+        "$tsc"
+      ]
+    },
+    {
+      "label": "run:vscode-extension-host",
+      "type": "process",
+      "command": "code",
+      "args": [
+        "--new-window",
+        "--disable-extensions",
+        "--disable-workspace-trust",
+        "--skip-welcome",
+        "--extensionDevelopmentPath=${workspaceFolder}\\examples\\vscode-extension",
+        "${workspaceFolder}"
+      ],
+      "group": "test",
+      "dependsOn": "compile:vscode-extension",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/examples/vscode-extension/.vscode/launch.json
+++ b/examples/vscode-extension/.vscode/launch.json
@@ -6,11 +6,12 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
+        "--disable-extensions",
+        "--disable-workspace-trust",
+        "--skip-welcome",
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
-      "outFiles": [
-        "${workspaceFolder}/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
       "preLaunchTask": "npm: compile"
     }
   ]

--- a/examples/vscode-extension/README.md
+++ b/examples/vscode-extension/README.md
@@ -1,124 +1,142 @@
-# Ωedit™ Hex Editor — Reference VS Code Extension
+# OmegaEdit Hex Editor - Reference VS Code Extension
 
-A minimal, standalone reference VS Code extension that demonstrates how to use [Ωedit™](https://github.com/ctc-oss/omega-edit) as a data/hex editor. This is intended as a starting point for extension developers — not a production hex editor.
+A standalone reference VS Code extension that demonstrates how to use [OmegaEdit](https://github.com/ctc-oss/omega-edit) as a fast, usable data/hex editor. It is still intentionally smaller than a marketplace-grade product, but it now covers the core editing, navigation, save, replay, and testing paths needed to evaluate a serious integration.
 
-![Ωedit™ Hex Editor](../../images/omega-edit-logo.png)
+![OmegaEdit Hex Editor](../../images/omega-edit-logo.png)
 
 ## What This Demonstrates
 
-| Integration Point | Where |
-|---|---|
-| Start Ωedit™ server on `activate()` | [extension.ts](src/extension.ts) |
-| Stop server on `deactivate()` | [extension.ts](src/extension.ts) |
-| `CustomReadonlyEditorProvider` wired to Ωedit™ | [hexEditorProvider.ts](src/hexEditorProvider.ts) |
-| Create session per opened file | [hexEditorProvider.ts](src/hexEditorProvider.ts) |
-| Viewport → webview data flow (reactive) | [hexEditorProvider.ts](src/hexEditorProvider.ts) |
-| Subscribe to viewport & session events | [hexEditorProvider.ts](src/hexEditorProvider.ts) |
-| Insert / delete / overwrite from UI | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts) |
-| Search (text & hex, case-insensitive) | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts) |
-| Undo / redo | [hexEditorProvider.ts](src/hexEditorProvider.ts) |
-| Extension settings (port, log level, bytes/row) | [package.json](package.json) |
-| Hex + ASCII webview rendering | [webview.ts](src/webview.ts) |
+| Integration Point                                         | Where                                                                               |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Start OmegaEdit server on `activate()`                    | [extension.ts](src/extension.ts)                                                    |
+| Stop server on `deactivate()`                             | [extension.ts](src/extension.ts)                                                    |
+| `CustomReadonlyEditorProvider` wired to OmegaEdit         | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
+| Direct open from command palette / explorer               | [extension.ts](src/extension.ts)                                                    |
+| Create session per opened file                            | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
+| Viewport to webview data flow                             | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
+| Insert / delete / overwrite / replace from UI             | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
+| Search and replace with text/hex and direction controls   | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
+| Undo / redo with stack counts                             | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
+| Save / Save As / dirty tracking                           | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
+| Export / replay JSON change scripts                       | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [extension.ts](src/extension.ts) |
+| Bytes-per-row and offset-radix controls                   | [webview.ts](src/webview.ts)                                                        |
+| Status bar, binary inspector, and server health indicator | [webview.ts](src/webview.ts)                                                        |
+| Extension settings                                        | [package.json](package.json)                                                        |
 
 ## Quick Start
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) ≥ 18
-- [VS Code](https://code.visualstudio.com/) ≥ 1.80
+- [Node.js](https://nodejs.org/) >= 18
+- [VS Code](https://code.visualstudio.com/) >= 1.110
 
-### Run with F5
+The current VS Code floor is `1.110` because that is the oldest version exercised in CI and it matches the `@types/vscode` version used to compile the example. If the support range is widened later, the CI matrix should be widened with it.
+
+### Run With F5
 
 ```bash
 cd examples/vscode-extension
 npm install
+npm test
 ```
 
-Then open this folder in VS Code and press **F5**. A new Extension Development Host window will open.
+Then open this folder in VS Code and press `F5`. A new Extension Development Host window will open.
 
-In the new window, right-click any file → **"Open With…"** → **"Ωedit™ Hex Editor"**.
+In the new window:
 
-### What Happens Under the Hood
+- Run `OmegaEdit: Open in Hex Editor` from the Command Palette to pick any file directly
+- Or right-click a file in the Explorer and choose `OmegaEdit: Open in Hex Editor`
 
-1. **`activate()`** reads the `omegaEdit.serverPort` setting (default: `9000`) and calls `startServer(port)` from `@omega-edit/client`. The server binary is bundled inside the npm package — no separate install needed.
+## What Happens Under The Hood
 
-2. When you open a file with the hex editor, the provider:
-   - Creates an **Ωedit™ session** for the file (`createSession(filePath)`)
-   - Creates a **viewport** at offset 0 with 1 KiB capacity (`createViewport()`)
-   - **Subscribes to viewport events** so edits anywhere (including from other sessions sharing the same file) push fresh data to the webview
-
-3. Edits from the UI (Insert/Delete/Overwrite buttons or keyboard) are sent to the extension host, which calls the corresponding `@omega-edit/client` function (`insert()`, `del()`, `overwrite()`). The viewport event subscription automatically updates the webview.
-
-4. **`deactivate()`** calls `stopServerGraceful()` — the server finishes in-flight work and exits.
+1. `activate()` reads the `omegaEdit.serverPort` setting and starts the bundled native server through `@omega-edit/client`.
+2. Opening a file creates an OmegaEdit session and viewport, then subscribes to viewport and session updates.
+3. The native server now uses server-managed checkpoint directories under the host temp directory for auto-managed sessions, which keeps checkpoint artifacts out of the source file's folder and makes cleanup predictable.
+4. The webview drives edits, navigation, search, replace, save, and replay through the provider, and the provider pushes back reactive state updates for the viewport, undo/redo counts, dirty state, replace counts, and server health.
+5. `deactivate()` calls `stopServerGraceful()` so the server can shut down cleanly.
 
 ## Extension Settings
 
-| Setting | Default | Description |
-|---|---|---|
-| `omegaEdit.serverPort` | `9000` | gRPC server port |
-| `omegaEdit.logLevel` | `info` | Client log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`) |
-| `omegaEdit.bytesPerRow` | `16` | Bytes displayed per row (8 / 16 / 32) |
+| Setting                 | Default | Description                                                                |
+| ----------------------- | ------- | -------------------------------------------------------------------------- |
+| `omegaEdit.serverPort`  | `9000`  | gRPC server port                                                           |
+| `omegaEdit.logLevel`    | `info`  | Client log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`) |
+| `omegaEdit.bytesPerRow` | `16`    | Bytes displayed per row (8 / 16 / 32)                                      |
 
-## Keyboard Shortcuts (in the hex view)
+## Keyboard Shortcuts
 
-| Key | Action |
-|---|---|
-| Ctrl+Z | Undo |
-| Ctrl+Y | Redo |
-| Ctrl+S | Save |
-| Ctrl+F | Focus search box |
-| Page Up / Page Down | Scroll by 32 rows |
-| Ctrl+Home / Ctrl+End | Jump to start / end |
-| Mouse wheel | Scroll by 4 rows |
+| Key                      | Action                                                     |
+| ------------------------ | ---------------------------------------------------------- |
+| `Ctrl+Z`                 | Undo                                                       |
+| `Ctrl+Y`                 | Redo                                                       |
+| `Ctrl+S`                 | Save                                                       |
+| `Ctrl+Shift+S`           | Save As                                                    |
+| `Ctrl+F`                 | Focus search                                               |
+| Arrow keys               | Move selection, or scroll by line when nothing is selected |
+| `Page Up` / `Page Down`  | Scroll by 32 rows                                          |
+| `Ctrl+Home` / `Ctrl+End` | Jump to start / end                                        |
+| Mouse wheel              | Scroll by 4 rows                                           |
+
+## Testing
+
+The example is exercised in CI on Linux and Windows against both the declared VS Code floor and latest stable release.
+
+Useful local commands:
+
+```bash
+npm run lint
+npm run format:check
+npm run compile
+npm run test:unit
+VSCODE_VERSION=1.110.0 npm run test:integration
+VSCODE_VERSION=stable npm run test:integration
+```
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────────────┐
-│  VS Code Extension Host                                 │
-│  ┌─────────────┐    ┌──────────────────────────┐        │
-│  │ extension.ts │───▶│ hexEditorProvider.ts      │        │
-│  │ activate()   │    │ - createSession()         │        │
-│  │ deactivate() │    │ - createViewport()        │        │
-│  └──────┬───────┘    │ - subscribe to events     │        │
-│         │            │ - handle insert/del/...   │        │
-│         │            └────────┬────────▲─────────┘        │
-│         │                     │        │                  │
-│  ┌──────▼───────┐    ┌────────▼────────┴─────────┐       │
-│  │ startServer() │    │ Webview (webview.ts)       │       │
-│  │ stopServer()  │    │ - hex + ASCII grid         │       │
-│  └──────┬───────┘    │ - edit dialog               │       │
-│         │            │ - search UI                  │       │
-│         │            └──────────────────────────────┘       │
-│  ┌──────▼───────────────────────────────────────────┐      │
-│  │  @omega-edit/client  (npm package)               │      │
-│  │  - TypeScript API wrappers                        │      │
-│  │  - Bundled native gRPC server binary              │      │
-│  └──────┬───────────────────────────────────────────┘      │
-│         │ gRPC                                              │
-│  ┌──────▼───────────────────────────────────────────┐      │
-│  │  Ωedit™ C++ Server (child process)               │      │
-│  │  - Session management                             │      │
-│  │  - Change tracking with undo/redo                 │      │
-│  │  - Viewport event streaming                       │      │
-│  │  - Server-side save (replay changes)              │      │
-│  └──────────────────────────────────────────────────┘      │
-└─────────────────────────────────────────────────────────────┘
+```text
++--------------------------------------------------------------+
+| VS Code Extension Host                                       |
+|  extension.ts                                                |
+|   -> startServer() / stopServerGraceful()                    |
+|   -> command registration                                    |
+|   -> custom editor registration                              |
+|                                                              |
+|  hexEditorProvider.ts                                        |
+|   -> createSession() / createViewport()                      |
+|   -> event subscriptions                                     |
+|   -> search / replace / save / replay                        |
+|   -> webview state sync                                      |
+|                                                              |
+|  webview.ts                                                  |
+|   -> hex + text rendering                                    |
+|   -> virtual navigation controls                             |
+|   -> toolbar / dialogs / status bar                          |
++-----------------------------+--------------------------------+
+                              |
+                              | gRPC
+                              v
++--------------------------------------------------------------+
+| OmegaEdit native server                                      |
+|  - sessions, viewports, undo/redo                            |
+|  - checkpoint handling                                       |
+|  - save and replay support                                   |
+|  - server info / heartbeat                                   |
++--------------------------------------------------------------+
 ```
 
 ## Extending This Example
 
-This reference implementation is intentionally minimal. Here are some ideas for extension:
+This reference implementation is intentionally compact. A few natural next steps are:
 
-- **Read-write custom editor**: Switch from `CustomReadonlyEditorProvider` to `CustomEditorProvider` to integrate with VS Code's dirty-document model (backup, revert, etc.)
-- **Multiple viewports**: Create additional viewports for split-pane views or overview panels
-- **Data profiling**: Call `profileSession()` to show byte frequency statistics
-- **Replace**: Wire `replaceSession()` to the search UI
-- **Transactions**: Use `beginSessionTransaction()` / `endSessionTransaction()` to group edits
-- **Multi-author**: Share a session ID across extension instances for collaborative editing
+- Switch from `CustomReadonlyEditorProvider` to `CustomEditorProvider` for full VS Code dirty-document integration
+- Add multiple coordinated viewports or overview panels
+- Surface richer profiling / structure analysis views
+- Add bookmarks and richer navigation helpers
+- Share session IDs across instances for collaborative or multi-tool workflows
 
 ## Related
 
-- [Ωedit™ TypeScript Examples](../typescript/) — Standalone Node.js examples using `@omega-edit/client`
-- [@omega-edit/client on npm](https://www.npmjs.com/package/@omega-edit/client) — The client package used here
-- [Apache Daffodil™ VS Code Extension](https://github.com/apache/daffodil-vscode) — Production extension using Ωedit™
+- [OmegaEdit TypeScript Examples](../typescript/) - Standalone Node.js examples using `@omega-edit/client`
+- [@omega-edit/client on npm](https://www.npmjs.com/package/@omega-edit/client) - The client package used here
+- [Apache Daffodil VS Code Extension](https://github.com/apache/daffodil-vscode) - Production extension using OmegaEdit

--- a/examples/vscode-extension/eslint.config.js
+++ b/examples/vscode-extension/eslint.config.js
@@ -1,0 +1,66 @@
+const globals = require('globals')
+const prettierPlugin = require('eslint-plugin-prettier')
+const prettierConfig = require('eslint-config-prettier')
+const tsParser = require('@typescript-eslint/parser')
+const tsPlugin = require('@typescript-eslint/eslint-plugin')
+
+module.exports = [
+  {
+    ignores: ['node_modules/**', 'out/**', '.vscode-test/**'],
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      prettier: prettierPlugin,
+    },
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2021,
+      },
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+      'prettier/prettier': 'error',
+    },
+  },
+  {
+    files: ['**/*.{js,cjs,mjs}'],
+    plugins: { prettier: prettierPlugin },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'commonjs',
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
+    },
+    rules: {
+      'no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+      'prettier/prettier': 'error',
+    },
+  },
+  prettierConfig,
+]

--- a/examples/vscode-extension/package-lock.json
+++ b/examples/vscode-extension/package-lock.json
@@ -1,0 +1,3172 @@
+{
+  "name": "omega-edit-hex-editor",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omega-edit-hex-editor",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@omega-edit/client": "^1.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "^18.0.0",
+        "@types/vscode": "^1.110.0",
+        "@typescript-eslint/eslint-plugin": "^8.57.2",
+        "@typescript-eslint/parser": "^8.57.2",
+        "@vscode/test-electron": "^2.5.2",
+        "eslint": "^10.1.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-prettier": "^5.5.5",
+        "globals": "^17.4.0",
+        "mocha": "^10.8.2",
+        "prettier": "^3.8.1",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "vscode": "^1.110.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.2.tgz",
+      "integrity": "sha512-bgxdZmgTrJZX50OjyVwz3+mNEnCTNkh3cIqGPWVNeW9jX6bn1ZkU80uPd+67/ZpIJIjRQ9qaHCjhavyoWYxumg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@omega-edit/client": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@omega-edit/client/-/client-1.0.1.tgz",
+      "integrity": "sha512-M2K23JtdRyZO+gm1nXG642bhk4vM9DxoZWvBVKTjndSaBNc6cJgpUkRwxPMLr7lyvvU+AWyJcV+XyI9pfYTT0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "1.12.2",
+        "@omega-edit/server": "1.0.1",
+        "@types/google-protobuf": "3.15.12",
+        "google-protobuf": "3.21.4",
+        "pid-port": "2.0.0",
+        "pino": "10.0.0",
+        "wait-port": "1.1.0"
+      }
+    },
+    "node_modules/@omega-edit/server": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@omega-edit/server/-/server-1.0.1.tgz",
+      "integrity": "sha512-ayQer7NmvM2abjk56m4mjYbeW240Vt57Ia3i6xkiuGjg0Ddh6C9lRiDgqnYwFLxOwci5rBPQjF06fOMhLzsdoQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/google-protobuf": {
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz",
+      "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.110.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
+      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
+      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/type-utils": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
+      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.2",
+        "@typescript-eslint/types": "^8.57.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
+      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
+      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
+      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.2",
+        "@typescript-eslint/tsconfig-utils": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
+      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.12"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pid-port": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pid-port/-/pid-port-2.0.0.tgz",
+      "integrity": "sha512-EDmfRxLl6lkhPjDI+19l5pkII89xVsiCP3aGjS808f7M16DyCKSXEWthD/hjyDLn5I4gKqTVw7hSgdvdXRJDTw==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^9.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wait-port": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "wait-port": "bin/wait-port.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/examples/vscode-extension/package.json
+++ b/examples/vscode-extension/package.json
@@ -1,26 +1,29 @@
 {
   "name": "omega-edit-hex-editor",
-  "displayName": "Ωedit™ Hex Editor",
-  "description": "A minimal reference hex/data editor VS Code extension powered by Ωedit™",
+  "displayName": "OmegaEdit Hex Editor",
+  "description": "A minimal reference hex/data editor VS Code extension powered by OmegaEdit",
   "version": "0.1.0",
   "publisher": "omega-edit-example",
   "license": "Apache-2.0",
   "engines": {
-    "vscode": "^1.80.0"
+    "vscode": "^1.110.0"
   },
   "categories": [
     "Other"
   ],
   "activationEvents": [
     "onCustomEditor:omegaEdit.hexEditor",
-    "onCommand:omegaEdit.goToOffset"
+    "onCommand:omegaEdit.openInHexEditor",
+    "onCommand:omegaEdit.goToOffset",
+    "onCommand:omegaEdit.exportChangeScript",
+    "onCommand:omegaEdit.replayChangeScript"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "customEditors": [
       {
         "viewType": "omegaEdit.hexEditor",
-        "displayName": "Ωedit™ Hex Editor",
+        "displayName": "OmegaEdit Hex Editor",
         "selector": [
           {
             "filenamePattern": "*"
@@ -30,12 +33,12 @@
       }
     ],
     "configuration": {
-      "title": "Ωedit™ Hex Editor",
+      "title": "OmegaEdit Hex Editor",
       "properties": {
         "omegaEdit.serverPort": {
           "type": "number",
           "default": 9000,
-          "description": "Port for the Ωedit™ gRPC server"
+          "description": "Port for the OmegaEdit gRPC server"
         },
         "omegaEdit.logLevel": {
           "type": "string",
@@ -48,7 +51,7 @@
             "error",
             "fatal"
           ],
-          "description": "Log level for the Ωedit™ client"
+          "description": "Log level for the OmegaEdit client"
         },
         "omegaEdit.bytesPerRow": {
           "type": "number",
@@ -64,22 +67,79 @@
     },
     "commands": [
       {
+        "command": "omegaEdit.openInHexEditor",
+        "title": "OmegaEdit: Open in Hex Editor"
+      },
+      {
         "command": "omegaEdit.goToOffset",
-        "title": "Ωedit™: Go to Offset"
+        "title": "OmegaEdit: Go to Offset"
+      },
+      {
+        "command": "omegaEdit.exportChangeScript",
+        "title": "OmegaEdit: Export Change Script"
+      },
+      {
+        "command": "omegaEdit.replayChangeScript",
+        "title": "OmegaEdit: Replay Change Script"
       }
-    ]
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "omegaEdit.openInHexEditor",
+          "when": "resourceScheme == file",
+          "group": "navigation"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "omegaEdit.openInHexEditor",
+          "when": "resourceScheme == file",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "omegaEdit.openInHexEditor"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "format:check": "prettier --check package.json README.md eslint.config.js src tests .vscode",
+    "format:write": "prettier --write package.json README.md eslint.config.js src tests .vscode",
+    "lint": "npm run format:check && eslint .",
+    "lint:fix": "npm run format:write && eslint --fix .",
+    "test:unit": "node --test tests/extension.test.js",
+    "test:integration": "node ./tests/run-vscode-tests.js",
+    "test:integration:observe": "node ./tests/run-vscode-observe.js",
+    "test": "npm run lint && npm run compile && npm run test:unit && npm run test:integration"
   },
   "dependencies": {
     "@omega-edit/client": "^1.0.1"
   },
   "devDependencies": {
+    "@vscode/test-electron": "^2.5.2",
+    "@typescript-eslint/eslint-plugin": "^8.57.2",
+    "@typescript-eslint/parser": "^8.57.2",
     "@types/node": "^18.0.0",
-    "@types/vscode": "^1.80.0",
+    "@types/vscode": "^1.110.0",
+    "eslint": "^10.1.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.5",
+    "globals": "^17.4.0",
+    "mocha": "^10.8.2",
+    "prettier": "^3.8.1",
     "typescript": "^5.0.0"
+  },
+  "prettier": {
+    "endOfLine": "auto",
+    "semi": false,
+    "singleQuote": true,
+    "tabWidth": 2,
+    "trailingComma": "es5"
   }
 }

--- a/examples/vscode-extension/src/constants.ts
+++ b/examples/vscode-extension/src/constants.ts
@@ -1,0 +1,7 @@
+export const OMEGA_EDIT_VIEW_TYPE = 'omegaEdit.hexEditor'
+export const OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND = 'omegaEdit.openInHexEditor'
+export const OMEGA_EDIT_GO_TO_OFFSET_COMMAND = 'omegaEdit.goToOffset'
+export const OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND =
+  'omegaEdit.exportChangeScript'
+export const OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND =
+  'omegaEdit.replayChangeScript'

--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -24,11 +24,25 @@
 
 import * as vscode from 'vscode'
 import { startServer, stopServerGraceful, getClient } from '@omega-edit/client'
+import {
+  OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND,
+  OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+  OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+  OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND,
+  OMEGA_EDIT_VIEW_TYPE,
+} from './constants'
 import { HexEditorProvider } from './hexEditorProvider'
 
 let serverPid: number | undefined
+let activeProvider: HexEditorProvider | undefined
 
-export async function activate(context: vscode.ExtensionContext): Promise<void> {
+function isTestRuntime(): boolean {
+  return process.env.NODE_ENV === 'test'
+}
+
+export async function activate(
+  context: vscode.ExtensionContext
+): Promise<void> {
   const config = vscode.workspace.getConfiguration('omegaEdit')
   const port = config.get<number>('serverPort', 9000)
 
@@ -65,6 +79,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // --- Step 2: Register the hex editor ---
   const provider = new HexEditorProvider(context, port)
+  activeProvider = provider
   context.subscriptions.push(
     vscode.window.registerCustomEditorProvider(
       HexEditorProvider.viewType,
@@ -78,20 +93,76 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // --- Commands ---
   context.subscriptions.push(
-    vscode.commands.registerCommand('omegaEdit.goToOffset', async () => {
-      const input = await vscode.window.showInputBox({
-        prompt: 'Enter byte offset (decimal or 0x hex)',
-        placeHolder: '0x0000',
-        validateInput: (v) => {
-          const n = v.startsWith('0x') ? parseInt(v, 16) : parseInt(v, 10)
-          return isNaN(n) || n < 0 ? 'Enter a valid non-negative integer' : null
-        },
-      })
-      if (input !== undefined) {
-        const offset = input.startsWith('0x') ? parseInt(input, 16) : parseInt(input, 10)
-        provider.goToOffset(offset)
+    vscode.commands.registerCommand(
+      OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+      async (resource?: vscode.Uri) => {
+        let target = resource ?? vscode.window.activeTextEditor?.document.uri
+
+        if (!target) {
+          target = (
+            await vscode.window.showOpenDialog({
+              canSelectMany: false,
+              canSelectFiles: true,
+              canSelectFolders: false,
+              openLabel: 'Open in OmegaEdit Hex Editor',
+              title: 'Select a file to open in OmegaEdit Hex Editor',
+            })
+          )?.[0]
+        }
+
+        if (!target) {
+          return
+        }
+
+        await vscode.commands.executeCommand(
+          'vscode.openWith',
+          target,
+          OMEGA_EDIT_VIEW_TYPE
+        )
       }
-    })
+    )
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+      async () => {
+        const input = await vscode.window.showInputBox({
+          prompt: 'Enter byte offset (decimal or 0x hex)',
+          placeHolder: '0x0000',
+          validateInput: (v) => {
+            const n = v.startsWith('0x') ? parseInt(v, 16) : parseInt(v, 10)
+            return isNaN(n) || n < 0
+              ? 'Enter a valid non-negative integer'
+              : null
+          },
+        })
+        if (input !== undefined) {
+          const offset = input.startsWith('0x')
+            ? parseInt(input, 16)
+            : parseInt(input, 10)
+          provider.goToOffset(offset)
+        }
+      }
+    )
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND,
+      async () => {
+        await provider.exportActiveChangeScript()
+      }
+    )
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND,
+      async () => {
+        await provider.replayActiveChangeScript()
+      }
+    )
   )
 
   // Listen for configuration changes
@@ -105,6 +176,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 }
 
 export async function deactivate(): Promise<void> {
+  activeProvider = undefined
+
   // --- Step 3: Graceful shutdown ---
   // stopServerGraceful() tells the server to stop accepting new sessions and
   // exit once all existing sessions are destroyed. This mirrors the pattern
@@ -114,4 +187,10 @@ export async function deactivate(): Promise<void> {
   } catch {
     // Server may already be stopped; swallow errors during deactivation
   }
+}
+
+export function getHexEditorProviderForTesting():
+  | HexEditorProvider
+  | undefined {
+  return isTestRuntime() ? activeProvider : undefined
 }

--- a/examples/vscode-extension/src/hexEditorProvider.ts
+++ b/examples/vscode-extension/src/hexEditorProvider.ts
@@ -29,44 +29,77 @@
 
 import * as vscode from 'vscode'
 import {
-  getClient,
+  ALL_EVENTS,
+  EventSubscriptionRequest,
+  IOFlags,
+  SessionEventKind,
+  ViewportEventKind,
   createSession,
-  destroySession,
-  saveSession,
-  getComputedFileSize,
-  insert,
+  createViewport,
   del,
+  destroySession,
+  destroyViewport,
+  editSimple,
+  getClient,
+  getClientVersion,
+  getServerHeartbeat,
+  getServerInfo,
+  getSegment,
+  getComputedFileSize,
+  getViewportData,
+  insert,
+  modifyViewport,
   overwrite,
-  import {
-    getClient,
-    createSession,
-    destroySession,
-    saveSession,
-    getComputedFileSize,
-    insert,
-    del,
-    overwrite,
-    undo,
-    redo,
-    createViewport,
-    modifyViewport,
-    destroyViewport,
-    getViewportData,
-    searchSession,
-    IOFlags,
-    EventSubscriptionRequest,
-    ALL_EVENTS,
-    ViewportEventKind,
-    SessionEventKind,
-  } from '@omega-edit/client'
+  redo,
+  saveSession,
+  searchSession,
+  undo,
+} from '@omega-edit/client'
+import { OMEGA_EDIT_VIEW_TYPE } from './constants'
+import { getWebviewContent } from './webview'
+
+interface EditorSession {
+  sessionId: string
+  viewportId: string
+  fileSize: number
+  offset: number
+  visibleRows: number
+  capacity: number
   filePath: string
+  savedChangeDepth: number
   panel: vscode.WebviewPanel
+  changeLog: ChangeRecord[]
+  undoneChangeLog: ChangeRecord[]
+  disposed: boolean
+  pendingScrollOffset?: number
+  scrollTask?: Promise<void>
   viewportStream?: { cancel(): void }
   sessionStream?: { cancel(): void }
 }
 
+type ChangeRecordKind = 'INSERT' | 'DELETE' | 'OVERWRITE' | 'REPLACE'
+
+interface ChangeRecord {
+  serial: number
+  kind: ChangeRecordKind
+  offset: number
+  length: number
+  data: string
+}
+
+interface ServerHealthState {
+  type: 'serverHealth'
+  ok: boolean
+  summary: string
+  detail: string
+}
+
+const SESSION_SYNC_TIMEOUT_MS = 2000
+const SESSION_SYNC_POLL_MS = 25
+const VIEWPORT_BUFFER_BYTES = 8 * 1024
+
 export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
-  public static readonly viewType = 'omegaEdit.hexEditor'
+  public static readonly viewType = OMEGA_EDIT_VIEW_TYPE
 
   /** Active editor sessions keyed by document URI string */
   private sessions = new Map<string, EditorSession>()
@@ -74,10 +107,45 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
   /** The editor that last had focus (for goToOffset command routing) */
   private activeSession: EditorSession | undefined
 
+  private heartbeatTimer: ReturnType<typeof setInterval> | undefined
+
+  private heartbeatInFlight = false
+
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly port: number
   ) {}
+
+  private getViewportCapacity(bytesPerRow: number): number {
+    const bufferedRows = Math.max(
+      128,
+      Math.ceil(VIEWPORT_BUFFER_BYTES / bytesPerRow)
+    )
+    return bufferedRows * bytesPerRow
+  }
+
+  public getSessionForTesting(uri: vscode.Uri): EditorSession | undefined {
+    if (process.env.NODE_ENV !== 'test') {
+      return undefined
+    }
+    return this.sessions.get(uri.toString())
+  }
+
+  public async dispatchWebviewMessageForTesting(
+    uri: vscode.Uri,
+    msg: WebviewMessage
+  ): Promise<void> {
+    if (process.env.NODE_ENV !== 'test') {
+      throw new Error('Test-only message dispatch is unavailable outside tests')
+    }
+
+    const session = this.sessions.get(uri.toString())
+    if (!session) {
+      throw new Error(`No session found for ${uri.toString()}`)
+    }
+
+    await this.handleWebviewMessage(session, msg)
+  }
 
   // ── VS Code Custom Editor API ───────────────────────────────────────
 
@@ -105,8 +173,9 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
     const config = vscode.workspace.getConfiguration('omegaEdit')
     const bytesPerRow = config.get<number>('bytesPerRow', 16)
 
-    // Viewport capacity: enough rows to fill a typical editor pane
-    const capacity = bytesPerRow * 64 // 1 KiB at 16 bytes/row
+    // Keep a fixed buffered viewport so resizing the editor does not need to
+    // resize the server-side viewport. Only the visible row count changes.
+    const capacity = this.getViewportCapacity(bytesPerRow)
 
     // --- Create a viewport starting at offset 0 ---
     const vpResp = await createViewport(
@@ -123,9 +192,14 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
       viewportId,
       fileSize,
       offset: 0,
+      visibleRows: 32,
       capacity,
       filePath,
+      savedChangeDepth: 0,
       panel: webviewPanel,
+      changeLog: [],
+      undoneChangeLog: [],
+      disposed: false,
     }
     this.sessions.set(uri.toString(), session)
     this.activeSession = session
@@ -136,6 +210,8 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
 
     // Send initial data to the webview
     await this.sendViewportData(session)
+    this.postEditState(session)
+    this.startHealthPolling()
 
     // --- Subscribe to viewport events for live updates ---
     this.subscribeToViewportEvents(session)
@@ -157,14 +233,18 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
 
     // --- Cleanup on close ---
     webviewPanel.onDidDispose(async () => {
+      session.disposed = true
       this.sessions.delete(uri.toString())
       if (this.activeSession === session) {
         this.activeSession = undefined
       }
+      if (this.sessions.size === 0) {
+        this.stopHealthPolling()
+      }
       session.viewportStream?.cancel()
       session.sessionStream?.cancel()
       try {
-        await destroyViewport(viewportId)
+        await destroyViewport(session.viewportId)
       } catch {
         /* already destroyed */
       }
@@ -191,9 +271,67 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
     const bytesPerRow = config.get<number>('bytesPerRow', 16)
     for (const session of this.sessions.values()) {
       session.panel.webview.html = getWebviewContent(bytesPerRow)
-      session.capacity = bytesPerRow * 64
+      session.capacity = this.getViewportCapacity(bytesPerRow)
       this.sendViewportData(session)
+      this.postEditState(session)
     }
+  }
+
+  async exportActiveChangeScript(targetUri?: vscode.Uri): Promise<void> {
+    if (!this.activeSession) {
+      vscode.window.showWarningMessage('Open an OmegaEdit editor first')
+      return
+    }
+
+    const session = this.activeSession
+    const scriptUri =
+      targetUri ??
+      (await vscode.window.showSaveDialog({
+        defaultUri: vscode.Uri.file(
+          `${session.filePath}.omega-edit-changes.json`
+        ),
+        filters: { JSON: ['json'] },
+      }))
+
+    if (!scriptUri) {
+      return
+    }
+
+    const content = Buffer.from(
+      JSON.stringify(session.changeLog, null, 2),
+      'utf8'
+    )
+    await vscode.workspace.fs.writeFile(scriptUri, content)
+    vscode.window.showInformationMessage(
+      `Change script saved to ${scriptUri.fsPath}`
+    )
+  }
+
+  async replayActiveChangeScript(sourceUri?: vscode.Uri): Promise<void> {
+    if (!this.activeSession) {
+      vscode.window.showWarningMessage('Open an OmegaEdit editor first')
+      return
+    }
+
+    const scriptUri =
+      sourceUri ??
+      (
+        await vscode.window.showOpenDialog({
+          canSelectMany: false,
+          filters: { JSON: ['json'] },
+        })
+      )?.[0]
+
+    if (!scriptUri) {
+      return
+    }
+
+    const content = await vscode.workspace.fs.readFile(scriptUri)
+    const changes = JSON.parse(
+      Buffer.from(content).toString('utf8')
+    ) as ChangeRecord[]
+    await this.replayChanges(this.activeSession, changes)
+    vscode.window.showInformationMessage(`Replayed ${changes.length} change(s)`)
   }
 
   // ── Event Subscriptions ─────────────────────────────────────────────
@@ -216,11 +354,11 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
       .on('data', async (event) => {
         const kind = event.getViewportEventKind()
         if (
-          kind === ViewportEventKind.VIEWPORT_EVENT_KIND_EDIT ||
-          kind === ViewportEventKind.VIEWPORT_EVENT_KIND_UNDO ||
-          kind === ViewportEventKind.VIEWPORT_EVENT_KIND_CLEAR ||
-          kind === ViewportEventKind.VIEWPORT_EVENT_KIND_TRANSFORM ||
-          kind === ViewportEventKind.VIEWPORT_EVENT_KIND_MODIFY
+          kind === ViewportEventKind.VIEWPORT_EVT_EDIT ||
+          kind === ViewportEventKind.VIEWPORT_EVT_UNDO ||
+          kind === ViewportEventKind.VIEWPORT_EVT_CLEAR ||
+          kind === ViewportEventKind.VIEWPORT_EVT_TRANSFORM ||
+          kind === ViewportEventKind.VIEWPORT_EVT_MODIFY
         ) {
           await this.sendViewportData(session)
         }
@@ -247,9 +385,9 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
       .on('data', async (event) => {
         const kind = event.getSessionEventKind()
         if (
-          kind === SessionEventKind.SESSION_EVENT_KIND_EDIT ||
-          kind === SessionEventKind.SESSION_EVENT_KIND_UNDO ||
-          kind === SessionEventKind.SESSION_EVENT_KIND_CLEAR
+          kind === SessionEventKind.SESSION_EVT_EDIT ||
+          kind === SessionEventKind.SESSION_EVT_UNDO ||
+          kind === SessionEventKind.SESSION_EVT_CLEAR
         ) {
           session.fileSize = await getComputedFileSize(session.sessionId)
           session.panel.webview.postMessage({
@@ -271,6 +409,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
     session.panel.webview.postMessage({
       type: 'viewportData',
       offset: resp.getOffset(),
+      visibleOffset: session.offset,
       data: Array.from(data),
       length: resp.getLength(),
       fileSize: session.fileSize,
@@ -278,18 +417,386 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
     })
   }
 
+  private async recreateViewport(
+    session: EditorSession,
+    offset: number,
+    capacity: number
+  ): Promise<void> {
+    if (session.disposed) {
+      return
+    }
+
+    const previousViewportId = session.viewportId
+    session.viewportStream?.cancel()
+
+    const vpResp = await createViewport(
+      undefined,
+      session.sessionId,
+      offset,
+      capacity,
+      false
+    )
+    session.viewportId = vpResp.getViewportId()
+
+    try {
+      await destroyViewport(previousViewportId)
+    } catch {
+      /* ignore stale viewport cleanup errors */
+    }
+
+    await this.subscribeToViewportEvents(session)
+    await this.sendViewportData(session)
+  }
+
+  private postEditState(session: EditorSession): void {
+    session.panel.webview.postMessage({
+      type: 'editState',
+      canUndo: session.changeLog.length > 0,
+      canRedo: session.undoneChangeLog.length > 0,
+      undoCount: session.changeLog.length,
+      redoCount: session.undoneChangeLog.length,
+      isDirty: session.changeLog.length !== session.savedChangeDepth,
+      savedChangeDepth: session.savedChangeDepth,
+    })
+  }
+
+  private async refreshSessionFileSize(
+    session: EditorSession,
+    expectedFileSize?: number
+  ): Promise<void> {
+    let nextFileSize = session.fileSize
+    const deadline = Date.now() + SESSION_SYNC_TIMEOUT_MS
+
+    while (Date.now() <= deadline) {
+      nextFileSize = await getComputedFileSize(session.sessionId)
+      if (
+        expectedFileSize === undefined
+          ? nextFileSize !== session.fileSize
+          : nextFileSize === expectedFileSize
+      ) {
+        break
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, SESSION_SYNC_POLL_MS))
+    }
+
+    if (expectedFileSize !== undefined && nextFileSize !== expectedFileSize) {
+      throw new Error(
+        `Timed out waiting for session size ${expectedFileSize}; last size was ${nextFileSize}`
+      )
+    }
+
+    if (nextFileSize === session.fileSize) {
+      return
+    }
+
+    session.fileSize = nextFileSize
+    session.panel.webview.postMessage({
+      type: 'fileSizeChanged',
+      fileSize: nextFileSize,
+    })
+  }
+
+  private pushChange(session: EditorSession, change: ChangeRecord): void {
+    session.changeLog.push(change)
+    session.undoneChangeLog = []
+    this.postEditState(session)
+  }
+
+  private startHealthPolling(): void {
+    if (this.heartbeatTimer) {
+      return
+    }
+
+    void this.publishServerHealth()
+    this.heartbeatTimer = setInterval(() => {
+      void this.publishServerHealth()
+    }, 5000)
+  }
+
+  private stopHealthPolling(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = undefined
+    }
+  }
+
+  private async publishServerHealth(): Promise<void> {
+    if (this.heartbeatInFlight || this.sessions.size === 0) {
+      return
+    }
+
+    this.heartbeatInFlight = true
+    try {
+      const [serverInfo, heartbeat] = await Promise.all([
+        getServerInfo(),
+        getServerHeartbeat(
+          Array.from(this.sessions.values(), (session) => session.sessionId),
+          1000
+        ),
+      ])
+
+      const uptimeSeconds = Math.max(
+        0,
+        Math.round(heartbeat.serverUptime / 1000)
+      )
+      const usedMemoryMb = Math.round(
+        heartbeat.serverUsedMemory / (1024 * 1024)
+      )
+      const committedMemoryMb = Math.round(
+        heartbeat.serverCommittedMemory / (1024 * 1024)
+      )
+      const detailParts = [
+        `server ${serverInfo.serverVersion}`,
+        `client ${getClientVersion()}`,
+        `host ${serverInfo.serverHostname}`,
+        `pid ${serverInfo.serverProcessId}`,
+        `latency ${heartbeat.latency} ms`,
+        `sessions ${heartbeat.sessionCount}`,
+        `uptime ${uptimeSeconds}s`,
+        `cpu ${heartbeat.serverCpuCount} cores`,
+        `load ${heartbeat.serverCpuLoadAverage.toFixed(2)}`,
+        `memory ${usedMemoryMb}/${committedMemoryMb} MiB`,
+      ]
+
+      if (serverInfo.jvmVersion) {
+        detailParts.push(`jvm ${serverInfo.jvmVersion}`)
+      }
+
+      this.broadcastServerHealth({
+        type: 'serverHealth',
+        ok: true,
+        summary: `OE ${heartbeat.latency} ms`,
+        detail: detailParts.join('\n'),
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      this.broadcastServerHealth({
+        type: 'serverHealth',
+        ok: false,
+        summary: 'OE unavailable',
+        detail: message,
+      })
+    } finally {
+      this.heartbeatInFlight = false
+    }
+  }
+
+  private broadcastServerHealth(payload: ServerHealthState): void {
+    for (const session of this.sessions.values()) {
+      session.panel.webview.postMessage(payload)
+    }
+  }
+
+  private async replayChanges(
+    session: EditorSession,
+    changes: ChangeRecord[]
+  ): Promise<void> {
+    for (const change of changes) {
+      const expectedFileSize = this.getExpectedFileSizeAfterRecord(
+        session.fileSize,
+        change
+      )
+      switch (change.kind) {
+        case 'INSERT': {
+          const serial = await insert(
+            session.sessionId,
+            change.offset,
+            Buffer.from(change.data, 'hex')
+          )
+          this.pushChange(session, {
+            serial,
+            kind: 'INSERT',
+            offset: change.offset,
+            length: 0,
+            data: change.data,
+          })
+          break
+        }
+        case 'DELETE': {
+          const serial = await del(
+            session.sessionId,
+            change.offset,
+            change.length
+          )
+          this.pushChange(session, {
+            serial,
+            kind: 'DELETE',
+            offset: change.offset,
+            length: change.length,
+            data: '',
+          })
+          break
+        }
+        case 'OVERWRITE': {
+          const serial = await overwrite(
+            session.sessionId,
+            change.offset,
+            Buffer.from(change.data, 'hex')
+          )
+          this.pushChange(session, {
+            serial,
+            kind: 'OVERWRITE',
+            offset: change.offset,
+            length: Buffer.from(change.data, 'hex').length,
+            data: change.data,
+          })
+          break
+        }
+        case 'REPLACE':
+          await this.applyReplace(
+            session,
+            change.offset,
+            change.length,
+            change.data
+          )
+          break
+      }
+      await this.refreshSessionFileSize(session, expectedFileSize)
+    }
+  }
+
+  private getExpectedFileSizeAfterRecord(
+    currentFileSize: number,
+    change: Pick<ChangeRecord, 'kind' | 'length' | 'data'>
+  ): number {
+    const insertedLength = change.data.length / 2
+    switch (change.kind) {
+      case 'INSERT':
+        return currentFileSize + insertedLength
+      case 'DELETE':
+        return Math.max(0, currentFileSize - change.length)
+      case 'OVERWRITE':
+        return currentFileSize
+      case 'REPLACE':
+        return Math.max(0, currentFileSize - change.length + insertedLength)
+    }
+  }
+
+  private async applyReplace(
+    session: EditorSession,
+    offset: number,
+    length: number,
+    dataHex: string
+  ): Promise<boolean> {
+    const originalSegment =
+      length > 0
+        ? await getSegment(session.sessionId, offset, length)
+        : new Uint8Array()
+    const replacementSegment = Buffer.from(dataHex, 'hex')
+    const changeSerial = await editSimple(
+      session.sessionId,
+      offset,
+      originalSegment,
+      replacementSegment
+    )
+
+    if (changeSerial > 0) {
+      this.pushChange(session, {
+        serial: changeSerial,
+        kind: 'REPLACE',
+        offset,
+        length,
+        data: dataHex,
+      })
+      return true
+    }
+
+    return false
+  }
+
+  private async saveToPath(
+    session: EditorSession,
+    filePath: string,
+    successMessage: string,
+    markClean: boolean
+  ): Promise<void> {
+    await saveSession(session.sessionId, filePath, IOFlags.IO_FLG_OVERWRITE)
+    if (markClean) {
+      session.savedChangeDepth = session.changeLog.length
+      this.postEditState(session)
+    }
+    vscode.window.showInformationMessage(successMessage)
+  }
+
   /** Scroll the viewport to a given offset, clamped to file bounds */
-  private async scrollTo(
+  private async applyScrollTo(
     session: EditorSession,
     offset: number
   ): Promise<void> {
+    if (session.disposed) {
+      return
+    }
+
+    const config = vscode.workspace.getConfiguration('omegaEdit')
+    const bytesPerRow = config.get<number>('bytesPerRow', 16)
+    const viewportRows = Math.max(32, session.visibleRows || 32)
+    const bufferedRows = Math.max(
+      viewportRows,
+      Math.floor(session.capacity / bytesPerRow)
+    )
     const clamped = Math.max(
       0,
       Math.min(offset, Math.max(0, session.fileSize - 1))
     )
-    session.offset = clamped
-    await modifyViewport(session.viewportId, clamped, session.capacity)
+    const rowAlignedOffset = clamped - (clamped % bytesPerRow)
+    const preloadBeforeRows = Math.max(
+      0,
+      Math.floor((bufferedRows - viewportRows) / 2)
+    )
+    const bufferOffset = Math.max(
+      0,
+      rowAlignedOffset - preloadBeforeRows * bytesPerRow
+    )
+    session.offset = rowAlignedOffset
+    try {
+      await modifyViewport(session.viewportId, bufferOffset, session.capacity)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+
+      // Resizing can occasionally race the native viewport state. Recreate the
+      // viewport in place so the editor stays usable instead of surfacing an error.
+      if (
+        message.includes('modifyViewport error') ||
+        message.includes('modify viewport failed')
+      ) {
+        await this.recreateViewport(session, bufferOffset, session.capacity)
+        return
+      }
+
+      throw error
+    }
     // Viewport event subscription will trigger sendViewportData
+  }
+
+  /** Coalesce rapid viewport updates from resize/scroll into a single in-flight mutation */
+  private async scrollTo(
+    session: EditorSession,
+    offset: number
+  ): Promise<void> {
+    if (session.disposed) {
+      return
+    }
+
+    session.pendingScrollOffset = offset
+    if (session.scrollTask) {
+      return session.scrollTask
+    }
+
+    session.scrollTask = (async () => {
+      while (
+        !session.disposed &&
+        typeof session.pendingScrollOffset === 'number'
+      ) {
+        const nextOffset = session.pendingScrollOffset
+        session.pendingScrollOffset = undefined
+        await this.applyScrollTo(session, nextOffset)
+      }
+    })().finally(() => {
+      session.scrollTask = undefined
+    })
+
+    return session.scrollTask
   }
 
   // ── Webview Message Handler ─────────────────────────────────────────
@@ -315,60 +822,222 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
           break
         }
 
+        case 'setBytesPerRow': {
+          const resource = vscode.Uri.file(session.filePath)
+          const workspaceFolder = vscode.workspace.getWorkspaceFolder(resource)
+          const configuration = vscode.workspace.getConfiguration(
+            'omegaEdit',
+            resource
+          )
+          const targets = workspaceFolder
+            ? [
+                vscode.ConfigurationTarget.WorkspaceFolder,
+                vscode.ConfigurationTarget.Workspace,
+                vscode.ConfigurationTarget.Global,
+              ]
+            : vscode.workspace.workspaceFolders &&
+                vscode.workspace.workspaceFolders.length > 0
+              ? [
+                  vscode.ConfigurationTarget.Workspace,
+                  vscode.ConfigurationTarget.Global,
+                ]
+              : [vscode.ConfigurationTarget.Global]
+
+          let lastError: unknown
+          let updated = false
+          for (const target of targets) {
+            try {
+              await configuration.update('bytesPerRow', msg.bytesPerRow, target)
+              updated = true
+              break
+            } catch (err) {
+              lastError = err
+            }
+          }
+
+          if (!updated && lastError) {
+            throw lastError
+          }
+          break
+        }
+
+        case 'setViewportMetrics': {
+          session.visibleRows = Math.max(1, Math.floor(msg.visibleRows))
+          break
+        }
+
         // --- Editing ---
         case 'insert': {
-          await insert(
-            session.sessionId,
-            msg.offset,
-            Buffer.from(msg.data, 'hex')
-          )
+          const data = Buffer.from(msg.data, 'hex')
+          const expectedFileSize = session.fileSize + data.length
+          const serial = await insert(session.sessionId, msg.offset, data)
+          this.pushChange(session, {
+            serial,
+            kind: 'INSERT',
+            offset: msg.offset,
+            length: 0,
+            data: msg.data,
+          })
+          await this.refreshSessionFileSize(session, expectedFileSize)
           break
         }
 
         case 'delete': {
-          await del(session.sessionId, msg.offset, msg.length)
+          const expectedFileSize = Math.max(0, session.fileSize - msg.length)
+          const serial = await del(session.sessionId, msg.offset, msg.length)
+          this.pushChange(session, {
+            serial,
+            kind: 'DELETE',
+            offset: msg.offset,
+            length: msg.length,
+            data: '',
+          })
+          await this.refreshSessionFileSize(session, expectedFileSize)
           break
         }
 
         case 'overwrite': {
-          await overwrite(
+          const serial = await overwrite(
             session.sessionId,
             msg.offset,
             Buffer.from(msg.data, 'hex')
           )
+          this.pushChange(session, {
+            serial,
+            kind: 'OVERWRITE',
+            offset: msg.offset,
+            length: msg.data.length / 2,
+            data: msg.data,
+          })
+          await this.refreshSessionFileSize(session)
+          break
+        }
+
+        case 'replace': {
+          const expectedFileSize = this.getExpectedFileSizeAfterRecord(
+            session.fileSize,
+            { kind: 'REPLACE', length: msg.length, data: msg.data }
+          )
+          const changed = await this.applyReplace(
+            session,
+            msg.offset,
+            msg.length,
+            msg.data
+          )
+          session.panel.webview.postMessage({
+            type: 'replaceComplete',
+            selectionOffset: changed && msg.data.length > 0 ? msg.offset : -1,
+            replacedCount: changed ? 1 : 0,
+          })
+          await this.refreshSessionFileSize(session, expectedFileSize)
+          break
+        }
+
+        case 'replaceAllMatches': {
+          const offsets = [...msg.offsets].sort((a, b) => b - a)
+          let changedOffset = -1
+          let replacedCount = 0
+          for (const offset of offsets) {
+            const expectedFileSize = this.getExpectedFileSizeAfterRecord(
+              session.fileSize,
+              { kind: 'REPLACE', length: msg.length, data: msg.data }
+            )
+            const changed = await this.applyReplace(
+              session,
+              offset,
+              msg.length,
+              msg.data
+            )
+            if (changed && msg.data.length > 0) {
+              changedOffset = offset
+            }
+            if (changed) {
+              replacedCount += 1
+            }
+            await this.refreshSessionFileSize(session, expectedFileSize)
+          }
+          session.panel.webview.postMessage({
+            type: 'replaceComplete',
+            selectionOffset: changedOffset,
+            replacedCount,
+          })
           break
         }
 
         // --- Undo / Redo ---
         case 'undo': {
+          if (session.changeLog.length === 0) {
+            this.postEditState(session)
+            break
+          }
           await undo(session.sessionId)
+          const lastChange = session.changeLog.pop()
+          if (lastChange) {
+            session.undoneChangeLog.push(lastChange)
+          }
+          await this.refreshSessionFileSize(session)
+          this.postEditState(session)
           break
         }
 
         case 'redo': {
+          if (session.undoneChangeLog.length === 0) {
+            this.postEditState(session)
+            break
+          }
           await redo(session.sessionId)
+          const redoneChange = session.undoneChangeLog.pop()
+          if (redoneChange) {
+            session.changeLog.push(redoneChange)
+          }
+          await this.refreshSessionFileSize(session)
+          this.postEditState(session)
           break
         }
 
         // --- Save ---
         case 'save': {
-          await saveSession(
-            session.sessionId,
-            session.filePath, // original file path
-            IOFlags.IO_FLG_OVERWRITE
+          await this.saveToPath(session, session.filePath, 'File saved', true)
+          break
+        }
+
+        case 'saveAs': {
+          const saveUri = await vscode.window.showSaveDialog({
+            defaultUri: vscode.Uri.file(session.filePath),
+            title: 'Save OmegaEdit contents as',
+          })
+          if (!saveUri) {
+            break
+          }
+          await this.saveToPath(
+            session,
+            saveUri.fsPath,
+            `File saved as ${saveUri.fsPath}`,
+            false
           )
-          vscode.window.showInformationMessage('File saved')
           break
         }
 
         // --- Search ---
         case 'search': {
-          const pattern = msg.isHex ? Buffer.from(msg.query, 'hex') : msg.query
+          const normalizedQuery = msg.query.trim()
+          if (!normalizedQuery) {
+            session.panel.webview.postMessage({
+              type: 'searchResults',
+              matches: [],
+              patternLength: 0,
+            })
+            break
+          }
+
+          const pattern = msg.isHex
+            ? Buffer.from(normalizedQuery, 'hex')
+            : Buffer.from(normalizedQuery, 'utf8')
           const matches = await searchSession(
             session.sessionId,
             pattern,
             msg.caseInsensitive ?? false,
-            false, // forward
+            msg.isReverse ?? false,
             0,
             0,
             1000 // reasonable limit
@@ -376,6 +1045,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
           session.panel.webview.postMessage({
             type: 'searchResults',
             matches,
+            patternLength: pattern.length,
           })
           // Jump to first match if any
           if (matches.length > 0) {
@@ -391,7 +1061,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      vscode.window.showErrorMessage(`Ωedit™ error: ${message}`)
+      vscode.window.showErrorMessage(`OmegaEdit error: ${message}`)
     }
   }
 }
@@ -401,11 +1071,27 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
 type WebviewMessage =
   | { type: 'scroll'; direction: 'up' | 'down' }
   | { type: 'scrollTo'; offset: number }
+  | { type: 'setViewportMetrics'; visibleRows: number }
+  | { type: 'setBytesPerRow'; bytesPerRow: 8 | 16 | 32 }
   | { type: 'insert'; offset: number; data: string }
   | { type: 'delete'; offset: number; length: number }
   | { type: 'overwrite'; offset: number; data: string }
+  | { type: 'replace'; offset: number; length: number; data: string }
+  | {
+      type: 'replaceAllMatches'
+      offsets: number[]
+      length: number
+      data: string
+    }
   | { type: 'undo' }
   | { type: 'redo' }
   | { type: 'save' }
-  | { type: 'search'; query: string; isHex: boolean; caseInsensitive?: boolean }
+  | { type: 'saveAs' }
+  | {
+      type: 'search'
+      query: string
+      isHex: boolean
+      caseInsensitive?: boolean
+      isReverse?: boolean
+    }
   | { type: 'goToMatch'; offset: number }

--- a/examples/vscode-extension/src/webview.ts
+++ b/examples/vscode-extension/src/webview.ts
@@ -31,6 +31,16 @@
  */
 
 export function getWebviewContent(bytesPerRow: number): string {
+  const groupSize = 8
+  const byteCellWidth = 22
+  const byteGap = 6
+  const groupGap = 4
+  const groupSeparators = Math.floor((bytesPerRow - 1) / groupSize)
+  const hexColumnWidth =
+    bytesPerRow * byteCellWidth +
+    (bytesPerRow - 1) * byteGap +
+    groupSeparators * groupGap
+
   return /* html */ `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -43,7 +53,9 @@ export function getWebviewContent(bytesPerRow: number): string {
     --fg: var(--vscode-editor-foreground);
     --border: var(--vscode-panel-border, #444);
     --highlight: var(--vscode-editor-findMatchHighlightBackground, rgba(234, 192, 0, 0.3));
+    --highlight-fg: var(--vscode-editor-findMatchForeground, var(--fg));
     --selected: var(--vscode-editor-selectionBackground, rgba(38, 79, 120, 0.6));
+    --selected-fg: var(--vscode-editor-selectionForeground, var(--fg));
     --toolbar-bg: var(--vscode-sideBar-background, #252526);
     --input-bg: var(--vscode-input-background, #3c3c3c);
     --input-fg: var(--vscode-input-foreground, #ccc);
@@ -52,9 +64,13 @@ export function getWebviewContent(bytesPerRow: number): string {
     --button-fg: var(--vscode-button-foreground, #fff);
     --button-hover: var(--vscode-button-hoverBackground, #1177bb);
     --offset-fg: var(--vscode-editorLineNumber-foreground, #858585);
+    --offset-column-fg: var(--vscode-terminal-ansiCyan, #4fc1ff);
     --ascii-fg: var(--vscode-terminal-ansiGreen, #6a9955);
+    --ascii-muted-fg: color-mix(in srgb, var(--ascii-fg) 45%, var(--fg) 55%);
     --mono: var(--vscode-editor-font-family, 'Consolas', 'Courier New', monospace);
     --font-size: var(--vscode-editor-font-size, 13px);
+    --contrast-border: var(--vscode-contrastActiveBorder, transparent);
+    --offset-col-width: 80px;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
@@ -90,6 +106,7 @@ export function getWebviewContent(bytesPerRow: number): string {
     border-left: 1px solid var(--border);
   }
   .toolbar label { font-size: 11px; color: var(--offset-fg); margin-right: 2px; }
+  .toolbar label.disabled { opacity: 0.5; }
   .toolbar input, .toolbar select {
     background: var(--input-bg);
     color: var(--input-fg);
@@ -114,6 +131,11 @@ export function getWebviewContent(bytesPerRow: number): string {
   }
   button:hover { background: var(--button-hover); }
   button:active { opacity: 0.8; }
+  button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  button:disabled:hover { background: inherit; }
   button.secondary {
     background: transparent;
     border: 1px solid var(--border);
@@ -122,6 +144,65 @@ export function getWebviewContent(bytesPerRow: number): string {
   button.secondary:hover { background: var(--input-bg); }
 
   /* ── Hex Grid ────────────────────────────────────── */
+  .viewer-shell {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+  }
+  .viewer-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .hex-header {
+    display: flex;
+    align-items: center;
+    padding: 4px 10px 6px;
+    border-bottom: 1px solid var(--border);
+    background: color-mix(in srgb, var(--toolbar-bg) 84%, var(--bg) 16%);
+    line-height: 1.6;
+  }
+  .hex-header .offset-col {
+    color: var(--offset-fg);
+  }
+  .offset-header-label {
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .hex-column-header {
+    width: ${hexColumnWidth}px;
+    flex: 0 0 ${hexColumnWidth}px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0 6px;
+  }
+  .hex-column-label {
+    width: 22px;
+    text-align: center;
+    color: var(--offset-column-fg);
+    font-size: var(--font-size);
+    line-height: 1.6;
+  }
+  .hex-column-label.group-sep {
+    margin-left: 4px;
+  }
+  .hex-column-label.hover {
+    color: var(--fg);
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 2px;
+  }
+  .ascii-header {
+    color: var(--offset-fg);
+    padding-left: 12px;
+    border-left: 1px solid var(--border);
+    min-width: calc(${bytesPerRow}ch + 12px);
+    flex-shrink: 0;
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
   .hex-container {
     flex: 1;
     overflow: hidden;
@@ -134,14 +215,21 @@ export function getWebviewContent(bytesPerRow: number): string {
   }
   .hex-row:hover { background: rgba(255, 255, 255, 0.03); }
   .offset-col {
-    color: var(--offset-fg);
-    min-width: 80px;
+    color: var(--offset-column-fg);
+    width: var(--offset-col-width);
+    min-width: var(--offset-col-width);
+    flex: 0 0 var(--offset-col-width);
     text-align: right;
     padding-right: 12px;
-    flex-shrink: 0;
+  }
+  .offset-col.hover {
+    color: var(--fg);
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 2px;
   }
   .hex-col {
-    flex: 1;
+    width: ${hexColumnWidth}px;
+    flex: 0 0 ${hexColumnWidth}px;
     display: flex;
     flex-wrap: wrap;
     gap: 0 6px;
@@ -152,26 +240,111 @@ export function getWebviewContent(bytesPerRow: number): string {
     cursor: pointer;
     border-radius: 2px;
   }
-  .hex-byte:hover { background: var(--selected); }
-  .hex-byte.selected { background: var(--selected); }
-  .hex-byte.match { background: var(--highlight); }
+  .hex-byte:hover {
+    background: var(--selected);
+    color: var(--selected-fg);
+    outline: 1px solid var(--contrast-border);
+    outline-offset: -1px;
+  }
+  .hex-byte.selected {
+    background: var(--selected);
+    color: var(--selected-fg);
+    outline: 1px solid var(--contrast-border);
+    outline-offset: -1px;
+  }
+  .hex-byte.match {
+    background: var(--highlight);
+    color: var(--highlight-fg);
+  }
   .hex-byte.group-sep { margin-left: 4px; }
   .ascii-col {
     color: var(--ascii-fg);
+    display: inline-grid;
+    grid-template-columns: repeat(${bytesPerRow}, 1ch);
     padding-left: 12px;
     border-left: 1px solid var(--border);
     min-width: calc(${bytesPerRow}ch + 12px);
-    letter-spacing: 1px;
     flex-shrink: 0;
   }
-  .ascii-char { cursor: pointer; }
-  .ascii-char:hover { background: var(--selected); }
-  .ascii-char.selected { background: var(--selected); }
-  .ascii-char.match { background: var(--highlight); }
+  .ascii-char {
+    cursor: pointer;
+    display: inline-block;
+    width: 1ch;
+    text-align: center;
+    white-space: pre;
+  }
+  .ascii-char:hover {
+    background: var(--selected);
+    color: var(--selected-fg);
+    outline: 1px solid var(--contrast-border);
+    outline-offset: -1px;
+  }
+  .ascii-char.selected {
+    background: var(--selected);
+    color: var(--selected-fg);
+    outline: 1px solid var(--contrast-border);
+    outline-offset: -1px;
+  }
+  .ascii-char.match {
+    background: var(--highlight);
+    color: var(--highlight-fg);
+  }
+  .ascii-char.non-printable {
+    color: var(--ascii-muted-fg);
+  }
+  .ascii-char.empty {
+    color: transparent;
+  }
+  .scrollbar {
+    width: 18px;
+    padding: 4px 4px 4px 0;
+    background: var(--bg);
+    border-left: 1px solid var(--border);
+    user-select: none;
+  }
+  .scrollbar.dragging {
+    cursor: ns-resize;
+  }
+  .scrollbar-track {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: var(--toolbar-bg);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+  }
+  .scrollbar-track.disabled {
+    opacity: 0.45;
+  }
+  .scrollbar-thumb {
+    position: absolute;
+    left: 1px;
+    right: 1px;
+    top: 0;
+    min-height: 24px;
+    background: var(--button-bg);
+    border-radius: 999px;
+    cursor: pointer;
+    touch-action: none;
+    transform-origin: top center;
+    will-change: transform;
+  }
+  .scrollbar-thumb:hover {
+    background: var(--button-hover);
+  }
+  .interaction-blocker {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    cursor: ns-resize;
+    background: transparent;
+  }
 
   /* ── Status Bar ──────────────────────────────────── */
   .status-bar {
     display: flex;
+    flex-wrap: wrap;
+    align-items: center;
     gap: 16px;
     padding: 4px 10px;
     background: var(--toolbar-bg);
@@ -180,6 +353,43 @@ export function getWebviewContent(bytesPerRow: number): string {
     color: var(--offset-fg);
   }
   .status-bar .highlight { color: var(--fg); }
+  .status-fill {
+    flex: 1 1 auto;
+  }
+  .status-inline-button {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--fg);
+    padding: 1px 6px;
+    font-size: 11px;
+    line-height: 1.2;
+  }
+  .status-inline-button:hover {
+    background: var(--input-bg);
+  }
+  .status-action {
+    color: var(--vscode-terminal-ansiYellow, #dcdcaa);
+  }
+  .server-health {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: auto;
+    cursor: default;
+  }
+  .server-health-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--vscode-descriptionForeground, #888);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
+  }
+  .server-health-dot.ok {
+    background: var(--vscode-testing-iconPassed, #73c991);
+  }
+  .server-health-dot.error {
+    background: var(--vscode-testing-iconFailed, #f14c4c);
+  }
 
   /* ── Edit Dialog ─────────────────────────────────── */
   .edit-dialog {
@@ -220,14 +430,41 @@ export function getWebviewContent(bytesPerRow: number): string {
 <!-- ── Toolbar ──────────────────────────────────────── -->
 <div class="toolbar">
   <div class="toolbar-group">
+    <label for="bytesPerRowSelect">Row:</label>
+    <select id="bytesPerRowSelect" title="Bytes per row">
+      <option value="8"${bytesPerRow === 8 ? ' selected' : ''}>8</option>
+      <option value="16"${bytesPerRow === 16 ? ' selected' : ''}>16</option>
+      <option value="32"${bytesPerRow === 32 ? ' selected' : ''}>32</option>
+    </select>
+  </div>
+  <div class="toolbar-group">
+    <label for="offsetRadixSelect">Offsets:</label>
+    <select id="offsetRadixSelect" title="Offset display radix">
+      <option value="hex" selected>Hex</option>
+      <option value="dec">Dec</option>
+    </select>
+  </div>
+  <div class="toolbar-group">
     <label>Search:</label>
     <input type="text" id="searchInput" placeholder="text or hex bytes" />
+    <input type="text" id="replaceInput" placeholder="replace with" />
     <label><input type="checkbox" id="searchHex" /> Hex</label>
-    <label><input type="checkbox" id="searchCase" /> Aa</label>
-    <button id="searchBtn">Find</button>
+    <label id="searchCaseLabel"><input type="checkbox" id="searchCase" /> Aa</label>
+    <label for="searchDirectionSelect">Dir:</label>
+    <select id="searchDirectionSelect" title="Search direction">
+      <option value="forward" selected>Top to Bottom</option>
+      <option value="reverse">Bottom to Top</option>
+    </select>
+    <button class="secondary" id="searchBtn">Find</button>
+    <button class="secondary" id="replaceBtn">Replace</button>
+    <button class="secondary" id="replaceAllBtn">All</button>
     <span class="match-nav" id="matchNav"></span>
     <button class="secondary" id="prevMatch" title="Previous match">&#9650;</button>
     <button class="secondary" id="nextMatch" title="Next match">&#9660;</button>
+  </div>
+  <div class="toolbar-group">
+    <button class="secondary" id="topBtn" title="Jump to top">Top</button>
+    <button class="secondary" id="bottomBtn" title="Jump to bottom">Bottom</button>
   </div>
   <div class="toolbar-group">
     <button class="secondary" id="insertBtn" title="Insert bytes at selected offset">Ins</button>
@@ -237,19 +474,46 @@ export function getWebviewContent(bytesPerRow: number): string {
   <div class="toolbar-group">
     <button class="secondary" id="undoBtn" title="Undo (Ctrl+Z)">Undo</button>
     <button class="secondary" id="redoBtn" title="Redo (Ctrl+Y)">Redo</button>
-    <button id="saveBtn" title="Save (Ctrl+S)">Save</button>
+    <button class="secondary" id="saveBtn" title="Save (Ctrl+S)">Save</button>
+    <button class="secondary" id="saveAsBtn" title="Save As (Ctrl+Shift+S)">Save As</button>
   </div>
 </div>
 
 <!-- ── Hex View ─────────────────────────────────────── -->
-<div class="hex-container" id="hexContainer"></div>
+<div class="viewer-shell">
+  <div class="viewer-main">
+    <div class="hex-header" id="hexHeader">
+      <span class="offset-col offset-header-label">Offset</span>
+      <span class="hex-column-header" id="hexColumnHeader"></span>
+      <span class="ascii-header">Text</span>
+    </div>
+    <div class="hex-container" id="hexContainer"></div>
+  </div>
+  <div class="scrollbar" id="scrollbar">
+    <div class="scrollbar-track" id="scrollbarTrack" title="Navigate file">
+      <div class="scrollbar-thumb" id="scrollbarThumb" title="Current viewport"></div>
+    </div>
+  </div>
+</div>
 
 <!-- ── Status Bar ───────────────────────────────────── -->
 <div class="status-bar">
+  <span>State: <span class="highlight" id="statusDirty">Saved</span></span>
   <span>Offset: <span class="highlight" id="statusOffset">0x00000000</span></span>
   <span>Selected: <span class="highlight" id="statusSelected">-</span></span>
   <span>Size: <span class="highlight" id="statusSize">0</span> bytes</span>
+  <span>View: <span class="highlight" id="statusProgress">0.00%</span></span>
   <span id="statusMatches"></span>
+  <span class="status-action" id="statusAction"></span>
+  <span>
+    Inspect
+    <button class="status-inline-button" id="inspectorEndianBtn" title="Toggle inspector endianness">LE</button>:
+    <span class="highlight" id="statusInspector">-</span>
+  </span>
+  <span class="status-fill"></span>
+  <span class="server-health" id="serverHealth" title="Waiting for Î©editâ„¢ heartbeat...">
+    <span class="server-health-dot" id="serverHealthDot"></span>
+  </span>
 </div>
 
 <!-- ── Edit Dialog ──────────────────────────────────── -->
@@ -284,25 +548,64 @@ export function getWebviewContent(bytesPerRow: number): string {
   const GROUP_SIZE = 8 // visual separator every N bytes
 
   // ── State ───────────────────────────────────────────
-  let viewportOffset = 0
+  let bufferOffset = 0
+  let visibleOffset = 0
+  let pendingVisibleOffset = 0
   let viewportData = []      // number[]
   let viewportLength = 0
   let fileSize = 0
   let selectedOffset = -1    // absolute byte offset of selected byte
   let searchMatches = []     // number[] of match offsets
+  let matchedByteOffsets = new Set()
   let searchMatchIndex = -1
   let searchPatternLength = 0
+  let isDraggingScrollbar = false
+  let scrollbarDragOffsetY = 0
+  let accumulatedWheelPixels = 0
+  let scrollbarInteractionBlocker = null
+  let measuredRowHeight = 0
+  let offsetRadix = 'hex'
+  let offsetWidthMeasurer = null
+  let inspectorLittleEndian = true
+  let hoveredColumn = -1
+  let hoveredRowIndex = -1
 
   // ── DOM Refs ────────────────────────────────────────
   const hexContainer = document.getElementById('hexContainer')
+  const hexColumnHeader = document.getElementById('hexColumnHeader')
+  const scrollbarTrack = document.getElementById('scrollbarTrack')
+  const scrollbarThumb = document.getElementById('scrollbarThumb')
+  const bytesPerRowSelect = document.getElementById('bytesPerRowSelect')
+  const offsetRadixSelect = document.getElementById('offsetRadixSelect')
   const statusOffset = document.getElementById('statusOffset')
   const statusSelected = document.getElementById('statusSelected')
+  const statusDirty = document.getElementById('statusDirty')
   const statusSize = document.getElementById('statusSize')
+  const statusProgress = document.getElementById('statusProgress')
   const statusMatches = document.getElementById('statusMatches')
+  const statusAction = document.getElementById('statusAction')
+  const statusInspector = document.getElementById('statusInspector')
+  const inspectorEndianBtn = document.getElementById('inspectorEndianBtn')
+  const serverHealth = document.getElementById('serverHealth')
+  const serverHealthDot = document.getElementById('serverHealthDot')
   const searchInput = document.getElementById('searchInput')
+  const replaceInput = document.getElementById('replaceInput')
   const searchHex = document.getElementById('searchHex')
   const searchCase = document.getElementById('searchCase')
+  const searchCaseLabel = document.getElementById('searchCaseLabel')
+  const searchDirectionSelect = document.getElementById('searchDirectionSelect')
+  const searchBtn = document.getElementById('searchBtn')
+  const replaceBtn = document.getElementById('replaceBtn')
+  const replaceAllBtn = document.getElementById('replaceAllBtn')
   const matchNav = document.getElementById('matchNav')
+  const prevMatchBtn = document.getElementById('prevMatch')
+  const nextMatchBtn = document.getElementById('nextMatch')
+  const topBtn = document.getElementById('topBtn')
+  const bottomBtn = document.getElementById('bottomBtn')
+  const undoBtn = document.getElementById('undoBtn')
+  const redoBtn = document.getElementById('redoBtn')
+  const saveBtn = document.getElementById('saveBtn')
+  const saveAsBtn = document.getElementById('saveAsBtn')
   const editDialog = document.getElementById('editDialog')
   const overlay = document.getElementById('overlay')
   const editTitle = document.getElementById('editTitle')
@@ -311,6 +614,10 @@ export function getWebviewContent(bytesPerRow: number): string {
   const editData = document.getElementById('editData')
   const editLengthField = document.getElementById('editLengthField')
   const editDataField = document.getElementById('editDataField')
+
+  function clamp(min, value, max) {
+    return Math.max(min, Math.min(value, max))
+  }
 
   // ── Render ──────────────────────────────────────────
 
@@ -322,65 +629,609 @@ export function getWebviewContent(bytesPerRow: number): string {
     return n.toString(16).toUpperCase().padStart(2, '0')
   }
 
+  function formatRowOffset(offset) {
+    return offsetRadix === 'dec'
+      ? offset.toLocaleString()
+      : toHex8(offset)
+  }
+
+  function formatOffsetDisplay(offset) {
+    return '0x' + toHex8(offset) + ' (' + offset.toLocaleString() + ')'
+  }
+
+  function formatColumnOffset(offset) {
+    if (offsetRadix === 'dec') {
+      return offset.toString().padStart(2, '0')
+    }
+    return toHex2(offset)
+  }
+
+  function getOffsetWidthMeasurer() {
+    if (offsetWidthMeasurer) {
+      return offsetWidthMeasurer
+    }
+
+    offsetWidthMeasurer = document.createElement('span')
+    offsetWidthMeasurer.style.position = 'absolute'
+    offsetWidthMeasurer.style.visibility = 'hidden'
+    offsetWidthMeasurer.style.whiteSpace = 'pre'
+    offsetWidthMeasurer.style.pointerEvents = 'none'
+    offsetWidthMeasurer.style.inset = '-9999px auto auto -9999px'
+    document.body.appendChild(offsetWidthMeasurer)
+    return offsetWidthMeasurer
+  }
+
+  function updateOffsetColumnWidth() {
+    const measurer = getOffsetWidthMeasurer()
+    const computed = window.getComputedStyle(document.body)
+    const maxRowOffset = Math.max(0, Math.max(0, fileSize - 1) - (Math.max(0, fileSize - 1) % BYTES_PER_ROW))
+    const widestLabel = formatRowOffset(maxRowOffset)
+    const headerLabel = 'Offset'
+
+    measurer.style.fontFamily = computed.fontFamily
+    measurer.style.fontSize = computed.fontSize
+    measurer.style.fontWeight = computed.fontWeight
+    measurer.style.letterSpacing = 'normal'
+    measurer.textContent = widestLabel.length >= headerLabel.length ? widestLabel : headerLabel
+
+    const contentWidth = Math.ceil(measurer.getBoundingClientRect().width)
+    const totalWidth = Math.max(80, contentWidth + 12)
+    document.documentElement.style.setProperty('--offset-col-width', totalWidth + 'px')
+  }
+
+  function renderColumnHeader() {
+    let html = ''
+    for (let i = 0; i < BYTES_PER_ROW; i++) {
+      const sep = (i > 0 && i % GROUP_SIZE === 0) ? ' group-sep' : ''
+      const hover = i === hoveredColumn ? ' hover' : ''
+      html += '<span class="hex-column-label' + sep + hover + '" data-col="' + i + '">' +
+        formatColumnOffset(i) +
+        '</span>'
+    }
+    hexColumnHeader.innerHTML = html
+  }
+
+  function updateHoverHighlights(nextRowIndex, nextColumn) {
+    if (hoveredRowIndex === nextRowIndex && hoveredColumn === nextColumn) {
+      return
+    }
+
+    if (hoveredRowIndex >= 0) {
+      hexContainer
+        .querySelector('.hex-row[data-row-index="' + hoveredRowIndex + '"] .offset-col')
+        ?.classList.remove('hover')
+    }
+
+    if (hoveredColumn >= 0) {
+      hexColumnHeader
+        .querySelector('.hex-column-label[data-col="' + hoveredColumn + '"]')
+        ?.classList.remove('hover')
+    }
+
+    hoveredRowIndex = nextRowIndex
+    hoveredColumn = nextColumn
+
+    if (hoveredRowIndex >= 0) {
+      hexContainer
+        .querySelector('.hex-row[data-row-index="' + hoveredRowIndex + '"] .offset-col')
+        ?.classList.add('hover')
+    }
+
+    if (hoveredColumn >= 0) {
+      hexColumnHeader
+        .querySelector('.hex-column-label[data-col="' + hoveredColumn + '"]')
+        ?.classList.add('hover')
+    }
+  }
+
   function isPrintable(b) {
     return b >= 0x20 && b <= 0x7e
   }
 
-  function isMatchByte(absOffset) {
-    for (const m of searchMatches) {
-      if (absOffset >= m && absOffset < m + searchPatternLength) return true
+  function escapeHtml(text) {
+    return text
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+  }
+
+  function clearSearchResults(message = '') {
+    searchMatches = []
+    matchedByteOffsets = new Set()
+    searchMatchIndex = -1
+    searchPatternLength = 0
+    matchNav.textContent = message
+    statusMatches.textContent = ''
+    updateSearchButtons()
+    render()
+  }
+
+  function updateOffsetStatus() {
+    statusOffset.textContent = formatOffsetDisplay(visibleOffset)
+  }
+
+  function updateSelectedStatus() {
+    statusSelected.textContent = selectedOffset >= 0
+      ? formatOffsetDisplay(selectedOffset)
+      : '-'
+    updateInspectorStatus()
+  }
+
+  function updateDirtyStatus(isDirty) {
+    statusDirty.textContent = isDirty ? 'Dirty' : 'Saved'
+    saveBtn.disabled = !isDirty
+  }
+
+  function updateActionStatus(message = '') {
+    statusAction.textContent = message
+  }
+
+  function updateServerHealthStatus(message) {
+    const ok = !!message?.ok
+    serverHealth.title = message?.detail || 'Waiting for Ωedit™ heartbeat...'
+    serverHealthDot.classList.toggle('ok', ok)
+    serverHealthDot.classList.toggle('error', !!message && !ok)
+  }
+
+  function updateInspectorEndianLabel() {
+    inspectorEndianBtn.textContent = inspectorLittleEndian ? 'LE' : 'BE'
+    inspectorEndianBtn.title = inspectorLittleEndian
+      ? 'Switch inspector to big-endian'
+      : 'Switch inspector to little-endian'
+  }
+
+  function updateInspectorStatus() {
+    if (selectedOffset < 0) {
+      statusInspector.textContent = '-'
+      return
     }
-    return false
+
+    const index = selectedOffset - bufferOffset
+    if (index < 0 || index >= viewportLength) {
+      statusInspector.textContent = 'move selection into view'
+      return
+    }
+
+    const bytes = viewportData.slice(index, Math.min(index + 4, viewportLength))
+    if (bytes.length === 0) {
+      statusInspector.textContent = '-'
+      return
+    }
+
+    const u8 = bytes[0]
+    const ascii = isPrintable(u8) ? String.fromCharCode(u8) : '?'
+    const endianLabel = inspectorLittleEndian ? 'le' : 'be'
+    const u16 = bytes.length >= 2
+      ? new DataView(Uint8Array.from(bytes.slice(0, 2)).buffer).getUint16(0, inspectorLittleEndian)
+      : null
+    const u32 = bytes.length >= 4
+      ? new DataView(Uint8Array.from(bytes.slice(0, 4)).buffer).getUint32(0, inspectorLittleEndian)
+      : null
+
+    statusInspector.textContent =
+      '0x' + toHex2(u8) +
+      ' | ' + u8 +
+      " | '" + ascii + "'" +
+      ' | u16' + endianLabel + ' ' + (u16 === null ? '-' : u16.toLocaleString()) +
+      ' | u32' + endianLabel + ' ' + (u32 === null ? '-' : u32.toLocaleString())
+  }
+
+  function updateProgressStatus() {
+    if (fileSize <= 0) {
+      statusProgress.textContent = '0.00%'
+      return
+    }
+
+    const visibleByteCount = currentVisibleByteCount()
+    const visibleEnd = Math.min(
+      fileSize,
+      visibleOffset + visibleByteCount
+    )
+    const progress = (visibleEnd / fileSize) * 100
+    statusProgress.textContent = progress.toFixed(2) + '%'
+  }
+
+  function updateSearchButtons() {
+    searchBtn.disabled = searchInput.value.trim().length === 0
+    const hasMatches = searchMatches.length > 0
+    prevMatchBtn.disabled = !hasMatches
+    nextMatchBtn.disabled = !hasMatches
+    replaceBtn.disabled = !hasMatches
+    replaceAllBtn.disabled = !hasMatches
+  }
+
+  function updateEditButtons(canUndo, canRedo, undoCount = 0, redoCount = 0) {
+    undoBtn.disabled = !canUndo
+    redoBtn.disabled = !canRedo
+    undoBtn.textContent = 'Undo (' + undoCount + ')'
+    redoBtn.textContent = 'Redo (' + redoCount + ')'
+    undoBtn.title = 'Undo ' + undoCount + ' change(s) (Ctrl+Z)'
+    redoBtn.title = 'Redo ' + redoCount + ' change(s) (Ctrl+Y)'
+  }
+
+  function totalRows() {
+    return Math.max(1, Math.ceil(fileSize / BYTES_PER_ROW))
+  }
+
+  function visibleRows() {
+    if (measuredRowHeight > 0 && hexContainer.clientHeight > 0) {
+      return Math.max(1, Math.floor(hexContainer.clientHeight / measuredRowHeight))
+    }
+    return Math.max(1, Math.ceil(Math.max(viewportLength, BYTES_PER_ROW) / BYTES_PER_ROW))
+  }
+
+  function currentVisibleByteCount() {
+    return Math.min(
+      Math.max(BYTES_PER_ROW, visibleRows() * BYTES_PER_ROW),
+      Math.max(0, fileSize - visibleOffset),
+      Math.max(viewportLength, BYTES_PER_ROW)
+    )
+  }
+
+  function reportViewportMetrics() {
+    vscode.postMessage({
+      type: 'setViewportMetrics',
+      visibleRows: visibleRows(),
+    })
+  }
+
+  function maxStartRow() {
+    return Math.max(0, totalRows() - visibleRows())
+  }
+
+  function currentStartRow() {
+    return Math.floor(visibleOffset / BYTES_PER_ROW)
+  }
+
+  function clampOffset(offset) {
+    if (fileSize <= 0) {
+      return 0
+    }
+    return Math.max(0, Math.min(offset, fileSize - 1))
+  }
+
+  function updateScrollbar() {
+    const trackHeight = scrollbarTrack.clientHeight
+    if (!trackHeight) {
+      return
+    }
+
+    const total = totalRows()
+    const visible = visibleRows()
+    const maxRow = maxStartRow()
+    const trackDisabled = total <= visible || fileSize <= 0
+    scrollbarTrack.classList.toggle('disabled', trackDisabled)
+    scrollbarThumb.style.opacity = trackDisabled ? '0' : '1'
+    scrollbarThumb.style.pointerEvents = trackDisabled ? 'none' : 'auto'
+
+    const thumbHeight = trackDisabled
+      ? trackHeight - 2
+      : Math.max(24, Math.round((visible / total) * trackHeight))
+    const travel = Math.max(0, trackHeight - thumbHeight)
+    const thumbTop = trackDisabled || maxRow === 0
+      ? 0
+      : Math.round((currentStartRow() / maxRow) * travel)
+
+    scrollbarThumb.style.height = trackHeight + 'px'
+    scrollbarThumb.style.transform =
+      'translateY(' + thumbTop + 'px) scaleY(' + (thumbHeight / trackHeight) + ')'
+  }
+
+  function scrollToViewportOffset(offset) {
+    const clampedOffset = clampOffset(offset)
+    const rowAlignedOffset = clampedOffset - (clampedOffset % BYTES_PER_ROW)
+    const renderedByteCount = currentVisibleByteCount()
+    const bufferEnd = bufferOffset + viewportLength
+    const fitsInBuffer =
+      rowAlignedOffset >= bufferOffset &&
+      rowAlignedOffset + renderedByteCount <= bufferEnd
+
+    if (fitsInBuffer) {
+      visibleOffset = rowAlignedOffset
+      pendingVisibleOffset = rowAlignedOffset
+      render()
+      return
+    }
+
+    pendingVisibleOffset = rowAlignedOffset
+    vscode.postMessage({
+      type: 'scrollTo',
+      offset: rowAlignedOffset,
+    })
+  }
+
+  function scrollToRow(row) {
+    const clampedRow = Math.max(0, Math.min(row, maxStartRow()))
+    scrollToViewportOffset(clampedRow * BYTES_PER_ROW)
+  }
+
+  function scrollFromTrackPosition(clientY, offsetWithinThumb) {
+    const rect = scrollbarTrack.getBoundingClientRect()
+    const trackHeight = rect.height
+    const thumbHeight = scrollbarThumb.getBoundingClientRect().height
+    const travel = Math.max(0, trackHeight - thumbHeight)
+    const rawY = clientY - rect.top - offsetWithinThumb
+    const thumbTop = clamp(0, rawY, travel)
+    const ratio = travel === 0 ? 0 : thumbTop / travel
+    scrollToRow(Math.round(ratio * maxStartRow()))
+  }
+
+  function setScrollbarDragging(isDragging) {
+    isDraggingScrollbar = isDragging
+    scrollbarTrack.classList.toggle('dragging', isDragging)
+    scrollbarThumb.classList.toggle('dragging', isDragging)
+    document.body.classList.toggle('scrollbar-dragging', isDragging)
+    scrollbarTrack.parentElement.classList.toggle('dragging', isDragging)
+  }
+
+  function removeScrollbarInteractionBlocker() {
+    if (!scrollbarInteractionBlocker) {
+      return
+    }
+    scrollbarInteractionBlocker.remove()
+    scrollbarInteractionBlocker = null
+  }
+
+  function ensureScrollbarInteractionBlocker() {
+    if (scrollbarInteractionBlocker) {
+      return
+    }
+    scrollbarInteractionBlocker = document.createElement('div')
+    scrollbarInteractionBlocker.className = 'interaction-blocker'
+    document.body.appendChild(scrollbarInteractionBlocker)
+  }
+
+  function startScrollbarDrag(clientY, offsetWithinThumb) {
+    setScrollbarDragging(true)
+    scrollbarDragOffsetY = offsetWithinThumb
+    ensureScrollbarInteractionBlocker()
+    scrollFromTrackPosition(clientY, scrollbarDragOffsetY)
+  }
+
+  function stopScrollbarDrag() {
+    setScrollbarDragging(false)
+    scrollbarDragOffsetY = 0
+    removeScrollbarInteractionBlocker()
+  }
+
+  function offsetIsVisible(offset) {
+    return (
+      offset >= visibleOffset &&
+      offset < visibleOffset + currentVisibleByteCount()
+    )
+  }
+
+  function updateRenderedSelection(previousOffset, nextOffset) {
+    if (!hexContainer) {
+      return
+    }
+
+    if (previousOffset >= 0) {
+      hexContainer
+        .querySelectorAll('[data-offset="' + previousOffset + '"].selected')
+        .forEach((el) => el.classList.remove('selected'))
+    }
+
+    if (nextOffset >= 0 && offsetIsVisible(nextOffset)) {
+      hexContainer
+        .querySelectorAll('[data-offset="' + nextOffset + '"]')
+        .forEach((el) => el.classList.add('selected'))
+    }
+  }
+
+  function selectOffset(offset) {
+    const previousOffset = selectedOffset
+
+    if (offset < 0 || fileSize <= 0) {
+      selectedOffset = -1
+      updateSelectedStatus()
+      updateRenderedSelection(previousOffset, selectedOffset)
+      return
+    }
+
+    selectedOffset = clampOffset(offset)
+    updateSelectedStatus()
+    updateRenderedSelection(previousOffset, selectedOffset)
+  }
+
+  function ensureSelectionVisible(direction) {
+    if (selectedOffset < 0) {
+      return
+    }
+
+    const visibleByteSpan = currentVisibleByteCount()
+    const firstFullyVisibleOffset = visibleOffset
+    const lastFullyVisibleRowStart = Math.max(
+      visibleOffset,
+      visibleOffset + Math.max(0, visibleByteSpan - BYTES_PER_ROW)
+    )
+
+    if (direction === 'up' && selectedOffset <= firstFullyVisibleOffset) {
+      scrollToViewportOffset(selectedOffset)
+      return
+    }
+
+    if (direction === 'down' && selectedOffset >= lastFullyVisibleRowStart) {
+      scrollToViewportOffset(
+        selectedOffset - Math.max(0, visibleByteSpan - BYTES_PER_ROW)
+      )
+      return
+    }
+
+    if (selectedOffset < visibleOffset) {
+      scrollToViewportOffset(visibleOffset - BYTES_PER_ROW)
+      return
+    }
+
+    if (selectedOffset >= visibleOffset + visibleByteSpan) {
+      scrollToViewportOffset(visibleOffset + BYTES_PER_ROW)
+    }
+  }
+
+  function isEditableTarget(target) {
+    return target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+  }
+
+  function moveSelection(direction) {
+    if (fileSize <= 0) {
+      return
+    }
+
+    if (selectedOffset < 0) {
+      if (direction === 'up') {
+        scrollToViewportOffset(visibleOffset - BYTES_PER_ROW)
+      } else if (direction === 'down') {
+        scrollToViewportOffset(visibleOffset + BYTES_PER_ROW)
+      }
+      return
+    }
+
+    const deltas = {
+      left: -1,
+      right: 1,
+      up: -BYTES_PER_ROW,
+      down: BYTES_PER_ROW,
+    }
+    const delta = deltas[direction]
+    const nextOffset = clampOffset(selectedOffset + delta)
+
+    if (nextOffset === selectedOffset) {
+      return
+    }
+
+    selectOffset(nextOffset)
+    ensureSelectionVisible(direction)
+  }
+
+  function syncSearchMode() {
+    const hexMode = searchHex.checked
+    searchCase.disabled = hexMode
+    searchCaseLabel.classList.toggle('disabled', hexMode)
+    if (hexMode) {
+      searchCase.checked = false
+    }
+  }
+
+  function updateMatchNav() {
+    if (searchMatches.length === 0) {
+      matchNav.textContent = 'No matches'
+      statusMatches.textContent = ''
+      updateSearchButtons()
+      return
+    }
+
+    matchNav.innerHTML = '<span>' + (searchMatchIndex + 1) + '</span> / ' + searchMatches.length
+    statusMatches.textContent = searchMatches.length + ' matches'
+    updateSearchButtons()
+  }
+
+  function normalizedHexQuery(query) {
+    const compact = query.replace(/\s/g, '')
+    if (!compact) return ''
+    return /^[0-9a-fA-F]+$/.test(compact) && compact.length % 2 === 0
+      ? compact
+      : null
+  }
+
+  function utf8ToHex(text) {
+    return Array.from(new TextEncoder().encode(text))
+      .map((value) => value.toString(16).toUpperCase().padStart(2, '0'))
+      .join('')
+  }
+
+  function getReplacementHex() {
+    const replacement = replaceInput.value
+    if (!searchHex.checked) {
+      return utf8ToHex(replacement)
+    }
+    return normalizedHexQuery(replacement)
+  }
+
+  function rebuildMatchedByteOffsets() {
+    const offsets = new Set()
+    if (searchPatternLength <= 0) {
+      matchedByteOffsets = offsets
+      return
+    }
+
+    for (const matchOffset of searchMatches) {
+      for (let i = 0; i < searchPatternLength; i += 1) {
+        offsets.add(matchOffset + i)
+      }
+    }
+
+    matchedByteOffsets = offsets
+  }
+
+  function isMatchByte(absOffset) {
+    return matchedByteOffsets.has(absOffset)
   }
 
   function render() {
-    const rows = Math.ceil(viewportLength / BYTES_PER_ROW)
+    if (selectedOffset >= fileSize) {
+      selectedOffset = fileSize > 0 ? fileSize - 1 : -1
+      updateSelectedStatus()
+    }
+
+    updateOffsetColumnWidth()
+    renderColumnHeader()
+    const startIndex = Math.max(0, visibleOffset - bufferOffset)
+    const visibleByteCount = currentVisibleByteCount()
+    const rows = Math.max(1, Math.ceil(visibleByteCount / BYTES_PER_ROW))
     let html = ''
 
     for (let r = 0; r < rows; r++) {
-      const rowOffset = viewportOffset + r * BYTES_PER_ROW
+      const rowOffset = visibleOffset + r * BYTES_PER_ROW
       let hexCells = ''
       let asciiCells = ''
 
       for (let c = 0; c < BYTES_PER_ROW; c++) {
-        const idx = r * BYTES_PER_ROW + c
-        const absOff = viewportOffset + idx
+        const idx = startIndex + r * BYTES_PER_ROW + c
+        const absOff = rowOffset + c
         const sep = (c > 0 && c % GROUP_SIZE === 0) ? ' group-sep' : ''
 
-        if (idx < viewportLength) {
+        if (idx >= 0 && idx < viewportLength && absOff < fileSize) {
           const b = viewportData[idx]
           const sel = absOff === selectedOffset ? ' selected' : ''
           const mat = isMatchByte(absOff) ? ' match' : ''
           hexCells += '<span class="hex-byte' + sep + sel + mat +
             '" data-offset="' + absOff + '">' + toHex2(b) + '</span>'
-          const ch = isPrintable(b) ? String.fromCharCode(b) : '.'
-          asciiCells += '<span class="ascii-char' + sel + mat +
-            '" data-offset="' + absOff + '">' +
-            (ch === '<' ? '&lt;' : ch === '>' ? '&gt;' : ch === '&' ? '&amp;' : ch) +
-            '</span>'
+          const printable = isPrintable(b)
+          const asciiClass = printable ? 'ascii-char' : 'ascii-char non-printable'
+          const ch = printable ? String.fromCharCode(b) : '?'
+          asciiCells += '<span class="' + asciiClass + sel + mat +
+            '" data-offset="' + absOff + '">' + escapeHtml(ch) + '</span>'
         } else {
           hexCells += '<span class="hex-byte' + sep + '">  </span>'
-          asciiCells += '<span class="ascii-char"> </span>'
+          asciiCells += '<span class="ascii-char empty">&nbsp;</span>'
         }
       }
 
-      html += '<div class="hex-row">' +
-        '<span class="offset-col">' + toHex8(rowOffset) + '</span>' +
+      html += '<div class="hex-row" data-row-index="' + r + '">' +
+        '<span class="offset-col">' + formatRowOffset(rowOffset) + '</span>' +
         '<span class="hex-col">' + hexCells + '</span>' +
         '<span class="ascii-col">' + asciiCells + '</span>' +
         '</div>'
     }
 
     hexContainer.innerHTML = html
-    statusOffset.textContent = '0x' + toHex8(viewportOffset)
+    const firstRow = hexContainer.querySelector('.hex-row')
+    if (firstRow) {
+      measuredRowHeight = firstRow.getBoundingClientRect().height || measuredRowHeight
+    }
+    updateOffsetStatus()
     statusSize.textContent = fileSize.toLocaleString()
+    updateProgressStatus()
+    updateInspectorStatus()
+    updateScrollbar()
 
     // Attach click handlers to hex bytes and ascii chars
     hexContainer.querySelectorAll('[data-offset]').forEach(el => {
       el.addEventListener('click', () => {
-        selectedOffset = parseInt(el.dataset.offset, 10)
-        statusSelected.textContent = '0x' + toHex8(selectedOffset)
-        render()
+        selectOffset(parseInt(el.dataset.offset, 10))
       })
     })
   }
@@ -391,7 +1242,10 @@ export function getWebviewContent(bytesPerRow: number): string {
     const msg = event.data
     switch (msg.type) {
       case 'viewportData':
-        viewportOffset = msg.offset
+        bufferOffset = msg.offset
+        visibleOffset =
+          typeof msg.visibleOffset === 'number' ? msg.visibleOffset : pendingVisibleOffset
+        pendingVisibleOffset = visibleOffset
         viewportData = msg.data
         viewportLength = msg.length
         fileSize = msg.fileSize
@@ -401,16 +1255,51 @@ export function getWebviewContent(bytesPerRow: number): string {
       case 'fileSizeChanged':
         fileSize = msg.fileSize
         statusSize.textContent = fileSize.toLocaleString()
+        updateProgressStatus()
+        updateSelectedStatus()
+        updateOffsetColumnWidth()
+        updateScrollbar()
         break
 
       case 'searchResults':
         searchMatches = msg.matches
+        searchPatternLength = msg.patternLength || searchPatternLength
+        rebuildMatchedByteOffsets()
         searchMatchIndex = msg.matches.length > 0 ? 0 : -1
-        matchNav.innerHTML = msg.matches.length > 0
-          ? '<span>' + (searchMatchIndex + 1) + '</span> / ' + msg.matches.length
-          : 'No matches'
-        statusMatches.textContent = msg.matches.length + ' matches'
+        if (searchMatches.length > 0) {
+          selectOffset(searchMatches[0])
+        }
+        updateMatchNav()
+        if (searchMatches.length === 0) {
+          render()
+        }
+        break
+
+      case 'editState':
+        updateEditButtons(
+          msg.canUndo,
+          msg.canRedo,
+          msg.undoCount ?? 0,
+          msg.redoCount ?? 0
+        )
+        updateDirtyStatus(msg.isDirty ?? false)
         render()
+        break
+
+      case 'replaceComplete':
+        updateActionStatus(
+          (msg.replacedCount ?? 0) === 1
+            ? 'Replaced 1 match'
+            : 'Replaced ' + (msg.replacedCount ?? 0) + ' matches'
+        )
+        if (typeof msg.selectionOffset === 'number' && msg.selectionOffset >= 0) {
+          selectOffset(msg.selectionOffset)
+        }
+        doSearch()
+        break
+
+      case 'serverHealth':
+        updateServerHealthStatus(msg)
         break
     }
   })
@@ -419,43 +1308,159 @@ export function getWebviewContent(bytesPerRow: number): string {
 
   hexContainer.addEventListener('wheel', (e) => {
     e.preventDefault()
-    vscode.postMessage({
-      type: 'scroll',
-      direction: e.deltaY < 0 ? 'up' : 'down',
-    })
+    const rowHeight = Math.max(1, measuredRowHeight || 1)
+    accumulatedWheelPixels += e.deltaY
+    const deltaRows = accumulatedWheelPixels > 0
+      ? Math.floor(accumulatedWheelPixels / rowHeight)
+      : Math.ceil(accumulatedWheelPixels / rowHeight)
+
+    if (deltaRows === 0) {
+      return
+    }
+
+    accumulatedWheelPixels -= deltaRows * rowHeight
+    scrollToViewportOffset(visibleOffset + deltaRows * BYTES_PER_ROW)
   }, { passive: false })
+
+  hexContainer.addEventListener('pointermove', (e) => {
+    const target = e.target.closest('[data-offset]')
+    if (!target) {
+      updateHoverHighlights(-1, -1)
+      return
+    }
+
+    const offset = parseInt(target.dataset.offset, 10)
+    if (Number.isNaN(offset)) {
+      updateHoverHighlights(-1, -1)
+      return
+    }
+
+    const row = target.closest('.hex-row')
+    const rowIndex = row ? parseInt(row.dataset.rowIndex, 10) : -1
+    updateHoverHighlights(
+      Number.isNaN(rowIndex) ? -1 : rowIndex,
+      offset % BYTES_PER_ROW
+    )
+  })
+
+  hexContainer.addEventListener('pointerleave', () => {
+    updateHoverHighlights(-1, -1)
+  })
+
+  scrollbarTrack.addEventListener('pointerdown', (e) => {
+    if (e.target === scrollbarThumb || scrollbarTrack.classList.contains('disabled')) {
+      return
+    }
+    e.preventDefault()
+    const thumbHeight = scrollbarThumb.getBoundingClientRect().height
+    startScrollbarDrag(e.clientY, thumbHeight / 2)
+  })
+
+  scrollbarThumb.addEventListener('pointerdown', (e) => {
+    if (scrollbarTrack.classList.contains('disabled')) {
+      return
+    }
+    e.preventDefault()
+    const thumbRect = scrollbarThumb.getBoundingClientRect()
+    startScrollbarDrag(e.clientY, clamp(0, e.clientY - thumbRect.top, thumbRect.height))
+  })
+
+  window.addEventListener('pointermove', (e) => {
+    if (!isDraggingScrollbar) {
+      return
+    }
+    if (e.buttons === 0) {
+      stopScrollbarDrag()
+      return
+    }
+    e.preventDefault()
+    scrollFromTrackPosition(e.clientY, scrollbarDragOffsetY)
+  })
+
+  window.addEventListener('pointerup', () => {
+    if (isDraggingScrollbar) {
+      stopScrollbarDrag()
+    }
+  })
+
+  window.addEventListener('pointercancel', () => {
+    if (isDraggingScrollbar) {
+      stopScrollbarDrag()
+    }
+  })
+  window.addEventListener('resize', updateScrollbar)
+  if (typeof ResizeObserver !== 'undefined') {
+    const resizeObserver = new ResizeObserver(() => {
+      measuredRowHeight = 0
+      reportViewportMetrics()
+      render()
+    })
+    resizeObserver.observe(hexContainer)
+  }
 
   // ── Keyboard Shortcuts ──────────────────────────────
 
   document.addEventListener('keydown', (e) => {
+    if (isEditableTarget(e.target)) {
+      return
+    }
+
     if (e.ctrlKey && e.key === 'z') {
       e.preventDefault()
-      vscode.postMessage({ type: 'undo' })
+      if (!undoBtn.disabled) {
+        vscode.postMessage({ type: 'undo' })
+      }
     } else if (e.ctrlKey && e.key === 'y') {
       e.preventDefault()
-      vscode.postMessage({ type: 'redo' })
+      if (!redoBtn.disabled) {
+        vscode.postMessage({ type: 'redo' })
+      }
     } else if (e.ctrlKey && e.key === 's') {
       e.preventDefault()
-      vscode.postMessage({ type: 'save' })
+      if (e.shiftKey) {
+        vscode.postMessage({ type: 'saveAs' })
+      } else if (!saveBtn.disabled) {
+        vscode.postMessage({ type: 'save' })
+      }
     } else if (e.ctrlKey && e.key === 'f') {
       e.preventDefault()
       searchInput.focus()
     } else if (e.ctrlKey && e.key === 'g') {
       e.preventDefault()
       // Go to offset — trigger via VS Code command instead
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      moveSelection('left')
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      moveSelection('right')
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      moveSelection('up')
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      moveSelection('down')
+    } else if (e.key === 'Delete') {
+      if (selectedOffset >= 0 && fileSize > 0) {
+        e.preventDefault()
+        vscode.postMessage({ type: 'delete', offset: selectedOffset, length: 1 })
+      }
     } else if (e.key === 'PageDown') {
       e.preventDefault()
-      vscode.postMessage({ type: 'scrollTo', offset: viewportOffset + BYTES_PER_ROW * 32 })
+      scrollToViewportOffset(
+        visibleOffset + Math.max(BYTES_PER_ROW, currentVisibleByteCount())
+      )
     } else if (e.key === 'PageUp') {
       e.preventDefault()
-      const newOffset = Math.max(0, viewportOffset - BYTES_PER_ROW * 32)
-      vscode.postMessage({ type: 'scrollTo', offset: newOffset })
+      scrollToViewportOffset(
+        visibleOffset - Math.max(BYTES_PER_ROW, currentVisibleByteCount())
+      )
     } else if (e.key === 'Home' && e.ctrlKey) {
       e.preventDefault()
-      vscode.postMessage({ type: 'scrollTo', offset: 0 })
+      scrollToViewportOffset(0)
     } else if (e.key === 'End' && e.ctrlKey) {
       e.preventDefault()
-      vscode.postMessage({ type: 'scrollTo', offset: Math.max(0, fileSize - BYTES_PER_ROW) })
+      scrollToViewportOffset(Math.max(0, fileSize - BYTES_PER_ROW))
     }
   })
 
@@ -463,33 +1468,109 @@ export function getWebviewContent(bytesPerRow: number): string {
 
   function doSearch() {
     const query = searchInput.value.trim()
-    if (!query) return
+    if (!query) {
+      clearSearchResults()
+      return
+    }
     const isHex = searchHex.checked
-    searchPatternLength = isHex ? query.replace(/\\s/g, '').length / 2 : query.length
+    const normalizedQuery = isHex ? normalizedHexQuery(query) : query
+    if (normalizedQuery === null) {
+      clearSearchResults('Invalid hex')
+      return
+    }
+    searchPatternLength = isHex ? normalizedQuery.length / 2 : query.length
     vscode.postMessage({
       type: 'search',
-      query: isHex ? query.replace(/\\s/g, '') : query,
+      query: normalizedQuery,
       isHex: isHex,
-      caseInsensitive: searchCase.checked,
+      caseInsensitive: !isHex && searchCase.checked,
+      isReverse: searchDirectionSelect.value === 'reverse',
     })
   }
 
-  document.getElementById('searchBtn').addEventListener('click', doSearch)
+  function replaceCurrentMatch() {
+    if (searchMatches.length === 0 || searchMatchIndex < 0 || searchPatternLength <= 0) {
+      return
+    }
+    const replacementHex = getReplacementHex()
+    if (replacementHex === null) {
+      matchNav.textContent = 'Invalid replacement hex'
+      return
+    }
+    vscode.postMessage({
+      type: 'replace',
+      offset: searchMatches[searchMatchIndex],
+      length: searchPatternLength,
+      data: replacementHex,
+    })
+  }
+
+  function replaceAllMatches() {
+    if (searchMatches.length === 0 || searchPatternLength <= 0) {
+      return
+    }
+    const replacementHex = getReplacementHex()
+    if (replacementHex === null) {
+      matchNav.textContent = 'Invalid replacement hex'
+      return
+    }
+    vscode.postMessage({
+      type: 'replaceAllMatches',
+      offsets: searchMatches.slice(),
+      length: searchPatternLength,
+      data: replacementHex,
+    })
+  }
+
+  searchBtn.addEventListener('click', doSearch)
+  replaceBtn.addEventListener('click', replaceCurrentMatch)
+  replaceAllBtn.addEventListener('click', replaceAllMatches)
+  bytesPerRowSelect.addEventListener('change', () => {
+    const nextBytesPerRow = parseInt(bytesPerRowSelect.value, 10)
+    if ([8, 16, 32].includes(nextBytesPerRow)) {
+      vscode.postMessage({
+        type: 'setBytesPerRow',
+        bytesPerRow: nextBytesPerRow,
+      })
+    }
+  })
+  offsetRadixSelect.addEventListener('change', () => {
+    offsetRadix = offsetRadixSelect.value === 'dec' ? 'dec' : 'hex'
+    render()
+  })
+  searchHex.addEventListener('change', syncSearchMode)
+  searchInput.addEventListener('input', () => {
+    updateSearchButtons()
+  })
   searchInput.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') doSearch()
+    if (e.key === 'Enter' && !searchBtn.disabled) doSearch()
+  })
+  replaceInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') replaceCurrentMatch()
+  })
+  inspectorEndianBtn.addEventListener('click', () => {
+    inspectorLittleEndian = !inspectorLittleEndian
+    updateInspectorEndianLabel()
+    updateInspectorStatus()
   })
 
-  document.getElementById('nextMatch').addEventListener('click', () => {
+  nextMatchBtn.addEventListener('click', () => {
     if (searchMatches.length === 0) return
     searchMatchIndex = (searchMatchIndex + 1) % searchMatches.length
-    matchNav.innerHTML = '<span>' + (searchMatchIndex + 1) + '</span> / ' + searchMatches.length
+    selectedOffset = searchMatches[searchMatchIndex]
+    updateSelectedStatus()
+    updateMatchNav()
+    render()
     vscode.postMessage({ type: 'goToMatch', offset: searchMatches[searchMatchIndex] })
   })
 
-  document.getElementById('prevMatch').addEventListener('click', () => {
+  prevMatchBtn.addEventListener('click', () => {
     if (searchMatches.length === 0) return
     searchMatchIndex = (searchMatchIndex - 1 + searchMatches.length) % searchMatches.length
-    matchNav.innerHTML = '<span>' + (searchMatchIndex + 1) + '</span> / ' + searchMatches.length
+    selectedOffset = searchMatches[searchMatchIndex]
+    updateSelectedStatus()
+    updateMatchNav()
+    render()
     vscode.postMessage({ type: 'goToMatch', offset: searchMatches[searchMatchIndex] })
   })
 
@@ -544,6 +1625,12 @@ export function getWebviewContent(bytesPerRow: number): string {
   document.getElementById('insertBtn').addEventListener('click', () => openEditDialog('insert'))
   document.getElementById('overwriteBtn').addEventListener('click', () => openEditDialog('overwrite'))
   document.getElementById('deleteBtn').addEventListener('click', () => openEditDialog('delete'))
+  topBtn.addEventListener('click', () => {
+    scrollToViewportOffset(0)
+  })
+  bottomBtn.addEventListener('click', () => {
+    scrollToViewportOffset(Math.max(0, fileSize - BYTES_PER_ROW))
+  })
   document.getElementById('editCancel').addEventListener('click', closeEditDialog)
   document.getElementById('editOk').addEventListener('click', submitEdit)
   overlay.addEventListener('click', closeEditDialog)
@@ -555,15 +1642,38 @@ export function getWebviewContent(bytesPerRow: number): string {
 
   // ── Undo / Redo / Save Buttons ──────────────────────
 
-  document.getElementById('undoBtn').addEventListener('click', () => {
-    vscode.postMessage({ type: 'undo' })
+  undoBtn.addEventListener('click', () => {
+    if (!undoBtn.disabled) {
+      vscode.postMessage({ type: 'undo' })
+    }
   })
-  document.getElementById('redoBtn').addEventListener('click', () => {
-    vscode.postMessage({ type: 'redo' })
+  redoBtn.addEventListener('click', () => {
+    if (!redoBtn.disabled) {
+      vscode.postMessage({ type: 'redo' })
+    }
   })
-  document.getElementById('saveBtn').addEventListener('click', () => {
-    vscode.postMessage({ type: 'save' })
+  saveBtn.addEventListener('click', () => {
+    if (!saveBtn.disabled) {
+      vscode.postMessage({ type: 'save' })
+    }
   })
+  saveAsBtn.addEventListener('click', () => {
+    vscode.postMessage({ type: 'saveAs' })
+  })
+
+  updateSearchButtons()
+  updateEditButtons(false, false)
+  syncSearchMode()
+  updateDirtyStatus(false)
+  updateActionStatus('')
+  updateInspectorEndianLabel()
+  updateInspectorStatus()
+  updateServerHealthStatus(null)
+  updateOffsetStatus()
+  updateSelectedStatus()
+  updateProgressStatus()
+  renderColumnHeader()
+  reportViewportMetrics()
 })()
 </script>
 </body>

--- a/examples/vscode-extension/tests/extension.test.js
+++ b/examples/vscode-extension/tests/extension.test.js
@@ -1,0 +1,182 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const packageJson = require('../package.json')
+const {
+  OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND,
+  OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+  OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+  OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND,
+  OMEGA_EDIT_VIEW_TYPE,
+} = require('../out/constants.js')
+const { getWebviewContent } = require('../out/webview.js')
+
+test('package.json matches shared extension constants', () => {
+  assert.equal(packageJson.main, './out/extension.js')
+  assert.deepEqual(packageJson.activationEvents, [
+    `onCustomEditor:${OMEGA_EDIT_VIEW_TYPE}`,
+    `onCommand:${OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND}`,
+    `onCommand:${OMEGA_EDIT_GO_TO_OFFSET_COMMAND}`,
+    `onCommand:${OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND}`,
+    `onCommand:${OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND}`,
+  ])
+  assert.equal(
+    packageJson.contributes.customEditors[0].viewType,
+    OMEGA_EDIT_VIEW_TYPE
+  )
+  assert.equal(
+    packageJson.contributes.commands[0].command,
+    OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND
+  )
+  assert.equal(
+    packageJson.contributes.commands[1].command,
+    OMEGA_EDIT_GO_TO_OFFSET_COMMAND
+  )
+  assert.equal(
+    packageJson.contributes.commands[2].command,
+    OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND
+  )
+  assert.equal(
+    packageJson.contributes.commands[3].command,
+    OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND
+  )
+})
+
+test('compiled extension entrypoints exist after build', () => {
+  assert.equal(
+    fs.existsSync(path.resolve(__dirname, '../out/extension.js')),
+    true
+  )
+  assert.equal(
+    fs.existsSync(path.resolve(__dirname, '../out/hexEditorProvider.js')),
+    true
+  )
+  assert.equal(
+    fs.existsSync(path.resolve(__dirname, '../out/webview.js')),
+    true
+  )
+
+  const providerJs = fs.readFileSync(
+    path.resolve(__dirname, '../out/hexEditorProvider.js'),
+    'utf8'
+  )
+  assert.match(providerJs, /editSimple/)
+  assert.match(providerJs, /getSegment/)
+  assert.match(providerJs, /kind:\s*['"]REPLACE['"]/)
+  assert.match(providerJs, /getServerHeartbeat/)
+  assert.match(providerJs, /getServerInfo/)
+})
+
+test('webview HTML includes core controls and configured row width', () => {
+  const html = getWebviewContent(32)
+
+  assert.match(html, /const BYTES_PER_ROW = 32/)
+  assert.match(html, /id="hexContainer"/)
+  assert.match(html, /id="hexHeader"/)
+  assert.match(html, /id="hexColumnHeader"/)
+  assert.match(html, /id="bytesPerRowSelect"/)
+  assert.match(html, /id="offsetRadixSelect"/)
+  assert.match(html, /id="searchDirectionSelect"/)
+  assert.match(html, /class="secondary" id="searchBtn"/)
+  assert.match(html, /id="replaceInput"/)
+  assert.match(html, /id="replaceBtn"/)
+  assert.match(html, /id="replaceAllBtn"/)
+  assert.match(html, /id="topBtn"/)
+  assert.match(html, /id="bottomBtn"/)
+  assert.match(html, /id="scrollbarTrack"/)
+  assert.match(html, /id="scrollbarThumb"/)
+  assert.match(html, /class="secondary" id="saveBtn"/)
+  assert.match(html, /id="saveAsBtn"/)
+  assert.match(html, /id="editDialog"/)
+  assert.match(html, /id="searchCaseLabel"/)
+  assert.match(html, /id="statusDirty"/)
+  assert.match(html, /id="statusAction"/)
+  assert.match(html, /id="statusInspector"/)
+  assert.match(html, /id="inspectorEndianBtn"/)
+  assert.match(html, /id="serverHealthDot"/)
+  assert.match(html, /id="statusProgress"/)
+  assert.match(html, /title="Undo \(Ctrl\+Z\)">Undo<\/button>/)
+  assert.match(html, /title="Redo \(Ctrl\+Y\)">Redo<\/button>/)
+  assert.match(html, /grid-template-columns: repeat\(32, 1ch\);/)
+  assert.match(html, /min-width: calc\(32ch \+ 12px\);/)
+  assert.match(
+    html,
+    /--selected-fg: var\(--vscode-editor-selectionForeground, var\(--fg\)\);/
+  )
+  assert.match(
+    html,
+    /--offset-column-fg: var\(--vscode-terminal-ansiCyan, #4fc1ff\);/
+  )
+  assert.match(html, /\.toolbar label\.disabled/)
+  assert.match(html, /\.scrollbar-thumb/)
+  assert.match(html, /searchCase\.disabled = hexMode/)
+  assert.match(html, /function formatOffsetDisplay\(offset\)/)
+  assert.match(html, /function formatRowOffset\(offset\)/)
+  assert.match(html, /function formatColumnOffset\(offset\)/)
+  assert.match(html, /function renderColumnHeader\(\)/)
+  assert.match(html, /let matchedByteOffsets = new Set\(\)/)
+  assert.match(html, /function rebuildMatchedByteOffsets\(\)/)
+  assert.match(html, /progress\.toFixed\(2\) \+ '%'/)
+  assert.match(html, /function scrollToViewportOffset\(offset\)/)
+  assert.match(html, /rowAlignedOffset >= bufferOffset/)
+  assert.match(html, /type: 'setViewportMetrics'/)
+  assert.match(html, /function reportViewportMetrics\(\)/)
+  assert.match(html, /visibleOffset =/)
+  assert.match(html, /bufferOffset = msg\.offset/)
+  assert.match(html, /measuredRowHeight/)
+  assert.match(html, /hexContainer\.clientHeight \/ measuredRowHeight/)
+  assert.match(html, /ResizeObserver/)
+  assert.match(html, /moveSelection\('left'\)/)
+  assert.match(html, /moveSelection\('right'\)/)
+  assert.match(html, /moveSelection\('up'\)/)
+  assert.match(html, /moveSelection\('down'\)/)
+  assert.match(html, /scrollToViewportOffset\(0\)/)
+  assert.match(
+    html,
+    /scrollToViewportOffset\(Math\.max\(0, fileSize - BYTES_PER_ROW\)\)/
+  )
+  assert.match(html, /type: 'setBytesPerRow'/)
+  assert.match(html, /type: 'search'/)
+  assert.match(html, /type: 'replace'/)
+  assert.match(html, /type: 'replaceAllMatches'/)
+  assert.match(
+    html,
+    /searchBtn\.disabled = searchInput\.value\.trim\(\)\.length === 0/
+  )
+  assert.match(html, /saveBtn\.disabled = !isDirty/)
+  assert.match(
+    html,
+    /if \(e\.shiftKey\) {\s*vscode\.postMessage\({ type: 'saveAs' }\)\s*} else if \(!saveBtn\.disabled\) {\s*vscode\.postMessage\({ type: 'save' }\)/
+  )
+  assert.match(html, /type: 'saveAs'/)
+  assert.match(html, /function replaceCurrentMatch\(\)/)
+  assert.match(html, /function replaceAllMatches\(\)/)
+  assert.match(html, /undoBtn\.textContent = 'Undo \(' \+ undoCount \+ '\)'/)
+  assert.match(html, /redoBtn\.textContent = 'Redo \(' \+ redoCount \+ '\)'/)
+  assert.match(
+    html,
+    /undoBtn\.title = 'Undo ' \+ undoCount \+ ' change\(s\) \(Ctrl\+Z\)'/
+  )
+  assert.match(
+    html,
+    /redoBtn\.title = 'Redo ' \+ redoCount \+ ' change\(s\) \(Ctrl\+Y\)'/
+  )
+  assert.match(html, /function updateDirtyStatus\(isDirty\)/)
+  assert.match(html, /function updateInspectorEndianLabel\(\)/)
+  assert.match(html, /function updateInspectorStatus\(\)/)
+  assert.match(html, /inspectorEndianBtn\.addEventListener\('click'/)
+  assert.match(html, /inspectorLittleEndian = !inspectorLittleEndian/)
+  assert.match(html, /u16' \+ endianLabel/)
+  assert.match(html, /u32' \+ endianLabel/)
+  assert.match(html, /function updateServerHealthStatus\(message\)/)
+  assert.match(html, /case 'serverHealth'/)
+  assert.match(html, /msg\.isDirty \?\? false/)
+  assert.match(html, /msg\.replacedCount \?\? 0/)
+  assert.match(html, /isReverse: searchDirectionSelect\.value === 'reverse'/)
+  assert.match(html, /case 'editState'/)
+  assert.match(html, /msg\.undoCount \?\? 0/)
+  assert.match(html, /msg\.redoCount \?\? 0/)
+  assert.match(html, /case 'replaceComplete'/)
+})

--- a/examples/vscode-extension/tests/run-vscode-observe.js
+++ b/examples/vscode-extension/tests/run-vscode-observe.js
@@ -1,0 +1,31 @@
+const cp = require('node:child_process')
+const path = require('node:path')
+
+const env = {
+  ...process.env,
+  OMEGA_EDIT_OBSERVE: process.env.OMEGA_EDIT_OBSERVE ?? '1',
+  OMEGA_EDIT_OBSERVE_DELAY_MS:
+    process.env.OMEGA_EDIT_OBSERVE_DELAY_MS ?? '2000',
+  OMEGA_EDIT_OBSERVE_FINAL_DELAY_MS:
+    process.env.OMEGA_EDIT_OBSERVE_FINAL_DELAY_MS ?? '10000',
+}
+
+const child = cp.spawn(
+  process.execPath,
+  [path.resolve(__dirname, 'run-vscode-tests.js')],
+  {
+    env,
+    shell: false,
+    stdio: 'inherit',
+    windowsHide: false,
+  }
+)
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+
+  process.exit(code ?? 1)
+})

--- a/examples/vscode-extension/tests/run-vscode-tests.js
+++ b/examples/vscode-extension/tests/run-vscode-tests.js
@@ -1,0 +1,85 @@
+const cp = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
+const { downloadAndUnzipVSCode } = require('@vscode/test-electron')
+
+async function main() {
+  const extensionDevelopmentPath = path.resolve(__dirname, '..')
+  const extensionTestsPath = path.resolve(__dirname, 'suite', 'index.js')
+  const version = process.env.VSCODE_VERSION || undefined
+  const versionTag = sanitizeVersionTag(version ?? 'stable')
+  const profileRoot = path.join(
+    extensionDevelopmentPath,
+    '.vscode-test',
+    `profile-${versionTag}`
+  )
+  const extensionsDir = path.join(profileRoot, 'extensions')
+  const userDataDir = path.join(profileRoot, 'user-data')
+
+  try {
+    const vscodeExecutablePath = await downloadAndUnzipVSCode(
+      version ? { version } : undefined
+    )
+    fs.rmSync(profileRoot, { recursive: true, force: true })
+    const args = [
+      '--no-sandbox',
+      '--disable-gpu-sandbox',
+      '--disable-updates',
+      '--disable-extensions',
+      '--disable-workspace-trust',
+      '--skip-release-notes',
+      '--skip-welcome',
+      `--extensionTestsPath=${extensionTestsPath}`,
+      `--extensionDevelopmentPath=${extensionDevelopmentPath}`,
+      `--extensions-dir=${extensionsDir}`,
+      `--user-data-dir=${userDataDir}`,
+    ]
+
+    await runProcess(vscodeExecutablePath, args, extensionDevelopmentPath)
+  } catch (error) {
+    console.error('Failed to run VS Code integration tests')
+    console.error(error)
+    process.exit(1)
+  }
+}
+
+function runProcess(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const env = {
+      ...process.env,
+      NODE_ENV: 'test',
+      ELECTRON_RUN_AS_NODE: undefined,
+      VSCODE_DEV: undefined,
+    }
+
+    const child = cp.spawn(command, args, {
+      cwd,
+      env,
+      shell: false,
+      stdio: 'inherit',
+      windowsHide: true,
+    })
+
+    child.on('error', reject)
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+
+      reject(
+        new Error(
+          signal
+            ? `VS Code test run terminated with signal ${signal}`
+            : `VS Code test run failed with exit code ${code}`
+        )
+      )
+    })
+  })
+}
+
+function sanitizeVersionTag(rawVersion) {
+  return rawVersion.replace(/[^a-zA-Z0-9._-]/g, '_')
+}
+
+void main()

--- a/examples/vscode-extension/tests/suite/extension.integration.test.js
+++ b/examples/vscode-extension/tests/suite/extension.integration.test.js
@@ -1,0 +1,615 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const vscode = require('vscode')
+const { getComputedFileSize, getSegment } = require('@omega-edit/client')
+
+const packageJson = require('../../package.json')
+const { getHexEditorProviderForTesting } = require('../../out/extension.js')
+const { HexEditorProvider } = require('../../out/hexEditorProvider.js')
+const {
+  OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND,
+  OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+  OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+  OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND,
+  OMEGA_EDIT_VIEW_TYPE,
+} = require('../../out/constants.js')
+
+const OBSERVE_MODE = process.env.OMEGA_EDIT_OBSERVE === '1'
+const OBSERVE_STEP_DELAY_MS = parseDelay(
+  process.env.OMEGA_EDIT_OBSERVE_DELAY_MS,
+  2000
+)
+const OBSERVE_FINAL_DELAY_MS = parseDelay(
+  process.env.OMEGA_EDIT_OBSERVE_FINAL_DELAY_MS,
+  10000
+)
+
+suite('OmegaEdit VS Code extension', () => {
+  let testPort
+
+  suiteSetup(async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+
+    testPort = 43000 + Math.floor(Math.random() * 10000) + (process.pid % 1000)
+    await vscode.workspace
+      .getConfiguration('omegaEdit')
+      .update('serverPort', testPort, vscode.ConfigurationTarget.Global)
+
+    const extensionId = `${packageJson.publisher}.${packageJson.name}`
+    const extension = vscode.extensions.getExtension(extensionId)
+
+    assert.ok(extension, `Expected extension ${extensionId} to be present`)
+    await extension.activate()
+    assert.equal(extension.isActive, true)
+  })
+
+  teardown(async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+  })
+
+  test('registers the go to offset command', async () => {
+    const commands = await vscode.commands.getCommands(true)
+    assert.ok(commands.includes(OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND))
+    assert.ok(commands.includes(OMEGA_EDIT_GO_TO_OFFSET_COMMAND))
+    assert.ok(commands.includes(OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND))
+    assert.ok(commands.includes(OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND))
+  })
+
+  test('opens sample file through the explicit open-in-hex-editor command', async () => {
+    const uri = vscode.Uri.file(
+      path.resolve(__dirname, '..', 'workspace', 'sample.txt')
+    )
+
+    await vscode.commands.executeCommand(
+      OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+      uri
+    )
+
+    const activeTab = await waitForTab(
+      (tab) =>
+        tab?.input instanceof vscode.TabInputCustom &&
+        tab.input.viewType === OMEGA_EDIT_VIEW_TYPE &&
+        tab.input.uri.fsPath === uri.fsPath
+    )
+
+    assert.ok(
+      activeTab,
+      'Expected the explicit OmegaEdit open command to open the custom editor'
+    )
+  })
+
+  test('opens sample file in the custom editor', async () => {
+    const uri = vscode.Uri.file(
+      path.resolve(__dirname, '..', 'workspace', 'sample.txt')
+    )
+
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      uri,
+      OMEGA_EDIT_VIEW_TYPE
+    )
+
+    const activeTab = await waitForTab(
+      (tab) =>
+        tab?.input instanceof vscode.TabInputCustom &&
+        tab.input.viewType === OMEGA_EDIT_VIEW_TYPE &&
+        tab.input.uri.fsPath === uri.fsPath
+    )
+
+    assert.ok(activeTab, 'Expected the OmegaEdit custom editor tab to open')
+  })
+
+  test('exports and replays a JSON change script that reproduces the saved file', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-')
+    )
+    const sourcePath = path.join(tmpDir, 'source.bin')
+    const replayPath = path.join(tmpDir, 'replay.bin')
+    const scriptPath = path.join(tmpDir, 'changes.json')
+    await fs.writeFile(sourcePath, Buffer.from('ABCDEFGH', 'utf8'))
+    await fs.writeFile(replayPath, Buffer.from('ABCDEFGH', 'utf8'))
+
+    const provider1 = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel1 = createMockWebviewPanel()
+    const document1 = await provider1.openCustomDocument(
+      vscode.Uri.file(sourcePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider1.resolveCustomEditor(
+      document1,
+      panel1,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session1 = provider1.getSessionForTesting(document1.uri)
+    assert.ok(
+      session1,
+      'Expected a live editor session after resolving the editor'
+    )
+
+    await provider1.dispatchWebviewMessageForTesting(document1.uri, {
+      type: 'insert',
+      offset: 1,
+      data: Buffer.from('12', 'utf8').toString('hex'),
+    })
+    await assertSessionText(session1.sessionId, 'A12BCDEFGH')
+    await provider1.dispatchWebviewMessageForTesting(document1.uri, {
+      type: 'delete',
+      offset: 3,
+      length: 2,
+    })
+    await assertSessionText(session1.sessionId, 'A12DEFGH')
+    await provider1.dispatchWebviewMessageForTesting(document1.uri, {
+      type: 'overwrite',
+      offset: 4,
+      data: Buffer.from('xy', 'utf8').toString('hex'),
+    })
+    await assertSessionText(session1.sessionId, 'A12DxyGH')
+    await provider1.dispatchWebviewMessageForTesting(document1.uri, {
+      type: 'replace',
+      offset: 6,
+      length: 2,
+      data: Buffer.from('ZZ', 'utf8').toString('hex'),
+    })
+    await assertSessionText(session1.sessionId, 'A12DxyZZ')
+    await provider1.exportActiveChangeScript(vscode.Uri.file(scriptPath))
+    await provider1.dispatchWebviewMessageForTesting(document1.uri, {
+      type: 'save',
+    })
+
+    const script = JSON.parse(await fs.readFile(scriptPath, 'utf8'))
+    assert.ok(Array.isArray(script), 'Expected export to produce a JSON array')
+    assert.ok(
+      script.length > 0,
+      'Expected the exported change script to capture at least one change'
+    )
+    assert.ok(
+      script.every((change) =>
+        ['DELETE', 'INSERT', 'OVERWRITE', 'REPLACE'].includes(change.kind)
+      ),
+      'Expected exported change kinds to stay within the supported replay operations'
+    )
+
+    const provider2 = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel2 = createMockWebviewPanel()
+    const document2 = await provider2.openCustomDocument(
+      vscode.Uri.file(replayPath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider2.resolveCustomEditor(
+      document2,
+      panel2,
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider2.replayActiveChangeScript(vscode.Uri.file(scriptPath))
+
+    const session2 = provider2.getSessionForTesting(document2.uri)
+    assert.ok(
+      session2,
+      'Expected a replay session after resolving the second editor'
+    )
+    await provider2.dispatchWebviewMessageForTesting(document2.uri, {
+      type: 'save',
+    })
+
+    const saved = await fs.readFile(sourcePath, 'utf8')
+    const replayed = await fs.readFile(replayPath, 'utf8')
+    assert.equal(saved, 'A12DxyZZ')
+    assert.equal(replayed, saved)
+
+    await panel1.fireDidDispose()
+    await panel2.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('reports search matches and keeps undo/redo disabled state in sync', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-state-')
+    )
+    const samplePath = path.join(tmpDir, 'search.bin')
+    await fs.writeFile(samplePath, Buffer.from('Alpha alpha ALPHA', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a live session for the search test')
+
+    const initialState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(initialState, {
+      type: 'editState',
+      canUndo: false,
+      canRedo: false,
+      undoCount: 0,
+      redoCount: 0,
+      isDirty: false,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'search',
+      query: 'alpha',
+      isHex: false,
+      caseInsensitive: true,
+    })
+
+    const searchResults = lastMessageOfType(panel.messages, 'searchResults')
+    assert.ok(
+      searchResults,
+      'Expected search results to be posted back to the webview'
+    )
+    assert.deepEqual(searchResults.matches, [0, 6, 12])
+    assert.equal(
+      searchResults.patternLength,
+      Buffer.from('alpha', 'utf8').length
+    )
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'insert',
+      offset: 0,
+      data: Buffer.from('!', 'utf8').toString('hex'),
+    })
+
+    let editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'undo',
+    })
+    editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: false,
+      canRedo: true,
+      undoCount: 0,
+      redoCount: 1,
+      isDirty: false,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'redo',
+    })
+    editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('tracks optimized replace counts and clears dirty state on save', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-replace-')
+    )
+    const samplePath = path.join(tmpDir, 'replace.bin')
+    await fs.writeFile(samplePath, Buffer.from('foo foo foo foo', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a live session for the replace test')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'replaceAllMatches',
+      offsets: [0, 4, 8, 12],
+      length: 3,
+      data: Buffer.from('qux', 'utf8').toString('hex'),
+    })
+
+    const replaceComplete = lastMessageOfType(panel.messages, 'replaceComplete')
+    assert.deepEqual(replaceComplete, {
+      type: 'replaceComplete',
+      selectionOffset: 0,
+      replacedCount: 4,
+    })
+
+    let editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 4,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+    assert.equal(session.changeLog.length, 4)
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'save',
+    })
+    editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 4,
+      redoCount: 0,
+      isDirty: false,
+      savedChangeDepth: 4,
+    })
+
+    const saved = await fs.readFile(samplePath, 'utf8')
+    assert.equal(saved, 'qux qux qux qux')
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('shows a live custom-editor demo when observation mode is enabled', async function () {
+    if (!OBSERVE_MODE) {
+      this.skip()
+      return
+    }
+
+    this.timeout(180000)
+
+    const provider = getHexEditorProviderForTesting()
+    assert.ok(
+      provider,
+      'Expected the activated extension to expose its provider'
+    )
+
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-observe-')
+    )
+    const sourcePath = path.join(tmpDir, 'observe-source.bin')
+    const replayPath = path.join(tmpDir, 'observe-replay.bin')
+    const scriptPath = path.join(tmpDir, 'observe-script.json')
+    await fs.writeFile(sourcePath, Buffer.from('ABCDEFGH', 'utf8'))
+    await fs.writeFile(replayPath, Buffer.from('ABCDEFGH', 'utf8'))
+
+    const sourceUri = vscode.Uri.file(sourcePath)
+    const replayUri = vscode.Uri.file(replayPath)
+
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      sourceUri,
+      OMEGA_EDIT_VIEW_TYPE
+    )
+    const sourceSession = await waitForSession(provider, sourceUri)
+    assert.ok(
+      sourceSession,
+      'Expected the observation source session to be ready'
+    )
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await provider.dispatchWebviewMessageForTesting(sourceUri, {
+      type: 'insert',
+      offset: 1,
+      data: Buffer.from('12', 'utf8').toString('hex'),
+    })
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await provider.dispatchWebviewMessageForTesting(sourceUri, {
+      type: 'delete',
+      offset: 3,
+      length: 2,
+    })
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await provider.dispatchWebviewMessageForTesting(sourceUri, {
+      type: 'overwrite',
+      offset: 4,
+      data: Buffer.from('xy', 'utf8').toString('hex'),
+    })
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await provider.dispatchWebviewMessageForTesting(sourceUri, {
+      type: 'replace',
+      offset: 6,
+      length: 2,
+      data: Buffer.from('ZZ', 'utf8').toString('hex'),
+    })
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await provider.exportActiveChangeScript(vscode.Uri.file(scriptPath))
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await provider.dispatchWebviewMessageForTesting(sourceUri, { type: 'save' })
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      replayUri,
+      OMEGA_EDIT_VIEW_TYPE
+    )
+    const replaySession = await waitForSession(provider, replayUri)
+    assert.ok(
+      replaySession,
+      'Expected the observation replay session to be ready'
+    )
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await provider.replayActiveChangeScript(vscode.Uri.file(scriptPath))
+    await delay(OBSERVE_STEP_DELAY_MS)
+
+    await provider.dispatchWebviewMessageForTesting(replayUri, { type: 'save' })
+
+    const saved = await fs.readFile(sourcePath, 'utf8')
+    const replayed = await fs.readFile(replayPath, 'utf8')
+    assert.equal(saved, 'A12DxyZZ')
+    assert.equal(replayed, saved)
+
+    await delay(OBSERVE_FINAL_DELAY_MS)
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+})
+
+async function waitForTab(predicate, timeoutMs = 30000, intervalMs = 200) {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab
+    if (predicate(activeTab)) {
+      return activeTab
+    }
+
+    await delay(intervalMs)
+  }
+
+  return undefined
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitForSession(
+  provider,
+  uri,
+  timeoutMs = 30000,
+  intervalMs = 200
+) {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    const session = provider.getSessionForTesting(uri)
+    if (session) {
+      return session
+    }
+
+    await delay(intervalMs)
+  }
+
+  return undefined
+}
+
+async function assertSessionText(
+  sessionId,
+  expected,
+  timeoutMs = 3000,
+  intervalMs = 50
+) {
+  const deadline = Date.now() + timeoutMs
+  const expectedBuffer = Buffer.from(expected, 'utf8')
+  let lastValue = ''
+
+  while (Date.now() < deadline) {
+    const size = await getComputedFileSize(sessionId)
+    const segment = await getSegment(sessionId, 0, size)
+    lastValue = Buffer.from(segment).toString('utf8')
+    if (lastValue === expected) {
+      return
+    }
+
+    await delay(intervalMs)
+  }
+
+  assert.equal(lastValue, expectedBuffer.toString('utf8'))
+}
+
+function parseDelay(rawValue, fallbackMs) {
+  const parsed = Number.parseInt(rawValue ?? '', 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallbackMs
+}
+
+function createMockWebviewPanel() {
+  const receiveMessageListeners = []
+  const viewStateListeners = []
+  const disposeListeners = []
+
+  const webview = {
+    html: '',
+    options: undefined,
+    messages: [],
+    onDidReceiveMessage(listener) {
+      receiveMessageListeners.push(listener)
+      return new vscode.Disposable(() => {
+        const index = receiveMessageListeners.indexOf(listener)
+        if (index >= 0) {
+          receiveMessageListeners.splice(index, 1)
+        }
+      })
+    },
+    postMessage(message) {
+      webview.messages.push(message)
+      return Promise.resolve(true)
+    },
+  }
+
+  return {
+    active: true,
+    webview,
+    messages: webview.messages,
+    onDidChangeViewState(listener) {
+      viewStateListeners.push(listener)
+      return new vscode.Disposable(() => {
+        const index = viewStateListeners.indexOf(listener)
+        if (index >= 0) {
+          viewStateListeners.splice(index, 1)
+        }
+      })
+    },
+    onDidDispose(listener) {
+      disposeListeners.push(listener)
+      return new vscode.Disposable(() => {
+        const index = disposeListeners.indexOf(listener)
+        if (index >= 0) {
+          disposeListeners.splice(index, 1)
+        }
+      })
+    },
+    async fireDidDispose() {
+      for (const listener of disposeListeners) {
+        await listener()
+      }
+    },
+  }
+}
+
+function lastMessageOfType(messages, type) {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.type === type) {
+      return messages[i]
+    }
+  }
+
+  return undefined
+}

--- a/examples/vscode-extension/tests/suite/index.js
+++ b/examples/vscode-extension/tests/suite/index.js
@@ -1,0 +1,24 @@
+const path = require('node:path')
+const Mocha = require('mocha')
+
+async function run() {
+  const mocha = new Mocha({
+    ui: 'tdd',
+    color: true,
+    timeout: 120000,
+  })
+
+  mocha.addFile(path.resolve(__dirname, 'extension.integration.test.js'))
+
+  await new Promise((resolve, reject) => {
+    mocha.run((failures) => {
+      if (failures > 0) {
+        reject(new Error(`${failures} integration test(s) failed.`))
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+module.exports = { run }

--- a/examples/vscode-extension/tests/workspace/sample.txt
+++ b/examples/vscode-extension/tests/workspace/sample.txt
@@ -1,0 +1,1 @@
+OmegaEdit integration test fixture

--- a/examples/vscode-extension/tsconfig.json
+++ b/examples/vscode-extension/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node", "vscode"],
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "declaration": true,

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -15,6 +15,7 @@
 #include "session_manager.h"
 
 #include <omega_edit/edit.h>
+#include <omega_edit/filesystem.h>
 #include <omega_edit/search.h>
 #include <omega_edit/segment.h>
 #include <omega_edit/session.h>
@@ -22,21 +23,106 @@
 #include <omega_edit/viewport.h>
 
 #include <algorithm>
-#include <cstdio>
-#include <cstring>
+#include <cctype>
+#include <cerrno>
 #include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
 #include <random>
 #include <sstream>
+#include <system_error>
 
 #ifdef _WIN32
+#include <windows.h>
 #include <rpc.h>
 #pragma comment(lib, "rpcrt4.lib")
 #else
+#include <signal.h>
+#include <unistd.h>
 #include <uuid/uuid.h>
 #endif
 
 namespace omega_edit {
 namespace grpc_server {
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr char kManagedTempRootName[] = "omega-edit-grpc-server";
+constexpr char kManagedServerPrefix[] = "server-";
+constexpr char kManagedSessionPrefix[] = "session-";
+
+int get_current_process_id() {
+#ifdef _WIN32
+    return static_cast<int>(GetCurrentProcessId());
+#else
+    return static_cast<int>(getpid());
+#endif
+}
+
+std::string get_managed_temp_root_path() {
+    char *temp_dir = omega_util_get_temp_directory();
+    if (temp_dir == nullptr) {
+        return "";
+    }
+
+    const std::string root_path = (fs::path(temp_dir) / kManagedTempRootName).string();
+    free(temp_dir);
+    return root_path;
+}
+
+bool parse_managed_server_root_pid(const std::string &name, int &pid_out) {
+    if (name.rfind(kManagedServerPrefix, 0) != 0) {
+        return false;
+    }
+
+    const size_t pid_start = std::strlen(kManagedServerPrefix);
+    const size_t pid_end = name.find('-', pid_start);
+    if (pid_end == std::string::npos || pid_end == pid_start) {
+        return false;
+    }
+
+    const std::string pid_str = name.substr(pid_start, pid_end - pid_start);
+    if (!std::all_of(pid_str.begin(), pid_str.end(), [](unsigned char ch) { return std::isdigit(ch) != 0; })) {
+        return false;
+    }
+
+    try {
+        pid_out = std::stoi(pid_str);
+    } catch (...) {
+        return false;
+    }
+
+    return pid_out > 0;
+}
+
+bool is_process_alive(int pid) {
+    if (pid <= 0) {
+        return false;
+    }
+
+#ifdef _WIN32
+    HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(pid));
+    if (process == nullptr) {
+        return false;
+    }
+
+    DWORD exit_code = 0;
+    const BOOL ok = GetExitCodeProcess(process, &exit_code);
+    CloseHandle(process);
+    return ok != FALSE && exit_code == STILL_ACTIVE;
+#else
+    if (kill(static_cast<pid_t>(pid), 0) == 0) {
+        return true;
+    }
+
+    return errno == EPERM;
+#endif
+}
+
+} // namespace
 
 // ── Base64 encoding (URL-safe, no padding — matches Java Base64.getUrlEncoder().withoutPadding()) ──
 static const char base64_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
@@ -109,6 +195,111 @@ std::string SessionManager::make_viewport_fqid(const std::string &session_id, co
     return session_id + ":" + viewport_id;
 }
 
+void SessionManager::cleanup_directory_best_effort(const std::string &directory_path) {
+    if (directory_path.empty()) {
+        return;
+    }
+
+    std::error_code ec;
+    fs::remove_all(fs::path(directory_path), ec);
+}
+
+void SessionManager::cleanup_stale_server_roots_best_effort(const std::string &root_path) {
+    if (root_path.empty()) {
+        return;
+    }
+
+    std::error_code ec;
+    const fs::path managed_root(root_path);
+    if (!fs::exists(managed_root, ec) || !fs::is_directory(managed_root, ec)) {
+        return;
+    }
+
+    for (fs::directory_iterator it(managed_root, ec), end; !ec && it != end; it.increment(ec)) {
+        std::error_code entry_ec;
+        if (!it->is_directory(entry_ec)) {
+            continue;
+        }
+
+        const std::string name = it->path().filename().string();
+        if (!is_managed_server_root_name(name)) {
+            continue;
+        }
+
+        int pid = 0;
+        if (!parse_managed_server_root_pid(name, pid) || is_process_alive(pid)) {
+            continue;
+        }
+
+        std::error_code remove_ec;
+        fs::remove_all(it->path(), remove_ec);
+    }
+}
+
+bool SessionManager::is_managed_server_root_name(const std::string &name) {
+    int pid = 0;
+    return parse_managed_server_root_pid(name, pid);
+}
+
+std::string SessionManager::create_server_root_name() {
+    return std::string(kManagedServerPrefix) + std::to_string(get_current_process_id()) + "-" + generate_uuid();
+}
+
+std::string SessionManager::create_managed_checkpoint_directory() {
+    if (managed_server_root_.empty()) {
+        const std::string managed_root_parent = get_managed_temp_root_path();
+        if (managed_root_parent.empty()) {
+            return "";
+        }
+
+        std::error_code ec;
+        const fs::path managed_root_parent_path(managed_root_parent);
+        fs::create_directories(managed_root_parent_path, ec);
+        if (ec) {
+            return "";
+        }
+
+        cleanup_stale_server_roots_best_effort(managed_root_parent);
+
+        const fs::path server_root = managed_root_parent_path / create_server_root_name();
+        ec.clear();
+        fs::create_directories(server_root, ec);
+        if (ec) {
+            return "";
+        }
+
+        managed_server_root_ = server_root.string();
+    }
+
+    std::error_code ec;
+    const fs::path checkpoint_directory =
+        fs::path(managed_server_root_) / (std::string(kManagedSessionPrefix) + generate_uuid());
+    fs::create_directories(checkpoint_directory, ec);
+    if (ec) {
+        return "";
+    }
+
+    return checkpoint_directory.string();
+}
+
+void SessionManager::cleanup_managed_server_root_if_empty() {
+    if (managed_server_root_.empty() || !sessions_.empty()) {
+        return;
+    }
+
+    std::error_code ec;
+    const fs::path server_root(managed_server_root_);
+    if (fs::exists(server_root, ec) && fs::is_directory(server_root, ec) && fs::is_empty(server_root, ec)) {
+        ec.clear();
+        fs::remove(server_root, ec);
+    }
+
+    ec.clear();
+    if (!fs::exists(server_root, ec)) {
+        managed_server_root_.clear();
+    }
+}
+
 // ── Callbacks ────────────────────────────────────────────────────────────────
 void SessionManager::session_event_callback(const omega_session_t *session, omega_session_event_t event,
                                             const void *ptr) {
@@ -178,7 +369,9 @@ void SessionManager::viewport_event_callback(const omega_viewport_t *viewport, o
 }
 
 // ── Constructor / Destructor ─────────────────────────────────────────────────
-SessionManager::SessionManager(ResourceLimits limits) : limits_(limits) {}
+SessionManager::SessionManager(ResourceLimits limits) : limits_(limits) {
+    cleanup_stale_server_roots_best_effort(get_managed_temp_root_path());
+}
 
 SessionManager::~SessionManager() { destroy_all(); }
 
@@ -223,13 +416,29 @@ std::string SessionManager::create_session(const std::string &file_path, const s
     sessions_[session_id] = info;
 
     const char *path = file_path.empty() ? nullptr : file_path.c_str();
-    const char *chkpt_dir = checkpoint_directory.empty() ? nullptr : checkpoint_directory.c_str();
+    std::string effective_checkpoint_directory = checkpoint_directory;
+    if (effective_checkpoint_directory.empty()) {
+        effective_checkpoint_directory = create_managed_checkpoint_directory();
+        if (effective_checkpoint_directory.empty()) {
+            sessions_.erase(session_id);
+            if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+            return "";
+        }
+        info->owns_checkpoint_directory = true;
+    }
+
+    info->checkpoint_directory = effective_checkpoint_directory;
+    const char *chkpt_dir = effective_checkpoint_directory.empty() ? nullptr : effective_checkpoint_directory.c_str();
 
     omega_session_t *session =
         omega_edit_create_session(path, session_event_callback, info.get(), 0, chkpt_dir);
 
     if (!session) {
+        if (info->owns_checkpoint_directory) {
+            cleanup_directory_best_effort(info->checkpoint_directory);
+        }
         sessions_.erase(session_id);
+        cleanup_managed_server_root_if_empty();
         if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
         return ""; // Failed to create
     }
@@ -239,6 +448,9 @@ std::string SessionManager::create_session(const std::string &file_path, const s
 
     const char *chkpt = omega_session_get_checkpoint_directory(session);
     checkpoint_dir_out = chkpt ? chkpt : "";
+    if (!checkpoint_dir_out.empty()) {
+        info->checkpoint_directory = checkpoint_dir_out;
+    }
 
     return session_id;
 }
@@ -266,8 +478,12 @@ bool SessionManager::destroy_session(const std::string &session_id) {
 
     // Destroy the session (this also destroys all viewports)
     omega_edit_destroy_session(info->session);
+    if (info->owns_checkpoint_directory) {
+        cleanup_directory_best_effort(info->checkpoint_directory);
+    }
 
     sessions_.erase(it);
+    cleanup_managed_server_root_if_empty();
     return true;
 }
 
@@ -443,8 +659,12 @@ void SessionManager::destroy_all() {
             if (vp.second->event_queue) vp.second->event_queue->close();
         }
         omega_edit_destroy_session(info->session);
+        if (info->owns_checkpoint_directory) {
+            cleanup_directory_best_effort(info->checkpoint_directory);
+        }
     }
     sessions_.clear();
+    cleanup_managed_server_root_if_empty();
 }
 
 void SessionManager::touch_session(const std::string &session_id) {

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -141,6 +141,8 @@ struct ViewportInfo {
 struct SessionInfo {
     omega_session_t *session;
     std::string session_id;
+    std::string checkpoint_directory;
+    bool owns_checkpoint_directory{false};
     std::map<std::string, std::shared_ptr<ViewportInfo>> viewports;
     std::shared_ptr<EventQueue<SessionEventData>> event_queue;
     int32_t event_interest;
@@ -207,6 +209,12 @@ public:
 private:
     static std::string generate_uuid();
     static std::string make_viewport_fqid(const std::string &session_id, const std::string &viewport_id);
+    static void cleanup_directory_best_effort(const std::string &directory_path);
+    static void cleanup_stale_server_roots_best_effort(const std::string &root_path);
+    static bool is_managed_server_root_name(const std::string &name);
+    static std::string create_server_root_name();
+    std::string create_managed_checkpoint_directory();
+    void cleanup_managed_server_root_if_empty();
 
     // Callbacks
     static void session_event_callback(const omega_session_t *session, omega_session_event_t event, const void *ptr);
@@ -216,6 +224,7 @@ private:
     mutable std::mutex mutex_;
     ResourceLimits limits_;
     std::map<std::string, std::shared_ptr<SessionInfo>> sessions_;
+    std::string managed_server_root_;
 };
 
 } // namespace grpc_server


### PR DESCRIPTION
Fixes #1356

## Summary
- repair the broken VS Code example extension build
- add extension-host tests for open, edit, save, export, and replay flows
- test the declared VS Code support range at 1.110.0 and latest stable in CI
- add JSON change-script export/replay commands that follow the existing record/replay examples

## Notes
- The extension's current tested minimum VS Code version is 1.110.0, and CI exercises both 1.110.0 and latest stable.

## Verification
- npm test (examples/vscode-extension)
- VSCODE_VERSION=1.110.0 npm run test:integration
- VSCODE_VERSION=stable npm run test:integration