### PR TITLE
Modernize native server info and heartbeat

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,11 +39,12 @@ jobs:
           cache: npm
           cache-dependency-path: examples/vscode-extension/package-lock.json
 
-      - name: Install workspace dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build local OmegaEdit client for the example
-        run: yarn workspace @omega-edit/client prepare
+      - name: Build local OmegaEdit middleware for the example
+        uses: ./.github/workflows/build-middleware
+        with:
+          runner-os: ${{ runner.os }}
+          os-name: ${{ matrix.os }}
+          skip-tests: 'true'
 
       - name: Install VS Code extension example dependencies
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
         run: npm run lint && npm run compile && npm run test:unit
         working-directory: examples/vscode-extension
         env:
+          CPP_SERVER_BINARY: ''
           VSCODE_VERSION: ${{ matrix.vscode-version }}
 
       - name: Run VS Code extension integration tests on Linux
@@ -65,6 +66,7 @@ jobs:
         run: xvfb-run -a npm run test:integration
         working-directory: examples/vscode-extension
         env:
+          CPP_SERVER_BINARY: ''
           VSCODE_VERSION: ${{ matrix.vscode-version }}
 
       - name: Run VS Code extension integration tests on Windows
@@ -72,6 +74,7 @@ jobs:
         run: npm run test:integration
         working-directory: examples/vscode-extension
         env:
+          CPP_SERVER_BINARY: ''
           VSCODE_VERSION: ${{ matrix.vscode-version }}
 
   build-native:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,18 @@ jobs:
           cache: npm
           cache-dependency-path: examples/vscode-extension/package-lock.json
 
+      - name: Install workspace dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build local OmegaEdit client for the example
+        run: yarn workspace @omega-edit/client prepare
+
       - name: Install VS Code extension example dependencies
         run: npm ci
+        working-directory: examples/vscode-extension
+
+      - name: Use local OmegaEdit client in the VS Code extension example
+        run: npm install ../../packages/client --no-save
         working-directory: examples/vscode-extension
 
       - name: Build and run fast VS Code extension checks

--- a/examples/vscode-extension/src/hexEditorProvider.ts
+++ b/examples/vscode-extension/src/hexEditorProvider.ts
@@ -540,28 +540,32 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         0,
         Math.round(heartbeat.serverUptime / 1000)
       )
-      const usedMemoryMb = Math.round(
-        heartbeat.serverUsedMemory / (1024 * 1024)
-      )
-      const committedMemoryMb = Math.round(
-        heartbeat.serverCommittedMemory / (1024 * 1024)
-      )
+      const formatMemoryMiB = (bytes?: number): string =>
+        bytes === undefined ? 'n/a' : `${Math.round(bytes / (1024 * 1024))} MiB`
+
       const detailParts = [
         `server ${serverInfo.serverVersion}`,
         `client ${getClientVersion()}`,
         `host ${serverInfo.serverHostname}`,
         `pid ${serverInfo.serverProcessId}`,
+        `runtime ${serverInfo.runtimeKind}/${serverInfo.runtimeName}`,
+        `platform ${serverInfo.platform}`,
+        `compiler ${serverInfo.compiler}`,
+        `build ${serverInfo.buildType}`,
+        `c++ ${serverInfo.cppStandard}`,
         `latency ${heartbeat.latency} ms`,
         `sessions ${heartbeat.sessionCount}`,
         `uptime ${uptimeSeconds}s`,
         `cpu ${heartbeat.serverCpuCount} cores`,
-        `load ${heartbeat.serverCpuLoadAverage.toFixed(2)}`,
-        `memory ${usedMemoryMb}/${committedMemoryMb} MiB`,
+        `load ${
+          heartbeat.serverCpuLoadAverage === undefined
+            ? 'n/a'
+            : heartbeat.serverCpuLoadAverage.toFixed(2)
+        }`,
+        `rss ${formatMemoryMiB(heartbeat.serverResidentMemoryBytes)}`,
+        `virtual ${formatMemoryMiB(heartbeat.serverVirtualMemoryBytes)}`,
+        `peak rss ${formatMemoryMiB(heartbeat.serverPeakResidentMemoryBytes)}`,
       ]
-
-      if (serverInfo.jvmVersion) {
-        detailParts.push(`jvm ${serverInfo.jvmVersion}`)
-      }
 
       this.broadcastServerHealth({
         type: 'serverHealth',

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -88,6 +88,8 @@ await stopServerGraceful()
 ### Server Health API Migration
 
 `getServerInfo()` and `getServerHeartbeat()` now expose native-runtime metadata instead of JVM-shaped placeholders.
+The client-facing TypeScript API is renamed, while the protobuf layer keeps the
+legacy fields for wire compatibility.
 
 Current `getServerInfo()` fields:
 
@@ -116,8 +118,8 @@ Current `getServerHeartbeat()` fields:
 
 Migration notes:
 
-- `jvmVersion`, `jvmVendor`, and `jvmPath` were removed. Use `runtimeKind`, `runtimeName`, `platform`, and `compiler` instead.
-- `serverMaxMemory`, `serverCommittedMemory`, and `serverUsedMemory` were removed. They were JVM-heap concepts and are now replaced with process-memory metrics.
+- `jvmVersion`, `jvmVendor`, and `jvmPath` were removed from the client-facing TypeScript API. Use `runtimeKind`, `runtimeName`, `platform`, and `compiler` instead.
+- `serverMaxMemory`, `serverCommittedMemory`, and `serverUsedMemory` were removed from the client-facing TypeScript API. They were JVM-heap concepts and are now replaced with process-memory metrics.
 - Optional heartbeat fields may be `undefined` when the host platform cannot report them. Treat missing values as "unavailable", not zero.
 - `serverVirtualMemoryBytes` is intentionally best-effort and may be omitted on platforms where the available process metric is not semantically comparable.
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -82,8 +82,43 @@ await stopServerGraceful()
 | `startServerUnixSocket(socketPath, ...)`          | Start using a Unix domain socket          |
 | `stopServerGraceful()`                            | Graceful shutdown                         |
 | `stopServerImmediate()`                           | Immediate shutdown                        |
-| `getServerInfo()`                                 | Server version, uptime, and session count |
-| `getServerHeartbeat(sessions, interval?)`         | Heartbeat and session health              |
+| `getServerInfo()`                                 | Runtime metadata for the native server    |
+| `getServerHeartbeat(sessions, interval?)`         | Heartbeat and process health              |
+
+### Server Health API Migration
+
+`getServerInfo()` and `getServerHeartbeat()` now expose native-runtime metadata instead of JVM-shaped placeholders.
+
+Current `getServerInfo()` fields:
+
+- `serverHostname`
+- `serverProcessId`
+- `serverVersion`
+- `runtimeKind`
+- `runtimeName`
+- `platform`
+- `availableProcessors`
+- `compiler`
+- `buildType`
+- `cppStandard`
+
+Current `getServerHeartbeat()` fields:
+
+- `latency`
+- `sessionCount`
+- `serverTimestamp`
+- `serverUptime`
+- `serverCpuCount`
+- `serverCpuLoadAverage?`
+- `serverResidentMemoryBytes?`
+- `serverVirtualMemoryBytes?`
+- `serverPeakResidentMemoryBytes?`
+
+Migration notes:
+
+- `jvmVersion`, `jvmVendor`, and `jvmPath` were removed. Use `runtimeKind`, `runtimeName`, `platform`, and `compiler` instead.
+- `serverMaxMemory`, `serverCommittedMemory`, and `serverUsedMemory` were removed. They were JVM-heap concepts and are now replaced with process-memory metrics.
+- Optional heartbeat fields may be `undefined` when the host platform cannot report them. Treat missing values as "unavailable", not zero.
 
 ### Client Connection
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -119,6 +119,7 @@ Migration notes:
 - `jvmVersion`, `jvmVendor`, and `jvmPath` were removed. Use `runtimeKind`, `runtimeName`, `platform`, and `compiler` instead.
 - `serverMaxMemory`, `serverCommittedMemory`, and `serverUsedMemory` were removed. They were JVM-heap concepts and are now replaced with process-memory metrics.
 - Optional heartbeat fields may be `undefined` when the host platform cannot report them. Treat missing values as "unavailable", not zero.
+- `serverVirtualMemoryBytes` is intentionally best-effort and may be omitted on platforms where the available process metric is not semantically comparable.
 
 ### Client Connection
 

--- a/packages/client/src/omega_edit_pb.ts
+++ b/packages/client/src/omega_edit_pb.ts
@@ -302,7 +302,7 @@ export class HeartbeatResponse {
   }
 
   getCpuLoadAverage(): number | undefined {
-    return this.response_.cpuLoadAverage
+    return this.response_.loadAverage ?? this.response_.cpuLoadAverage
   }
 
   getResidentMemoryBytes(): number | undefined {

--- a/packages/client/src/omega_edit_pb.ts
+++ b/packages/client/src/omega_edit_pb.ts
@@ -229,20 +229,32 @@ export class ServerInfoResponse {
     return this.response_.serverVersion
   }
 
-  getJvmVersion(): string {
-    return this.response_.jvmVersion
+  getRuntimeKind(): string {
+    return this.response_.runtimeKind
   }
 
-  getJvmVendor(): string {
-    return this.response_.jvmVendor
+  getRuntimeName(): string {
+    return this.response_.runtimeName
   }
 
-  getJvmPath(): string {
-    return this.response_.jvmPath
+  getPlatform(): string {
+    return this.response_.platform
   }
 
   getAvailableProcessors(): number {
     return this.response_.availableProcessors
+  }
+
+  getCompiler(): string {
+    return this.response_.compiler
+  }
+
+  getBuildType(): string {
+    return this.response_.buildType
+  }
+
+  getCppStandard(): string {
+    return this.response_.cppStandard
   }
 
   toObject(): RawGetServerInfoResponse {
@@ -289,20 +301,20 @@ export class HeartbeatResponse {
     return this.response_.cpuCount
   }
 
-  getCpuLoadAverage(): number {
+  getCpuLoadAverage(): number | undefined {
     return this.response_.cpuLoadAverage
   }
 
-  getMaxMemory(): number {
-    return this.response_.maxMemory
+  getResidentMemoryBytes(): number | undefined {
+    return this.response_.residentMemoryBytes
   }
 
-  getCommittedMemory(): number {
-    return this.response_.committedMemory
+  getVirtualMemoryBytes(): number | undefined {
+    return this.response_.virtualMemoryBytes
   }
 
-  getUsedMemory(): number {
-    return this.response_.usedMemory
+  getPeakResidentMemoryBytes(): number | undefined {
+    return this.response_.peakResidentMemoryBytes
   }
 
   toObject(): RawGetHeartbeatResponse {

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -55,31 +55,46 @@ export interface GetServerInfoResponse {
    */
   serverVersion: string // Omega Edit server version string.
   /**
-   * @generated from protobuf field: string runtime_kind = 4
+   * @deprecated
+   * @generated from protobuf field: string jvm_version = 4 [deprecated = true]
    */
-  runtimeKind: string // Runtime family, e.g. "native" or "jvm".  (was jvm_version before v2)
+  jvmVersion: string // Legacy field kept for compatibility with older clients.
   /**
-   * @generated from protobuf field: string runtime_name = 5
+   * @deprecated
+   * @generated from protobuf field: string jvm_vendor = 5 [deprecated = true]
    */
-  runtimeName: string // Runtime implementation name, e.g. "C++". (was jvm_vendor before v2)
+  jvmVendor: string // Legacy field kept for compatibility with older clients.
   /**
-   * @generated from protobuf field: string platform = 6
+   * @deprecated
+   * @generated from protobuf field: string jvm_path = 6 [deprecated = true]
    */
-  platform: string // Host platform and architecture summary.  (was jvm_path before v2)
+  jvmPath: string // Legacy field kept for compatibility with older clients.
   /**
    * @generated from protobuf field: int32 available_processors = 7
    */
   availableProcessors: number // Number of logical CPU cores.
   /**
-   * @generated from protobuf field: string compiler = 8
+   * @generated from protobuf field: string runtime_kind = 8
+   */
+  runtimeKind: string // Runtime family, e.g. "native" or "jvm".
+  /**
+   * @generated from protobuf field: string runtime_name = 9
+   */
+  runtimeName: string // Runtime implementation name, e.g. "C++".
+  /**
+   * @generated from protobuf field: string platform = 10
+   */
+  platform: string // Host platform and architecture summary.
+  /**
+   * @generated from protobuf field: string compiler = 11
    */
   compiler: string // Compiler or toolchain used to build the server.
   /**
-   * @generated from protobuf field: string build_type = 9
+   * @generated from protobuf field: string build_type = 12
    */
   buildType: string // Build configuration, e.g. "Release" or "Debug".
   /**
-   * @generated from protobuf field: string cpp_standard = 10
+   * @generated from protobuf field: string cpp_standard = 13
    */
   cppStandard: string // C++ standard used, e.g. "C++17".
 }
@@ -160,21 +175,41 @@ export interface GetHeartbeatResponse {
    */
   cpuCount: number // Number of logical CPU cores.
   /**
-   * @generated from protobuf field: optional double cpu_load_average = 5
+   * @deprecated
+   * @generated from protobuf field: double cpu_load_average = 5 [deprecated = true]
    */
-  cpuLoadAverage?: number // 1-min load average (POSIX only, unset on Windows). (was non-optional before v2)
+  cpuLoadAverage: number // Legacy load average field kept for compatibility with older clients.
   /**
-   * @generated from protobuf field: optional int64 resident_memory_bytes = 6
+   * @deprecated
+   * @generated from protobuf field: int64 max_memory = 6 [deprecated = true]
    */
-  residentMemoryBytes?: number // Resident set size (RSS) in bytes.         (was max_memory before v2)
+  maxMemory: number // Legacy memory field kept for compatibility with older clients.
   /**
-   * @generated from protobuf field: optional int64 virtual_memory_bytes = 7
+   * @deprecated
+   * @generated from protobuf field: int64 committed_memory = 7 [deprecated = true]
    */
-  virtualMemoryBytes?: number // Virtual address space usage in bytes when the platform can report it consistently. (was committed_memory before v2)
+  committedMemory: number // Legacy memory field kept for compatibility with older clients.
   /**
-   * @generated from protobuf field: optional int64 peak_resident_memory_bytes = 8
+   * @deprecated
+   * @generated from protobuf field: int64 used_memory = 8 [deprecated = true]
    */
-  peakResidentMemoryBytes?: number // Peak RSS in bytes.                   (was used_memory before v2)
+  usedMemory: number // Legacy memory field kept for compatibility with older clients.
+  /**
+   * @generated from protobuf field: optional double load_average = 9
+   */
+  loadAverage?: number // 1-min load average when the platform can report it.
+  /**
+   * @generated from protobuf field: optional int64 resident_memory_bytes = 10
+   */
+  residentMemoryBytes?: number // Resident set size (RSS) in bytes.
+  /**
+   * @generated from protobuf field: optional int64 virtual_memory_bytes = 11
+   */
+  virtualMemoryBytes?: number // Virtual address space usage in bytes when the platform can report it consistently.
+  /**
+   * @generated from protobuf field: optional int64 peak_resident_memory_bytes = 12
+   */
+  peakResidentMemoryBytes?: number // Peak RSS in bytes.
 }
 // ===========================================================================
 // Request / Response messages — Session lifecycle
@@ -1867,27 +1902,40 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
       },
       {
         no: 4,
-        name: 'runtime_kind',
+        name: 'jvm_version',
         kind: 'scalar',
         T: 9 /*ScalarType.STRING*/,
       },
-      {
-        no: 5,
-        name: 'runtime_name',
-        kind: 'scalar',
-        T: 9 /*ScalarType.STRING*/,
-      },
-      { no: 6, name: 'platform', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 5, name: 'jvm_vendor', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 6, name: 'jvm_path', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
       {
         no: 7,
         name: 'available_processors',
         kind: 'scalar',
         T: 5 /*ScalarType.INT32*/,
       },
-      { no: 8, name: 'compiler', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
-      { no: 9, name: 'build_type', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
       {
-        no: 10,
+        no: 8,
+        name: 'runtime_kind',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 9,
+        name: 'runtime_name',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      { no: 10, name: 'platform', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 11, name: 'compiler', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 12,
+        name: 'build_type',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 13,
         name: 'cpp_standard',
         kind: 'scalar',
         T: 9 /*ScalarType.STRING*/,
@@ -1899,10 +1947,13 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
     message.hostname = ''
     message.processId = 0
     message.serverVersion = ''
+    message.jvmVersion = ''
+    message.jvmVendor = ''
+    message.jvmPath = ''
+    message.availableProcessors = 0
     message.runtimeKind = ''
     message.runtimeName = ''
     message.platform = ''
-    message.availableProcessors = 0
     message.compiler = ''
     message.buildType = ''
     message.cppStandard = ''
@@ -1930,25 +1981,34 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
         case /* string server_version */ 3:
           message.serverVersion = reader.string()
           break
-        case /* string runtime_kind */ 4:
-          message.runtimeKind = reader.string()
+        case /* string jvm_version = 4 [deprecated = true] */ 4:
+          message.jvmVersion = reader.string()
           break
-        case /* string runtime_name */ 5:
-          message.runtimeName = reader.string()
+        case /* string jvm_vendor = 5 [deprecated = true] */ 5:
+          message.jvmVendor = reader.string()
           break
-        case /* string platform */ 6:
-          message.platform = reader.string()
+        case /* string jvm_path = 6 [deprecated = true] */ 6:
+          message.jvmPath = reader.string()
           break
         case /* int32 available_processors */ 7:
           message.availableProcessors = reader.int32()
           break
-        case /* string compiler */ 8:
+        case /* string runtime_kind */ 8:
+          message.runtimeKind = reader.string()
+          break
+        case /* string runtime_name */ 9:
+          message.runtimeName = reader.string()
+          break
+        case /* string platform */ 10:
+          message.platform = reader.string()
+          break
+        case /* string compiler */ 11:
           message.compiler = reader.string()
           break
-        case /* string build_type */ 9:
+        case /* string build_type */ 12:
           message.buildType = reader.string()
           break
-        case /* string cpp_standard */ 10:
+        case /* string cpp_standard */ 13:
           message.cppStandard = reader.string()
           break
         default:
@@ -1984,27 +2044,36 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
     /* string server_version = 3; */
     if (message.serverVersion !== '')
       writer.tag(3, WireType.LengthDelimited).string(message.serverVersion)
-    /* string runtime_kind = 4; */
-    if (message.runtimeKind !== '')
-      writer.tag(4, WireType.LengthDelimited).string(message.runtimeKind)
-    /* string runtime_name = 5; */
-    if (message.runtimeName !== '')
-      writer.tag(5, WireType.LengthDelimited).string(message.runtimeName)
-    /* string platform = 6; */
-    if (message.platform !== '')
-      writer.tag(6, WireType.LengthDelimited).string(message.platform)
+    /* string jvm_version = 4 [deprecated = true]; */
+    if (message.jvmVersion !== '')
+      writer.tag(4, WireType.LengthDelimited).string(message.jvmVersion)
+    /* string jvm_vendor = 5 [deprecated = true]; */
+    if (message.jvmVendor !== '')
+      writer.tag(5, WireType.LengthDelimited).string(message.jvmVendor)
+    /* string jvm_path = 6 [deprecated = true]; */
+    if (message.jvmPath !== '')
+      writer.tag(6, WireType.LengthDelimited).string(message.jvmPath)
     /* int32 available_processors = 7; */
     if (message.availableProcessors !== 0)
       writer.tag(7, WireType.Varint).int32(message.availableProcessors)
-    /* string compiler = 8; */
+    /* string runtime_kind = 8; */
+    if (message.runtimeKind !== '')
+      writer.tag(8, WireType.LengthDelimited).string(message.runtimeKind)
+    /* string runtime_name = 9; */
+    if (message.runtimeName !== '')
+      writer.tag(9, WireType.LengthDelimited).string(message.runtimeName)
+    /* string platform = 10; */
+    if (message.platform !== '')
+      writer.tag(10, WireType.LengthDelimited).string(message.platform)
+    /* string compiler = 11; */
     if (message.compiler !== '')
-      writer.tag(8, WireType.LengthDelimited).string(message.compiler)
-    /* string build_type = 9; */
+      writer.tag(11, WireType.LengthDelimited).string(message.compiler)
+    /* string build_type = 12; */
     if (message.buildType !== '')
-      writer.tag(9, WireType.LengthDelimited).string(message.buildType)
-    /* string cpp_standard = 10; */
+      writer.tag(12, WireType.LengthDelimited).string(message.buildType)
+    /* string cpp_standard = 13; */
     if (message.cppStandard !== '')
-      writer.tag(10, WireType.LengthDelimited).string(message.cppStandard)
+      writer.tag(13, WireType.LengthDelimited).string(message.cppStandard)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -2326,11 +2395,38 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
         no: 5,
         name: 'cpu_load_average',
         kind: 'scalar',
-        opt: true,
         T: 1 /*ScalarType.DOUBLE*/,
       },
       {
         no: 6,
+        name: 'max_memory',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 7,
+        name: 'committed_memory',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 8,
+        name: 'used_memory',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 9,
+        name: 'load_average',
+        kind: 'scalar',
+        opt: true,
+        T: 1 /*ScalarType.DOUBLE*/,
+      },
+      {
+        no: 10,
         name: 'resident_memory_bytes',
         kind: 'scalar',
         opt: true,
@@ -2338,7 +2434,7 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
         L: 2 /*LongType.NUMBER*/,
       },
       {
-        no: 7,
+        no: 11,
         name: 'virtual_memory_bytes',
         kind: 'scalar',
         opt: true,
@@ -2346,7 +2442,7 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
         L: 2 /*LongType.NUMBER*/,
       },
       {
-        no: 8,
+        no: 12,
         name: 'peak_resident_memory_bytes',
         kind: 'scalar',
         opt: true,
@@ -2361,6 +2457,10 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
     message.timestamp = 0
     message.uptime = 0
     message.cpuCount = 0
+    message.cpuLoadAverage = 0
+    message.maxMemory = 0
+    message.committedMemory = 0
+    message.usedMemory = 0
     if (value !== undefined)
       reflectionMergePartial<GetHeartbeatResponse>(this, message, value)
     return message
@@ -2388,16 +2488,28 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
         case /* int32 cpu_count */ 4:
           message.cpuCount = reader.int32()
           break
-        case /* optional double cpu_load_average */ 5:
+        case /* double cpu_load_average = 5 [deprecated = true] */ 5:
           message.cpuLoadAverage = reader.double()
           break
-        case /* optional int64 resident_memory_bytes */ 6:
+        case /* int64 max_memory = 6 [deprecated = true] */ 6:
+          message.maxMemory = reader.int64().toNumber()
+          break
+        case /* int64 committed_memory = 7 [deprecated = true] */ 7:
+          message.committedMemory = reader.int64().toNumber()
+          break
+        case /* int64 used_memory = 8 [deprecated = true] */ 8:
+          message.usedMemory = reader.int64().toNumber()
+          break
+        case /* optional double load_average */ 9:
+          message.loadAverage = reader.double()
+          break
+        case /* optional int64 resident_memory_bytes */ 10:
           message.residentMemoryBytes = reader.int64().toNumber()
           break
-        case /* optional int64 virtual_memory_bytes */ 7:
+        case /* optional int64 virtual_memory_bytes */ 11:
           message.virtualMemoryBytes = reader.int64().toNumber()
           break
-        case /* optional int64 peak_resident_memory_bytes */ 8:
+        case /* optional int64 peak_resident_memory_bytes */ 12:
           message.peakResidentMemoryBytes = reader.int64().toNumber()
           break
         default:
@@ -2436,18 +2548,30 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
     /* int32 cpu_count = 4; */
     if (message.cpuCount !== 0)
       writer.tag(4, WireType.Varint).int32(message.cpuCount)
-    /* optional double cpu_load_average = 5; */
-    if (message.cpuLoadAverage !== undefined)
+    /* double cpu_load_average = 5 [deprecated = true]; */
+    if (message.cpuLoadAverage !== 0)
       writer.tag(5, WireType.Bit64).double(message.cpuLoadAverage)
-    /* optional int64 resident_memory_bytes = 6; */
+    /* int64 max_memory = 6 [deprecated = true]; */
+    if (message.maxMemory !== 0)
+      writer.tag(6, WireType.Varint).int64(message.maxMemory)
+    /* int64 committed_memory = 7 [deprecated = true]; */
+    if (message.committedMemory !== 0)
+      writer.tag(7, WireType.Varint).int64(message.committedMemory)
+    /* int64 used_memory = 8 [deprecated = true]; */
+    if (message.usedMemory !== 0)
+      writer.tag(8, WireType.Varint).int64(message.usedMemory)
+    /* optional double load_average = 9; */
+    if (message.loadAverage !== undefined)
+      writer.tag(9, WireType.Bit64).double(message.loadAverage)
+    /* optional int64 resident_memory_bytes = 10; */
     if (message.residentMemoryBytes !== undefined)
-      writer.tag(6, WireType.Varint).int64(message.residentMemoryBytes)
-    /* optional int64 virtual_memory_bytes = 7; */
+      writer.tag(10, WireType.Varint).int64(message.residentMemoryBytes)
+    /* optional int64 virtual_memory_bytes = 11; */
     if (message.virtualMemoryBytes !== undefined)
-      writer.tag(7, WireType.Varint).int64(message.virtualMemoryBytes)
-    /* optional int64 peak_resident_memory_bytes = 8; */
+      writer.tag(11, WireType.Varint).int64(message.virtualMemoryBytes)
+    /* optional int64 peak_resident_memory_bytes = 12; */
     if (message.peakResidentMemoryBytes !== undefined)
-      writer.tag(8, WireType.Varint).int64(message.peakResidentMemoryBytes)
+      writer.tag(12, WireType.Varint).int64(message.peakResidentMemoryBytes)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -57,15 +57,15 @@ export interface GetServerInfoResponse {
   /**
    * @generated from protobuf field: string runtime_kind = 4
    */
-  runtimeKind: string // Runtime family, for example "native" or "jvm".
+  runtimeKind: string // Runtime family, e.g. "native" or "jvm".  (was jvm_version before v2)
   /**
    * @generated from protobuf field: string runtime_name = 5
    */
-  runtimeName: string // Runtime implementation name, for example "C++".
+  runtimeName: string // Runtime implementation name, e.g. "C++". (was jvm_vendor before v2)
   /**
    * @generated from protobuf field: string platform = 6
    */
-  platform: string // Host platform and architecture summary.
+  platform: string // Host platform and architecture summary.  (was jvm_path before v2)
   /**
    * @generated from protobuf field: int32 available_processors = 7
    */
@@ -162,19 +162,19 @@ export interface GetHeartbeatResponse {
   /**
    * @generated from protobuf field: optional double cpu_load_average = 5
    */
-  cpuLoadAverage?: number // Load average when the platform can report it.
+  cpuLoadAverage?: number // 1-min load average (POSIX only, unset on Windows). (was non-optional before v2)
   /**
    * @generated from protobuf field: optional int64 resident_memory_bytes = 6
    */
-  residentMemoryBytes?: number // Resident set size (RSS) in bytes.
+  residentMemoryBytes?: number // Resident set size (RSS) in bytes.         (was max_memory before v2)
   /**
    * @generated from protobuf field: optional int64 virtual_memory_bytes = 7
    */
-  virtualMemoryBytes?: number // Virtual address space usage in bytes.
+  virtualMemoryBytes?: number // Virtual address space usage in bytes when the platform can report it consistently. (was committed_memory before v2)
   /**
    * @generated from protobuf field: optional int64 peak_resident_memory_bytes = 8
    */
-  peakResidentMemoryBytes?: number // Peak resident set size in bytes.
+  peakResidentMemoryBytes?: number // Peak RSS in bytes.                   (was used_memory before v2)
 }
 // ===========================================================================
 // Request / Response messages — Session lifecycle
@@ -1886,7 +1886,12 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
       },
       { no: 8, name: 'compiler', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
       { no: 9, name: 'build_type', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
-      { no: 10, name: 'cpp_standard', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 10,
+        name: 'cpp_standard',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
     ])
   }
   create(value?: PartialMessage<GetServerInfoResponse>): GetServerInfoResponse {

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -53,23 +53,35 @@ export interface GetServerInfoResponse {
   /**
    * @generated from protobuf field: string server_version = 3
    */
-  serverVersion: string // Ωedit server version string.
+  serverVersion: string // Omega Edit server version string.
   /**
-   * @generated from protobuf field: string jvm_version = 4
+   * @generated from protobuf field: string runtime_kind = 4
    */
-  jvmVersion: string // JVM version (empty for native builds).
+  runtimeKind: string // Runtime family, for example "native" or "jvm".
   /**
-   * @generated from protobuf field: string jvm_vendor = 5
+   * @generated from protobuf field: string runtime_name = 5
    */
-  jvmVendor: string // JVM vendor (empty for native builds).
+  runtimeName: string // Runtime implementation name, for example "C++".
   /**
-   * @generated from protobuf field: string jvm_path = 6
+   * @generated from protobuf field: string platform = 6
    */
-  jvmPath: string // Path to the JVM (empty for native builds).
+  platform: string // Host platform and architecture summary.
   /**
    * @generated from protobuf field: int32 available_processors = 7
    */
   availableProcessors: number // Number of logical CPU cores.
+  /**
+   * @generated from protobuf field: string compiler = 8
+   */
+  compiler: string // Compiler or toolchain used to build the server.
+  /**
+   * @generated from protobuf field: string build_type = 9
+   */
+  buildType: string // Build configuration, e.g. "Release" or "Debug".
+  /**
+   * @generated from protobuf field: string cpp_standard = 10
+   */
+  cppStandard: string // C++ standard used, e.g. "C++17".
 }
 /**
  * Request to send a control command to the server.
@@ -148,21 +160,21 @@ export interface GetHeartbeatResponse {
    */
   cpuCount: number // Number of logical CPU cores.
   /**
-   * @generated from protobuf field: double cpu_load_average = 5
+   * @generated from protobuf field: optional double cpu_load_average = 5
    */
-  cpuLoadAverage: number // CPU load average as a percentage.
+  cpuLoadAverage?: number // Load average when the platform can report it.
   /**
-   * @generated from protobuf field: int64 max_memory = 6
+   * @generated from protobuf field: optional int64 resident_memory_bytes = 6
    */
-  maxMemory: number // Maximum memory available in bytes.
+  residentMemoryBytes?: number // Resident set size (RSS) in bytes.
   /**
-   * @generated from protobuf field: int64 committed_memory = 7
+   * @generated from protobuf field: optional int64 virtual_memory_bytes = 7
    */
-  committedMemory: number // Committed (allocated) memory in bytes.
+  virtualMemoryBytes?: number // Virtual address space usage in bytes.
   /**
-   * @generated from protobuf field: int64 used_memory = 8
+   * @generated from protobuf field: optional int64 peak_resident_memory_bytes = 8
    */
-  usedMemory: number // Currently used memory in bytes.
+  peakResidentMemoryBytes?: number // Peak resident set size in bytes.
 }
 // ===========================================================================
 // Request / Response messages — Session lifecycle
@@ -1855,18 +1867,26 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
       },
       {
         no: 4,
-        name: 'jvm_version',
+        name: 'runtime_kind',
         kind: 'scalar',
         T: 9 /*ScalarType.STRING*/,
       },
-      { no: 5, name: 'jvm_vendor', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
-      { no: 6, name: 'jvm_path', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 5,
+        name: 'runtime_name',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      { no: 6, name: 'platform', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
       {
         no: 7,
         name: 'available_processors',
         kind: 'scalar',
         T: 5 /*ScalarType.INT32*/,
       },
+      { no: 8, name: 'compiler', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 9, name: 'build_type', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 10, name: 'cpp_standard', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
     ])
   }
   create(value?: PartialMessage<GetServerInfoResponse>): GetServerInfoResponse {
@@ -1874,10 +1894,13 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
     message.hostname = ''
     message.processId = 0
     message.serverVersion = ''
-    message.jvmVersion = ''
-    message.jvmVendor = ''
-    message.jvmPath = ''
+    message.runtimeKind = ''
+    message.runtimeName = ''
+    message.platform = ''
     message.availableProcessors = 0
+    message.compiler = ''
+    message.buildType = ''
+    message.cppStandard = ''
     if (value !== undefined)
       reflectionMergePartial<GetServerInfoResponse>(this, message, value)
     return message
@@ -1902,17 +1925,26 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
         case /* string server_version */ 3:
           message.serverVersion = reader.string()
           break
-        case /* string jvm_version */ 4:
-          message.jvmVersion = reader.string()
+        case /* string runtime_kind */ 4:
+          message.runtimeKind = reader.string()
           break
-        case /* string jvm_vendor */ 5:
-          message.jvmVendor = reader.string()
+        case /* string runtime_name */ 5:
+          message.runtimeName = reader.string()
           break
-        case /* string jvm_path */ 6:
-          message.jvmPath = reader.string()
+        case /* string platform */ 6:
+          message.platform = reader.string()
           break
         case /* int32 available_processors */ 7:
           message.availableProcessors = reader.int32()
+          break
+        case /* string compiler */ 8:
+          message.compiler = reader.string()
+          break
+        case /* string build_type */ 9:
+          message.buildType = reader.string()
+          break
+        case /* string cpp_standard */ 10:
+          message.cppStandard = reader.string()
           break
         default:
           let u = options.readUnknownField
@@ -1947,18 +1979,27 @@ class GetServerInfoResponse$Type extends MessageType<GetServerInfoResponse> {
     /* string server_version = 3; */
     if (message.serverVersion !== '')
       writer.tag(3, WireType.LengthDelimited).string(message.serverVersion)
-    /* string jvm_version = 4; */
-    if (message.jvmVersion !== '')
-      writer.tag(4, WireType.LengthDelimited).string(message.jvmVersion)
-    /* string jvm_vendor = 5; */
-    if (message.jvmVendor !== '')
-      writer.tag(5, WireType.LengthDelimited).string(message.jvmVendor)
-    /* string jvm_path = 6; */
-    if (message.jvmPath !== '')
-      writer.tag(6, WireType.LengthDelimited).string(message.jvmPath)
+    /* string runtime_kind = 4; */
+    if (message.runtimeKind !== '')
+      writer.tag(4, WireType.LengthDelimited).string(message.runtimeKind)
+    /* string runtime_name = 5; */
+    if (message.runtimeName !== '')
+      writer.tag(5, WireType.LengthDelimited).string(message.runtimeName)
+    /* string platform = 6; */
+    if (message.platform !== '')
+      writer.tag(6, WireType.LengthDelimited).string(message.platform)
     /* int32 available_processors = 7; */
     if (message.availableProcessors !== 0)
       writer.tag(7, WireType.Varint).int32(message.availableProcessors)
+    /* string compiler = 8; */
+    if (message.compiler !== '')
+      writer.tag(8, WireType.LengthDelimited).string(message.compiler)
+    /* string build_type = 9; */
+    if (message.buildType !== '')
+      writer.tag(9, WireType.LengthDelimited).string(message.buildType)
+    /* string cpp_standard = 10; */
+    if (message.cppStandard !== '')
+      writer.tag(10, WireType.LengthDelimited).string(message.cppStandard)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -2280,26 +2321,30 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
         no: 5,
         name: 'cpu_load_average',
         kind: 'scalar',
+        opt: true,
         T: 1 /*ScalarType.DOUBLE*/,
       },
       {
         no: 6,
-        name: 'max_memory',
+        name: 'resident_memory_bytes',
         kind: 'scalar',
+        opt: true,
         T: 3 /*ScalarType.INT64*/,
         L: 2 /*LongType.NUMBER*/,
       },
       {
         no: 7,
-        name: 'committed_memory',
+        name: 'virtual_memory_bytes',
         kind: 'scalar',
+        opt: true,
         T: 3 /*ScalarType.INT64*/,
         L: 2 /*LongType.NUMBER*/,
       },
       {
         no: 8,
-        name: 'used_memory',
+        name: 'peak_resident_memory_bytes',
         kind: 'scalar',
+        opt: true,
         T: 3 /*ScalarType.INT64*/,
         L: 2 /*LongType.NUMBER*/,
       },
@@ -2311,10 +2356,6 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
     message.timestamp = 0
     message.uptime = 0
     message.cpuCount = 0
-    message.cpuLoadAverage = 0
-    message.maxMemory = 0
-    message.committedMemory = 0
-    message.usedMemory = 0
     if (value !== undefined)
       reflectionMergePartial<GetHeartbeatResponse>(this, message, value)
     return message
@@ -2342,17 +2383,17 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
         case /* int32 cpu_count */ 4:
           message.cpuCount = reader.int32()
           break
-        case /* double cpu_load_average */ 5:
+        case /* optional double cpu_load_average */ 5:
           message.cpuLoadAverage = reader.double()
           break
-        case /* int64 max_memory */ 6:
-          message.maxMemory = reader.int64().toNumber()
+        case /* optional int64 resident_memory_bytes */ 6:
+          message.residentMemoryBytes = reader.int64().toNumber()
           break
-        case /* int64 committed_memory */ 7:
-          message.committedMemory = reader.int64().toNumber()
+        case /* optional int64 virtual_memory_bytes */ 7:
+          message.virtualMemoryBytes = reader.int64().toNumber()
           break
-        case /* int64 used_memory */ 8:
-          message.usedMemory = reader.int64().toNumber()
+        case /* optional int64 peak_resident_memory_bytes */ 8:
+          message.peakResidentMemoryBytes = reader.int64().toNumber()
           break
         default:
           let u = options.readUnknownField
@@ -2390,18 +2431,18 @@ class GetHeartbeatResponse$Type extends MessageType<GetHeartbeatResponse> {
     /* int32 cpu_count = 4; */
     if (message.cpuCount !== 0)
       writer.tag(4, WireType.Varint).int32(message.cpuCount)
-    /* double cpu_load_average = 5; */
-    if (message.cpuLoadAverage !== 0)
+    /* optional double cpu_load_average = 5; */
+    if (message.cpuLoadAverage !== undefined)
       writer.tag(5, WireType.Bit64).double(message.cpuLoadAverage)
-    /* int64 max_memory = 6; */
-    if (message.maxMemory !== 0)
-      writer.tag(6, WireType.Varint).int64(message.maxMemory)
-    /* int64 committed_memory = 7; */
-    if (message.committedMemory !== 0)
-      writer.tag(7, WireType.Varint).int64(message.committedMemory)
-    /* int64 used_memory = 8; */
-    if (message.usedMemory !== 0)
-      writer.tag(8, WireType.Varint).int64(message.usedMemory)
+    /* optional int64 resident_memory_bytes = 6; */
+    if (message.residentMemoryBytes !== undefined)
+      writer.tag(6, WireType.Varint).int64(message.residentMemoryBytes)
+    /* optional int64 virtual_memory_bytes = 7; */
+    if (message.virtualMemoryBytes !== undefined)
+      writer.tag(7, WireType.Varint).int64(message.virtualMemoryBytes)
+    /* optional int64 peak_resident_memory_bytes = 8; */
+    if (message.peakResidentMemoryBytes !== undefined)
+      writer.tag(8, WireType.Varint).int64(message.peakResidentMemoryBytes)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -1233,7 +1233,11 @@ export async function getServerHeartbeat(
           serverTimestamp: heartbeatResponse.timestamp,
           serverUptime: heartbeatResponse.uptime,
           serverCpuCount: heartbeatResponse.cpuCount,
-          serverCpuLoadAverage: heartbeatResponse.cpuLoadAverage,
+          serverCpuLoadAverage:
+            heartbeatResponse.loadAverage ??
+            (heartbeatResponse.cpuLoadAverage >= 0
+              ? heartbeatResponse.cpuLoadAverage
+              : undefined),
           serverResidentMemoryBytes: heartbeatResponse.residentMemoryBytes,
           serverVirtualMemoryBytes: heartbeatResponse.virtualMemoryBytes,
           serverPeakResidentMemoryBytes:

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -1102,14 +1102,20 @@ export interface IServerInfo {
   serverProcessId: number
   /** Ωedit server version string. */
   serverVersion: string
-  /** JVM version (empty for native builds). */
-  jvmVersion: string
-  /** JVM vendor (empty for native builds). */
-  jvmVendor: string
-  /** Path to the JVM (empty for native builds). */
-  jvmPath: string
+  /** Runtime family, for example `native`. */
+  runtimeKind: string
+  /** Runtime implementation name, for example `C++`. */
+  runtimeName: string
+  /** Host platform and architecture summary. */
+  platform: string
   /** Number of logical CPU cores. */
   availableProcessors: number
+  /** Compiler or toolchain used to build the server. */
+  compiler: string
+  /** Build configuration, e.g. "Release" or "Debug". */
+  buildType: string
+  /** C++ standard used, e.g. "C++17". */
+  cppStandard: string
 }
 
 /**
@@ -1146,10 +1152,13 @@ export async function getServerInfo(): Promise<IServerInfo> {
         serverHostname: serverInfoResponse.hostname,
         serverProcessId: serverInfoResponse.processId,
         serverVersion: serverInfoResponse.serverVersion,
-        jvmVersion: serverInfoResponse.jvmVersion,
-        jvmVendor: serverInfoResponse.jvmVendor,
-        jvmPath: serverInfoResponse.jvmPath,
+        runtimeKind: serverInfoResponse.runtimeKind,
+        runtimeName: serverInfoResponse.runtimeName,
+        platform: serverInfoResponse.platform,
         availableProcessors: serverInfoResponse.availableProcessors,
+        compiler: serverInfoResponse.compiler,
+        buildType: serverInfoResponse.buildType,
+        cppStandard: serverInfoResponse.cppStandard,
       })
     })
   })
@@ -1164,10 +1173,10 @@ export interface IServerHeartbeat {
   serverTimestamp: number // timestamp in ms
   serverUptime: number // uptime in ms
   serverCpuCount: number // cpu count
-  serverCpuLoadAverage: number // cpu load average
-  serverMaxMemory: number // max memory in bytes
-  serverCommittedMemory: number // committed memory in bytes
-  serverUsedMemory: number // used memory in bytes
+  serverCpuLoadAverage?: number // load average when available
+  serverResidentMemoryBytes?: number // resident memory in bytes
+  serverVirtualMemoryBytes?: number // virtual memory in bytes
+  serverPeakResidentMemoryBytes?: number // peak resident memory in bytes
 }
 
 /**
@@ -1225,9 +1234,10 @@ export async function getServerHeartbeat(
           serverUptime: heartbeatResponse.uptime,
           serverCpuCount: heartbeatResponse.cpuCount,
           serverCpuLoadAverage: heartbeatResponse.cpuLoadAverage,
-          serverMaxMemory: heartbeatResponse.maxMemory,
-          serverCommittedMemory: heartbeatResponse.committedMemory,
-          serverUsedMemory: heartbeatResponse.usedMemory,
+          serverResidentMemoryBytes: heartbeatResponse.residentMemoryBytes,
+          serverVirtualMemoryBytes: heartbeatResponse.virtualMemoryBytes,
+          serverPeakResidentMemoryBytes:
+            heartbeatResponse.peakResidentMemoryBytes,
         })
       }
     )

--- a/packages/client/src/shims/omega-edit-server.ts
+++ b/packages/client/src/shims/omega-edit-server.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Concurrent Technologies Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ChildProcess } from 'child_process'
+
+/**
+ * Local compile-time contract for `@omega-edit/server`.
+ *
+ * The published package exposes generated declarations from `packages/server/out`,
+ * but a fresh monorepo checkout does not have those build artifacts yet. The
+ * client only needs a small surface from the server package at compile time, so
+ * we provide that contract here and keep the runtime import pointing at the real
+ * package name.
+ */
+export interface HeartbeatOptions {
+  sessionTimeoutMs?: number
+  cleanupIntervalMs?: number
+  shutdownWhenNoSessions?: boolean
+  sessionEventQueueCapacity?: number
+  viewportEventQueueCapacity?: number
+  maxChangeBytes?: number
+  maxViewportsPerSession?: number
+}
+
+export declare function runServer(
+  port: number,
+  host?: string,
+  pidfile?: string,
+  heartbeat?: HeartbeatOptions
+): Promise<ChildProcess>
+
+export declare function runServerWithArgs(
+  args: string[],
+  heartbeat?: HeartbeatOptions
+): Promise<ChildProcess>
+
+declare const omegaEditServer: {
+  runServer: typeof runServer
+  runServerWithArgs: typeof runServerWithArgs
+}
+
+export default omegaEditServer

--- a/packages/client/tests/specs/protoCompatibility.spec.ts
+++ b/packages/client/tests/specs/protoCompatibility.spec.ts
@@ -226,6 +226,15 @@ describe('Proto Compatibility', () => {
     expect(heartbeat.getVirtualMemoryBytes()).to.equal(11)
     expect(heartbeat.getPeakResidentMemoryBytes()).to.equal(12)
 
+    const heartbeatWithLoadAverageOnly = new HeartbeatResponse({
+      sessionCount: 1,
+      timestamp: 2,
+      uptime: 3,
+      cpuCount: 4,
+      loadAverage: 0.75,
+    })
+    expect(heartbeatWithLoadAverageOnly.getCpuLoadAverage()).to.equal(0.75)
+
     const viewportData = new ViewportDataResponse({
       viewportId: 'vid',
       offset: 5,
@@ -388,6 +397,9 @@ describe('Proto Compatibility', () => {
     expect(
       wrapHeartbeatResponse(heartbeat.toObject()).getSessionCount()
     ).to.equal(2)
+    expect(
+      wrapHeartbeatResponse(heartbeatWithLoadAverageOnly.toObject()).getCpuLoadAverage()
+    ).to.equal(0.75)
     expect(
       wrapViewportDataResponse(viewportData.toObject()).getFollowingByteCount()
     ).to.equal(7)

--- a/packages/client/tests/specs/protoCompatibility.spec.ts
+++ b/packages/client/tests/specs/protoCompatibility.spec.ts
@@ -177,18 +177,24 @@ describe('Proto Compatibility', () => {
       hostname: 'host',
       processId: 99,
       serverVersion: '1.0.1',
-      jvmVersion: '',
-      jvmVendor: '',
-      jvmPath: '',
+      runtimeKind: 'native',
+      runtimeName: 'C++',
+      platform: 'linux-x64',
       availableProcessors: 16,
+      compiler: 'Clang 20.0.0',
+      buildType: 'Release',
+      cppStandard: 'C++17',
     })
     expect(serverInfo.getHostname()).to.equal('host')
     expect(serverInfo.getProcessId()).to.equal(99)
     expect(serverInfo.getServerVersion()).to.equal('1.0.1')
-    expect(serverInfo.getJvmVersion()).to.equal('')
-    expect(serverInfo.getJvmVendor()).to.equal('')
-    expect(serverInfo.getJvmPath()).to.equal('')
+    expect(serverInfo.getRuntimeKind()).to.equal('native')
+    expect(serverInfo.getRuntimeName()).to.equal('C++')
+    expect(serverInfo.getPlatform()).to.equal('linux-x64')
     expect(serverInfo.getAvailableProcessors()).to.equal(16)
+    expect(serverInfo.getCompiler()).to.equal('Clang 20.0.0')
+    expect(serverInfo.getBuildType()).to.equal('Release')
+    expect(serverInfo.getCppStandard()).to.equal('C++17')
 
     const serverControl = new ServerControlResponse({
       kind: ProtoServerControlKind.IMMEDIATE_SHUTDOWN,
@@ -207,18 +213,18 @@ describe('Proto Compatibility', () => {
       uptime: 4,
       cpuCount: 8,
       cpuLoadAverage: 1.5,
-      maxMemory: 10,
-      committedMemory: 11,
-      usedMemory: 12,
+      residentMemoryBytes: 10,
+      virtualMemoryBytes: 11,
+      peakResidentMemoryBytes: 12,
     })
     expect(heartbeat.getSessionCount()).to.equal(2)
     expect(heartbeat.getTimestamp()).to.equal(3)
     expect(heartbeat.getUptime()).to.equal(4)
     expect(heartbeat.getCpuCount()).to.equal(8)
     expect(heartbeat.getCpuLoadAverage()).to.equal(1.5)
-    expect(heartbeat.getMaxMemory()).to.equal(10)
-    expect(heartbeat.getCommittedMemory()).to.equal(11)
-    expect(heartbeat.getUsedMemory()).to.equal(12)
+    expect(heartbeat.getResidentMemoryBytes()).to.equal(10)
+    expect(heartbeat.getVirtualMemoryBytes()).to.equal(11)
+    expect(heartbeat.getPeakResidentMemoryBytes()).to.equal(12)
 
     const viewportData = new ViewportDataResponse({
       viewportId: 'vid',

--- a/packages/client/tests/specs/protoCompatibility.spec.ts
+++ b/packages/client/tests/specs/protoCompatibility.spec.ts
@@ -398,7 +398,9 @@ describe('Proto Compatibility', () => {
       wrapHeartbeatResponse(heartbeat.toObject()).getSessionCount()
     ).to.equal(2)
     expect(
-      wrapHeartbeatResponse(heartbeatWithLoadAverageOnly.toObject()).getCpuLoadAverage()
+      wrapHeartbeatResponse(
+        heartbeatWithLoadAverageOnly.toObject()
+      ).getCpuLoadAverage()
     ).to.equal(0.75)
     expect(
       wrapViewportDataResponse(viewportData.toObject()).getFollowingByteCount()

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -95,13 +95,30 @@ describe('Server Edge Cases', () => {
       }
 
       expect(serverInfo.serverVersion).to.be.a('string').and.not.be.empty
+      expect(serverInfo.runtimeKind).to.equal('native')
+      expect(serverInfo.runtimeName).to.be.a('string').and.not.be.empty
+      expect(serverInfo.platform).to.be.a('string').and.not.be.empty
       expect(serverInfo.availableProcessors).to.be.greaterThan(0)
+      expect(serverInfo.compiler).to.be.a('string').and.not.be.empty
+      expect(serverInfo.buildType).to.be.a('string').and.not.be.empty
+      expect(serverInfo.cppStandard).to.be.a('string').and.not.be.empty
 
       const heartbeat = await getServerHeartbeat([], 250)
       expect(heartbeat.latency).to.be.greaterThanOrEqual(0)
       expect(heartbeat.sessionCount).to.equal(0)
       expect(heartbeat.serverCpuCount).to.be.greaterThanOrEqual(0)
-      expect(heartbeat.serverMaxMemory).to.be.greaterThanOrEqual(0)
+      if (heartbeat.serverCpuLoadAverage !== undefined) {
+        expect(heartbeat.serverCpuLoadAverage).to.be.a('number')
+      }
+      if (heartbeat.serverResidentMemoryBytes !== undefined) {
+        expect(heartbeat.serverResidentMemoryBytes).to.be.greaterThanOrEqual(0)
+      }
+      if (heartbeat.serverVirtualMemoryBytes !== undefined) {
+        expect(heartbeat.serverVirtualMemoryBytes).to.be.greaterThanOrEqual(0)
+      }
+      if (heartbeat.serverPeakResidentMemoryBytes !== undefined) {
+        expect(heartbeat.serverPeakResidentMemoryBytes).to.be.greaterThanOrEqual(0)
+      }
 
       expect(await stopServerImmediate()).to.equal(0)
       for (let attempt = 0; attempt < 30; attempt += 1) {

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -117,7 +117,9 @@ describe('Server Edge Cases', () => {
         expect(heartbeat.serverVirtualMemoryBytes).to.be.greaterThanOrEqual(0)
       }
       if (heartbeat.serverPeakResidentMemoryBytes !== undefined) {
-        expect(heartbeat.serverPeakResidentMemoryBytes).to.be.greaterThanOrEqual(0)
+        expect(
+          heartbeat.serverPeakResidentMemoryBytes
+        ).to.be.greaterThanOrEqual(0)
       }
       if (process.platform === 'win32') {
         expect(heartbeat.serverVirtualMemoryBytes).to.equal(undefined)

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -119,6 +119,9 @@ describe('Server Edge Cases', () => {
       if (heartbeat.serverPeakResidentMemoryBytes !== undefined) {
         expect(heartbeat.serverPeakResidentMemoryBytes).to.be.greaterThanOrEqual(0)
       }
+      if (process.platform === 'win32') {
+        expect(heartbeat.serverVirtualMemoryBytes).to.equal(undefined)
+      }
 
       expect(await stopServerImmediate()).to.equal(0)
       for (let attempt = 0; attempt < 30; attempt += 1) {

--- a/packages/client/tsconfig.base.json
+++ b/packages/client/tsconfig.base.json
@@ -21,7 +21,11 @@
     "target": "es6",
     "lib": ["es6", "es2021", "es2017"],
     "rootDir": "src",
+    "baseUrl": ".",
     "moduleResolution": "node",
+    "paths": {
+      "@omega-edit/server": ["src/shims/omega-edit-server"]
+    },
     "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/proto/README.md
+++ b/proto/README.md
@@ -23,6 +23,8 @@ The v1 server-health messages intentionally model the native C++ server now:
 
 Consumers migrating from older JVM-oriented fields should treat missing optional
 heartbeat metrics as "unavailable" rather than `0`.
+`virtual_memory_bytes` is best-effort and may be unset on platforms where an
+equivalent process metric is not consistently available.
 
 ## Using with Buf
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -17,14 +17,16 @@ Defines the `Editor` service with RPCs for:
 
 The v1 server-health messages intentionally model the native C++ server now:
 
-- `GetServerInfoResponse` uses `runtime_kind`, `runtime_name`, `platform`, `compiler`, `build_type`, and `cpp_standard`
+- `GetServerInfoResponse` adds `runtime_kind`, `runtime_name`, `platform`, `compiler`, `build_type`, and `cpp_standard`
 - `GetHeartbeatResponse` uses optional process-memory fields:
-  `resident_memory_bytes`, `virtual_memory_bytes`, and `peak_resident_memory_bytes`
+  `load_average`, `resident_memory_bytes`, `virtual_memory_bytes`, and `peak_resident_memory_bytes`
 
 Consumers migrating from older JVM-oriented fields should treat missing optional
 heartbeat metrics as "unavailable" rather than `0`.
 `virtual_memory_bytes` is best-effort and may be unset on platforms where an
 equivalent process metric is not consistently available.
+The legacy JVM-shaped fields remain in the schema as deprecated compatibility
+fields so existing protobuf consumers do not break on the wire.
 
 ## Using with Buf
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -13,6 +13,17 @@ Defines the `Editor` service with RPCs for:
 - **Event streams** — server-push notifications for session and viewport changes
 - **Server lifecycle** — heartbeat, graceful/immediate shutdown
 
+### Server Health Schema Note
+
+The v1 server-health messages intentionally model the native C++ server now:
+
+- `GetServerInfoResponse` uses `runtime_kind`, `runtime_name`, `platform`, `compiler`, `build_type`, and `cpp_standard`
+- `GetHeartbeatResponse` uses optional process-memory fields:
+  `resident_memory_bytes`, `virtual_memory_bytes`, and `peak_resident_memory_bytes`
+
+Consumers migrating from older JVM-oriented fields should treat missing optional
+heartbeat metrics as "unavailable" rather than `0`.
+
 ## Using with Buf
 
 The proto is published to [buf.build/ctc-oss/omega-edit](https://buf.build/ctc-oss/omega-edit) for easy multi-language stub generation.

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -376,7 +376,7 @@ message GetHeartbeatResponse {
   int32 cpu_count = 4;                      // Number of logical CPU cores.
   optional double cpu_load_average = 5;     // 1-min load average (POSIX only, unset on Windows). (was non-optional before v2)
   optional int64 resident_memory_bytes = 6; // Resident set size (RSS) in bytes.         (was max_memory before v2)
-  optional int64 virtual_memory_bytes = 7;  // Virtual address space usage in bytes.     (was committed_memory before v2)
+  optional int64 virtual_memory_bytes = 7;  // Virtual address space usage in bytes when the platform can report it consistently. (was committed_memory before v2)
   optional int64 peak_resident_memory_bytes = 8; // Peak RSS in bytes.                   (was used_memory before v2)
 }
 

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -338,13 +338,16 @@ message GetServerInfoResponse {
   string hostname = 1;             // Server hostname.
   int32 process_id = 2;            // Server OS process ID.
   string server_version = 3;       // Omega Edit server version string.
-  string runtime_kind = 4;         // Runtime family, e.g. "native" or "jvm".  (was jvm_version before v2)
-  string runtime_name = 5;         // Runtime implementation name, e.g. "C++". (was jvm_vendor before v2)
-  string platform = 6;             // Host platform and architecture summary.  (was jvm_path before v2)
+  string jvm_version = 4 [deprecated = true]; // Legacy field kept for compatibility with older clients.
+  string jvm_vendor = 5 [deprecated = true];  // Legacy field kept for compatibility with older clients.
+  string jvm_path = 6 [deprecated = true];    // Legacy field kept for compatibility with older clients.
   int32 available_processors = 7;  // Number of logical CPU cores.
-  string compiler = 8;             // Compiler or toolchain used to build the server.
-  string build_type = 9;           // Build configuration, e.g. "Release" or "Debug".
-  string cpp_standard = 10;        // C++ standard used, e.g. "C++17".
+  string runtime_kind = 8;         // Runtime family, e.g. "native" or "jvm".
+  string runtime_name = 9;         // Runtime implementation name, e.g. "C++".
+  string platform = 10;            // Host platform and architecture summary.
+  string compiler = 11;            // Compiler or toolchain used to build the server.
+  string build_type = 12;          // Build configuration, e.g. "Release" or "Debug".
+  string cpp_standard = 13;        // C++ standard used, e.g. "C++17".
 }
 
 // Request to send a control command to the server.
@@ -374,10 +377,14 @@ message GetHeartbeatResponse {
   int64 timestamp = 2;                      // Server wall-clock time in milliseconds since epoch.
   int64 uptime = 3;                         // Server uptime in milliseconds.
   int32 cpu_count = 4;                      // Number of logical CPU cores.
-  optional double cpu_load_average = 5;     // 1-min load average (POSIX only, unset on Windows). (was non-optional before v2)
-  optional int64 resident_memory_bytes = 6; // Resident set size (RSS) in bytes.         (was max_memory before v2)
-  optional int64 virtual_memory_bytes = 7;  // Virtual address space usage in bytes when the platform can report it consistently. (was committed_memory before v2)
-  optional int64 peak_resident_memory_bytes = 8; // Peak RSS in bytes.                   (was used_memory before v2)
+  double cpu_load_average = 5 [deprecated = true]; // Legacy load average field kept for compatibility with older clients.
+  int64 max_memory = 6 [deprecated = true];        // Legacy memory field kept for compatibility with older clients.
+  int64 committed_memory = 7 [deprecated = true];  // Legacy memory field kept for compatibility with older clients.
+  int64 used_memory = 8 [deprecated = true];       // Legacy memory field kept for compatibility with older clients.
+  optional double load_average = 9;                // 1-min load average when the platform can report it.
+  optional int64 resident_memory_bytes = 10;       // Resident set size (RSS) in bytes.
+  optional int64 virtual_memory_bytes = 11;        // Virtual address space usage in bytes when the platform can report it consistently.
+  optional int64 peak_resident_memory_bytes = 12;  // Peak RSS in bytes.
 }
 
 // ===========================================================================

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -335,13 +335,16 @@ message GetServerInfoRequest {}
 
 // Server metadata returned by GetServerInfo.
 message GetServerInfoResponse {
-  string hostname = 1;            // Server hostname.
-  int32 process_id = 2;           // Server OS process ID.
-  string server_version = 3;      // Ωedit server version string.
-  string jvm_version = 4;         // JVM version (empty for native builds).
-  string jvm_vendor = 5;          // JVM vendor (empty for native builds).
-  string jvm_path = 6;            // Path to the JVM (empty for native builds).
-  int32 available_processors = 7; // Number of logical CPU cores.
+  string hostname = 1;             // Server hostname.
+  int32 process_id = 2;            // Server OS process ID.
+  string server_version = 3;       // Omega Edit server version string.
+  string runtime_kind = 4;         // Runtime family, e.g. "native" or "jvm".  (was jvm_version before v2)
+  string runtime_name = 5;         // Runtime implementation name, e.g. "C++". (was jvm_vendor before v2)
+  string platform = 6;             // Host platform and architecture summary.  (was jvm_path before v2)
+  int32 available_processors = 7;  // Number of logical CPU cores.
+  string compiler = 8;             // Compiler or toolchain used to build the server.
+  string build_type = 9;           // Build configuration, e.g. "Release" or "Debug".
+  string cpp_standard = 10;        // C++ standard used, e.g. "C++17".
 }
 
 // Request to send a control command to the server.
@@ -367,14 +370,14 @@ message GetHeartbeatRequest {
 
 // Server heartbeat response with resource metrics.
 message GetHeartbeatResponse {
-  int32 session_count = 1;       // Total active sessions on the server.
-  int64 timestamp = 2;           // Server wall-clock time in milliseconds since epoch.
-  int64 uptime = 3;              // Server uptime in milliseconds.
-  int32 cpu_count = 4;           // Number of logical CPU cores.
-  double cpu_load_average = 5;   // CPU load average as a percentage.
-  int64 max_memory = 6;          // Maximum memory available in bytes.
-  int64 committed_memory = 7;    // Committed (allocated) memory in bytes.
-  int64 used_memory = 8;         // Currently used memory in bytes.
+  int32 session_count = 1;                  // Total active sessions on the server.
+  int64 timestamp = 2;                      // Server wall-clock time in milliseconds since epoch.
+  int64 uptime = 3;                         // Server uptime in milliseconds.
+  int32 cpu_count = 4;                      // Number of logical CPU cores.
+  optional double cpu_load_average = 5;     // 1-min load average (POSIX only, unset on Windows). (was non-optional before v2)
+  optional int64 resident_memory_bytes = 6; // Resident set size (RSS) in bytes.         (was max_memory before v2)
+  optional int64 virtual_memory_bytes = 7;  // Virtual address space usage in bytes.     (was committed_memory before v2)
+  optional int64 peak_resident_memory_bytes = 8; // Peak RSS in bytes.                   (was used_memory before v2)
 }
 
 // ===========================================================================

--- a/server/cpp/CMakeLists.txt
+++ b/server/cpp/CMakeLists.txt
@@ -233,7 +233,7 @@ endif()
 
 # Platform-specific link libraries
 if(WIN32)
-    target_link_libraries(omega-edit-grpc-server PRIVATE rpcrt4)
+    target_link_libraries(omega-edit-grpc-server PRIVATE rpcrt4 psapi)
 elseif(NOT APPLE)
     # libuuid on Linux
     find_library(UUID_LIB uuid)

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -22,12 +22,20 @@
 #include <algorithm>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
+#include <optional>
 #include <sstream>
 #include <thread>
 
 #ifdef _WIN32
 #include <windows.h>
+#include <psapi.h>
+#elif defined(__APPLE__)
+#include <mach/mach.h>
+#include <sys/resource.h>
+#include <unistd.h>
 #else
+#include <sys/resource.h>
 #include <unistd.h>
 #endif
 
@@ -56,6 +64,185 @@ static int get_pid() {
 static int get_cpu_count() {
     auto n = std::thread::hardware_concurrency();
     return n > 0 ? static_cast<int>(n) : 1;
+}
+
+struct process_memory_metrics {
+    std::optional<int64_t> resident_memory_bytes;
+    std::optional<int64_t> virtual_memory_bytes;
+    std::optional<int64_t> peak_resident_memory_bytes;
+};
+
+static const std::string &get_runtime_kind() {
+    static const std::string value = "native";
+    return value;
+}
+
+static const std::string &get_runtime_name() {
+    static const std::string value = "C++";
+    return value;
+}
+
+static const std::string &get_platform_summary() {
+    static const std::string value = []() {
+#ifdef _WIN32
+        std::string os = "windows";
+#elif defined(__APPLE__)
+        std::string os = "macos";
+#elif defined(__linux__)
+        std::string os = "linux";
+#else
+        std::string os = "unknown";
+#endif
+
+#if defined(_M_X64) || defined(__x86_64__)
+        std::string arch = "x64";
+#elif defined(_M_ARM64) || defined(__aarch64__)
+        std::string arch = "arm64";
+#elif defined(_M_IX86) || defined(__i386__)
+        std::string arch = "x86";
+#elif defined(_M_ARM) || defined(__arm__)
+        std::string arch = "arm";
+#else
+        std::string arch = "unknown";
+#endif
+        return os + "-" + arch;
+    }();
+    return value;
+}
+
+static const std::string &get_compiler_info() {
+    static const std::string value =
+#if defined(__clang__)
+        "Clang " + std::to_string(__clang_major__) + "." + std::to_string(__clang_minor__) + "." +
+        std::to_string(__clang_patchlevel__);
+#elif defined(_MSC_FULL_VER)
+        "MSVC " + std::to_string(_MSC_FULL_VER);
+#elif defined(_MSC_VER)
+        "MSVC " + std::to_string(_MSC_VER);
+#elif defined(__GNUC__)
+        "GCC " + std::to_string(__GNUC__) + "." + std::to_string(__GNUC_MINOR__) + "." +
+        std::to_string(__GNUC_PATCHLEVEL__);
+#else
+        "unknown";
+#endif
+    return value;
+}
+
+static const std::string &get_build_type() {
+#ifdef NDEBUG
+    static const std::string value = "Release";
+#else
+    static const std::string value = "Debug";
+#endif
+    return value;
+}
+
+static const std::string &get_cpp_standard() {
+    static const std::string value = []() -> std::string {
+#if __cplusplus >= 202302L
+        return "C++23";
+#elif __cplusplus >= 202002L
+        return "C++20";
+#elif __cplusplus >= 201703L
+        return "C++17";
+#elif __cplusplus >= 201402L
+        return "C++14";
+#elif __cplusplus >= 201103L
+        return "C++11";
+#elif defined(_MSVC_LANG)
+#if _MSVC_LANG >= 202302L
+        return "C++23";
+#elif _MSVC_LANG >= 202002L
+        return "C++20";
+#elif _MSVC_LANG >= 201703L
+        return "C++17";
+#elif _MSVC_LANG >= 201402L
+        return "C++14";
+#else
+        return "C++11";
+#endif
+#else
+        return "unknown";
+#endif
+    }();
+    return value;
+}
+
+static std::optional<double> get_cpu_load_average() {
+#ifdef _WIN32
+    return std::nullopt;
+#else
+    double loadavg[1] = {0.0};
+    if (getloadavg(loadavg, 1) == 1) {
+        return loadavg[0];
+    }
+    return std::nullopt;
+#endif
+}
+
+#if defined(__linux__)
+static std::optional<int64_t> read_proc_status_kibibytes(const char *label) {
+    std::ifstream status_file("/proc/self/status");
+    if (!status_file.is_open()) {
+        return std::nullopt;
+    }
+
+    std::string line;
+    while (std::getline(status_file, line)) {
+        if (line.rfind(label, 0) != 0) {
+            continue;
+        }
+
+        std::istringstream stream(line.substr(std::strlen(label)));
+        int64_t kibibytes = 0;
+        std::string unit;
+        if (stream >> kibibytes >> unit) {
+            return kibibytes * 1024;
+        }
+    }
+
+    return std::nullopt;
+}
+#endif
+
+static process_memory_metrics get_process_memory_metrics() {
+    process_memory_metrics metrics;
+
+#ifdef _WIN32
+    PROCESS_MEMORY_COUNTERS_EX counters = {};
+    if (GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PROCESS_MEMORY_COUNTERS *>(&counters),
+                             sizeof(counters))) {
+        metrics.resident_memory_bytes = static_cast<int64_t>(counters.WorkingSetSize);
+        metrics.virtual_memory_bytes = static_cast<int64_t>(counters.PrivateUsage);
+        metrics.peak_resident_memory_bytes = static_cast<int64_t>(counters.PeakWorkingSetSize);
+    }
+#elif defined(__APPLE__)
+    mach_task_basic_info info = {};
+    mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &info_count) ==
+        KERN_SUCCESS) {
+        metrics.resident_memory_bytes = static_cast<int64_t>(info.resident_size);
+        metrics.virtual_memory_bytes = static_cast<int64_t>(info.virtual_size);
+    }
+
+    struct rusage usage = {};
+    if (getrusage(RUSAGE_SELF, &usage) == 0) {
+        metrics.peak_resident_memory_bytes = static_cast<int64_t>(usage.ru_maxrss);
+    }
+#elif defined(__linux__)
+    metrics.resident_memory_bytes = read_proc_status_kibibytes("VmRSS:");
+    metrics.virtual_memory_bytes = read_proc_status_kibibytes("VmSize:");
+    metrics.peak_resident_memory_bytes = read_proc_status_kibibytes("VmHWM:");
+
+    if (!metrics.peak_resident_memory_bytes.has_value()) {
+        struct rusage usage = {};
+        if (getrusage(RUSAGE_SELF, &usage) == 0) {
+            metrics.peak_resident_memory_bytes = static_cast<int64_t>(usage.ru_maxrss) * 1024;
+        }
+    }
+#endif
+
+    return metrics;
 }
 
 static grpc::Status validate_change_payload_size(const ::omega_edit::v1::SubmitChangeRequest *request,
@@ -187,12 +374,13 @@ grpc::Status EditorServiceImpl::GetServerInfo(grpc::ServerContext * /*context*/,
     std::ostringstream ver;
     ver << omega_version_major() << "." << omega_version_minor() << "." << omega_version_patch();
     response->set_server_version(ver.str());
-
-    // No JVM for C++ server
-    response->set_jvm_version("N/A (C++ server)");
-    response->set_jvm_vendor("N/A");
-    response->set_jvm_path("N/A");
+    response->set_runtime_kind(get_runtime_kind());
+    response->set_runtime_name(get_runtime_name());
+    response->set_platform(get_platform_summary());
     response->set_available_processors(get_cpu_count());
+    response->set_compiler(get_compiler_info());
+    response->set_build_type(get_build_type());
+    response->set_cpp_standard(get_cpp_standard());
     return grpc::Status::OK;
 }
 
@@ -1080,23 +1268,20 @@ grpc::Status EditorServiceImpl::GetHeartbeat(grpc::ServerContext * /*context*/,
     response->set_uptime(std::chrono::duration_cast<std::chrono::milliseconds>(uptime).count());
     response->set_cpu_count(get_cpu_count());
 
-    // CPU load average - only available on POSIX
-#ifdef _WIN32
-    response->set_cpu_load_average(-1.0);
-#else
-    double loadavg[1] = {0.0};
-    if (getloadavg(loadavg, 1) == 1) {
-        response->set_cpu_load_average(loadavg[0]);
-    } else {
-        response->set_cpu_load_average(-1.0);
+    if (const auto load_average = get_cpu_load_average(); load_average.has_value()) {
+        response->set_cpu_load_average(*load_average);
     }
-#endif
 
-    // Memory stats - rough approximation since C++ doesn't have JVM-like memory reporting
-    // We report reasonable defaults
-    response->set_max_memory(0);
-    response->set_committed_memory(0);
-    response->set_used_memory(0);
+    const process_memory_metrics memory = get_process_memory_metrics();
+    if (memory.resident_memory_bytes.has_value()) {
+        response->set_resident_memory_bytes(*memory.resident_memory_bytes);
+    }
+    if (memory.virtual_memory_bytes.has_value()) {
+        response->set_virtual_memory_bytes(*memory.virtual_memory_bytes);
+    }
+    if (memory.peak_resident_memory_bytes.has_value()) {
+        response->set_peak_resident_memory_bytes(*memory.peak_resident_memory_bytes);
+    }
 
     return grpc::Status::OK;
 }

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -213,7 +213,6 @@ static process_memory_metrics get_process_memory_metrics() {
     if (GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PROCESS_MEMORY_COUNTERS *>(&counters),
                              sizeof(counters))) {
         metrics.resident_memory_bytes = static_cast<int64_t>(counters.WorkingSetSize);
-        metrics.virtual_memory_bytes = static_cast<int64_t>(counters.PrivateUsage);
         metrics.peak_resident_memory_bytes = static_cast<int64_t>(counters.PeakWorkingSetSize);
     }
 #elif defined(__APPLE__)

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -373,6 +373,9 @@ grpc::Status EditorServiceImpl::GetServerInfo(grpc::ServerContext * /*context*/,
     std::ostringstream ver;
     ver << omega_version_major() << "." << omega_version_minor() << "." << omega_version_patch();
     response->set_server_version(ver.str());
+    response->set_jvm_version("N/A (native server)");
+    response->set_jvm_vendor("N/A");
+    response->set_jvm_path("N/A");
     response->set_runtime_kind(get_runtime_kind());
     response->set_runtime_name(get_runtime_name());
     response->set_platform(get_platform_summary());
@@ -1266,9 +1269,14 @@ grpc::Status EditorServiceImpl::GetHeartbeat(grpc::ServerContext * /*context*/,
     response->set_timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
     response->set_uptime(std::chrono::duration_cast<std::chrono::milliseconds>(uptime).count());
     response->set_cpu_count(get_cpu_count());
+    response->set_cpu_load_average(-1.0);
+    response->set_max_memory(0);
+    response->set_committed_memory(0);
+    response->set_used_memory(0);
 
     if (const auto load_average = get_cpu_load_average(); load_average.has_value()) {
         response->set_cpu_load_average(*load_average);
+        response->set_load_average(*load_average);
     }
 
     const process_memory_metrics memory = get_process_memory_metrics();


### PR DESCRIPTION
Fixes #1360

## Summary
- replace JVM-specific server info fields with native runtime metadata in the v1 proto and TS client surface
- replace JVM heap-style heartbeat fields with optional native process memory metrics and optional load average
- implement native runtime/compiler/platform reporting and process memory collection in the C++ server
- refresh the VS Code health tooltip and document the API migration for downstream integrations

## Breaking API Changes
- removed jvmVersion, jvmVendor, and jvmPath from the v1 server info surface
- removed serverMaxMemory, serverCommittedMemory, and serverUsedMemory from the heartbeat surface
- added untimeKind, untimeName, platform, and compiler
- added optional serverCpuLoadAverage, serverResidentMemoryBytes, serverVirtualMemoryBytes, and serverPeakResidentMemoryBytes
- heartbeat metrics that are unavailable now stay unset instead of returning misleading zero values

## Verification
- yarn build in packages/client
- yarn workspace @omega-edit/server prepackage
- targeted mocha: protoCompatibility.spec.ts
- targeted mocha: serverEdgeCases.spec.ts
