### PR TITLE
Fix UDS client endpoint targeting

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -19,10 +19,13 @@
 
 import type * as grpc from '@grpc/grpc-js'
 import {
+  type ClientConnectionOptions,
   getClient as getSharedClient,
   resetClient as resetSharedClient,
   waitForReady as waitForReadySharedClient,
 } from './protobuf_ts/client'
+
+export type { ClientConnectionOptions }
 
 // subscription events
 export const NO_EVENTS = 0 // subscribe to no events
@@ -54,6 +57,10 @@ export function waitForReady(
  * @param host interface to connect to
  * @return connected editor client
  */
-export async function getClient(port?: number, host?: string) {
-  return getSharedClient(port, host)
+export async function getClient(
+  port?: number,
+  host?: string,
+  options?: ClientConnectionOptions
+) {
+  return getSharedClient(port, host, options)
 }

--- a/packages/client/src/protobuf_ts/client.ts
+++ b/packages/client/src/protobuf_ts/client.ts
@@ -21,17 +21,25 @@ import * as grpc from '@grpc/grpc-js'
 import { EditorClient } from '../omega_edit_grpc_pb'
 import { getLogger } from '../logger'
 
-let clientInstance_: EditorClient | undefined = undefined
-let pendingInit_: Promise<EditorClient> | undefined = undefined
+export interface ClientConnectionOptions {
+  serverUri?: string
+  socketPath?: string
+  allowTcpFallback?: boolean
+}
+
+const clientInstances_ = new Map<string, EditorClient>()
+const pendingInit_ = new Map<string, Promise<EditorClient>>()
 
 const DEFAULT_PORT = 9000
 const DEFAULT_HOST = '127.0.0.1'
 const DEFAULT_DEADLINE_SECONDS = 10
 
 export function resetClient() {
-  const client = clientInstance_
-  clientInstance_ = undefined
-  if (client) {
+  const clients = Array.from(new Set(clientInstances_.values()))
+  clientInstances_.clear()
+  pendingInit_.clear()
+
+  for (const client of clients) {
     try {
       client.close()
     } catch (err) {
@@ -75,50 +83,114 @@ export function waitForReady(
   })
 }
 
-async function initClient(port: number, host: string): Promise<EditorClient> {
-  const log = getLogger()
+function normalizeUnixSocketTarget(socket: string): string {
+  if (socket.startsWith('unix:')) return socket
+  if (socket.startsWith('/')) return `unix:///${socket.slice(1)}`
+  return `unix:${socket}`
+}
 
-  log.debug({
-    fn: 'protobufTs.getClient',
-    port: port,
-    host: host,
-    state: 'initializing',
-  })
+function resolveCandidates(
+  port: number,
+  host: string,
+  options?: ClientConnectionOptions
+): { requestKey: string; candidates: string[] } {
+  if (options?.serverUri && options?.socketPath) {
+    throw new Error(
+      'getClient accepts either serverUri or socketPath, not both'
+    )
+  }
+
+  const tcpUri = `${host}:${port}`
+
+  if (options?.serverUri) {
+    return {
+      requestKey: options.serverUri,
+      candidates: [options.serverUri],
+    }
+  }
+
+  if (options?.socketPath) {
+    const socketUri = normalizeUnixSocketTarget(options.socketPath)
+    const candidates = options.allowTcpFallback
+      ? [socketUri, tcpUri]
+      : [socketUri]
+
+    return {
+      requestKey: candidates.join('|'),
+      candidates,
+    }
+  }
 
   const serverUri = process.env.OMEGA_EDIT_SERVER_URI
   const serverSocket = process.env.OMEGA_EDIT_SERVER_SOCKET
 
-  const normalizeUnixSocketTarget = (socket: string): string => {
-    if (socket.startsWith('unix:')) return socket
-    if (socket.startsWith('/')) return `unix:///${socket.slice(1)}`
-    return `unix:${socket}`
+  if (serverUri) {
+    return {
+      requestKey: serverUri,
+      candidates: [serverUri],
+    }
   }
 
-  const tcpUri = `${host}:${port}`
-  const candidates = serverUri
-    ? [serverUri]
-    : serverSocket
-      ? [normalizeUnixSocketTarget(serverSocket), tcpUri]
-      : [tcpUri]
+  if (serverSocket) {
+    const socketUri = normalizeUnixSocketTarget(serverSocket)
+    const candidates = [socketUri, tcpUri]
+    return {
+      requestKey: candidates.join('|'),
+      candidates,
+    }
+  }
+
+  return {
+    requestKey: tcpUri,
+    candidates: [tcpUri],
+  }
+}
+
+async function initClient(
+  port: number,
+  host: string,
+  candidates: string[]
+): Promise<EditorClient> {
+  const log = getLogger()
+
+  log.debug({
+    fn: 'protobufTs.getClient',
+    port,
+    host,
+    candidates,
+    state: 'initializing',
+  })
 
   let lastError: unknown
 
   for (const uri of candidates) {
+    const cachedClient = clientInstances_.get(uri)
+    if (cachedClient) {
+      log.debug({
+        fn: 'protobufTs.getClient',
+        port,
+        host,
+        uri,
+        state: 'reused cached endpoint',
+      })
+      return cachedClient
+    }
+
     const client = new EditorClient(uri, grpc.credentials.createInsecure())
 
     try {
       await waitForReady(client)
 
-      clientInstance_ = client
+      clientInstances_.set(uri, client)
       log.debug({
         fn: 'protobufTs.getClient',
-        port: port,
-        host: host,
-        uri: uri,
+        port,
+        host,
+        uri,
         state: 'ready',
       })
 
-      return clientInstance_
+      return client
     } catch (err) {
       lastError = err
       try {
@@ -130,9 +202,9 @@ async function initClient(port: number, host: string): Promise<EditorClient> {
       if (err instanceof Error) {
         log.error({
           fn: 'protobufTs.getClient',
-          host: host,
-          port: port,
-          uri: uri,
+          host,
+          port,
+          uri,
           state: 'not ready',
           err: {
             name: err.name,
@@ -143,9 +215,9 @@ async function initClient(port: number, host: string): Promise<EditorClient> {
       } else {
         log.error({
           fn: 'protobufTs.getClient',
-          host: host,
-          port: port,
-          uri: uri,
+          host,
+          port,
+          uri,
           state: 'not ready',
           err: {
             msg: String(err),
@@ -155,25 +227,48 @@ async function initClient(port: number, host: string): Promise<EditorClient> {
     }
   }
 
-  resetClient()
   throw lastError
 }
 
 export async function getClient(
   port: number = DEFAULT_PORT,
-  host: string = DEFAULT_HOST
+  host: string = DEFAULT_HOST,
+  options?: ClientConnectionOptions
 ): Promise<EditorClient> {
-  if (clientInstance_) {
-    return clientInstance_
+  const hasExplicitTarget =
+    !!options?.serverUri ||
+    !!options?.socketPath ||
+    !!process.env.OMEGA_EDIT_SERVER_URI ||
+    !!process.env.OMEGA_EDIT_SERVER_SOCKET
+
+  if (
+    !hasExplicitTarget &&
+    port === DEFAULT_PORT &&
+    host === DEFAULT_HOST &&
+    clientInstances_.size === 1
+  ) {
+    return clientInstances_.values().next().value as EditorClient
   }
 
-  if (pendingInit_) {
-    return pendingInit_
+  const { requestKey, candidates } = resolveCandidates(port, host, options)
+
+  const primaryCandidate = candidates[0]
+  const cachedClient = primaryCandidate
+    ? clientInstances_.get(primaryCandidate)
+    : undefined
+  if (cachedClient) {
+    return cachedClient
   }
 
-  pendingInit_ = initClient(port, host).finally(() => {
-    pendingInit_ = undefined
+  const pending = pendingInit_.get(requestKey)
+  if (pending) {
+    return pending
+  }
+
+  const initPromise = initClient(port, host, candidates).finally(() => {
+    pendingInit_.delete(requestKey)
   })
+  pendingInit_.set(requestKey, initPromise)
 
-  return pendingInit_
+  return initPromise
 }

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -935,7 +935,7 @@ export async function startServerUnixSocket(
       ...logMetadata,
       pid: pid,
     })
-    await getClient()
+    await getClient(port, host, { socketPath })
     return pid
   } else {
     const errMsg = 'Error getting server pid'

--- a/packages/client/tests/specs/clientUtilities.spec.ts
+++ b/packages/client/tests/specs/clientUtilities.spec.ts
@@ -46,6 +46,8 @@ const {
 
 describe('Client Utilities', () => {
   let restoreLogger = () => {}
+  let originalServerUri: string | undefined
+  let originalServerSocket: string | undefined
 
   before(async () => {
     await initChai()
@@ -53,13 +55,23 @@ describe('Client Utilities', () => {
 
   beforeEach(() => {
     restoreLogger = silenceClientLogger(require)
+    originalServerUri = process.env.OMEGA_EDIT_SERVER_URI
+    originalServerSocket = process.env.OMEGA_EDIT_SERVER_SOCKET
   })
 
   afterEach(() => {
     restoreLogger()
     resetClient()
-    delete process.env.OMEGA_EDIT_SERVER_URI
-    delete process.env.OMEGA_EDIT_SERVER_SOCKET
+    if (originalServerUri === undefined) {
+      delete process.env.OMEGA_EDIT_SERVER_URI
+    } else {
+      process.env.OMEGA_EDIT_SERVER_URI = originalServerUri
+    }
+    if (originalServerSocket === undefined) {
+      delete process.env.OMEGA_EDIT_SERVER_SOCKET
+    } else {
+      process.env.OMEGA_EDIT_SERVER_SOCKET = originalServerSocket
+    }
   })
 
   const removeDirWithRetry = async (dirPath: string) => {

--- a/packages/client/tests/specs/clientUtilities.spec.ts
+++ b/packages/client/tests/specs/clientUtilities.spec.ts
@@ -314,6 +314,68 @@ describe('Client Utilities', () => {
     }
   })
 
+  it('should keep separate cached clients per endpoint and close them on reset', async () => {
+    resetClient()
+    const uris: string[] = []
+    const closedUris: string[] = []
+
+    class FakeEditorClient {
+      uri: string
+
+      constructor(uri: string) {
+        this.uri = uri
+        uris.push(uri)
+      }
+
+      waitForReady(_deadline: unknown, callback: (err?: Error) => void) {
+        callback()
+      }
+
+      close() {
+        closedUris.push(this.uri)
+      }
+    }
+
+    const restoreEditorClient = overrideProperty(
+      grpcClientModule as Record<string, any>,
+      'EditorClient',
+      FakeEditorClient
+    )
+    const restoreCreateInsecure = overrideProperty(
+      grpcModule.credentials as Record<string, any>,
+      'createInsecure',
+      () => ({})
+    )
+
+    try {
+      const tcpClient = await clientModule.getClient(9314, '127.0.0.1')
+      const socketClient = await clientModule.getClient(9314, '127.0.0.1', {
+        socketPath: 'relative.sock',
+      })
+
+      expect(socketClient).to.not.equal(tcpClient)
+      expect(await clientModule.getClient(9314, '127.0.0.1')).to.equal(
+        tcpClient
+      )
+      expect(
+        await clientModule.getClient(9314, '127.0.0.1', {
+          socketPath: 'relative.sock',
+        })
+      ).to.equal(socketClient)
+      expect(uris).to.deep.equal(['127.0.0.1:9314', 'unix:relative.sock'])
+
+      resetClient()
+      expect(closedUris.sort()).to.deep.equal([
+        '127.0.0.1:9314',
+        'unix:relative.sock',
+      ])
+    } finally {
+      resetClient()
+      restoreCreateInsecure()
+      restoreEditorClient()
+    }
+  })
+
   it('should reset the client when all connection candidates fail', async () => {
     resetClient()
     const uris: string[] = []

--- a/packages/client/tests/specs/clientUtilities.spec.ts
+++ b/packages/client/tests/specs/clientUtilities.spec.ts
@@ -328,6 +328,8 @@ describe('Client Utilities', () => {
 
   it('should keep separate cached clients per endpoint and close them on reset', async () => {
     resetClient()
+    delete process.env.OMEGA_EDIT_SERVER_URI
+    delete process.env.OMEGA_EDIT_SERVER_SOCKET
     const uris: string[] = []
     const closedUris: string[] = []
 
@@ -446,6 +448,8 @@ describe('Client Utilities', () => {
 
   it('should share a single in-flight client initialization', async () => {
     resetClient()
+    delete process.env.OMEGA_EDIT_SERVER_URI
+    delete process.env.OMEGA_EDIT_SERVER_SOCKET
     const uris: string[] = []
     const readyCallbacks: Array<(err?: Error) => void> = []
 

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -200,6 +200,56 @@ describe('Server Edge Cases', () => {
     }
   }).timeout(20000)
 
+  it('should verify UDS startup against the launched socket endpoint', async function () {
+    if (process.platform === 'win32') {
+      this.skip()
+    }
+
+    const tcpPort = await findFirstAvailablePort(9401, 9500)
+    expect(tcpPort).to.not.equal(null)
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'omega-edit-uds-target-')
+    )
+    const tcpPidFile = path.join(tempDir, 'omega-edit-tcp.pid')
+    const socketPath = path.join(tempDir, 'omega-edit.sock')
+    const udsPidFile = path.join(tempDir, 'omega-edit-uds.pid')
+
+    let tcpPid: number | undefined
+    let udsPid: number | undefined
+    try {
+      delete process.env.OMEGA_EDIT_SERVER_SOCKET
+      delete process.env.OMEGA_EDIT_SERVER_URI
+      resetClient()
+
+      tcpPid = await startServer(tcpPort as number, '127.0.0.1', tcpPidFile)
+      expect(tcpPid).to.be.a('number').greaterThan(0)
+      expect((await getServerInfo()).serverProcessId).to.equal(tcpPid)
+
+      process.env.OMEGA_EDIT_SERVER_SOCKET = socketPath
+      delete process.env.OMEGA_EDIT_SERVER_URI
+
+      udsPid = await startServerUnixSocket(socketPath, udsPidFile, true)
+      expect(udsPid).to.be.a('number').greaterThan(0)
+      expect((await getServerInfo()).serverProcessId).to.equal(udsPid)
+
+      expect(await stopServerImmediate()).to.equal(0)
+    } finally {
+      delete process.env.OMEGA_EDIT_SERVER_SOCKET
+      delete process.env.OMEGA_EDIT_SERVER_URI
+      resetClient()
+
+      if (udsPid && pidIsRunning(udsPid)) {
+        await stopProcessUsingPID(udsPid, 'SIGKILL')
+      }
+      if (tcpPid && pidIsRunning(tcpPid)) {
+        await stopProcessUsingPID(tcpPid, 'SIGKILL')
+      }
+
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  }).timeout(25000)
+
   it('should reject server info failures from the RPC client', async () => {
     const restoreGetClient = overrideProperty(
       clientModule as Record<string, any>,

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -45,6 +45,8 @@ const {
 
 describe('Server Edge Cases', () => {
   let restoreLogger = () => {}
+  let originalServerUri: string | undefined
+  let originalServerSocket: string | undefined
 
   before(async () => {
     await initChai()
@@ -58,10 +60,23 @@ describe('Server Edge Cases', () => {
       require('../../dist/cjs/server.js') as typeof import('../../src/server')
   })
 
+  beforeEach(() => {
+    originalServerUri = process.env.OMEGA_EDIT_SERVER_URI
+    originalServerSocket = process.env.OMEGA_EDIT_SERVER_SOCKET
+  })
+
   afterEach(() => {
     resetClient()
-    delete process.env.OMEGA_EDIT_SERVER_URI
-    delete process.env.OMEGA_EDIT_SERVER_SOCKET
+    if (originalServerUri === undefined) {
+      delete process.env.OMEGA_EDIT_SERVER_URI
+    } else {
+      process.env.OMEGA_EDIT_SERVER_URI = originalServerUri
+    }
+    if (originalServerSocket === undefined) {
+      delete process.env.OMEGA_EDIT_SERVER_SOCKET
+    } else {
+      process.env.OMEGA_EDIT_SERVER_SOCKET = originalServerSocket
+    }
   })
 
   after(() => {

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -84,6 +84,10 @@ describe('Server Edge Cases', () => {
   })
 
   it('should start a source server with a stale pid file and query info endpoints', async () => {
+    delete process.env.OMEGA_EDIT_SERVER_URI
+    delete process.env.OMEGA_EDIT_SERVER_SOCKET
+    resetClient()
+
     const port = await findFirstAvailablePort(9200, 9300)
     expect(port).to.not.equal(null)
 
@@ -95,7 +99,6 @@ describe('Server Edge Cases', () => {
     let pidFromFile: number | undefined
     let serverInfoPid: number | undefined
     try {
-      resetClient()
       pid = await startServer(port as number, '127.0.0.1', pidFile)
       expect(pid).to.be.a('number').greaterThan(0)
       expect(pidIsRunning(pid as number)).to.be.true


### PR DESCRIPTION
## Summary
This PR fixes `#1380` on the 2.0 release branch by making the TypeScript gRPC client cache endpoint-aware and making UDS startup verify the exact socket endpoint it launched.

## What Changed
- replace the single process-global cached gRPC client with endpoint-aware client and pending-init caches
- add explicit `ClientConnectionOptions` so callers can target a socket path or server URI without depending on ambient environment state
- make `startServerUnixSocket()` verify readiness against the launched socket endpoint instead of calling a generic `getClient()`
- preserve the legacy "single active client" behavior only when there is exactly one cached endpoint and no explicit target is in play
- add regression coverage for per-endpoint cache reset behavior and for mixed TCP/UDS usage so a stale TCP client is not reused after UDS startup

## Root Cause
`@omega-edit/client` cached exactly one gRPC client for the whole process. Once a TCP client existed, later UDS startup and no-arg client calls could silently keep talking to that old TCP endpoint instead of the socket the caller intended.

## Impact
This makes connection ownership explicit enough for mixed transport usage in one process while keeping the existing one-server convenience path intact.

## Validation
- `yarn workspace @omega-edit/client test:client`

## Notes
- The new mixed TCP/UDS integration coverage is skipped on Windows and is intended to run in non-Windows CI where Unix domain sockets are available.
- This PR targets `codex/release-2-0-0-rc1` so it lands cleanly in the 2.0 release work.
