### PR TITLE
Prepare VS Code extension release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,39 @@ jobs:
         id: ts-format
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: "TypeScript code is properly formatted"
+          checkName: "TypeScript code passes Biome checks"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check VS Code extension - Ubuntu 1.110.0
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: vscode-ubuntu-floor
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "VS Code extension checks on ubuntu-24.04 with VS Code 1.110.0"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check VS Code extension - Ubuntu stable
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: vscode-ubuntu-stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "VS Code extension checks on ubuntu-24.04 with VS Code stable"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check VS Code extension - Windows 1.110.0
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: vscode-windows-floor
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "VS Code extension checks on windows-2025 with VS Code 1.110.0"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check VS Code extension - Windows stable
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: vscode-windows-stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "VS Code extension checks on windows-2025 with VS Code stable"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check tests - macOS 15
@@ -100,6 +132,10 @@ jobs:
         if: |
           steps.rat-check.outputs.conclusion != 'success' ||
           steps.ts-format.outputs.conclusion != 'success' ||
+          steps.vscode-ubuntu-floor.outputs.conclusion != 'success' ||
+          steps.vscode-ubuntu-stable.outputs.conclusion != 'success' ||
+          steps.vscode-windows-floor.outputs.conclusion != 'success' ||
+          steps.vscode-windows-stable.outputs.conclusion != 'success' ||
           steps.macos15-tests.outputs.conclusion != 'success' ||
           steps.macos14-tests.outputs.conclusion != 'success' ||
           steps.ubuntu-tests.outputs.conclusion != 'success' ||
@@ -108,6 +144,10 @@ jobs:
         run: |
           echo "Rat Check Status: ${{ steps.rat-check.outputs.conclusion }}"
           echo "Typescript Format Status: ${{ steps.ts-format.outputs.conclusion }}"
+          echo "VS Code Ubuntu 1.110.0 Status: ${{ steps.vscode-ubuntu-floor.outputs.conclusion }}"
+          echo "VS Code Ubuntu stable Status: ${{ steps.vscode-ubuntu-stable.outputs.conclusion }}"
+          echo "VS Code Windows 1.110.0 Status: ${{ steps.vscode-windows-floor.outputs.conclusion }}"
+          echo "VS Code Windows stable Status: ${{ steps.vscode-windows-stable.outputs.conclusion }}"
           echo "MacOS 15 Test Status: ${{ steps.macos15-tests.outputs.conclusion }}"
           echo "MacOS 14 Test Status: ${{ steps.macos14-tests.outputs.conclusion }}"
           echo "Ubuntu Test Status: ${{ steps.ubuntu-tests.outputs.conclusion }}"

--- a/examples/vscode-extension/package-lock.json
+++ b/examples/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omega-edit-hex-editor",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omega-edit-hex-editor",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@omega-edit/client": "^1.0.1"

--- a/examples/vscode-extension/package.json
+++ b/examples/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "omega-edit-hex-editor",
   "displayName": "OmegaEdit Hex Editor",
   "description": "A minimal reference hex/data editor VS Code extension powered by OmegaEdit",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "publisher": "omega-edit-example",
   "license": "Apache-2.0",
   "repository": {

--- a/sync-version.js
+++ b/sync-version.js
@@ -55,4 +55,26 @@ fs.writeFileSync(
   JSON.stringify(serverPackageJson, null, 2) + '\n'
 )
 
+// Update VS Code extension example package.json
+const vscodeExtensionPackageJsonPath = path.join(
+  __dirname,
+  'examples',
+  'vscode-extension',
+  'package.json'
+)
+const vscodeExtensionPackageJson = JSON.parse(
+  fs.readFileSync(vscodeExtensionPackageJsonPath, 'utf8')
+)
+vscodeExtensionPackageJson.version = version
+if (
+  vscodeExtensionPackageJson.dependencies &&
+  vscodeExtensionPackageJson.dependencies['@omega-edit/client']
+) {
+  vscodeExtensionPackageJson.dependencies['@omega-edit/client'] = `^${version}`
+}
+fs.writeFileSync(
+  vscodeExtensionPackageJsonPath,
+  JSON.stringify(vscodeExtensionPackageJson, null, 2) + '\n'
+)
+
 console.log(`Updated all package.json files to version ${version}`)


### PR DESCRIPTION
## What changed
- make the tagged release quality gate wait for all four VS Code extension checks
- update the release gate to use the current Biome check name
- include `examples/vscode-extension/package.json` in `sync-version.js`
- align the VS Code extension package and lockfile version with the repo version

## Why
The release workflow now publishes a `.vsix`, so the release gate should block on the extension matrix checks too. The gate was also still watching an old Biome check name. Separately, the extension package version was still `0.1.0`, which would have produced mismatched release assets for future tags.

## Impact
Tagged releases should now stop if the VS Code extension checks are red, and the extension `.vsix` version will track the project version during release prep.

## Validation
- `yarn lint`
- `npm run compile` in `examples/vscode-extension`
- `npm run test:unit` in `examples/vscode-extension`
- verified `.vsix` packaging succeeds in a clean temporary worktree
