### PR TITLE
fix: avoid windows native test DLL copy race

### DIFF
--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -14,6 +14,19 @@ configure_file(
 
 find_program(VALGRIND "valgrind")
 
+if (WIN32 AND BUILD_SHARED_LIBS)
+    # Multiple test targets share the same runtime directory, so stage the DLL
+    # once up front instead of racing on per-target POST_BUILD copies.
+    add_custom_target(
+            omega_edit_test_runtime
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:omega_edit>
+            ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Copying omega_edit.dll to shared test runtime directory"
+            DEPENDS omega_edit
+    )
+endif ()
+
 foreach (test_src ${omega_test_srcs})
     get_filename_component(testname ${test_src} NAME_WE)
 
@@ -53,12 +66,7 @@ foreach (test_src ${omega_test_srcs})
     message(STATUS "Test ${testname}: WIN32=${WIN32}, BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}")
     if (WIN32 AND BUILD_SHARED_LIBS)
         message(STATUS "Using manual test registration for ${testname}")
-        add_dependencies(${testname} omega_edit)
-        add_custom_command(TARGET ${testname} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:omega_edit>
-            $<TARGET_FILE_DIR:${testname}>
-            COMMENT "Copying omega_edit.dll to test directory for ${testname}")
+        add_dependencies(${testname} omega_edit_test_runtime)
         
         # For Windows shared builds, add the test manually to avoid discovery issues
         add_test(NAME ${testname} COMMAND ${testname})

--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -12,18 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * Ωedit™ Hex Editor — VS Code Extension Entry Point
- *
- * This file demonstrates the minimal lifecycle management needed to integrate
- * Ωedit™ into a VS Code extension:
- *   1. activate()  — start the Ωedit™ gRPC server
- *   2. Register a CustomReadonlyEditorProvider (HexEditorProvider)
- *   3. deactivate() — gracefully shut down the server
- */
-
 import * as vscode from 'vscode'
-import { startServer, stopServerGraceful, getClient } from '@omega-edit/client'
+import { getClient, startServer, stopServerGraceful } from '@omega-edit/client'
 import {
   OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND,
   OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
@@ -36,50 +26,67 @@ import { HexEditorProvider } from './hexEditorProvider'
 let serverPid: number | undefined
 let activeProvider: HexEditorProvider | undefined
 
+const DEFAULT_SERVER_PORT = 9000
+const SERVER_PORT_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_PORT'
+
 function isTestRuntime(): boolean {
   return process.env.NODE_ENV === 'test'
+}
+
+function resolveServerPort(config: vscode.WorkspaceConfiguration): number {
+  const envPort = Number.parseInt(
+    process.env[SERVER_PORT_OVERRIDE_ENV] ?? '',
+    10
+  )
+  if (Number.isInteger(envPort) && envPort > 0 && envPort <= 65535) {
+    return envPort
+  }
+
+  return config.get<number>('serverPort', DEFAULT_SERVER_PORT)
+}
+
+function reportActivationError(message: string): void {
+  if (isTestRuntime()) {
+    console.error(message)
+    return
+  }
+
+  void vscode.window.showErrorMessage(message)
 }
 
 export async function activate(
   context: vscode.ExtensionContext
 ): Promise<void> {
   const config = vscode.workspace.getConfiguration('omegaEdit')
-  const port = config.get<number>('serverPort', 9000)
+  const port = resolveServerPort(config)
 
-  // Set log level from configuration before starting
   const logLevel = config.get<string>('logLevel', 'info')
   process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL = logLevel
 
-  // --- Step 1: Start the Ωedit™ gRPC server ---
-  // The server binary is bundled inside @omega-edit/client, so no external
-  // install is needed. startServer() spawns it as a child process.
   try {
     serverPid = await startServer(port)
-    if (serverPid) {
-      vscode.window.showInformationMessage(
-        `Ωedit™ server started on port ${port} (pid ${serverPid})`
+    if (serverPid && !isTestRuntime()) {
+      void vscode.window.showInformationMessage(
+        `OmegaEdit server started on port ${port} (pid ${serverPid})`
       )
     }
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Failed to start Ωedit™ server: ${err instanceof Error ? err.message : String(err)}`
+    reportActivationError(
+      `Failed to start OmegaEdit server: ${err instanceof Error ? err.message : String(err)}`
     )
     return
   }
 
-  // Verify the server is reachable
   try {
-    const client = await getClient(port)
-    const { waitForReady } = await import('@omega-edit/client')
-    await waitForReady(client)
+    await getClient(port)
   } catch {
-    vscode.window.showErrorMessage('Ωedit™ server started but is not reachable')
+    reportActivationError('OmegaEdit server started but is not reachable')
     return
   }
 
-  // --- Step 2: Register the hex editor ---
   const provider = new HexEditorProvider(context, port)
   activeProvider = provider
+
   context.subscriptions.push(
     vscode.window.registerCustomEditorProvider(
       HexEditorProvider.viewType,
@@ -91,7 +98,6 @@ export async function activate(
     )
   )
 
-  // --- Commands ---
   context.subscriptions.push(
     vscode.commands.registerCommand(
       OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
@@ -130,13 +136,16 @@ export async function activate(
         const input = await vscode.window.showInputBox({
           prompt: 'Enter byte offset (decimal or 0x hex)',
           placeHolder: '0x0000',
-          validateInput: (v) => {
-            const n = v.startsWith('0x') ? parseInt(v, 16) : parseInt(v, 10)
-            return isNaN(n) || n < 0
+          validateInput: (value) => {
+            const offset = value.startsWith('0x')
+              ? parseInt(value, 16)
+              : parseInt(value, 10)
+            return Number.isNaN(offset) || offset < 0
               ? 'Enter a valid non-negative integer'
               : null
           },
         })
+
         if (input !== undefined) {
           const offset = input.startsWith('0x')
             ? parseInt(input, 16)
@@ -165,10 +174,9 @@ export async function activate(
     )
   )
 
-  // Listen for configuration changes
   context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration('omegaEdit.bytesPerRow')) {
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('omegaEdit.bytesPerRow')) {
         provider.refreshBytesPerRow()
       }
     })
@@ -178,14 +186,10 @@ export async function activate(
 export async function deactivate(): Promise<void> {
   activeProvider = undefined
 
-  // --- Step 3: Graceful shutdown ---
-  // stopServerGraceful() tells the server to stop accepting new sessions and
-  // exit once all existing sessions are destroyed. This mirrors the pattern
-  // used by the Apache Daffodil™ VS Code extension.
   try {
     await stopServerGraceful()
   } catch {
-    // Server may already be stopped; swallow errors during deactivation
+    // Server may already be stopped; swallow errors during deactivation.
   }
 }
 

--- a/examples/vscode-extension/tests/run-vscode-tests.js
+++ b/examples/vscode-extension/tests/run-vscode-tests.js
@@ -1,5 +1,6 @@
 const cp = require('node:child_process')
 const fs = require('node:fs')
+const net = require('node:net')
 const path = require('node:path')
 const { downloadAndUnzipVSCode } = require('@vscode/test-electron')
 
@@ -20,6 +21,7 @@ async function main() {
     const vscodeExecutablePath = await downloadAndUnzipVSCode(
       version ? { version } : undefined
     )
+    const serverPort = await reserveServerPort()
     fs.rmSync(profileRoot, { recursive: true, force: true })
     const args = [
       '--no-sandbox',
@@ -35,7 +37,10 @@ async function main() {
       `--user-data-dir=${userDataDir}`,
     ]
 
-    await runProcess(vscodeExecutablePath, args, extensionDevelopmentPath)
+    console.log(`Using OmegaEdit test server port ${serverPort}`)
+    await runProcess(vscodeExecutablePath, args, extensionDevelopmentPath, {
+      OMEGA_EDIT_SERVER_PORT: String(serverPort),
+    })
   } catch (error) {
     console.error('Failed to run VS Code integration tests')
     console.error(error)
@@ -43,10 +48,11 @@ async function main() {
   }
 }
 
-function runProcess(command, args, cwd) {
+function runProcess(command, args, cwd, extraEnv = {}) {
   return new Promise((resolve, reject) => {
     const env = {
       ...process.env,
+      ...extraEnv,
       NODE_ENV: 'test',
       ELECTRON_RUN_AS_NODE: undefined,
       VSCODE_DEV: undefined,
@@ -74,6 +80,32 @@ function runProcess(command, args, cwd) {
             : `VS Code test run failed with exit code ${code}`
         )
       )
+    })
+  })
+}
+
+function reserveServerPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close(() => {
+          reject(new Error('Failed to reserve a TCP port for VS Code tests'))
+        })
+        return
+      }
+
+      server.close((err) => {
+        if (err) {
+          reject(err)
+          return
+        }
+
+        resolve(address.port)
+      })
     })
   })
 }

--- a/examples/vscode-extension/tests/suite/extension.integration.test.js
+++ b/examples/vscode-extension/tests/suite/extension.integration.test.js
@@ -32,10 +32,7 @@ suite('OmegaEdit VS Code extension', () => {
   suiteSetup(async () => {
     await vscode.commands.executeCommand('workbench.action.closeAllEditors')
 
-    testPort = 43000 + Math.floor(Math.random() * 10000) + (process.pid % 1000)
-    await vscode.workspace
-      .getConfiguration('omegaEdit')
-      .update('serverPort', testPort, vscode.ConfigurationTarget.Global)
+    testPort = getConfiguredTestPort()
 
     const extensionId = `${packageJson.publisher}.${packageJson.name}`
     const extension = vscode.extensions.getExtension(extensionId)
@@ -548,6 +545,15 @@ async function assertSessionText(
 function parseDelay(rawValue, fallbackMs) {
   const parsed = Number.parseInt(rawValue ?? '', 10)
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallbackMs
+}
+
+function getConfiguredTestPort() {
+  const parsed = Number.parseInt(process.env.OMEGA_EDIT_SERVER_PORT ?? '', 10)
+  assert.ok(
+    Number.isInteger(parsed) && parsed > 0 && parsed <= 65535,
+    'Expected OMEGA_EDIT_SERVER_PORT to be set to a valid TCP port'
+  )
+  return parsed
 }
 
 function createMockWebviewPanel() {


### PR DESCRIPTION
## Summary
- replace the per-test Windows POST_BUILD DLL copy with a single shared runtime staging target
- make each Windows shared-library test depend on that staged runtime copy instead of racing to copy omega_edit.dll
- keep the existing manual Windows test registration flow unchanged

## Why
The Native build and test on windows-2022 job in Actions run 23569333976 failed while linking filesystem_tests.exe because multiple test targets attempted to copy omega_edit.dll into the same output directory in parallel, triggering Permission denied.

## Validation
- local MSVC/Ninja build with -DBUILD_DOCS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON -DBUILD_TESTS=ON
- ctest -C Release --test-dir _ci-win-test/core --output-on-failure passed with 8/8 tests