### PR TITLE
Harden release dependency graph

### DIFF
--- a/examples/vscode-extension/package-lock.json
+++ b/examples/vscode-extension/package-lock.json
@@ -1449,9 +1449,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4395,16 +4395,6 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -4683,13 +4673,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {

--- a/examples/vscode-extension/package.json
+++ b/examples/vscode-extension/package.json
@@ -130,6 +130,12 @@
   "dependencies": {
     "@omega-edit/client": "^1.0.1"
   },
+  "overrides": {
+    "mocha": {
+      "brace-expansion": "2.0.3",
+      "serialize-javascript": "7.0.5"
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@vscode/vsce": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,19 @@
   },
   "resolutions": {
     "@types/eslint-scope": "8.4.0",
-    "@types/glob": "9.0.0"
+    "@types/glob": "9.0.0",
+    "copy-webpack-plugin/**/ajv": "8.18.0",
+    "copy-webpack-plugin/**/picomatch": "4.0.4",
+    "copy-webpack-plugin/serialize-javascript": "7.0.5",
+    "mocha/**/minimatch": "5.1.8",
+    "mocha/**/picomatch": "2.3.2",
+    "mocha/**/diff": "5.2.2",
+    "mocha/serialize-javascript": "7.0.5",
+    "ts-loader/**/picomatch": "2.3.2",
+    "webpack/**/ajv": "8.18.0",
+    "mocha/**/brace-expansion": "2.0.3",
+    "c8/**/brace-expansion": "5.0.5",
+    "globby/**/brace-expansion": "1.1.13",
+    "rimraf/**/brace-expansion": "1.1.13"
   }
 }

--- a/packages/client/tests/specs/clientUtilities.spec.ts
+++ b/packages/client/tests/specs/clientUtilities.spec.ts
@@ -22,7 +22,7 @@ import * as net from 'net'
 import * as os from 'os'
 import * as path from 'path'
 import { expect, initChai } from './common.js'
-import { overrideProperty } from './mockHelpers.js'
+import { overrideProperty, silenceClientLogger } from './mockHelpers.js'
 import { getModuleCompat } from './moduleCompat.js'
 
 const { require } = getModuleCompat(import.meta.url)
@@ -45,11 +45,18 @@ const {
 } = clientPackage
 
 describe('Client Utilities', () => {
+  let restoreLogger = () => {}
+
   before(async () => {
     await initChai()
   })
 
+  beforeEach(() => {
+    restoreLogger = silenceClientLogger(require)
+  })
+
   afterEach(() => {
+    restoreLogger()
     resetClient()
     delete process.env.OMEGA_EDIT_SERVER_URI
     delete process.env.OMEGA_EDIT_SERVER_SOCKET

--- a/packages/client/tests/specs/mockHelpers.ts
+++ b/packages/client/tests/specs/mockHelpers.ts
@@ -1,3 +1,5 @@
+import pino from 'pino'
+
 export function overrideProperty(
   target: Record<string, any>,
   key: string,
@@ -28,4 +30,22 @@ export function expectErrorMessage(
 ) {
   expect(err).to.be.instanceOf(Error)
   expect((err as Error).message).to.equal(message)
+}
+
+export function silenceClientLogger(requireFn: NodeRequire): () => void {
+  const loggerModule = requireFn(
+    '../../dist/cjs/logger.js'
+  ) as typeof import('../../src/logger')
+  const originalLogger = loggerModule.getLogger()
+  loggerModule.setLogger(
+    pino(
+      {
+        level: 'silent',
+      },
+      pino.destination(2)
+    )
+  )
+  return () => {
+    loggerModule.setLogger(originalLogger)
+  }
 }

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -21,16 +21,14 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { expect, initChai } from './common.js'
-import { overrideProperty } from './mockHelpers.js'
+import { overrideProperty, silenceClientLogger } from './mockHelpers.js'
 import { getModuleCompat } from './moduleCompat.js'
 
 const { require } = getModuleCompat(import.meta.url)
 const clientPackage =
   require('../../dist/cjs/index.js') as typeof import('../../src/index')
-const clientModule =
-  require('../../dist/cjs/client.js') as typeof import('../../src/client')
-const serverModule =
-  require('../../dist/cjs/server.js') as typeof import('../../src/server')
+let clientModule: typeof import('../../src/client')
+let serverModule: typeof import('../../src/server')
 const {
   delay,
   findFirstAvailablePort,
@@ -46,14 +44,28 @@ const {
 } = clientPackage
 
 describe('Server Edge Cases', () => {
+  let restoreLogger = () => {}
+
   before(async () => {
     await initChai()
+    delete require.cache[require.resolve('../../dist/cjs/logger.js')]
+    delete require.cache[require.resolve('../../dist/cjs/client.js')]
+    delete require.cache[require.resolve('../../dist/cjs/server.js')]
+    restoreLogger = silenceClientLogger(require)
+    clientModule =
+      require('../../dist/cjs/client.js') as typeof import('../../src/client')
+    serverModule =
+      require('../../dist/cjs/server.js') as typeof import('../../src/server')
   })
 
   afterEach(() => {
     resetClient()
     delete process.env.OMEGA_EDIT_SERVER_URI
     delete process.env.OMEGA_EDIT_SERVER_SOCKET
+  })
+
+  after(() => {
+    restoreLogger()
   })
 
   it('should start a source server with a stale pid file and query info endpoints', async () => {

--- a/packages/client/tests/specs/sessionEdgeCases.spec.ts
+++ b/packages/client/tests/specs/sessionEdgeCases.spec.ts
@@ -22,16 +22,35 @@ import {
   expectErrorMessage,
   makeObjectIdResponse,
   overrideProperty,
+  silenceClientLogger,
 } from './mockHelpers.js'
 import { getModuleCompat } from './moduleCompat.js'
 
 const { require } = getModuleCompat(import.meta.url)
-const clientModule =
-  require('../../dist/cjs/client.js') as typeof import('../../src/client')
-const sessionModule =
-  require('../../dist/cjs/session.js') as typeof import('../../src/session')
+let clientModule: typeof import('../../src/client')
+let sessionModule: typeof import('../../src/session')
 
 describe('Session Edge Cases', () => {
+  let restoreLogger = () => {}
+
+  before(() => {
+    delete require.cache[require.resolve('../../dist/cjs/logger.js')]
+    delete require.cache[require.resolve('../../dist/cjs/client.js')]
+    delete require.cache[require.resolve('../../dist/cjs/session.js')]
+    delete require.cache[
+      require.resolve('../../dist/cjs/protobuf_ts/session.js')
+    ]
+    restoreLogger = silenceClientLogger(require)
+    clientModule =
+      require('../../dist/cjs/client.js') as typeof import('../../src/client')
+    sessionModule =
+      require('../../dist/cjs/session.js') as typeof import('../../src/session')
+  })
+
+  after(() => {
+    restoreLogger()
+  })
+
   it('should reject createSession and saveSession failures', async () => {
     const restoreGetClient = overrideProperty(
       clientModule as Record<string, any>,

--- a/packages/client/tests/specs/viewportEdgeCases.spec.ts
+++ b/packages/client/tests/specs/viewportEdgeCases.spec.ts
@@ -22,16 +22,35 @@ import {
   expectErrorMessage,
   makeObjectIdResponse,
   overrideProperty,
+  silenceClientLogger,
 } from './mockHelpers.js'
 import { getModuleCompat } from './moduleCompat.js'
 
 const { require } = getModuleCompat(import.meta.url)
-const clientModule =
-  require('../../dist/cjs/client.js') as typeof import('../../src/client')
-const viewportModule =
-  require('../../dist/cjs/viewport.js') as typeof import('../../src/viewport')
+let clientModule: typeof import('../../src/client')
+let viewportModule: typeof import('../../src/viewport')
 
 describe('Viewport Edge Cases', () => {
+  let restoreLogger = () => {}
+
+  before(() => {
+    delete require.cache[require.resolve('../../dist/cjs/logger.js')]
+    delete require.cache[require.resolve('../../dist/cjs/client.js')]
+    delete require.cache[require.resolve('../../dist/cjs/viewport.js')]
+    delete require.cache[
+      require.resolve('../../dist/cjs/protobuf_ts/viewport.js')
+    ]
+    restoreLogger = silenceClientLogger(require)
+    clientModule =
+      require('../../dist/cjs/client.js') as typeof import('../../src/client')
+    viewportModule =
+      require('../../dist/cjs/viewport.js') as typeof import('../../src/viewport')
+  })
+
+  after(() => {
+    restoreLogger()
+  })
+
   it('should reject createViewport, modifyViewport, and destroyViewport failures', async () => {
     const restoreGetClient = overrideProperty(
       clientModule as Record<string, any>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,10 +610,10 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^8.0.0, ajv@^8.9.0:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+ajv@8.18.0, ajv@^8.0.0, ajv@^8.9.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
+  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -699,25 +699,25 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+brace-expansion@1.1.13, brace-expansion@^1.1.7:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.13.tgz#d37875c01dc9eff988dd49d112a57cb67b54efe6"
+  integrity sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+brace-expansion@2.0.3, brace-expansion@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
+  integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
   dependencies:
     balanced-match "^1.0.0"
 
-brace-expansion@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.2.tgz#b6c16d0791087af6c2bc463f52a8142046c06b6f"
-  integrity sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==
+brace-expansion@5.0.5, brace-expansion@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -945,15 +945,15 @@ detect-libc@^2.0.0:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.4.tgz#f04715b8ba815e53b4d8109655b6508a6865a7e8"
   integrity sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==
 
+diff@5.2.2, diff@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.2.tgz#0a4742797281d09cfa699b79ea32d27723623bad"
+  integrity sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
-
-diff@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
-  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 electron-to-chromium@^1.5.263:
   version "1.5.267"
@@ -1514,6 +1514,13 @@ mime-types@^2.1.27:
   dependencies:
     mime-db "1.52.0"
 
+minimatch@5.1.8, minimatch@^5.0.1, minimatch@^5.1.6:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.8.tgz#32a16ebcccd6421c674430acb199b8806c68169b"
+  integrity sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^10.2.2, minimatch@^10.2.4:
   version "10.2.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.4.tgz#465b3accbd0218b8281f5301e27cedc697f96fde"
@@ -1527,13 +1534,6 @@ minimatch@^3.1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@^5.0.1, minimatch@^5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
 
 minimist@^1.2.6:
   version "1.2.8"
@@ -1715,15 +1715,15 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@2.3.2, picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-picomatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
-  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+picomatch@4.0.4, picomatch@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -1823,13 +1823,6 @@ quick-format-unescaped@^4.0.3:
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
   integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
 
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
-
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -1900,11 +1893,6 @@ run-script-os@^1.1.6:
   resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.1.6.tgz#8b0177fb1b54c99a670f95c7fdc54f18b9c72347"
   integrity sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==
 
-safe-buffer@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 safe-stable-stringify@^2.3.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
@@ -1930,17 +1918,10 @@ semver@^7.5.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^7.0.3:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.4.tgz#c517735bd5b7631dd1fc191ee19cbb713ff8e05c"
-  integrity sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==
+serialize-javascript@7.0.5, serialize-javascript@^6.0.2, serialize-javascript@^7.0.3:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## What changed
- harden the root Yarn workspace with scoped `resolutions` for vulnerable transitive packages under `mocha`, `copy-webpack-plugin`, `ts-loader`, `webpack`, `c8`, `globby`, and `rimraf`
- harden the VS Code extension's npm graph with scoped `overrides` for `mocha` transitive dependencies
- refresh both lockfiles so the patched versions are actually installed

## Why
We are close to a release and the dependency graph still had open security findings in both the root workspace and the VS Code extension package. This keeps the fix surface narrow by lifting only patch-level transitive versions instead of taking broad toolchain upgrades right before release.

## Impact
- root `yarn audit` is clean locally
- `examples/vscode-extension` `npm audit` is clean locally
- the VS Code extension still compiles, tests, and packages into a `.vsix`

## Validation
- `yarn lint`
- `yarn audit --level low`
- `npm run compile` in `examples/vscode-extension`
- `npm run test:unit` in `examples/vscode-extension`
- `npm run package:vsix` in `examples/vscode-extension`
- `npm audit` in `examples/vscode-extension`
