### PR TITLE
Make tsconfig compatible with TypeScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "run-script-os": "^1.1.6",
     "ts-loader": "^9.5.4",
     "typedoc": "^0.28.18",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "webpack": "^5.105.4",
     "webpack-cli": "^7.0.2"
   },

--- a/packages/ai/tsconfig.base.json
+++ b/packages/ai/tsconfig.base.json
@@ -4,7 +4,7 @@
     "target": "es2020",
     "lib": ["es2020"],
     "rootDir": "src",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/ai/tsconfig.cjs.json
+++ b/packages/ai/tsconfig.cjs.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "outDir": "dist/cjs"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,9 +9,14 @@
   "typings": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "files": [

--- a/packages/client/tsconfig.base.json
+++ b/packages/client/tsconfig.base.json
@@ -21,10 +21,9 @@
     "target": "es6",
     "lib": ["es6", "es2021", "es2017"],
     "rootDir": "src",
-    "baseUrl": ".",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "paths": {
-      "@omega-edit/server": ["src/shims/omega-edit-server"]
+      "@omega-edit/server": ["./src/shims/omega-edit-server"]
     },
     "strict": true,
     "noImplicitReturns": true,

--- a/packages/client/tsconfig.cjs.json
+++ b/packages/client/tsconfig.cjs.json
@@ -18,7 +18,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "outDir": "dist/cjs"
   }
 }

--- a/packages/client/tsconfig.tests.esm.json
+++ b/packages/client/tsconfig.tests.esm.json
@@ -20,8 +20,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "rootDir": ".",
     "types": ["node", "mocha"]

--- a/packages/client/tsconfig.tests.json
+++ b/packages/client/tsconfig.tests.json
@@ -20,8 +20,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "rootDir": ".",
     "types": ["node", "mocha"]

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -21,6 +21,7 @@
     "target": "es6",
     "outDir": "out",
     "lib": ["es6", "es2021", "es2017"],
+    "types": ["node"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,

--- a/scripts/write-dist-package-jsons.js
+++ b/scripts/write-dist-package-jsons.js
@@ -58,6 +58,7 @@ const targets = [
     manifest: {
       type: 'commonjs',
       main: './index.js',
+      types: './index.d.ts',
     },
   },
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,10 +2154,10 @@ typescript@^3.9:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^5.9.3:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.2.tgz#0b1bfb15f68c64b97032f3d78abbf98bdbba501f"
+  integrity sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## What changed

This updates the TypeScript workspace configs so the repo can move to TypeScript 6 without changing application code.

- add explicit Node types to `@omega-edit/server`
- switch the client and AI workspace configs away from deprecated `moduleResolution: "node"`
- remove the deprecated client `baseUrl` usage and keep the existing path alias working
- update the client test configs to TS 6-safe module settings without forcing `.js` import rewrites

## Why

The TypeScript 6 upgrade PR was failing due to configuration changes in TS 6 rather than code-level incompatibilities.

The main issues were:

- `packages/server` relied on implicit Node globals/types
- `packages/client` and `packages/ai` still used deprecated `moduleResolution: "node"`
- `packages/client` also relied on deprecated `baseUrl`

## Impact

This keeps the upgrade scoped to packaging and compiler configuration chores.

No application logic or runtime behavior is intended to change.

## Validation

Verified with `typescript@6.0.2`:

- `tsc -p packages/server/tsconfig.json --noEmit`
- `tsc -p packages/client/tsconfig.cjs.json --noEmit`
- `tsc -p packages/client/tsconfig.esm.json --noEmit`
- `tsc -p packages/client/tsconfig.tests.esm.json --noEmit`
- `tsc -p packages/ai/tsconfig.cjs.json --noEmit`
- `tsc -p packages/ai/tsconfig.esm.json --noEmit`
- `tsc -p examples/vscode-extension/tsconfig.json --noEmit`

## Root cause

TypeScript 6 tightens config defaults and surfaces deprecations that TS 5 tolerated. The repo was still depending on those older assumptions in a few workspace tsconfigs.
