### PR TITLE
Support shared file-backed sessions

### DIFF
--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -244,8 +244,8 @@ export interface IEditorServiceClient {
     ) => void
   ): grpc.ClientUnaryCall
   /**
-   * Destroy a session and release all associated resources (viewports,
-   * checkpoints, and change history).
+   * Detach the caller from a session. The backing session and its resources
+   * are released when the last attachment is destroyed or reaped.
    *
    * @generated from protobuf rpc: DestroySession
    */
@@ -1496,7 +1496,7 @@ export interface IEditorServiceClient {
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToViewportEventsResponse>
   /**
-   * Cancel an active session-event subscription.
+   * Cancel all active session-event subscriptions for the session ID.
    *
    * @generated from protobuf rpc: UnsubscribeToSessionEvents
    */
@@ -1728,8 +1728,8 @@ export class EditorServiceClient
     )
   }
   /**
-   * Destroy a session and release all associated resources (viewports,
-   * checkpoints, and change history).
+   * Detach the caller from a session. The backing session and its resources
+   * are released when the last attachment is destroyed or reaped.
    *
    * @generated from protobuf rpc: DestroySession
    */
@@ -3043,7 +3043,7 @@ export class EditorServiceClient
     )
   }
   /**
-   * Cancel an active session-event subscription.
+   * Cancel all active session-event subscriptions for the session ID.
    *
    * @generated from protobuf rpc: UnsubscribeToSessionEvents
    */

--- a/packages/client/tests/specs/editing.spec.ts
+++ b/packages/client/tests/specs/editing.spec.ts
@@ -125,6 +125,10 @@ describe('Editing', () => {
       secondStream.on('error', registerStreamError)
 
       try {
+        // Give the streaming RPCs a moment to reach the server before the
+        // first edit so slower macOS runners don't miss the initial event.
+        await delay(200)
+
         const firstChangeSerial = await insert(session_id, 0, Buffer.from('A'))
         await waitForAssertion(() => {
           expect(firstSubscriberSerials).to.deep.equal([firstChangeSerial])

--- a/packages/client/tests/specs/editing.spec.ts
+++ b/packages/client/tests/specs/editing.spec.ts
@@ -153,6 +153,66 @@ describe('Editing', () => {
         await delay(50)
       }
     })
+
+    it('should honor per-subscriber session event interests', async () => {
+      const client = await getClient()
+      const editSubscriberEvents: number[] = []
+      const clearSubscriberEvents: number[] = []
+      const unexpectedStreamErrors: Error[] = []
+
+      const registerStreamError = (error: Error) => {
+        if (!isExpectedStreamCancellation(error)) {
+          unexpectedStreamErrors.push(error)
+        }
+      }
+
+      const editStream = client.subscribeToSessionEvents(
+        new EventSubscriptionRequest()
+          .setId(session_id)
+          .setInterest(SessionEventKind.SESSION_EVT_EDIT)
+      )
+      const clearStream = client.subscribeToSessionEvents(
+        new EventSubscriptionRequest()
+          .setId(session_id)
+          .setInterest(SessionEventKind.SESSION_EVT_CLEAR)
+      )
+
+      editStream.on('data', (event) => {
+        editSubscriberEvents.push(event.getSessionEventKind())
+      })
+      editStream.on('error', registerStreamError)
+      clearStream.on('data', (event) => {
+        clearSubscriberEvents.push(event.getSessionEventKind())
+      })
+      clearStream.on('error', registerStreamError)
+
+      try {
+        await delay(200)
+
+        await insert(session_id, 0, Buffer.from('A'))
+        await waitForAssertion(() => {
+          expect(editSubscriberEvents).to.deep.equal([
+            SessionEventKind.SESSION_EVT_EDIT,
+          ])
+          expect(clearSubscriberEvents).to.deep.equal([])
+        })
+
+        await clear(session_id)
+        await waitForAssertion(() => {
+          expect(editSubscriberEvents).to.deep.equal([
+            SessionEventKind.SESSION_EVT_EDIT,
+          ])
+          expect(clearSubscriberEvents).to.deep.equal([
+            SessionEventKind.SESSION_EVT_CLEAR,
+          ])
+        })
+        expect(unexpectedStreamErrors).to.deep.equal([])
+      } finally {
+        editStream.cancel()
+        clearStream.cancel()
+        await delay(50)
+      }
+    })
   })
 
   describe('Insert', () => {

--- a/packages/client/tests/specs/editing.spec.ts
+++ b/packages/client/tests/specs/editing.spec.ts
@@ -21,6 +21,7 @@ import {
   ALL_EVENTS,
   ChangeKind,
   clear,
+  delay,
   del,
   edit,
   editSimple,
@@ -28,8 +29,10 @@ import {
   editOperations,
   EditOperationType,
   EditStats,
+  EventSubscriptionRequest,
   getChangeCount,
   getChangeTransactionCount,
+  getClient,
   getComputedFileSize,
   getLastChange,
   getSegment,
@@ -49,6 +52,34 @@ import {
   testPort,
 } from './common.js'
 
+async function waitForAssertion(
+  assertion: () => void,
+  timeoutMs: number = 2000,
+  intervalMs: number = 25
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+
+  while (Date.now() < deadline) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await delay(intervalMs)
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError
+  }
+  throw new Error('Timed out waiting for assertion to pass')
+}
+
+function isExpectedStreamCancellation(error: Error): boolean {
+  return /cancelled|canceled|ECONNRESET/i.test(error.message)
+}
+
 describe('Editing', () => {
   let session_id = ''
 
@@ -58,6 +89,66 @@ describe('Editing', () => {
 
   afterEach('Destroy session', async () => {
     await destroyTestSession(session_id)
+  })
+
+  describe('Session Events', () => {
+    it('should keep remaining subscribers active after one session stream disconnects', async () => {
+      const client = await getClient()
+      const firstSubscriberSerials: number[] = []
+      const secondSubscriberSerials: number[] = []
+      const unexpectedStreamErrors: Error[] = []
+
+      const registerStreamError = (error: Error) => {
+        if (!isExpectedStreamCancellation(error)) {
+          unexpectedStreamErrors.push(error)
+        }
+      }
+
+      const firstStream = client.subscribeToSessionEvents(
+        new EventSubscriptionRequest()
+          .setId(session_id)
+          .setInterest(SessionEventKind.SESSION_EVT_EDIT)
+      )
+      const secondStream = client.subscribeToSessionEvents(
+        new EventSubscriptionRequest()
+          .setId(session_id)
+          .setInterest(SessionEventKind.SESSION_EVT_EDIT)
+      )
+
+      firstStream.on('data', (event) => {
+        firstSubscriberSerials.push(event.getSerial())
+      })
+      firstStream.on('error', registerStreamError)
+      secondStream.on('data', (event) => {
+        secondSubscriberSerials.push(event.getSerial())
+      })
+      secondStream.on('error', registerStreamError)
+
+      try {
+        const firstChangeSerial = await insert(session_id, 0, Buffer.from('A'))
+        await waitForAssertion(() => {
+          expect(firstSubscriberSerials).to.deep.equal([firstChangeSerial])
+          expect(secondSubscriberSerials).to.deep.equal([firstChangeSerial])
+        })
+
+        firstStream.cancel()
+        await delay(700)
+
+        const secondChangeSerial = await insert(session_id, 1, Buffer.from('B'))
+        await waitForAssertion(() => {
+          expect(firstSubscriberSerials).to.deep.equal([firstChangeSerial])
+          expect(secondSubscriberSerials).to.deep.equal([
+            firstChangeSerial,
+            secondChangeSerial,
+          ])
+        })
+        expect(unexpectedStreamErrors).to.deep.equal([])
+      } finally {
+        firstStream.cancel()
+        secondStream.cancel()
+        await delay(50)
+      }
+    })
   })
 
   describe('Insert', () => {

--- a/packages/client/tests/specs/editing.spec.ts
+++ b/packages/client/tests/specs/editing.spec.ts
@@ -158,6 +158,7 @@ describe('Editing', () => {
       const client = await getClient()
       const editSubscriberEvents: number[] = []
       const clearSubscriberEvents: number[] = []
+      const allExceptEditSubscriberEvents: number[] = []
       const unexpectedStreamErrors: Error[] = []
 
       const registerStreamError = (error: Error) => {
@@ -176,6 +177,11 @@ describe('Editing', () => {
           .setId(session_id)
           .setInterest(SessionEventKind.SESSION_EVT_CLEAR)
       )
+      const allExceptEditStream = client.subscribeToSessionEvents(
+        new EventSubscriptionRequest()
+          .setId(session_id)
+          .setInterest(ALL_EVENTS & ~SessionEventKind.SESSION_EVT_EDIT)
+      )
 
       editStream.on('data', (event) => {
         editSubscriberEvents.push(event.getSessionEventKind())
@@ -185,6 +191,10 @@ describe('Editing', () => {
         clearSubscriberEvents.push(event.getSessionEventKind())
       })
       clearStream.on('error', registerStreamError)
+      allExceptEditStream.on('data', (event) => {
+        allExceptEditSubscriberEvents.push(event.getSessionEventKind())
+      })
+      allExceptEditStream.on('error', registerStreamError)
 
       try {
         await delay(200)
@@ -195,6 +205,7 @@ describe('Editing', () => {
             SessionEventKind.SESSION_EVT_EDIT,
           ])
           expect(clearSubscriberEvents).to.deep.equal([])
+          expect(allExceptEditSubscriberEvents).to.deep.equal([])
         })
 
         await clear(session_id)
@@ -205,11 +216,15 @@ describe('Editing', () => {
           expect(clearSubscriberEvents).to.deep.equal([
             SessionEventKind.SESSION_EVT_CLEAR,
           ])
+          expect(allExceptEditSubscriberEvents).to.deep.equal([
+            SessionEventKind.SESSION_EVT_CLEAR,
+          ])
         })
         expect(unexpectedStreamErrors).to.deep.equal([])
       } finally {
         editStream.cancel()
         clearStream.cancel()
+        allExceptEditStream.cancel()
         await delay(50)
       }
     })

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -324,6 +324,32 @@ describe('Server Heartbeat Timeout', () => {
     // Stop activity and verify it eventually expires.
     await waitForSessionCount(0, 2000)
   })
+
+  it(`on port ${serverTestPort} should not extend shared session lifetime when one author detaches`, async () => {
+    const tempDir = await fsPromises.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-heartbeat-')
+    )
+    const sharedFilePath = path.join(tempDir, 'shared-session.txt')
+
+    try {
+      await fsPromises.writeFile(sharedFilePath, 'shared heartbeat test')
+      const author1 = await createSession(sharedFilePath)
+      const author2 = await createSession(sharedFilePath)
+      const sharedSessionId = author1.getSessionId()
+
+      expect(author2.getSessionId()).to.equal(sharedSessionId)
+      expect(await getSessionCount()).to.equal(1)
+
+      // Detaching one author should not count as activity for the shared
+      // session, so the remaining idle attachment should still expire on the
+      // original timeout schedule.
+      await delay(100)
+      expect(await destroySession(sharedSessionId)).to.equal(sharedSessionId)
+      await waitForSessionCount(0, 175)
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('Server Shutdown When No Sessions', () => {

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -346,9 +346,10 @@ describe('Server Heartbeat Timeout', () => {
       // after the timeout, not one attachment per cleanup interval. Using
       // several attachments widens the regression gap on slower macOS runners:
       // a buggy detach-per-cycle implementation needs multiple extra reaper
-      // ticks before teardown completes.
+      // ticks before teardown completes. Allow a wider observation window so
+      // cleanup cadence and scheduler jitter do not make this assertion flaky.
       await delay(625)
-      await waitForSessionCount(0, 50)
+      await waitForSessionCount(0, 250)
     } finally {
       await fsPromises.rm(tempDir, { recursive: true, force: true })
     }

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -333,15 +333,21 @@ describe('Server Heartbeat Timeout', () => {
 
     try {
       await fsPromises.writeFile(sharedFilePath, 'shared heartbeat test')
-      const author1 = await createSession(sharedFilePath)
-      const author2 = await createSession(sharedFilePath)
+      const authors = await Promise.all(
+        Array.from({ length: 5 }, () => createSession(sharedFilePath))
+      )
 
-      expect(author2.getSessionId()).to.equal(author1.getSessionId())
+      for (const author of authors.slice(1)) {
+        expect(author.getSessionId()).to.equal(authors[0].getSessionId())
+      }
       expect(await getSessionCount()).to.equal(1)
 
       // A shared session should be fully reaped on the first cleanup pass
-      // after the timeout, not one attachment per cleanup interval.
-      await delay(525)
+      // after the timeout, not one attachment per cleanup interval. Using
+      // several attachments widens the regression gap on slower macOS runners:
+      // a buggy detach-per-cycle implementation needs multiple extra reaper
+      // ticks before teardown completes.
+      await delay(625)
       await waitForSessionCount(0, 50)
     } finally {
       await fsPromises.rm(tempDir, { recursive: true, force: true })

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -325,6 +325,29 @@ describe('Server Heartbeat Timeout', () => {
     await waitForSessionCount(0, 2000)
   })
 
+  it(`on port ${serverTestPort} should reap an idle shared session in a single timeout window`, async () => {
+    const tempDir = await fsPromises.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-heartbeat-shared-idle-')
+    )
+    const sharedFilePath = path.join(tempDir, 'shared-session.txt')
+
+    try {
+      await fsPromises.writeFile(sharedFilePath, 'shared heartbeat test')
+      const author1 = await createSession(sharedFilePath)
+      const author2 = await createSession(sharedFilePath)
+
+      expect(author2.getSessionId()).to.equal(author1.getSessionId())
+      expect(await getSessionCount()).to.equal(1)
+
+      // A shared session should be fully reaped on the first cleanup pass
+      // after the timeout, not one attachment per cleanup interval.
+      await delay(525)
+      await waitForSessionCount(0, 50)
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
   it(`on port ${serverTestPort} should not extend shared session lifetime when one author detaches`, async () => {
     const tempDir = await fsPromises.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-heartbeat-')

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -219,7 +219,7 @@ describe('Server Heartbeat Timeout', () => {
   )
 
   const heartbeat: HeartbeatOptions = {
-    sessionTimeoutMs: 200,
+    sessionTimeoutMs: 500,
     cleanupIntervalMs: 50,
     shutdownWhenNoSessions: false,
   }
@@ -342,12 +342,12 @@ describe('Server Heartbeat Timeout', () => {
 
       // Detaching one author should not count as activity for the shared
       // session, so the remaining idle attachment should still expire on the
-      // original timeout schedule. Wait until the session is already close to
-      // expiring so the "correct" and "regressed" outcomes are separated by a
-      // much wider margin on slower macOS runners.
-      await delay(175)
+      // original timeout schedule. Use a wider timeout window here so the
+      // correct behavior and a detach-driven refresh stay far apart even on
+      // slower macOS runners.
+      await delay(425)
       expect(await destroySession(sharedSessionId)).to.equal(sharedSessionId)
-      await waitForSessionCount(0, 125)
+      await waitForSessionCount(0, 250)
     } finally {
       await fsPromises.rm(tempDir, { recursive: true, force: true })
     }

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -342,10 +342,12 @@ describe('Server Heartbeat Timeout', () => {
 
       // Detaching one author should not count as activity for the shared
       // session, so the remaining idle attachment should still expire on the
-      // original timeout schedule.
-      await delay(100)
+      // original timeout schedule. Wait until the session is already close to
+      // expiring so the "correct" and "regressed" outcomes are separated by a
+      // much wider margin on slower macOS runners.
+      await delay(175)
       expect(await destroySession(sharedSessionId)).to.equal(sharedSessionId)
-      await waitForSessionCount(0, 175)
+      await waitForSessionCount(0, 125)
     } finally {
       await fsPromises.rm(tempDir, { recursive: true, force: true })
     }

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -870,6 +870,70 @@ describe('Sessions', () => {
     expect(fs.existsSync(checkpointDir)).to.be.false
   })
 
+  it('Should only share file-backed sessions when checkpoint directories are compatible', async () => {
+    const sharedCheckpointDir = path.join(
+      __dirname,
+      'data',
+      'shared-checkpoint'
+    )
+    const conflictingCheckpointDir = path.join(
+      __dirname,
+      'data',
+      'conflicting-checkpoint'
+    )
+    let sharedSessionId = ''
+
+    removeDirectory(sharedCheckpointDir)
+    removeDirectory(conflictingCheckpointDir)
+
+    try {
+      const author1 = await createSession(testFile, '', sharedCheckpointDir)
+      const author2 = await createSession(testFile, '', sharedCheckpointDir)
+      sharedSessionId = author1.getSessionId()
+
+      expect(author2.getSessionId()).to.equal(sharedSessionId)
+      expect(author1.getCheckpointDirectory()).to.equal(sharedCheckpointDir)
+      expect(author2.getCheckpointDirectory()).to.equal(sharedCheckpointDir)
+      expect(await getSessionCount()).to.equal(1)
+      expect(fs.existsSync(sharedCheckpointDir)).to.be.true
+      expect(
+        await countMatchingFilesInDir(sharedCheckpointDir, '.OmegaEdit-orig.*')
+      ).to.equal(1)
+
+      let conflictingCreateError: Error | undefined
+      try {
+        await createSession(testFile, '', conflictingCheckpointDir)
+        expect.fail(
+          'createSession should reject when a shared file-backed session requests a different checkpoint directory'
+        )
+      } catch (error) {
+        conflictingCreateError = error as Error
+      }
+
+      expect(conflictingCreateError).to.exist
+      expect(conflictingCreateError?.message).to.include('ALREADY_EXISTS')
+      expect(await getSessionCount()).to.equal(1)
+      expect(fs.existsSync(conflictingCheckpointDir)).to.be.false
+    } finally {
+      while (sharedSessionId && (await getSessionCount()) > 0) {
+        expect(await destroySession(sharedSessionId)).to.equal(sharedSessionId)
+      }
+
+      if (fs.existsSync(sharedCheckpointDir)) {
+        expect(
+          await countMatchingFilesInDir(sharedCheckpointDir, '.OmegaEdit-orig.*')
+        ).to.equal(0)
+        removeDirectory(sharedCheckpointDir)
+      }
+      if (fs.existsSync(conflictingCheckpointDir)) {
+        removeDirectory(conflictingCheckpointDir)
+      }
+    }
+
+    expect(fs.existsSync(sharedCheckpointDir)).to.be.false
+    expect(fs.existsSync(conflictingCheckpointDir)).to.be.false
+  })
+
   it('Should create a clean baseline session from bytes', async () => {
     const memoryCheckpointDir = path.join(
       __dirname,

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -35,6 +35,7 @@ import {
   getSessionBytes,
   getServerHeartbeat,
   getSessionCount,
+  getViewportData,
   getViewportCount,
   insert,
   IOFlags,
@@ -217,6 +218,68 @@ describe('Sessions', () => {
       await destroySession(session_id)
       expect(await getSessionCount()).to.equal(0)
     }
+  })
+
+  it('Should allow multiple authors to share a file-backed session', async () => {
+    expect(await getSessionCount()).to.equal(0)
+
+    const author1 = await createSession(testFile)
+    const author2 = await createSession(testFile)
+    const author1SessionId = author1.getSessionId()
+    const author2SessionId = author2.getSessionId()
+    const expectedSharedData = Buffer.concat([fileBuffer, Buffer.from('A2A1')])
+
+    expect(author1SessionId).to.equal(expected_session_id)
+    expect(author2SessionId).to.equal(author1SessionId)
+    expect(author1.getFileSize()).to.equal(fileData.length)
+    expect(author2.getFileSize()).to.equal(fileData.length)
+    expect(await getSessionCount()).to.equal(1)
+
+    const viewport1 = await createViewport(
+      'shared-author-1',
+      author1SessionId,
+      0,
+      1000,
+      false
+    )
+    const viewport2 = await createViewport(
+      'shared-author-2',
+      author2SessionId,
+      0,
+      1000,
+      false
+    )
+
+    expect(await getViewportCount(author1SessionId)).to.equal(2)
+    expect(viewport1.getData_asU8()).to.deep.equal(fileBuffer)
+    expect(viewport2.getData_asU8()).to.deep.equal(fileBuffer)
+
+    await insert(author1SessionId, fileData.length, Buffer.from('A1'))
+    await insert(author2SessionId, fileData.length, Buffer.from('A2'))
+
+    expect(await getChangeCount(author1SessionId)).to.equal(2)
+    expect(await getComputedFileSize(author1SessionId)).to.equal(
+      fileData.length + 4
+    )
+    expect(
+      (await getViewportData(viewport1.getViewportId())).getData_asU8()
+    ).to.deep.equal(expectedSharedData)
+    expect(
+      (await getViewportData(viewport2.getViewportId())).getData_asU8()
+    ).to.deep.equal(expectedSharedData)
+
+    expect(await destroySession(author1SessionId)).to.equal(author1SessionId)
+    expect(await getSessionCount()).to.equal(1)
+    expect(await getViewportCount(author2SessionId)).to.equal(2)
+    expect(await getComputedFileSize(author2SessionId)).to.equal(
+      fileData.length + 4
+    )
+    expect(
+      (await getViewportData(viewport2.getViewportId())).getData_asU8()
+    ).to.deep.equal(expectedSharedData)
+
+    expect(await destroySession(author2SessionId)).to.equal(author2SessionId)
+    expect(await getSessionCount()).to.equal(0)
   })
 
   it('Should be able to save segments from a session', async () => {

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -921,7 +921,10 @@ describe('Sessions', () => {
 
       if (fs.existsSync(sharedCheckpointDir)) {
         expect(
-          await countMatchingFilesInDir(sharedCheckpointDir, '.OmegaEdit-orig.*')
+          await countMatchingFilesInDir(
+            sharedCheckpointDir,
+            '.OmegaEdit-orig.*'
+          )
         ).to.equal(0)
         removeDirectory(sharedCheckpointDir)
       }

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -57,8 +57,8 @@ service EditorService {
   // can limit the save to a sub-section of the data.
   rpc SaveSession(SaveSessionRequest) returns (SaveSessionResponse);
 
-  // Destroy a session and release all associated resources (viewports,
-  // checkpoints, and change history).
+  // Detach the caller from a session. The backing session and its resources
+  // are released when the last attachment is destroyed or reaped.
   rpc DestroySession(DestroySessionRequest) returns (DestroySessionResponse);
 
   // ---------------------------------------------------------------------------
@@ -211,7 +211,7 @@ service EditorService {
   // changes, modifications, etc.).
   rpc SubscribeToViewportEvents(SubscribeToViewportEventsRequest) returns (stream SubscribeToViewportEventsResponse);
 
-  // Cancel an active session-event subscription.
+  // Cancel all active session-event subscriptions for the session ID.
   rpc UnsubscribeToSessionEvents(UnsubscribeToSessionEventsRequest) returns (UnsubscribeToSessionEventsResponse);
 
   // Cancel an active viewport-event subscription.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -1335,7 +1335,7 @@ grpc::Status EditorServiceImpl::SubscribeToSessionEvents(
 
     // Unsubscribe so the event queue stops accumulating events after the
     // client disconnects (prevents unbounded memory growth).
-    session_manager_.unsubscribe_session_events(request->id());
+    session_manager_.unsubscribe_session_events(request->id(), queue);
     return grpc::Status::OK;
 }
 

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -496,7 +496,7 @@ grpc::Status EditorServiceImpl::SaveSession(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::DestroySession(grpc::ServerContext * /*context*/,
                                                 const ::omega_edit::v1::DestroySessionRequest *request,
                                                 ::omega_edit::v1::DestroySessionResponse *response) {
-    if (!session_manager_.destroy_session(request->id())) {
+    if (!session_manager_.detach_session(request->id())) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
     response->set_id(request->id());

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -400,8 +400,19 @@ std::string SessionManager::create_session(const std::string &file_path, const s
         session_id = generate_uuid();
     }
 
-    // Check for duplicate
-    if (sessions_.count(session_id)) {
+    const bool share_existing_file_session = desired_id.empty() && !file_path.empty() && initial_data == nullptr;
+
+    auto existing = sessions_.find(session_id);
+    if (existing != sessions_.end()) {
+        if (share_existing_file_session) {
+            auto &info = existing->second;
+            ++info->attachment_count;
+            info->last_activity = std::chrono::steady_clock::now();
+            file_size_out = omega_session_get_computed_file_size(info->session);
+            checkpoint_dir_out = info->checkpoint_directory;
+            return session_id;
+        }
+
         if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
         return ""; // Already exists
     }
@@ -411,6 +422,7 @@ std::string SessionManager::create_session(const std::string &file_path, const s
     info->event_queue = std::make_shared<EventQueue<SessionEventData>>(
         limits_.session_event_queue_capacity, "session subscription '" + session_id + "'");
     info->event_interest = 0;
+    info->attachment_count = 1;
     info->last_activity = std::chrono::steady_clock::now();
 
     // Store info first so the callback can find it
@@ -469,6 +481,11 @@ bool SessionManager::destroy_session(const std::string &session_id) {
     if (it == sessions_.end()) return false;
 
     auto &info = it->second;
+    if (info->attachment_count > 1) {
+        --info->attachment_count;
+        info->last_activity = std::chrono::steady_clock::now();
+        return true;
+    }
 
     // Close event queues
     if (info->event_queue) {

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -122,6 +122,17 @@ bool is_process_alive(int pid) {
 #endif
 }
 
+int32_t combine_session_event_interest(const std::vector<SessionEventSubscriptionInfo> &subscriptions) {
+    int32_t combined = 0;
+    for (const auto &subscription : subscriptions) {
+        if (subscription.interest < 0) {
+            return subscription.interest;
+        }
+        combined |= subscription.interest;
+    }
+    return combined;
+}
+
 } // namespace
 
 // ── Base64 encoding (URL-safe, no padding — matches Java Base64.getUrlEncoder().withoutPadding()) ──
@@ -304,7 +315,7 @@ void SessionManager::cleanup_managed_server_root_if_empty() {
 void SessionManager::session_event_callback(const omega_session_t *session, omega_session_event_t event,
                                             const void *ptr) {
     auto *info = static_cast<SessionInfo *>(const_cast<void *>(omega_session_get_user_data_ptr(session)));
-    if (!info || !info->event_queue) return;
+    if (!info) return;
 
     SessionEventData evt;
     evt.session_id = info->session_id;
@@ -329,7 +340,20 @@ void SessionManager::session_event_callback(const omega_session_t *session, omeg
         break;
     }
 
-    info->event_queue->push(evt);
+    std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
+    {
+        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+        subscribers.reserve(info->session_subscriptions.size());
+        for (const auto &subscription : info->session_subscriptions) {
+            if (subscription.event_queue) {
+                subscribers.push_back(subscription.event_queue);
+            }
+        }
+    }
+
+    for (const auto &subscriber : subscribers) {
+        subscriber->push(evt);
+    }
 }
 
 void SessionManager::viewport_event_callback(const omega_viewport_t *viewport, omega_viewport_event_t event,
@@ -400,11 +424,13 @@ std::string SessionManager::create_session(const std::string &file_path, const s
         session_id = generate_uuid();
     }
 
-    const bool share_existing_file_session = desired_id.empty() && !file_path.empty() && initial_data == nullptr;
+    const bool share_existing_file_session = desired_id.empty() && !file_path.empty() &&
+                                            initial_data == nullptr;
 
     auto existing = sessions_.find(session_id);
     if (existing != sessions_.end()) {
-        if (share_existing_file_session) {
+        if (share_existing_file_session &&
+            (checkpoint_directory.empty() || checkpoint_directory == existing->second->checkpoint_directory)) {
             auto &info = existing->second;
             ++info->attachment_count;
             info->last_activity = std::chrono::steady_clock::now();
@@ -419,9 +445,6 @@ std::string SessionManager::create_session(const std::string &file_path, const s
 
     auto info = std::make_shared<SessionInfo>();
     info->session_id = session_id;
-    info->event_queue = std::make_shared<EventQueue<SessionEventData>>(
-        limits_.session_event_queue_capacity, "session subscription '" + session_id + "'");
-    info->event_interest = 0;
     info->attachment_count = 1;
     info->last_activity = std::chrono::steady_clock::now();
 
@@ -483,13 +506,18 @@ bool SessionManager::destroy_session(const std::string &session_id) {
     auto &info = it->second;
     if (info->attachment_count > 1) {
         --info->attachment_count;
-        info->last_activity = std::chrono::steady_clock::now();
         return true;
     }
 
     // Close event queues
-    if (info->event_queue) {
-        info->event_queue->close();
+    {
+        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+        for (auto &subscription : info->session_subscriptions) {
+            if (subscription.event_queue) {
+                subscription.event_queue->close();
+            }
+        }
+        info->session_subscriptions.clear();
     }
 
     // Destroy all viewports first
@@ -620,9 +648,15 @@ SessionManager::subscribe_session_events(const std::string &session_id, int32_t 
     if (it == sessions_.end()) return nullptr;
 
     auto &info = it->second;
-    info->event_interest = interest;
-    omega_session_set_event_interest(info->session, interest);
-    return info->event_queue;
+    auto queue = std::make_shared<EventQueue<SessionEventData>>(
+        limits_.session_event_queue_capacity,
+        "session subscription '" + session_id + "#" + generate_uuid() + "'");
+    {
+        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+        info->session_subscriptions.push_back({queue, interest});
+        omega_session_set_event_interest(info->session, combine_session_event_interest(info->session_subscriptions));
+    }
+    return queue;
 }
 
 void SessionManager::unsubscribe_session_events(const std::string &session_id) {
@@ -632,10 +666,49 @@ void SessionManager::unsubscribe_session_events(const std::string &session_id) {
     if (it == sessions_.end()) return;
 
     auto &info = it->second;
-    info->event_interest = 0;
-    omega_session_set_event_interest(info->session, 0);
-    if (info->event_queue) {
-        info->event_queue->clear();
+    std::vector<std::shared_ptr<EventQueue<SessionEventData>>> removed_queues;
+    {
+        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+        for (const auto &subscription : info->session_subscriptions) {
+            if (subscription.event_queue) {
+                removed_queues.push_back(subscription.event_queue);
+            }
+        }
+        info->session_subscriptions.clear();
+        omega_session_set_event_interest(info->session, 0);
+    }
+
+    for (const auto &queue : removed_queues) {
+        queue->clear();
+        queue->close();
+    }
+}
+
+void SessionManager::unsubscribe_session_events(const std::string &session_id,
+                                                const std::shared_ptr<EventQueue<SessionEventData>> &queue) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(session_id);
+    if (it == sessions_.end() || !queue) return;
+
+    auto &info = it->second;
+    bool removed = false;
+    {
+        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+        auto &subscriptions = info->session_subscriptions;
+        subscriptions.erase(std::remove_if(subscriptions.begin(), subscriptions.end(),
+                                           [&queue, &removed](const SessionEventSubscriptionInfo &subscription) {
+                                               const bool matches = subscription.event_queue == queue;
+                                               removed = removed || matches;
+                                               return matches;
+                                           }),
+                            subscriptions.end());
+        omega_session_set_event_interest(info->session, combine_session_event_interest(subscriptions));
+    }
+
+    if (removed) {
+        queue->clear();
+        queue->close();
     }
 }
 
@@ -678,7 +751,13 @@ void SessionManager::destroy_all() {
 
     for (auto &pair : sessions_) {
         auto &info = pair.second;
-        if (info->event_queue) info->event_queue->close();
+        {
+            std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+            for (auto &subscription : info->session_subscriptions) {
+                if (subscription.event_queue) subscription.event_queue->close();
+            }
+            info->session_subscriptions.clear();
+        }
         for (auto &vp : info->viewports) {
             if (vp.second->event_queue) vp.second->event_queue->close();
         }

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -123,14 +123,11 @@ bool is_process_alive(int pid) {
 }
 
 int32_t combine_session_event_interest(const std::vector<SessionEventSubscriptionInfo> &subscriptions) {
-    int32_t combined = 0;
+    uint32_t combined = 0;
     for (const auto &subscription : subscriptions) {
-        if (subscription.interest < 0) {
-            return subscription.interest;
-        }
-        combined |= subscription.interest;
+        combined |= static_cast<uint32_t>(subscription.interest);
     }
-    return combined;
+    return static_cast<int32_t>(combined);
 }
 
 } // namespace
@@ -341,13 +338,14 @@ void SessionManager::session_event_callback(const omega_session_t *session, omeg
     }
 
     const auto event_kind = static_cast<int32_t>(event);
+    const auto event_mask = static_cast<uint32_t>(event_kind);
     std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
     {
         std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
         subscribers.reserve(info->session_subscriptions.size());
         for (const auto &subscription : info->session_subscriptions) {
             if (subscription.event_queue &&
-                (subscription.interest < 0 || (subscription.interest & event_kind) != 0)) {
+                ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
                 subscribers.push_back(subscription.event_queue);
             }
         }

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -340,12 +340,14 @@ void SessionManager::session_event_callback(const omega_session_t *session, omeg
         break;
     }
 
+    const auto event_kind = static_cast<int32_t>(event);
     std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
     {
         std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
         subscribers.reserve(info->session_subscriptions.size());
         for (const auto &subscription : info->session_subscriptions) {
-            if (subscription.event_queue) {
+            if (subscription.event_queue &&
+                (subscription.interest < 0 || (subscription.interest & event_kind) != 0)) {
                 subscribers.push_back(subscription.event_queue);
             }
         }
@@ -497,17 +499,8 @@ std::string SessionManager::create_session(const std::string &file_path, const s
     return session_id;
 }
 
-bool SessionManager::destroy_session(const std::string &session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end()) return false;
-
+bool SessionManager::destroy_session_locked(const std::map<std::string, std::shared_ptr<SessionInfo>>::iterator &it) {
     auto &info = it->second;
-    if (info->attachment_count > 1) {
-        --info->attachment_count;
-        return true;
-    }
 
     // Close event queues
     {
@@ -537,6 +530,30 @@ bool SessionManager::destroy_session(const std::string &session_id) {
     sessions_.erase(it);
     cleanup_managed_server_root_if_empty();
     return true;
+}
+
+bool SessionManager::destroy_session(const std::string &session_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(session_id);
+    if (it == sessions_.end()) return false;
+
+    return destroy_session_locked(it);
+}
+
+bool SessionManager::detach_session(const std::string &session_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(session_id);
+    if (it == sessions_.end()) return false;
+
+    auto &info = it->second;
+    if (info->attachment_count > 1) {
+        --info->attachment_count;
+        return true;
+    }
+
+    return destroy_session_locked(it);
 }
 
 omega_session_t *SessionManager::get_session(const std::string &session_id) {

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -187,6 +187,7 @@ public:
                                std::string &checkpoint_dir_out,
                                SessionCreateError *error_out = nullptr);
     bool destroy_session(const std::string &session_id);
+    bool detach_session(const std::string &session_id);
     omega_session_t *get_session(const std::string &session_id);
     int64_t session_count() const;
 
@@ -225,6 +226,7 @@ private:
     static std::string create_server_root_name();
     std::string create_managed_checkpoint_directory();
     void cleanup_managed_server_root_if_empty();
+    bool destroy_session_locked(const std::map<std::string, std::shared_ptr<SessionInfo>>::iterator &it);
 
     // Callbacks
     static void session_event_callback(const omega_session_t *session, omega_session_event_t event, const void *ptr);

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -143,6 +143,7 @@ struct SessionInfo {
     std::string session_id;
     std::string checkpoint_directory;
     bool owns_checkpoint_directory{false};
+    size_t attachment_count{0};
     std::map<std::string, std::shared_ptr<ViewportInfo>> viewports;
     std::shared_ptr<EventQueue<SessionEventData>> event_queue;
     int32_t event_interest;

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -128,6 +128,12 @@ private:
     std::atomic<bool> closed_{false};
 };
 
+/// Session event subscription state
+struct SessionEventSubscriptionInfo {
+    std::shared_ptr<EventQueue<SessionEventData>> event_queue;
+    int32_t interest;
+};
+
 /// Information about a viewport managed by the session manager
 struct ViewportInfo {
     omega_viewport_t *viewport;
@@ -145,8 +151,8 @@ struct SessionInfo {
     bool owns_checkpoint_directory{false};
     size_t attachment_count{0};
     std::map<std::string, std::shared_ptr<ViewportInfo>> viewports;
-    std::shared_ptr<EventQueue<SessionEventData>> event_queue;
-    int32_t event_interest;
+    std::mutex session_subscription_mutex;
+    std::vector<SessionEventSubscriptionInfo> session_subscriptions;
     std::chrono::steady_clock::time_point last_activity;
 };
 
@@ -195,6 +201,8 @@ public:
     std::shared_ptr<EventQueue<SessionEventData>> subscribe_session_events(const std::string &session_id,
                                                                            int32_t interest);
     void unsubscribe_session_events(const std::string &session_id);
+    void unsubscribe_session_events(const std::string &session_id,
+                                    const std::shared_ptr<EventQueue<SessionEventData>> &queue);
     std::shared_ptr<EventQueue<ViewportEventData>> subscribe_viewport_events(const std::string &session_id,
                                                                               const std::string &viewport_id,
                                                                               int32_t interest);


### PR DESCRIPTION
## Summary
This PR fixes `#1379` for the 2.0 release branch by making file-backed sessions explicitly shareable across multiple attached authors on the same server.

## What Changed
- reuse the existing implicit file-backed session when another author opens the same file without a custom session ID
- track attachment counts so `DestroySession` only tears down the backing session after the last author disconnects
- add a regression test that opens the same file-backed session twice, creates separate author viewports, performs edits from both authors, and verifies the shared result survives the first detach

## Root Cause
The native session manager still treated the path-derived session ID as a hard duplicate conflict. That prevented a second author from attaching to the same file-backed session and made the intended multi-author workflow fail at session creation time.

## Impact
This restores the intended 2.0 behavior for multiple simultaneous authors sharing one server-backed file session, while keeping the session count tied to backing sessions rather than attached clients.

## Validation
- `yarn workspace @omega-edit/client test:client`

## Notes
- This PR targets `codex/release-2-0-0-rc1` so it can merge cleanly into the existing 2.0 release work.
