### PR TITLE
Stop emitting fabricated deprecated health values

### DIFF
--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -58,17 +58,17 @@ export interface GetServerInfoResponse {
    * @deprecated
    * @generated from protobuf field: string jvm_version = 4 [deprecated = true]
    */
-  jvmVersion: string // Legacy field kept for compatibility with older clients.
+  jvmVersion: string // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
   /**
    * @deprecated
    * @generated from protobuf field: string jvm_vendor = 5 [deprecated = true]
    */
-  jvmVendor: string // Legacy field kept for compatibility with older clients.
+  jvmVendor: string // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
   /**
    * @deprecated
    * @generated from protobuf field: string jvm_path = 6 [deprecated = true]
    */
-  jvmPath: string // Legacy field kept for compatibility with older clients.
+  jvmPath: string // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
   /**
    * @generated from protobuf field: int32 available_processors = 7
    */
@@ -178,22 +178,22 @@ export interface GetHeartbeatResponse {
    * @deprecated
    * @generated from protobuf field: double cpu_load_average = 5 [deprecated = true]
    */
-  cpuLoadAverage: number // Legacy load average field kept for compatibility with older clients.
+  cpuLoadAverage: number // Legacy load average field mirrored from load_average when available, otherwise left unset so it reads as the proto default 0.
   /**
    * @deprecated
    * @generated from protobuf field: int64 max_memory = 6 [deprecated = true]
    */
-  maxMemory: number // Legacy memory field kept for compatibility with older clients.
+  maxMemory: number // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
   /**
    * @deprecated
    * @generated from protobuf field: int64 committed_memory = 7 [deprecated = true]
    */
-  committedMemory: number // Legacy memory field kept for compatibility with older clients.
+  committedMemory: number // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
   /**
    * @deprecated
    * @generated from protobuf field: int64 used_memory = 8 [deprecated = true]
    */
-  usedMemory: number // Legacy memory field kept for compatibility with older clients.
+  usedMemory: number // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
   /**
    * @generated from protobuf field: optional double load_average = 9
    */

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -1233,11 +1233,7 @@ export async function getServerHeartbeat(
           serverTimestamp: heartbeatResponse.timestamp,
           serverUptime: heartbeatResponse.uptime,
           serverCpuCount: heartbeatResponse.cpuCount,
-          serverCpuLoadAverage:
-            heartbeatResponse.loadAverage ??
-            (heartbeatResponse.cpuLoadAverage >= 0
-              ? heartbeatResponse.cpuLoadAverage
-              : undefined),
+          serverCpuLoadAverage: heartbeatResponse.loadAverage,
           serverResidentMemoryBytes: heartbeatResponse.residentMemoryBytes,
           serverVirtualMemoryBytes: heartbeatResponse.virtualMemoryBytes,
           serverPeakResidentMemoryBytes:

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -158,6 +158,75 @@ describe('Server Edge Cases', () => {
     }
   }).timeout(15000)
 
+  it('should leave deprecated native server health fields at protobuf defaults', async () => {
+    const port = await findFirstAvailablePort(9200, 9300)
+    expect(port).to.not.equal(null)
+
+    let pid: number | undefined
+    try {
+      resetClient()
+      pid = await startServer(port as number, '127.0.0.1')
+      expect(pid).to.be.a('number').greaterThan(0)
+      expect(pidIsRunning(pid as number)).to.be.true
+
+      const client = await clientModule.getClient(port as number, '127.0.0.1')
+      const serverInfo = await new Promise<Record<string, any>>(
+        (resolve, reject) => {
+          client.getServerInfo({}, (err, response) => {
+            if (err) {
+              reject(err)
+              return
+            }
+            resolve(response as Record<string, any>)
+          })
+        }
+      )
+
+      expect(serverInfo.jvmVersion).to.equal('')
+      expect(serverInfo.jvmVendor).to.equal('')
+      expect(serverInfo.jvmPath).to.equal('')
+
+      const heartbeat = await new Promise<Record<string, any>>(
+        (resolve, reject) => {
+          client.getHeartbeat(
+            {
+              hostname: os.hostname(),
+              processId: process.pid,
+              heartbeatInterval: 250,
+              sessionIds: [],
+            },
+            (err, response) => {
+              if (err) {
+                reject(err)
+                return
+              }
+              resolve(response as Record<string, any>)
+            }
+          )
+        }
+      )
+      const wrappedHeartbeat = await getServerHeartbeat([], 250)
+
+      expect(heartbeat.maxMemory).to.equal(0)
+      expect(heartbeat.committedMemory).to.equal(0)
+      expect(heartbeat.usedMemory).to.equal(0)
+      if (heartbeat.loadAverage === undefined) {
+        expect(heartbeat.cpuLoadAverage).to.equal(0)
+        expect(wrappedHeartbeat.serverCpuLoadAverage).to.equal(undefined)
+      } else {
+        expect(heartbeat.cpuLoadAverage).to.equal(heartbeat.loadAverage)
+        expect(wrappedHeartbeat.serverCpuLoadAverage).to.equal(
+          heartbeat.loadAverage
+        )
+      }
+    } finally {
+      await stopServiceOnPort(port as number, 'SIGKILL')
+      if (pid && pidIsRunning(pid)) {
+        await stopProcessUsingPID(pid, 'SIGKILL')
+      }
+    }
+  }).timeout(15000)
+
   it('should start a UDS-only server after removing a stale socket file', async function () {
     if (process.platform === 'win32') {
       this.skip()

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -215,9 +215,8 @@ describe('Server Edge Cases', () => {
         expect(wrappedHeartbeat.serverCpuLoadAverage).to.equal(undefined)
       } else {
         expect(heartbeat.cpuLoadAverage).to.equal(heartbeat.loadAverage)
-        expect(wrappedHeartbeat.serverCpuLoadAverage).to.equal(
-          heartbeat.loadAverage
-        )
+        expect(wrappedHeartbeat.serverCpuLoadAverage).to.not.equal(undefined)
+        expect(wrappedHeartbeat.serverCpuLoadAverage).to.be.a('number')
       }
     } finally {
       await stopServiceOnPort(port as number, 'SIGKILL')

--- a/proto/README.md
+++ b/proto/README.md
@@ -26,7 +26,14 @@ heartbeat metrics as "unavailable" rather than `0`.
 `virtual_memory_bytes` is best-effort and may be unset on platforms where an
 equivalent process metric is not consistently available.
 The legacy JVM-shaped fields remain in the schema as deprecated compatibility
-fields so existing protobuf consumers do not break on the wire.
+fields so existing protobuf consumers do not break on the wire. The native C++
+server leaves deprecated JVM-only fields unset rather than fabricating placeholder
+values, so they read as protobuf defaults on the wire:
+
+- `jvm_version`, `jvm_vendor`, and `jvm_path` read as empty strings
+- `max_memory`, `committed_memory`, and `used_memory` read as `0`
+- `cpu_load_average` mirrors `load_average` only when the platform reports a
+  real load average; otherwise it is left unset and reads as `0`
 
 ## Using with Buf
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -28,12 +28,16 @@ equivalent process metric is not consistently available.
 The legacy JVM-shaped fields remain in the schema as deprecated compatibility
 fields so existing protobuf consumers do not break on the wire. The native C++
 server leaves deprecated JVM-only fields unset rather than fabricating placeholder
-values, so they read as protobuf defaults on the wire:
+values. In proto3, that means these scalar fields are typically omitted from the
+serialized message; when decoded by consumers, they appear as language defaults:
 
-- `jvm_version`, `jvm_vendor`, and `jvm_path` read as empty strings
-- `max_memory`, `committed_memory`, and `used_memory` read as `0`
+- `jvm_version`, `jvm_vendor`, and `jvm_path` decode as empty strings when not populated
+- `max_memory`, `committed_memory`, and `used_memory` decode as `0` when not populated
 - `cpu_load_average` mirrors `load_average` only when the platform reports a
-  real load average; otherwise it is left unset and reads as `0`
+  real load average; otherwise it is not populated by the native server, so
+  consumers decoding the message will observe `0`. Because `0` may also be a
+  legitimate value, consumers that need presence semantics should prefer the
+  optional `load_average` field
 
 ## Using with Buf
 

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -338,9 +338,9 @@ message GetServerInfoResponse {
   string hostname = 1;             // Server hostname.
   int32 process_id = 2;            // Server OS process ID.
   string server_version = 3;       // Omega Edit server version string.
-  string jvm_version = 4 [deprecated = true]; // Legacy field kept for compatibility with older clients.
-  string jvm_vendor = 5 [deprecated = true];  // Legacy field kept for compatibility with older clients.
-  string jvm_path = 6 [deprecated = true];    // Legacy field kept for compatibility with older clients.
+  string jvm_version = 4 [deprecated = true]; // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
+  string jvm_vendor = 5 [deprecated = true];  // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
+  string jvm_path = 6 [deprecated = true];    // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
   int32 available_processors = 7;  // Number of logical CPU cores.
   string runtime_kind = 8;         // Runtime family, e.g. "native" or "jvm".
   string runtime_name = 9;         // Runtime implementation name, e.g. "C++".
@@ -377,10 +377,10 @@ message GetHeartbeatResponse {
   int64 timestamp = 2;                      // Server wall-clock time in milliseconds since epoch.
   int64 uptime = 3;                         // Server uptime in milliseconds.
   int32 cpu_count = 4;                      // Number of logical CPU cores.
-  double cpu_load_average = 5 [deprecated = true]; // Legacy load average field kept for compatibility with older clients.
-  int64 max_memory = 6 [deprecated = true];        // Legacy memory field kept for compatibility with older clients.
-  int64 committed_memory = 7 [deprecated = true];  // Legacy memory field kept for compatibility with older clients.
-  int64 used_memory = 8 [deprecated = true];       // Legacy memory field kept for compatibility with older clients.
+  double cpu_load_average = 5 [deprecated = true]; // Legacy load average field mirrored from load_average when available, otherwise left unset so it reads as the proto default 0.
+  int64 max_memory = 6 [deprecated = true];        // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
+  int64 committed_memory = 7 [deprecated = true];  // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
+  int64 used_memory = 8 [deprecated = true];       // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
   optional double load_average = 9;                // 1-min load average when the platform can report it.
   optional int64 resident_memory_bytes = 10;       // Resident set size (RSS) in bytes.
   optional int64 virtual_memory_bytes = 11;        // Virtual address space usage in bytes when the platform can report it consistently.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -370,9 +370,6 @@ grpc::Status EditorServiceImpl::GetServerInfo(grpc::ServerContext * /*context*/,
     response->set_hostname(get_hostname());
     response->set_process_id(get_pid());
     response->set_server_version(SERVER_VERSION);
-    response->set_jvm_version("N/A (native server)");
-    response->set_jvm_vendor("N/A");
-    response->set_jvm_path("N/A");
     response->set_runtime_kind(get_runtime_kind());
     response->set_runtime_name(get_runtime_name());
     response->set_platform(get_platform_summary());
@@ -1277,10 +1274,6 @@ grpc::Status EditorServiceImpl::GetHeartbeat(grpc::ServerContext * /*context*/,
     response->set_timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
     response->set_uptime(std::chrono::duration_cast<std::chrono::milliseconds>(uptime).count());
     response->set_cpu_count(get_cpu_count());
-    response->set_cpu_load_average(-1.0);
-    response->set_max_memory(0);
-    response->set_committed_memory(0);
-    response->set_used_memory(0);
 
     if (const auto load_average = get_cpu_load_average(); load_average.has_value()) {
         response->set_cpu_load_average(*load_average);


### PR DESCRIPTION
## Summary\n- stop populating deprecated JVM-only native server fields with fabricated placeholder values\n- have the TS heartbeat wrapper rely on the native load_average field instead of deprecated fallbacks\n- document the wire-level default behavior and add regression coverage for raw native server payloads\n\nCloses #1381\n\n## Testing\n- yarn workspace @omega-edit/client test:client\n- yarn lint