### PR TITLE
Add memory-backed session APIs

### DIFF
--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -53,6 +53,21 @@ omega_session_t *omega_edit_create_session(const char *file_path, omega_session_
                                            int32_t event_interest, const char *checkpoint_directory);
 
 /**
+ * Create an editing session backed by an in-memory byte buffer.
+ * @param data_ptr bytes to seed the session with, or nullptr if length is zero
+ * @param length number of bytes in data_ptr
+ * @param cbk user-defined callback function called whenever a content affecting change is made to this session
+ * @param user_data_ptr pointer to user-defined data to associate with this session
+ * @param event_interest oring together the session events of interest, or zero if all session events are desired
+ * @param checkpoint_directory directory to store checkpoints in, if null, the system temp directory (or current working
+ * directory as a last resort) will be used
+ * @return pointer to the created session, or NULL on failure
+ */
+omega_session_t *omega_edit_create_session_from_bytes(const omega_byte_t *data_ptr, int64_t length,
+                                                      omega_session_event_cbk_t cbk, void *user_data_ptr,
+                                                      int32_t event_interest, const char *checkpoint_directory);
+
+/**
  * Destroy the given session and all associated objects (changes, and viewports)
  * @param session_ptr session to destroy
  */
@@ -130,6 +145,27 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
  * @return 0 on success, non-zero otherwise
  */
 int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path);
+
+/**
+ * Copy a session byte range into a newly allocated memory buffer.
+ * @param session_ptr session to copy from
+ * @param data_ptr_out receives a malloc-allocated buffer containing the copied bytes (caller must free)
+ * @param length_out receives the number of copied bytes
+ * @param offset starting byte offset in the session
+ * @param length number of bytes to copy, or zero to copy from offset to the end of the session
+ * @return 0 on success, non-zero otherwise
+ */
+int omega_edit_save_segment_to_bytes(const omega_session_t *session_ptr, omega_byte_t **data_ptr_out,
+                                     int64_t *length_out, int64_t offset, int64_t length);
+
+/**
+ * Copy the full computed session content into a newly allocated memory buffer.
+ * @param session_ptr session to copy from
+ * @param data_ptr_out receives a malloc-allocated buffer containing the copied bytes (caller must free)
+ * @param length_out receives the number of copied bytes
+ * @return 0 on success, non-zero otherwise
+ */
+int omega_edit_save_to_bytes(const omega_session_t *session_ptr, omega_byte_t **data_ptr_out, int64_t *length_out);
 
 /**
  * Batch script operation kinds for sequential edit replay.

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -60,7 +60,8 @@ omega_session_t *omega_edit_create_session(const char *file_path, omega_session_
  * @param user_data_ptr pointer to user-defined data to associate with this session
  * @param event_interest oring together the session events of interest, or zero if all session events are desired
  * @param checkpoint_directory directory to store checkpoints in, if null, the system temp directory (or current working
- * directory as a last resort) will be used
+ * directory as a last resort) will be used.  A checkpoint file is still created internally so the session can reuse
+ * the standard file-backed model and checkpoint machinery.
  * @return pointer to the created session, or NULL on failure
  */
 omega_session_t *omega_edit_create_session_from_bytes(const omega_byte_t *data_ptr, int64_t length,
@@ -149,7 +150,8 @@ int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_
 /**
  * Copy a session byte range into a newly allocated memory buffer.
  * @param session_ptr session to copy from
- * @param data_ptr_out receives a malloc-allocated buffer containing the copied bytes (caller must free)
+ * @param data_ptr_out receives a malloc-allocated buffer containing the copied bytes (caller must free).  The buffer is
+ * null-terminated for convenience, but length_out reports the logical byte count.
  * @param length_out receives the number of copied bytes
  * @param offset starting byte offset in the session
  * @param length number of bytes to copy, or zero to copy from offset to the end of the session
@@ -161,7 +163,8 @@ int omega_edit_save_segment_to_bytes(const omega_session_t *session_ptr, omega_b
 /**
  * Copy the full computed session content into a newly allocated memory buffer.
  * @param session_ptr session to copy from
- * @param data_ptr_out receives a malloc-allocated buffer containing the copied bytes (caller must free)
+ * @param data_ptr_out receives a malloc-allocated buffer containing the copied bytes (caller must free).  The buffer is
+ * null-terminated for convenience, but length_out reports the logical byte count.
  * @param length_out receives the number of copied bytes
  * @return 0 on success, non-zero otherwise
  */

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -27,6 +27,7 @@
 #include "impl_/viewport_def.hpp"
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <memory>
 
 #ifdef OMEGA_BUILD_WINDOWS
@@ -50,6 +51,79 @@
 namespace {
     // 64KB I/O buffer for save and transform operations — reduces system-call overhead vs BUFSIZ (~8KB)
     constexpr int64_t OMEGA_IO_BUFFER_SIZE = 65536;
+
+    void initialize_model_segments_(omega_model_segments_t &model_segments, int64_t length);
+
+    auto resolve_checkpoint_directory_(const char *file_path, const char *checkpoint_directory,
+                                       std::string &checkpoint_directory_str) -> bool {
+        if (checkpoint_directory == nullptr) {
+            // First try to use the directory of the file being edited
+            if ((file_path != nullptr) && file_path[0] != '\0') {
+                auto *const dirname = omega_util_dirname(file_path, nullptr);
+                if (dirname != nullptr) {
+                    checkpoint_directory = checkpoint_directory_str.assign(dirname).c_str();
+                }
+            }
+            // If that doesn't work, then try to use the system temp directory
+            if (checkpoint_directory == nullptr) {
+                auto *const temp_dir = omega_util_get_temp_directory();
+                if (temp_dir != nullptr) {
+                    checkpoint_directory = checkpoint_directory_str.assign(temp_dir).c_str();
+                    free(temp_dir);
+                } else {
+                    // Finally, if that doesn't work, then use the current working directory
+                    auto *const current_dir = omega_util_get_current_dir(nullptr);
+                    if (current_dir != nullptr) {
+                        checkpoint_directory = checkpoint_directory_str.assign(current_dir).c_str();
+                    }
+                }
+            }
+        }
+        if (checkpoint_directory == nullptr) {
+            LOG_ERROR("failed to determine checkpoint directory");
+            return false;
+        }
+        if ((omega_util_directory_exists(checkpoint_directory) == 0) &&
+            0 != omega_util_create_directory(checkpoint_directory)) {
+            LOG_ERROR("failed to create checkpoint directory '" << checkpoint_directory << "'");
+            return false;
+        }
+        auto *const resolved_path = omega_util_normalize_path(checkpoint_directory, nullptr);
+        if (resolved_path == nullptr) {
+            LOG_ERROR("failed to resolve checkpoint_directory path '" << checkpoint_directory << "' to absolute path");
+            return false;
+        }
+        checkpoint_directory_str.assign(resolved_path);
+        return true;
+    }
+
+    auto create_session_with_backing_file_(FILE *file_ptr, const char *file_path, const char *checkpoint_file_name,
+                                           const std::string &checkpoint_directory, omega_session_event_cbk_t cbk,
+                                           void *user_data_ptr, int32_t event_interest) -> omega_session_t * {
+        off_t file_size = 0;
+        if (file_ptr != nullptr) {
+            if (0 != FSEEK(file_ptr, 0L, SEEK_END)) {
+                FCLOSE(file_ptr);
+                return nullptr;
+            }
+            file_size = FTELL(file_ptr);
+        }
+        auto *const session_ptr = new omega_session_t;
+        session_ptr->checkpoint_directory_ = checkpoint_directory;
+        session_ptr->event_handler = cbk;
+        session_ptr->user_data_ptr = user_data_ptr;
+        session_ptr->event_interest_ = event_interest;
+        session_ptr->num_changes_adjustment_ = 0;
+        session_ptr->models_.push_back(std::make_unique<omega_model_t>());
+        if (file_ptr != nullptr) {
+            session_ptr->models_.back()->file_ptr = file_ptr;
+            if (file_path != nullptr) { session_ptr->models_.back()->file_path.assign(file_path); }
+            if (checkpoint_file_name != nullptr) { session_ptr->checkpoint_file_name_.assign(checkpoint_file_name); }
+        }
+        initialize_model_segments_(session_ptr->models_.back()->model_segments, file_size);
+        omega_session_notify(session_ptr, SESSION_EVT_CREATE, nullptr);
+        return session_ptr;
+    }
 
     auto reserve_output_path_(const char *requested_path, int mode, char *reserved_path, size_t reserved_path_size)
             -> FILE * {
@@ -652,35 +726,7 @@ namespace {
 omega_session_t *omega_edit_create_session(const char *file_path, omega_session_event_cbk_t cbk, void *user_data_ptr,
                                            int32_t event_interest, const char *checkpoint_directory) {
     std::string checkpoint_directory_str;
-    // If no checkpoint directory is specified, then try to figure out a good default
-    if (checkpoint_directory == nullptr) {
-        // First try to use the directory of the file being edited
-        if ((file_path != nullptr) && file_path[0] != '\0') {
-            checkpoint_directory = checkpoint_directory_str.assign(omega_util_dirname(file_path, nullptr)).c_str();
-        }
-        // If that doesn't work, then try to use the system temp directory
-        if (checkpoint_directory == nullptr) {
-            auto *const temp_dir = omega_util_get_temp_directory();
-            if (temp_dir != nullptr) {
-                checkpoint_directory = checkpoint_directory_str.assign(temp_dir).c_str();
-                free(temp_dir);
-            } else {
-                // Finally, if that doesn't work, then use the current working directory
-                checkpoint_directory = checkpoint_directory_str.assign(omega_util_get_current_dir(nullptr)).c_str();
-            }
-        }
-    }
-    if ((omega_util_directory_exists(checkpoint_directory) == 0) &&
-        0 != omega_util_create_directory(checkpoint_directory)) {
-        LOG_ERROR("failed to create checkpoint directory '" << checkpoint_directory << "'");
-        return nullptr;
-    }
-    auto *const resolved_path = omega_util_normalize_path(checkpoint_directory, nullptr);
-    if (resolved_path == nullptr) {
-        LOG_ERROR("failed to resolve checkpoint_directory path '" << checkpoint_directory << "' to absolute path");
-        return nullptr;
-    }
-    checkpoint_directory_str.assign(resolved_path);
+    if (!resolve_checkpoint_directory_(file_path, checkpoint_directory, checkpoint_directory_str)) { return nullptr; }
     FILE *file_ptr = nullptr;
     char checkpoint_filename[FILENAME_MAX + 1]; // +1 for null terminator
     if ((file_path != nullptr) && file_path[0] != '\0') {
@@ -708,29 +754,54 @@ omega_session_t *omega_edit_create_session(const char *file_path, omega_session_
         file_ptr = FOPEN(checkpoint_filename, "rb");
         if (file_ptr == nullptr) { return nullptr; }
     }
-    off_t file_size = 0;
-    if (file_ptr != nullptr) {
-        if (0 != FSEEK(file_ptr, 0L, SEEK_END)) {
-            FCLOSE(file_ptr);
-            return nullptr;
-        }
-        file_size = FTELL(file_ptr);
+    return create_session_with_backing_file_(file_ptr, file_path, checkpoint_filename, checkpoint_directory_str, cbk,
+                                             user_data_ptr, event_interest);
+}
+
+omega_session_t *omega_edit_create_session_from_bytes(const omega_byte_t *data_ptr, int64_t length,
+                                                      omega_session_event_cbk_t cbk, void *user_data_ptr,
+                                                      int32_t event_interest, const char *checkpoint_directory) {
+    if (length < 0 || (length > 0 && data_ptr == nullptr)) { return nullptr; }
+
+    std::string checkpoint_directory_str;
+    if (!resolve_checkpoint_directory_(nullptr, checkpoint_directory, checkpoint_directory_str)) { return nullptr; }
+
+    char checkpoint_filename[FILENAME_MAX + 1];
+    if (FILENAME_MAX <=
+        snprintf(static_cast<char *>(checkpoint_filename), FILENAME_MAX, "%s%c.OmegaEdit-bytes.XXXXXX",
+                 checkpoint_directory_str.c_str(), omega_util_directory_separator())) {
+        LOG_ERROR("failed to create memory-backed checkpoint filename template");
+        return nullptr;
     }
-    auto *const session_ptr = new omega_session_t;
-    session_ptr->checkpoint_directory_ = checkpoint_directory_str;
-    session_ptr->event_handler = cbk;
-    session_ptr->user_data_ptr = user_data_ptr;
-    session_ptr->event_interest_ = event_interest;
-    session_ptr->num_changes_adjustment_ = 0;
-    session_ptr->models_.push_back(std::make_unique<omega_model_t>());
-    if (file_ptr != nullptr) {
-        session_ptr->models_.back()->file_ptr = file_ptr;
-        session_ptr->models_.back()->file_path.assign(file_path);
-        session_ptr->checkpoint_file_name_.assign(checkpoint_filename);
+
+    const auto checkpoint_fd = omega_util_mkstemp(static_cast<char *>(checkpoint_filename), 0600);// S_IRUSR | S_IWUSR
+    if (checkpoint_fd < 0) {
+        LOG_ERROR("omega_util_mkstemp failed for memory-backed checkpoint file '"
+                  << static_cast<char *>(checkpoint_filename) << "'");
+        return nullptr;
     }
-    initialize_model_segments_(session_ptr->models_.back()->model_segments, file_size);
-    omega_session_notify(session_ptr, SESSION_EVT_CREATE, nullptr);
-    return session_ptr;
+    close(checkpoint_fd);
+
+    auto *file_ptr = FOPEN(checkpoint_filename, "wb");
+    if (file_ptr == nullptr) {
+        omega_util_remove_file(checkpoint_filename);
+        return nullptr;
+    }
+    if ((length > 0) && (static_cast<int64_t>(fwrite(data_ptr, sizeof(omega_byte_t), length, file_ptr)) != length)) {
+        FCLOSE(file_ptr);
+        omega_util_remove_file(checkpoint_filename);
+        return nullptr;
+    }
+    FCLOSE(file_ptr);
+
+    file_ptr = FOPEN(checkpoint_filename, "rb");
+    if (file_ptr == nullptr) {
+        omega_util_remove_file(checkpoint_filename);
+        return nullptr;
+    }
+
+    return create_session_with_backing_file_(file_ptr, nullptr, checkpoint_filename, checkpoint_directory_str, cbk,
+                                             user_data_ptr, event_interest);
 }
 
 void omega_edit_destroy_session(omega_session_t *session_ptr) {
@@ -1127,6 +1198,64 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
 
 int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path) {
     return omega_edit_save_segment(session_ptr, file_path, io_flags, saved_file_path, 0, 0);
+}
+
+int omega_edit_save_segment_to_bytes(const omega_session_t *session_ptr, omega_byte_t **data_ptr_out,
+                                     int64_t *length_out, int64_t offset, int64_t length) {
+    if (!session_ptr || !data_ptr_out || !length_out || offset < 0 || length < 0) { return -1; }
+
+    *data_ptr_out = nullptr;
+    *length_out = 0;
+
+    const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (offset > computed_file_size) { return -1; }
+
+    const auto remaining_length = computed_file_size - offset;
+    const auto requested_length = (length == 0 || length > remaining_length) ? remaining_length : length;
+    if (requested_length < 0) { return -1; }
+
+    auto *const data_ptr = static_cast<omega_byte_t *>(malloc(static_cast<size_t>(requested_length) + 1));
+    if (data_ptr == nullptr) { return -1; }
+    data_ptr[requested_length] = '\0';
+
+    if (requested_length == 0) {
+        *data_ptr_out = data_ptr;
+        *length_out = 0;
+        return 0;
+    }
+
+    const auto chunk_capacity = std::min<int64_t>(requested_length, OMEGA_IO_BUFFER_SIZE);
+    auto *const segment = omega_segment_create(chunk_capacity);
+    if (!segment) {
+        free(data_ptr);
+        return -1;
+    }
+
+    int64_t bytes_copied = 0;
+    while (bytes_copied < requested_length) {
+        if (0 != omega_session_get_segment(session_ptr, segment, offset + bytes_copied)) {
+            omega_segment_destroy(segment);
+            free(data_ptr);
+            return -1;
+        }
+        const auto segment_length = std::min<int64_t>(omega_segment_get_length(segment), requested_length - bytes_copied);
+        if (segment_length <= 0) {
+            omega_segment_destroy(segment);
+            free(data_ptr);
+            return -1;
+        }
+        memcpy(data_ptr + bytes_copied, omega_segment_get_data(segment), static_cast<size_t>(segment_length));
+        bytes_copied += segment_length;
+    }
+
+    omega_segment_destroy(segment);
+    *data_ptr_out = data_ptr;
+    *length_out = requested_length;
+    return 0;
+}
+
+int omega_edit_save_to_bytes(const omega_session_t *session_ptr, omega_byte_t **data_ptr_out, int64_t *length_out) {
+    return omega_edit_save_segment_to_bytes(session_ptr, data_ptr_out, length_out, 0, 0);
 }
 
 int omega_edit_clear_changes(omega_session_t *session_ptr) {

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -59,7 +59,7 @@ npx ts-node record-replay.ts input.txt
 Each example calls `startServer(port)` to launch the native C++ gRPC server (bundled inside `@omega-edit/client`) and `stopServerGraceful()` to shut it down. In a production application (e.g., a VS Code extension), you would typically start the server once during activation and stop it during deactivation.
 
 ### Sessions
-A session represents an editing context for a file. Create one with `createSession(filePath)` (or omit the path for an empty session). All edits, viewports, and searches happen within a session. Destroy it with `destroySession(sessionId)` when done.
+A session represents an editing context for a file or byte buffer. Create one with `createSession(filePath)` for file-backed input, `createSessionFromBytes(data)` for in-memory input, or omit the path for an empty session. All edits, viewports, and searches happen within a session. Destroy it with `destroySession(sessionId)` when done.
 
 ### Viewports
 Viewports are windows into the session data at a given offset and capacity. They are a core Ωedit™ primitive — not an afterthought. Floating viewports automatically adjust their offset when inserts or deletes shift data before them.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -136,10 +136,12 @@ Migration notes:
 | Function                                                                  | Description                    |
 | ------------------------------------------------------------------------- | ------------------------------ |
 | `createSession(filePath?, sessionId?, checkpointDir?)`                    | Open an editing session        |
+| `createSessionFromBytes(data, sessionId?, checkpointDir?)`                | Open a session from bytes      |
 | `destroySession(sessionId)`                                               | Close and discard a session    |
 | `saveSession(sessionId, path, flags?, offset?, length?)`                  | Save session content to a file |
 | `getComputedFileSize(sessionId)`                                          | Logical file size after edits  |
 | `getSegment(sessionId, offset, length)`                                   | Read a byte range              |
+| `getSessionBytes(sessionId, offset?, length?)`                            | Read session bytes in memory   |
 | `getSessionCount()`                                                       | Number of active sessions      |
 | `pauseSessionChanges(sessionId)` / `resumeSessionChanges(sessionId)`      | Pause/resume change tracking   |
 | `beginSessionTransaction(sessionId)` / `endSessionTransaction(sessionId)` | Group edits atomically         |

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -240,6 +240,12 @@ export interface CreateSessionRequest {
    * @generated from protobuf field: optional string checkpoint_directory = 3
    */
   checkpointDirectory?: string
+  /**
+   * Initial bytes to seed the session with.  Mutually exclusive with file_path.
+   *
+   * @generated from protobuf field: optional bytes initial_data = 4
+   */
+  initialData?: Uint8Array
 }
 /**
  * Response after a session is successfully created.
@@ -2611,6 +2617,13 @@ class CreateSessionRequest$Type extends MessageType<CreateSessionRequest> {
         opt: true,
         T: 9 /*ScalarType.STRING*/,
       },
+      {
+        no: 4,
+        name: 'initial_data',
+        kind: 'scalar',
+        opt: true,
+        T: 12 /*ScalarType.BYTES*/,
+      },
     ])
   }
   create(value?: PartialMessage<CreateSessionRequest>): CreateSessionRequest {
@@ -2638,6 +2651,9 @@ class CreateSessionRequest$Type extends MessageType<CreateSessionRequest> {
           break
         case /* optional string checkpoint_directory */ 3:
           message.checkpointDirectory = reader.string()
+          break
+        case /* optional bytes initial_data */ 4:
+          message.initialData = reader.bytes()
           break
         default:
           let u = options.readUnknownField
@@ -2674,6 +2690,9 @@ class CreateSessionRequest$Type extends MessageType<CreateSessionRequest> {
       writer
         .tag(3, WireType.LengthDelimited)
         .string(message.checkpointDirectory)
+    /* optional bytes initial_data = 4; */
+    if (message.initialData !== undefined)
+      writer.tag(4, WireType.LengthDelimited).bytes(message.initialData)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -49,7 +49,8 @@ import {
 export async function createSession(
   filePath: string = '',
   sessionIdDesired: string = '',
-  checkpointDirectory: string = ''
+  checkpointDirectory: string = '',
+  initialData?: Uint8Array
 ): Promise<CreateSessionResponse> {
   const log = getLogger()
   const request: CreateSessionRequest = {}
@@ -59,6 +60,7 @@ export async function createSession(
   if (checkpointDirectory.length > 0) {
     request.checkpointDirectory = checkpointDirectory
   }
+  if (initialData !== undefined) request.initialData = initialData
 
   debugLog(log, () => ({ fn: 'protobufTs.createSession', rqst: request }))
   const client = await getClient()

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -138,6 +138,21 @@ export async function createSession(
   )
 }
 
+export async function createSessionFromBytes(
+  initial_data: Uint8Array,
+  session_id_desired: string = '',
+  checkpoint_directory: string = ''
+): Promise<CreateSessionResponse> {
+  return wrapCreateSessionResponse(
+    await rawCreateSession(
+      '',
+      session_id_desired,
+      checkpoint_directory,
+      initial_data
+    )
+  )
+}
+
 export function destroySession(session_id: string): Promise<string> {
   return rawDestroySession(session_id)
 }
@@ -191,6 +206,17 @@ export function getSegment(
   length: number
 ): Promise<Uint8Array> {
   return rawGetSegment(session_id, offset, length)
+}
+
+export async function getSessionBytes(
+  session_id: string,
+  offset: number = 0,
+  length: number = 0
+): Promise<Uint8Array> {
+  const computedSize = await getComputedFileSize(session_id)
+  const remaining = Math.max(0, computedSize - offset)
+  const effectiveLength = length > 0 ? Math.min(length, remaining) : remaining
+  return rawGetSegment(session_id, offset, effectiveLength)
 }
 
 export function getSessionCount(): Promise<number> {

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -213,6 +213,9 @@ export async function getSessionBytes(
   offset: number = 0,
   length: number = 0
 ): Promise<Uint8Array> {
+  // This helper issues separate size and segment RPCs, so callers should treat
+  // it as a convenience snapshot read when the session is not being
+  // concurrently modified.
   const computedSize = await getComputedFileSize(session_id)
   const remaining = Math.max(0, computedSize - offset)
   const effectiveLength = length > 0 ? Math.min(length, remaining) : remaining

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -22,6 +22,7 @@ import {
   del,
   countCharacters,
   createSession,
+  createSessionFromBytes,
   createViewport,
   destroySession,
   getByteOrderMark,
@@ -31,6 +32,7 @@ import {
   getContentType,
   getLanguage,
   getSegment,
+  getSessionBytes,
   getServerHeartbeat,
   getSessionCount,
   getViewportCount,
@@ -803,6 +805,54 @@ describe('Sessions', () => {
     ).to.equal(0)
     removeDirectory(checkpointDir)
     expect(fs.existsSync(checkpointDir)).to.be.false
+  })
+
+  it('Should create a clean baseline session from bytes', async () => {
+    const memoryCheckpointDir = path.join(__dirname, 'data', 'memory-checkpoint')
+    const seed = Buffer.from('memory seed')
+    let session_id = ''
+
+    removeDirectory(memoryCheckpointDir)
+    expect(fs.existsSync(memoryCheckpointDir)).to.be.false
+
+    try {
+      const session = await createSessionFromBytes(
+        seed,
+        'memory_seed_test',
+        memoryCheckpointDir
+      )
+      session_id = session.getSessionId()
+
+      expect(session_id).to.equal('memory_seed_test')
+      expect(session.getCheckpointDirectory()).to.equal(memoryCheckpointDir)
+      expect(session.getFileSize()).to.equal(seed.length)
+      expect(await getComputedFileSize(session_id)).to.equal(seed.length)
+      expect(await getChangeCount(session_id)).to.equal(0)
+      expect(await getSessionBytes(session_id)).to.deep.equal(seed)
+      expect(await getSessionBytes(session_id, 7, 4)).to.deep.equal(
+        Buffer.from('seed')
+      )
+      expect(
+        await countMatchingFilesInDir(memoryCheckpointDir, '.OmegaEdit-bytes.*')
+      ).to.equal(1)
+
+      await insert(session_id, seed.length, Buffer.from('!'))
+      expect(await getChangeCount(session_id)).to.equal(1)
+      expect(await getSessionBytes(session_id)).to.deep.equal(
+        Buffer.from('memory seed!')
+      )
+    } finally {
+      if (session_id) {
+        await destroySession(session_id)
+      }
+      if (fs.existsSync(memoryCheckpointDir)) {
+        expect(
+          await countMatchingFilesInDir(memoryCheckpointDir, '.OmegaEdit-bytes.*')
+        ).to.equal(0)
+        removeDirectory(memoryCheckpointDir)
+      }
+      expect(fs.existsSync(memoryCheckpointDir)).to.be.false
+    }
   })
 
   it('Should be able to handle different save flags', async () => {

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -808,7 +808,11 @@ describe('Sessions', () => {
   })
 
   it('Should create a clean baseline session from bytes', async () => {
-    const memoryCheckpointDir = path.join(__dirname, 'data', 'memory-checkpoint')
+    const memoryCheckpointDir = path.join(
+      __dirname,
+      'data',
+      'memory-checkpoint'
+    )
     const seed = Buffer.from('memory seed')
     let session_id = ''
 
@@ -847,7 +851,10 @@ describe('Sessions', () => {
       }
       if (fs.existsSync(memoryCheckpointDir)) {
         expect(
-          await countMatchingFilesInDir(memoryCheckpointDir, '.OmegaEdit-bytes.*')
+          await countMatchingFilesInDir(
+            memoryCheckpointDir,
+            '.OmegaEdit-bytes.*'
+          )
         ).to.equal(0)
         removeDirectory(memoryCheckpointDir)
       }

--- a/proto/omega_edit.proto
+++ b/proto/omega_edit.proto
@@ -200,6 +200,7 @@ message CreateSessionRequest {
   optional string file_path = 1;
   optional string session_id_desired = 2;
   optional string checkpoint_directory = 3;
+  optional bytes initial_data = 4;
 }
 
 message CreateSessionResponse {

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -400,6 +400,8 @@ message CreateSessionRequest {
   optional string session_id_desired = 2;
   // Directory for checkpoint files.  Defaults to a system temp directory.
   optional string checkpoint_directory = 3;
+  // Initial bytes to seed the session with.  Mutually exclusive with file_path.
+  optional bytes initial_data = 4;
 }
 
 // Response after a session is successfully created.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -403,6 +403,12 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
         file_path = request->file_path();
     }
 
+    const auto has_initial_data = request->has_initial_data();
+    if (!file_path.empty() && has_initial_data) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                            "create session accepts either file_path or initial_data, not both");
+    }
+
     // Validate file path exists if provided (match previous server behavior)
     if (!file_path.empty()) {
         std::error_code ec;
@@ -426,8 +432,13 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
     std::string checkpoint_dir_out;
     std::string session_id;
     SessionCreateError create_error = SessionCreateError::SUCCESS;
+    std::string initial_data;
+    if (has_initial_data) {
+        initial_data = request->initial_data();
+    }
+    const std::string *initial_data_ptr = has_initial_data ? &initial_data : nullptr;
     try {
-        session_id = session_manager_.create_session(file_path, desired_id, checkpoint_dir, file_size,
+        session_id = session_manager_.create_session(file_path, desired_id, checkpoint_dir, initial_data_ptr, file_size,
                                                      checkpoint_dir_out, &create_error);
     } catch (const std::exception &e) {
         return grpc::Status(grpc::StatusCode::INTERNAL, std::string("Failed to create session: ") + e.what());
@@ -448,7 +459,7 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
 
     response->set_session_id(session_id);
     response->set_checkpoint_directory(checkpoint_dir_out);
-    if (!file_path.empty()) {
+    if (!file_path.empty() || has_initial_data) {
         response->set_file_size(file_size);
     }
     return grpc::Status::OK;

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -377,7 +377,8 @@ SessionManager::~SessionManager() { destroy_all(); }
 
 // ── Session lifecycle ────────────────────────────────────────────────────────
 std::string SessionManager::create_session(const std::string &file_path, const std::string &desired_id,
-                                           const std::string &checkpoint_directory, int64_t &file_size_out,
+                                           const std::string &checkpoint_directory, const std::string *initial_data,
+                                           int64_t &file_size_out,
                                            std::string &checkpoint_dir_out,
                                            SessionCreateError *error_out) {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -415,7 +416,6 @@ std::string SessionManager::create_session(const std::string &file_path, const s
     // Store info first so the callback can find it
     sessions_[session_id] = info;
 
-    const char *path = file_path.empty() ? nullptr : file_path.c_str();
     std::string effective_checkpoint_directory = checkpoint_directory;
     if (effective_checkpoint_directory.empty()) {
         effective_checkpoint_directory = create_managed_checkpoint_directory();
@@ -430,8 +430,15 @@ std::string SessionManager::create_session(const std::string &file_path, const s
     info->checkpoint_directory = effective_checkpoint_directory;
     const char *chkpt_dir = effective_checkpoint_directory.empty() ? nullptr : effective_checkpoint_directory.c_str();
 
-    omega_session_t *session =
-        omega_edit_create_session(path, session_event_callback, info.get(), 0, chkpt_dir);
+    omega_session_t *session = nullptr;
+    if (initial_data != nullptr) {
+        session = omega_edit_create_session_from_bytes(
+            reinterpret_cast<const omega_byte_t *>(initial_data->data()), static_cast<int64_t>(initial_data->size()),
+            session_event_callback, info.get(), 0, chkpt_dir);
+    } else {
+        const char *path = file_path.empty() ? nullptr : file_path.c_str();
+        session = omega_edit_create_session(path, session_event_callback, info.get(), 0, chkpt_dir);
+    }
 
     if (!session) {
         if (info->owns_checkpoint_directory) {

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -175,7 +175,8 @@ public:
 
     // Session lifecycle
     std::string create_session(const std::string &file_path, const std::string &desired_id,
-                               const std::string &checkpoint_directory, int64_t &file_size_out,
+                               const std::string &checkpoint_directory, const std::string *initial_data,
+                               int64_t &file_size_out,
                                std::string &checkpoint_dir_out,
                                SessionCreateError *error_out = nullptr);
     bool destroy_session(const std::string &session_id);


### PR DESCRIPTION
## Summary
- add core support for creating sessions from in-memory bytes and exporting session data back to bytes
- extend the gRPC and TypeScript client surfaces with memory-backed session helpers
- add coverage for clean baseline semantics, byte round-tripping, and checkpoint cleanup

## Testing
- yarn workspace @omega-edit/client build
- 
ode --import ./tests/register-ts-node-esm.mjs ../../node_modules/mocha/bin/mocha.js --timeout 100000 --slow 50000 --file tests/client-suite.ts tests/specs/session.spec.ts --exit

Fixes #1350