### PR TITLE
Refresh release versioning directions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,8 @@ yarn sync-version
 ```
 
 This propagates the version to all `package.json` files and CMake
-configuration. See `VERSION_MANAGEMENT.md` for full details.
+configuration, including the VS Code extension example. See
+`VERSION_MANAGEMENT.md` for full details.
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -245,12 +245,19 @@ Node packages will be in `.tgz` files located at:
 /packages/ai/omega-edit-node-ai-${VERSION}.tgz
 ```
 
+Tagged releases also attach the VS Code extension example as:
+
+```
+omega-edit-hex-editor-v${VERSION}.vsix
+```
+
 More information about the node packages can be found in the [packages](packages/README.md) folder.
 
 ## Release Binaries
 
 [Binary releases](https://github.com/ctc-oss/omega-edit/releases) for macOS (Apple Silicon and x86), Windows (x86), and
-Linux (ARM, and x86; glibc 2.31 or greater required) are built and published via GitHub CI workflows.
+Linux (ARM, and x86; glibc 2.31 or greater required) are built and published via GitHub CI workflows. Tagged releases
+also attach the reference VS Code extension as a `.vsix` asset.
 
 Known limitation: Windows client integration tests do not currently cover emoji filenames end-to-end, even though native filesystem coverage exists for those paths.
 

--- a/VERSION_MANAGEMENT.md
+++ b/VERSION_MANAGEMENT.md
@@ -25,7 +25,10 @@ This will automatically update:
 - Root `package.json`
 - `packages/client/package.json`
 - `packages/server/package.json`
+- `examples/vscode-extension/package.json`
+- `examples/vscode-extension/package-lock.json` metadata
 - Client-server dependency versions
+- VS Code extension client dependency version
 
 ## Build System Integration
 
@@ -39,12 +42,19 @@ The Node.js packages use the `sync-version.js` script to maintain version consis
 - Workspace packages
 - Inter-package dependencies
 - Generated client version files
+- The VS Code extension example package and its lockfile metadata
+
+### VS Code Extension Release Asset
+The VS Code extension example uses the synced version in:
+- `examples/vscode-extension/package.json`
+- GitHub release asset naming for the generated `.vsix`
 
 ## Automated Version Management
 
 The version sync script ensures:
 - All package.json files have consistent versions
 - Client-server dependency versions are properly aligned
+- The VS Code extension package stays aligned with the repo version
 - Build artifacts use the correct version number
 
 ## Integration with Git Tags

--- a/sync-version.js
+++ b/sync-version.js
@@ -77,4 +77,25 @@ fs.writeFileSync(
   JSON.stringify(vscodeExtensionPackageJson, null, 2) + '\n'
 )
 
+// Update VS Code extension example package-lock.json metadata when present
+const vscodeExtensionPackageLockPath = path.join(
+  __dirname,
+  'examples',
+  'vscode-extension',
+  'package-lock.json'
+)
+if (fs.existsSync(vscodeExtensionPackageLockPath)) {
+  const vscodeExtensionPackageLock = JSON.parse(
+    fs.readFileSync(vscodeExtensionPackageLockPath, 'utf8')
+  )
+  vscodeExtensionPackageLock.version = version
+  if (vscodeExtensionPackageLock.packages?.['']) {
+    vscodeExtensionPackageLock.packages[''].version = version
+  }
+  fs.writeFileSync(
+    vscodeExtensionPackageLockPath,
+    JSON.stringify(vscodeExtensionPackageLock, null, 2) + '\n'
+  )
+}
+
 console.log(`Updated all package.json files to version ${version}`)


### PR DESCRIPTION
## What changed
- update the root version-management docs to include the VS Code extension example
- document that tagged releases attach the `.vsix` asset
- make `sync-version.js` update the VS Code extension lockfile metadata as well as the package manifest

## Why
We are preparing to cut a new release soon, and the written release/versioning directions on `main` were still missing the VS Code extension details. This keeps the docs aligned with the current release workflow and reduces the chance of version mismatches during release prep.

## Validation
- `node sync-version.js`
- `yarn lint`
