### PR TITLE
Make shutdown lifecycle explicit

### DIFF
--- a/UPGRADE-v1-to-v2.md
+++ b/UPGRADE-v1-to-v2.md
@@ -14,6 +14,7 @@
 - If you relied on the old Scala server scripts or deployment model, switch to the packaged C++ server (`@omega-edit/server` or `server/cpp`).
 - Server info and heartbeat responses now expose native-runtime metadata, while legacy JVM-shaped compatibility fields remain deprecated in the schema.
 - Caller-chosen `session_id_desired` values and caller-chosen `viewport_id_desired` values are now explicit uniqueness requests: duplicates are rejected with `ALREADY_EXISTS` instead of being remapped to a different ID.
+- `@omega-edit/client` server shutdown helpers now return structured results. `stopServerGraceful()` and `stopServerImmediate()` return `{ responseCode, serverProcessId, status }` instead of a bare numeric response code.
 
 ## Quick path
 

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -1,5 +1,6 @@
 import {
   ChangeKind,
+  type IServerControlResult,
   IOFlags,
   createSession,
   del,
@@ -148,11 +149,7 @@ export class OmegaEditToolkit {
     return await this.serverInfo()
   }
 
-  async stopServer(): Promise<{
-    responseCode: number
-    serverProcessId: number
-    status: string
-  }> {
+  async stopServer(): Promise<IServerControlResult> {
     await this.connectToRunningServer()
     const response = await stopServerGraceful()
     resetClient()

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -148,11 +148,15 @@ export class OmegaEditToolkit {
     return await this.serverInfo()
   }
 
-  async stopServer(): Promise<{ responseCode: number }> {
+  async stopServer(): Promise<{
+    responseCode: number
+    serverProcessId: number
+    status: string
+  }> {
     await this.connectToRunningServer()
-    const responseCode = await stopServerGraceful()
+    const response = await stopServerGraceful()
     resetClient()
-    return { responseCode }
+    return response
   }
 
   async serverInfo(): Promise<object> {

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -85,6 +85,10 @@ await stopServerGraceful()
 | `getServerInfo()`                                 | Runtime metadata for the native server    |
 | `getServerHeartbeat(sessions, interval?)`         | Heartbeat and process health              |
 
+Shutdown migration note:
+
+- In the 2.x line, `stopServerGraceful()` and `stopServerImmediate()` return a structured result object with `responseCode`, `serverProcessId`, and `status` instead of returning only a numeric response code.
+
 ### Server Health API Migration
 
 `getServerInfo()` and `getServerHeartbeat()` now expose native-runtime metadata instead of JVM-shaped placeholders.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -80,8 +80,8 @@ await stopServerGraceful()
 | ------------------------------------------------- | ----------------------------------------- |
 | `startServer(port?, host?, pidFile?, heartbeat?)` | Start the bundled native gRPC server      |
 | `startServerUnixSocket(socketPath, ...)`          | Start using a Unix domain socket          |
-| `stopServerGraceful()`                            | Graceful shutdown                         |
-| `stopServerImmediate()`                           | Immediate shutdown                        |
+| `stopServerGraceful()`                            | Graceful shutdown, returning status info  |
+| `stopServerImmediate()`                           | Immediate shutdown, returning status info |
 | `getServerInfo()`                                 | Runtime metadata for the native server    |
 | `getServerHeartbeat(sessions, interval?)`         | Heartbeat and process health              |
 

--- a/packages/client/src/omega_edit_pb.ts
+++ b/packages/client/src/omega_edit_pb.ts
@@ -277,6 +277,10 @@ export class ServerControlResponse {
     return this.response_.responseCode
   }
 
+  getStatus(): RawServerControlResponse['status'] {
+    return this.response_.status
+  }
+
   toObject(): RawServerControlResponse {
     return { ...this.response_ }
   }

--- a/packages/client/src/omega_edit_pb.ts
+++ b/packages/client/src/omega_edit_pb.ts
@@ -33,6 +33,7 @@ import type {
   SaveSessionResponse as RawSaveSessionResponse,
   ServerControlRequest as RawServerControlRequest,
   ServerControlResponse as RawServerControlResponse,
+  ServerControlStatus,
   SingleCount as RawSingleCount,
   SubscribeToSessionEventsRequest as RawSubscribeToSessionEventsRequest,
   SubscribeToSessionEventsResponse as RawSubscribeToSessionEventsResponse,
@@ -277,7 +278,7 @@ export class ServerControlResponse {
     return this.response_.responseCode
   }
 
-  getStatus(): RawServerControlResponse['status'] {
+  getStatus(): ServerControlStatus | undefined {
     return this.response_.status
   }
 

--- a/packages/client/src/proto.ts
+++ b/packages/client/src/proto.ts
@@ -64,6 +64,7 @@ export const ProtoServerControlStatus = {
   SERVER_CONTROL_STATUS_UNSPECIFIED: RawProtoServerControlStatus.UNSPECIFIED,
   SERVER_CONTROL_STATUS_COMPLETED: RawProtoServerControlStatus.COMPLETED,
   SERVER_CONTROL_STATUS_DRAINING: RawProtoServerControlStatus.DRAINING,
+  ...RawProtoServerControlStatus,
 }
 
 export const CountKind = {
@@ -93,4 +94,7 @@ export const ServerControlStatus = {
     ProtoServerControlStatus.SERVER_CONTROL_STATUS_COMPLETED,
   SERVER_CONTROL_STATUS_DRAINING:
     ProtoServerControlStatus.SERVER_CONTROL_STATUS_DRAINING,
+  UNSPECIFIED: RawProtoServerControlStatus.UNSPECIFIED,
+  COMPLETED: RawProtoServerControlStatus.COMPLETED,
+  DRAINING: RawProtoServerControlStatus.DRAINING,
 }

--- a/packages/client/src/proto.ts
+++ b/packages/client/src/proto.ts
@@ -20,6 +20,7 @@
 import {
   CountKind as RawProtoCountKind,
   ServerControlKind as RawProtoServerControlKind,
+  ServerControlStatus as RawProtoServerControlStatus,
 } from './protobuf_ts/generated/omega_edit/v1/omega_edit'
 
 export {
@@ -59,6 +60,12 @@ export const ProtoServerControlKind = {
   ...RawProtoServerControlKind,
 }
 
+export const ProtoServerControlStatus = {
+  SERVER_CONTROL_STATUS_UNSPECIFIED: RawProtoServerControlStatus.UNSPECIFIED,
+  SERVER_CONTROL_STATUS_COMPLETED: RawProtoServerControlStatus.COMPLETED,
+  SERVER_CONTROL_STATUS_DRAINING: RawProtoServerControlStatus.DRAINING,
+}
+
 export const CountKind = {
   COUNT_COMPUTED_FILE_SIZE: ProtoCountKind.COUNT_KIND_COMPUTED_FILE_SIZE,
   COUNT_CHANGES: ProtoCountKind.COUNT_KIND_CHANGES,
@@ -77,4 +84,13 @@ export const ServerControlKind = {
   SERVER_CONTROL_IMMEDIATE_SHUTDOWN:
     ProtoServerControlKind.SERVER_CONTROL_KIND_IMMEDIATE_SHUTDOWN,
   ...ProtoServerControlKind,
+}
+
+export const ServerControlStatus = {
+  SERVER_CONTROL_STATUS_UNSPECIFIED:
+    ProtoServerControlStatus.SERVER_CONTROL_STATUS_UNSPECIFIED,
+  SERVER_CONTROL_STATUS_COMPLETED:
+    ProtoServerControlStatus.SERVER_CONTROL_STATUS_COMPLETED,
+  SERVER_CONTROL_STATUS_DRAINING:
+    ProtoServerControlStatus.SERVER_CONTROL_STATUS_DRAINING,
 }

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -168,7 +168,8 @@ export interface IEditorServiceClient {
   /**
    * Create a new editing session, optionally backed by an existing file.
    * Returns the assigned session ID, checkpoint directory, and (if a file was
-   * provided) the original file size.
+   * provided) the original file size. If the server is already draining
+   * existing sessions for graceful shutdown, this RPC fails with UNAVAILABLE.
    *
    * @generated from protobuf rpc: CreateSession
    */
@@ -1656,7 +1657,8 @@ export class EditorServiceClient
   /**
    * Create a new editing session, optionally backed by an existing file.
    * Returns the assigned session ID, checkpoint directory, and (if a file was
-   * provided) the original file size.
+   * provided) the original file size. If the server is already draining
+   * existing sessions for graceful shutdown, this RPC fails with UNAVAILABLE.
    *
    * @generated from protobuf rpc: CreateSession
    */

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -168,8 +168,8 @@ export interface IEditorServiceClient {
   /**
    * Create a new editing session, optionally backed by an existing file.
    * Returns the assigned session ID, checkpoint directory, and (if a file was
-   * provided) the original file size. If the server is already draining
-   * existing sessions for graceful shutdown, this RPC fails with UNAVAILABLE.
+   * provided) the original file size. If the server has begun shutdown or is
+   * draining existing sessions, this RPC fails with UNAVAILABLE.
    *
    * @generated from protobuf rpc: CreateSession
    */
@@ -1657,8 +1657,8 @@ export class EditorServiceClient
   /**
    * Create a new editing session, optionally backed by an existing file.
    * Returns the assigned session ID, checkpoint directory, and (if a file was
-   * provided) the original file size. If the server is already draining
-   * existing sessions for graceful shutdown, this RPC fails with UNAVAILABLE.
+   * provided) the original file size. If the server has begun shutdown or is
+   * draining existing sessions, this RPC fails with UNAVAILABLE.
    *
    * @generated from protobuf rpc: CreateSession
    */

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -124,9 +124,14 @@ export interface ServerControlResponse {
    */
   pid: number // Server process ID.
   /**
-   * @generated from protobuf field: int32 response_code = 3
+   * @deprecated
+   * @generated from protobuf field: int32 response_code = 3 [deprecated = true]
    */
-  responseCode: number // 0 for success, non-zero for failure.
+  responseCode: number // Legacy field: 0 when the command was accepted, non-zero only for compatibility with older clients.
+  /**
+   * @generated from protobuf field: omega_edit.v1.ServerControlStatus status = 4
+   */
+  status: ServerControlStatus // Explicit shutdown progress for accepted commands.
 }
 /**
  * Client heartbeat request.  The client identifies itself and lists its
@@ -1834,6 +1839,29 @@ export enum ServerControlKind {
    */
   IMMEDIATE_SHUTDOWN = 2,
 }
+/**
+ * Status reported after a server-control command is accepted.
+ *
+ * @generated from protobuf enum omega_edit.v1.ServerControlStatus
+ */
+export enum ServerControlStatus {
+  /**
+   * @generated from protobuf enum value: SERVER_CONTROL_STATUS_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+  /**
+   * The requested shutdown path has completed and the server is stopping.
+   *
+   * @generated from protobuf enum value: SERVER_CONTROL_STATUS_COMPLETED = 1;
+   */
+  COMPLETED = 1,
+  /**
+   * Graceful shutdown was accepted, but the server is still draining sessions.
+   *
+   * @generated from protobuf enum value: SERVER_CONTROL_STATUS_DRAINING = 2;
+   */
+  DRAINING = 2,
+}
 // @generated message type with reflection information, may provide speed optimized methods
 class GetServerInfoRequest$Type extends MessageType<GetServerInfoRequest> {
   constructor() {
@@ -2192,6 +2220,16 @@ class ServerControlResponse$Type extends MessageType<ServerControlResponse> {
         kind: 'scalar',
         T: 5 /*ScalarType.INT32*/,
       },
+      {
+        no: 4,
+        name: 'status',
+        kind: 'enum',
+        T: () => [
+          'omega_edit.v1.ServerControlStatus',
+          ServerControlStatus,
+          'SERVER_CONTROL_STATUS_',
+        ],
+      },
     ])
   }
   create(value?: PartialMessage<ServerControlResponse>): ServerControlResponse {
@@ -2199,6 +2237,7 @@ class ServerControlResponse$Type extends MessageType<ServerControlResponse> {
     message.kind = 0
     message.pid = 0
     message.responseCode = 0
+    message.status = 0
     if (value !== undefined)
       reflectionMergePartial<ServerControlResponse>(this, message, value)
     return message
@@ -2220,8 +2259,11 @@ class ServerControlResponse$Type extends MessageType<ServerControlResponse> {
         case /* int32 pid */ 2:
           message.pid = reader.int32()
           break
-        case /* int32 response_code */ 3:
+        case /* int32 response_code = 3 [deprecated = true] */ 3:
           message.responseCode = reader.int32()
+          break
+        case /* omega_edit.v1.ServerControlStatus status */ 4:
+          message.status = reader.int32()
           break
         default:
           let u = options.readUnknownField
@@ -2251,9 +2293,12 @@ class ServerControlResponse$Type extends MessageType<ServerControlResponse> {
     if (message.kind !== 0) writer.tag(1, WireType.Varint).int32(message.kind)
     /* int32 pid = 2; */
     if (message.pid !== 0) writer.tag(2, WireType.Varint).int32(message.pid)
-    /* int32 response_code = 3; */
+    /* int32 response_code = 3 [deprecated = true]; */
     if (message.responseCode !== 0)
       writer.tag(3, WireType.Varint).int32(message.responseCode)
+    /* omega_edit.v1.ServerControlStatus status = 4; */
+    if (message.status !== 0)
+      writer.tag(4, WireType.Varint).int32(message.status)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -129,9 +129,9 @@ export interface ServerControlResponse {
    */
   responseCode: number // Legacy field: 0 when the command was accepted, non-zero only for compatibility with older clients.
   /**
-   * @generated from protobuf field: omega_edit.v1.ServerControlStatus status = 4
+   * @generated from protobuf field: optional omega_edit.v1.ServerControlStatus status = 4
    */
-  status: ServerControlStatus // Explicit shutdown progress for accepted commands.
+  status?: ServerControlStatus // Explicit shutdown progress for accepted commands; optional so clients can detect older servers that omitted the field and fall back to legacy compatibility handling.
 }
 /**
  * Client heartbeat request.  The client identifies itself and lists its
@@ -2227,6 +2227,7 @@ class ServerControlResponse$Type extends MessageType<ServerControlResponse> {
         no: 4,
         name: 'status',
         kind: 'enum',
+        opt: true,
         T: () => [
           'omega_edit.v1.ServerControlStatus',
           ServerControlStatus,
@@ -2240,7 +2241,6 @@ class ServerControlResponse$Type extends MessageType<ServerControlResponse> {
     message.kind = 0
     message.pid = 0
     message.responseCode = 0
-    message.status = 0
     if (value !== undefined)
       reflectionMergePartial<ServerControlResponse>(this, message, value)
     return message
@@ -2265,7 +2265,7 @@ class ServerControlResponse$Type extends MessageType<ServerControlResponse> {
         case /* int32 response_code = 3 [deprecated = true] */ 3:
           message.responseCode = reader.int32()
           break
-        case /* omega_edit.v1.ServerControlStatus status */ 4:
+        case /* optional omega_edit.v1.ServerControlStatus status */ 4:
           message.status = reader.int32()
           break
         default:
@@ -2299,8 +2299,8 @@ class ServerControlResponse$Type extends MessageType<ServerControlResponse> {
     /* int32 response_code = 3 [deprecated = true]; */
     if (message.responseCode !== 0)
       writer.tag(3, WireType.Varint).int32(message.responseCode)
-    /* omega_edit.v1.ServerControlStatus status = 4; */
-    if (message.status !== 0)
+    /* optional omega_edit.v1.ServerControlStatus status = 4; */
+    if (message.status !== undefined)
       writer.tag(4, WireType.Varint).int32(message.status)
     let u = options.writeUnknownFields
     if (u !== false)

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -957,9 +957,7 @@ export async function startServerUnixSocket(
  * @returns structured shutdown status
  */
 export function stopServerGraceful(): Promise<IServerControlResult> {
-  return new Promise<IServerControlResult>(async (resolve, _) => {
-    return resolve(stopServer(ServerControlKind.GRACEFUL_SHUTDOWN))
-  })
+  return stopServer(ServerControlKind.GRACEFUL_SHUTDOWN)
 }
 
 /**
@@ -967,9 +965,7 @@ export function stopServerGraceful(): Promise<IServerControlResult> {
  * @returns structured shutdown status
  */
 export function stopServerImmediate(): Promise<IServerControlResult> {
-  return new Promise<IServerControlResult>(async (resolve, _) => {
-    return resolve(stopServer(ServerControlKind.IMMEDIATE_SHUTDOWN))
-  })
+  return stopServer(ServerControlKind.IMMEDIATE_SHUTDOWN)
 }
 
 export type ServerControlState = 'completed' | 'draining' | 'unknown'

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -29,7 +29,10 @@ import waitPort from 'wait-port'
 
 // Re-export HeartbeatOptions so consumers can import it from @omega-edit/client
 export type { HeartbeatOptions }
-import { ServerControlKind } from './protobuf_ts/generated/omega_edit/v1/omega_edit'
+import {
+  ServerControlKind,
+  ServerControlStatus,
+} from './protobuf_ts/generated/omega_edit/v1/omega_edit'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 
@@ -951,34 +954,76 @@ export async function startServerUnixSocket(
 
 /**
  * Stops the server gracefully
- * @returns 0 if the server was stopped, non-zero otherwise
+ * @returns structured shutdown status
  */
-export function stopServerGraceful(): Promise<number> {
-  return new Promise<number>(async (resolve, _) => {
+export function stopServerGraceful(): Promise<IServerControlResult> {
+  return new Promise<IServerControlResult>(async (resolve, _) => {
     return resolve(stopServer(ServerControlKind.GRACEFUL_SHUTDOWN))
   })
 }
 
 /**
  * Stops the server immediately
- * @returns 0 if the server was stopped, non-zero otherwise
+ * @returns structured shutdown status
  */
-export function stopServerImmediate(): Promise<number> {
-  return new Promise<number>(async (resolve, _) => {
+export function stopServerImmediate(): Promise<IServerControlResult> {
+  return new Promise<IServerControlResult>(async (resolve, _) => {
     return resolve(stopServer(ServerControlKind.IMMEDIATE_SHUTDOWN))
   })
 }
 
-type ServerControlResponseCode = number
+export type ServerControlState = 'completed' | 'draining' | 'unknown'
+
+export interface IServerControlResult {
+  responseCode: number
+  serverProcessId: number
+  status: ServerControlState
+}
+
+type RawServerControlResponse =
+  | { responseCode: number; pid?: number; status?: ServerControlStatus }
+  | {
+      getResponseCode(): number
+      getPid?(): number
+      getStatus?(): ServerControlStatus
+    }
+
+function getServerControlStatus(
+  response: RawServerControlResponse,
+  kind: ServerControlKind,
+  responseCode: number
+): ServerControlState {
+  const rawStatus =
+    'getStatus' in response && typeof response.getStatus === 'function'
+      ? response.getStatus()
+      : 'status' in response
+        ? response.status
+        : undefined
+
+  switch (rawStatus) {
+    case ServerControlStatus.COMPLETED:
+      return 'completed'
+    case ServerControlStatus.DRAINING:
+      return 'draining'
+    default:
+      if (kind === ServerControlKind.GRACEFUL_SHUTDOWN && responseCode === 1) {
+        return 'draining'
+      }
+      if (responseCode === 0) {
+        return 'completed'
+      }
+      return 'unknown'
+  }
+}
 
 /**
  * Stop the server
  * @param kind defines how the server should shut down
- * @returns 0 if the server was stopped, non-zero otherwise
+ * @returns structured shutdown status
  */
 async function stopServer(
   kind: ServerControlKind
-): Promise<ServerControlResponseCode> {
+): Promise<IServerControlResult> {
   const logMetadata = {
     fn: 'stopServer',
     kind: kind.toString(),
@@ -988,8 +1033,8 @@ async function stopServer(
   const client = await getClient()
 
   try {
-    const resp: { responseCode: number } | { getResponseCode(): number } =
-      await new Promise((resolve, reject) => {
+    const resp: RawServerControlResponse = await new Promise(
+      (resolve, reject) => {
         client.serverControl({ kind }, (err, response) => {
           if (err) {
             reject(err)
@@ -999,12 +1044,20 @@ async function stopServer(
             resolve(response)
           }
         })
-      })
+      }
+    )
 
     const responseCode =
       'getResponseCode' in resp ? resp.getResponseCode() : resp.responseCode
+    const serverProcessId =
+      'getPid' in resp && typeof resp.getPid === 'function'
+        ? resp.getPid()
+        : 'pid' in resp && typeof resp.pid === 'number'
+          ? resp.pid
+          : -1
+    const status = getServerControlStatus(resp, kind, responseCode)
 
-    if (responseCode !== 0) {
+    if (responseCode !== 0 && status !== 'draining') {
       log.error({
         ...logMetadata,
         stopped: false,
@@ -1014,9 +1067,14 @@ async function stopServer(
       log.debug({
         ...logMetadata,
         stopped: true,
+        status,
       })
     }
-    return responseCode
+    return {
+      responseCode,
+      serverProcessId,
+      status,
+    }
   } catch (err: unknown) {
     if (err instanceof Error) {
       if ('code' in err) {
@@ -1071,7 +1129,11 @@ async function stopServer(
         },
       })
     }
-    return -1
+    return {
+      responseCode: -1,
+      serverProcessId: -1,
+      status: 'unknown',
+    }
   }
 }
 

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -1062,7 +1062,7 @@ async function stopServer(
     } else {
       log.debug({
         ...logMetadata,
-        stopped: true,
+        stopped: status === 'completed',
         status,
       })
     }

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -981,7 +981,7 @@ type RawServerControlResponse =
   | {
       getResponseCode(): number
       getPid?(): number
-      getStatus?(): ServerControlStatus
+      getStatus?(): ServerControlStatus | undefined
     }
 
 function getServerControlStatus(

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -1001,12 +1001,19 @@ function getServerControlStatus(
       return 'completed'
     case ServerControlStatus.DRAINING:
       return 'draining'
+    case ServerControlStatus.UNSPECIFIED:
+      return 'unknown'
     default:
-      if (kind === ServerControlKind.GRACEFUL_SHUTDOWN && responseCode === 1) {
-        return 'draining'
-      }
-      if (responseCode === 0) {
-        return 'completed'
+      if (rawStatus === undefined) {
+        if (
+          kind === ServerControlKind.GRACEFUL_SHUTDOWN &&
+          responseCode === 1
+        ) {
+          return 'draining'
+        }
+        if (responseCode === 0) {
+          return 'completed'
+        }
       }
       return 'unknown'
   }

--- a/packages/client/tests/specs/protoCompatibility.spec.ts
+++ b/packages/client/tests/specs/protoCompatibility.spec.ts
@@ -215,6 +215,9 @@ describe('Proto Compatibility', () => {
     expect(serverControl.getStatus()).to.equal(
       ServerControlStatus.SERVER_CONTROL_STATUS_COMPLETED
     )
+    expect(ServerControlStatus.COMPLETED).to.equal(
+      ServerControlStatus.SERVER_CONTROL_STATUS_COMPLETED
+    )
     expect(
       new ServerControlResponse({
         kind: ProtoServerControlKind.GRACEFUL_SHUTDOWN,

--- a/packages/client/tests/specs/protoCompatibility.spec.ts
+++ b/packages/client/tests/specs/protoCompatibility.spec.ts
@@ -22,13 +22,18 @@ import { expect, initChai } from './common.js'
 import { getModuleCompat } from './moduleCompat.js'
 
 const { require } = getModuleCompat(import.meta.url)
-const { CountKind, ServerControlKind } = require('../../dist/cjs/proto.js')
+const {
+  CountKind,
+  ServerControlKind,
+  ServerControlStatus,
+} = require('../../dist/cjs/proto.js')
 const {
   EditorServiceClient,
 } = require('../../dist/cjs/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.js')
 const {
   CountKind: ProtoCountKind,
   ServerControlKind: ProtoServerControlKind,
+  ServerControlStatus: ProtoServerControlStatus,
   SessionEventKind,
   ViewportEventKind,
 } = require('../../dist/cjs/protobuf_ts/generated/omega_edit/v1/omega_edit.js')
@@ -200,12 +205,16 @@ describe('Proto Compatibility', () => {
       kind: ProtoServerControlKind.IMMEDIATE_SHUTDOWN,
       pid: 99,
       responseCode: 0,
+      status: ProtoServerControlStatus.COMPLETED,
     })
     expect(serverControl.getKind()).to.equal(
       ProtoServerControlKind.IMMEDIATE_SHUTDOWN
     )
     expect(serverControl.getPid()).to.equal(99)
     expect(serverControl.getResponseCode()).to.equal(0)
+    expect(serverControl.getStatus()).to.equal(
+      ServerControlStatus.SERVER_CONTROL_STATUS_COMPLETED
+    )
 
     const heartbeat = new HeartbeatResponse({
       sessionCount: 2,

--- a/packages/client/tests/specs/protoCompatibility.spec.ts
+++ b/packages/client/tests/specs/protoCompatibility.spec.ts
@@ -215,6 +215,13 @@ describe('Proto Compatibility', () => {
     expect(serverControl.getStatus()).to.equal(
       ServerControlStatus.SERVER_CONTROL_STATUS_COMPLETED
     )
+    expect(
+      new ServerControlResponse({
+        kind: ProtoServerControlKind.GRACEFUL_SHUTDOWN,
+        pid: 77,
+        responseCode: 1,
+      }).getStatus()
+    ).to.equal(undefined)
 
     const heartbeat = new HeartbeatResponse({
       sessionCount: 2,
@@ -403,6 +410,13 @@ describe('Proto Compatibility', () => {
     expect(
       wrapServerControlResponse(serverControl.toObject()).getPid()
     ).to.equal(99)
+    expect(
+      wrapServerControlResponse({
+        kind: ProtoServerControlKind.GRACEFUL_SHUTDOWN,
+        pid: 77,
+        responseCode: 1,
+      }).getStatus()
+    ).to.equal(undefined)
     expect(
       wrapHeartbeatResponse(heartbeat.toObject()).getSessionCount()
     ).to.equal(2)

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -187,7 +187,7 @@ describe('Server', () => {
       expect.fail('createSession should reject while graceful shutdown drains')
     } catch (err) {
       expect((err as Error).message).to.include('UNAVAILABLE')
-      expect((err as Error).message).to.include('graceful shutdown')
+      expect((err as Error).message).to.include('server is shutting down')
     }
     expect(await getSessionCount()).to.equal(1)
 

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -173,13 +173,22 @@ describe('Server', () => {
 
   it(`on port ${serverTestPort} should stop gracefully via API`, async () => {
     // stop the server gracefully
-    await stopServerGraceful()
+    const response = await stopServerGraceful()
+    expect(response.responseCode).to.equal(0)
+    expect(response.status).to.equal('draining')
+    expect(response.serverProcessId).to.equal(pid)
 
     // for graceful shutdown, the server should still be running until the session count drops to 0
     expect(pidIsRunning(pid as number)).to.be.true
 
     // once the server is stopping gracefully, no new sessions should be allowed
-    expect((await createSession()).getSessionId()).to.be.empty
+    try {
+      await createSession()
+      expect.fail('createSession should reject while graceful shutdown drains')
+    } catch (err) {
+      expect((err as Error).message).to.include('UNAVAILABLE')
+      expect((err as Error).message).to.include('graceful shutdown')
+    }
     expect(await getSessionCount()).to.equal(1)
 
     // destroy the session, dropping the count to 0, then the server should stop
@@ -188,6 +197,24 @@ describe('Server', () => {
     // pause for up to 2 seconds to allow server some time to stop
     for (let i = 0; i < 20; ++i) {
       await delay(100) // 0.1 second
+      if (!pidIsRunning(pid as number)) {
+        break
+      }
+    }
+    expect(pidIsRunning(pid as number)).to.be.false
+  })
+
+  it(`on port ${serverTestPort} should stop gracefully via API when no sessions are active`, async () => {
+    expect(await destroySession(session_id)).to.equal(session_id)
+    expect(await getSessionCount()).to.equal(0)
+
+    const response = await stopServerGraceful()
+    expect(response.responseCode).to.equal(0)
+    expect(response.status).to.equal('completed')
+    expect(response.serverProcessId).to.equal(pid)
+
+    for (let i = 0; i < 20; ++i) {
+      await delay(100)
       if (!pidIsRunning(pid as number)) {
         break
       }

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -137,7 +137,7 @@ describe('Server Edge Cases', () => {
         expect(heartbeat.serverVirtualMemoryBytes).to.equal(undefined)
       }
 
-      expect(await stopServerImmediate()).to.equal(0)
+      expect((await stopServerImmediate()).responseCode).to.equal(0)
       for (let attempt = 0; attempt < 30; attempt += 1) {
         await delay(100)
         if (await stopServiceOnPort(port as number)) {
@@ -184,7 +184,7 @@ describe('Server Edge Cases', () => {
       const serverInfo = await getServerInfo()
       expect(serverInfo.serverProcessId).to.equal(pid)
 
-      expect(await stopServerImmediate()).to.equal(0)
+      expect((await stopServerImmediate()).responseCode).to.equal(0)
       for (let attempt = 0; attempt < 30; attempt += 1) {
         await delay(100)
         if (!pidIsRunning(pid as number)) {
@@ -318,9 +318,13 @@ describe('Server Edge Cases', () => {
     )
 
     try {
-      expect(await serverModule.stopServerImmediate()).to.equal(-1)
+      expect((await serverModule.stopServerImmediate()).responseCode).to.equal(
+        -1
+      )
       errorMessage = 'INTERNAL: unavailable'
-      expect(await serverModule.stopServerImmediate()).to.equal(-1)
+      expect((await serverModule.stopServerImmediate()).responseCode).to.equal(
+        -1
+      )
     } finally {
       restoreGetClient()
     }
@@ -333,11 +337,17 @@ describe('Server Edge Cases', () => {
       async () => ({
         serverControl(
           _request: unknown,
-          callback: (err: null, response: { getResponseCode(): number }) => void
+          callback: (
+            err: null,
+            response: { getResponseCode(): number; getStatus(): number }
+          ) => void
         ) {
           callback(null, {
             getResponseCode() {
               return 7
+            },
+            getStatus() {
+              return 0
             },
           })
         },
@@ -345,7 +355,9 @@ describe('Server Edge Cases', () => {
     )
 
     try {
-      expect(await serverModule.stopServerImmediate()).to.equal(7)
+      const response = await serverModule.stopServerImmediate()
+      expect(response.responseCode).to.equal(7)
+      expect(response.status).to.equal('unknown')
     } finally {
       restoreGetClient()
     }
@@ -372,9 +384,13 @@ describe('Server Edge Cases', () => {
     )
 
     try {
-      expect(await serverModule.stopServerImmediate()).to.equal(-1)
+      expect((await serverModule.stopServerImmediate()).responseCode).to.equal(
+        -1
+      )
       mode = 'string'
-      expect(await serverModule.stopServerImmediate()).to.equal(-1)
+      expect((await serverModule.stopServerImmediate()).responseCode).to.equal(
+        -1
+      )
     } finally {
       restoreGetClient()
     }

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -565,6 +565,36 @@ describe('Server Edge Cases', () => {
     }
   })
 
+  it('should infer draining for graceful shutdown when status is absent', async () => {
+    const restoreGetClient = overrideProperty(
+      clientModule as Record<string, any>,
+      'getClient',
+      async () => ({
+        serverControl(
+          _request: unknown,
+          callback: (
+            err: null,
+            response: { getResponseCode(): number; getStatus?: undefined }
+          ) => void
+        ) {
+          callback(null, {
+            getResponseCode() {
+              return 1
+            },
+          })
+        },
+      })
+    )
+
+    try {
+      const response = await serverModule.stopServerGraceful()
+      expect(response.responseCode).to.equal(1)
+      expect(response.status).to.equal('draining')
+    } finally {
+      restoreGetClient()
+    }
+  })
+
   it('should return an error code for generic shutdown exceptions', async () => {
     let mode: 'error' | 'string' = 'error'
     const restoreGetClient = overrideProperty(

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -319,7 +319,10 @@ describe('Server Edge Cases', () => {
       expect(udsPid).to.be.a('number').greaterThan(0)
       expect((await getServerInfo()).serverProcessId).to.equal(udsPid)
 
-      expect(await stopServerImmediate()).to.equal(0)
+      const stopResponse = await stopServerImmediate()
+      expect(stopResponse.responseCode).to.equal(0)
+      expect(stopResponse.status).to.equal('completed')
+      expect(stopResponse.serverProcessId).to.equal(udsPid)
     } finally {
       delete process.env.OMEGA_EDIT_SERVER_SOCKET
       delete process.env.OMEGA_EDIT_SERVER_URI

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -502,6 +502,69 @@ describe('Server Edge Cases', () => {
     }
   })
 
+  it('should treat an explicit UNSPECIFIED shutdown status as unknown', async () => {
+    const restoreGetClient = overrideProperty(
+      clientModule as Record<string, any>,
+      'getClient',
+      async () => ({
+        serverControl(
+          _request: unknown,
+          callback: (
+            err: null,
+            response: { getResponseCode(): number; getStatus(): number }
+          ) => void
+        ) {
+          callback(null, {
+            getResponseCode() {
+              return 0
+            },
+            getStatus() {
+              return 0
+            },
+          })
+        },
+      })
+    )
+
+    try {
+      const response = await serverModule.stopServerImmediate()
+      expect(response.responseCode).to.equal(0)
+      expect(response.status).to.equal('unknown')
+    } finally {
+      restoreGetClient()
+    }
+  })
+
+  it('should preserve response-code fallback when shutdown status is absent', async () => {
+    const restoreGetClient = overrideProperty(
+      clientModule as Record<string, any>,
+      'getClient',
+      async () => ({
+        serverControl(
+          _request: unknown,
+          callback: (
+            err: null,
+            response: { getResponseCode(): number; getStatus?: undefined }
+          ) => void
+        ) {
+          callback(null, {
+            getResponseCode() {
+              return 0
+            },
+          })
+        },
+      })
+    )
+
+    try {
+      const response = await serverModule.stopServerImmediate()
+      expect(response.responseCode).to.equal(0)
+      expect(response.status).to.equal('completed')
+    } finally {
+      restoreGetClient()
+    }
+  })
+
   it('should return an error code for generic shutdown exceptions', async () => {
     let mode: 'error' | 'string' = 'error'
     const restoreGetClient = overrideProperty(

--- a/proto/README.md
+++ b/proto/README.md
@@ -41,9 +41,10 @@ serialized message; when decoded by consumers, they appear as language defaults:
 
 ### Server Lifecycle Contract Note
 
-Graceful shutdown is now explicit in the wire contract:
+Shutdown lifecycle behavior is now explicit in the wire contract:
 
-- `CreateSession` fails with gRPC `UNAVAILABLE` once graceful shutdown begins
+- `CreateSession` fails with gRPC `UNAVAILABLE` once shutdown begins, including
+  both graceful and immediate shutdown
 - `ServerControlResponse.status` distinguishes `COMPLETED` from `DRAINING`
 - the deprecated `response_code` field remains for compatibility and is `0`
   for accepted commands, including graceful shutdown while draining

--- a/proto/README.md
+++ b/proto/README.md
@@ -46,6 +46,9 @@ Shutdown lifecycle behavior is now explicit in the wire contract:
 - `CreateSession` fails with gRPC `UNAVAILABLE` once shutdown begins, including
   both graceful and immediate shutdown
 - `ServerControlResponse.status` distinguishes `COMPLETED` from `DRAINING`
+  when present, and remains `optional` so newer clients can detect older
+  servers that omitted the field and fall back to legacy response-code
+  handling
 - the deprecated `response_code` field remains for compatibility and is `0`
   for accepted commands, including graceful shutdown while draining
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -28,6 +28,15 @@ equivalent process metric is not consistently available.
 The legacy JVM-shaped fields remain in the schema as deprecated compatibility
 fields so existing protobuf consumers do not break on the wire.
 
+### Server Lifecycle Contract Note
+
+Graceful shutdown is now explicit in the wire contract:
+
+- `CreateSession` fails with gRPC `UNAVAILABLE` once graceful shutdown begins
+- `ServerControlResponse.status` distinguishes `COMPLETED` from `DRAINING`
+- the deprecated `response_code` field remains for compatibility and is `0`
+  for accepted commands, including graceful shutdown while draining
+
 ## Using with Buf
 
 The proto is published to [buf.build/ctc-oss/omega-edit](https://buf.build/ctc-oss/omega-edit) for easy multi-language stub generation.

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -370,7 +370,7 @@ message ServerControlResponse {
   ServerControlKind kind = 1; // The command that was executed.
   int32 pid = 2;              // Server process ID.
   int32 response_code = 3 [deprecated = true]; // Legacy field: 0 when the command was accepted, non-zero only for compatibility with older clients.
-  ServerControlStatus status = 4;              // Explicit shutdown progress for accepted commands.
+  optional ServerControlStatus status = 4;     // Explicit shutdown progress for accepted commands; optional so clients can detect older servers that omitted the field and fall back to legacy compatibility handling.
 }
 
 // Client heartbeat request.  The client identifies itself and lists its

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -49,8 +49,8 @@ service EditorService {
 
   // Create a new editing session, optionally backed by an existing file.
   // Returns the assigned session ID, checkpoint directory, and (if a file was
-  // provided) the original file size. If the server is already draining
-  // existing sessions for graceful shutdown, this RPC fails with UNAVAILABLE.
+  // provided) the original file size. If the server has begun shutdown or is
+  // draining existing sessions, this RPC fails with UNAVAILABLE.
   rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
 
   // Persist the session's computed content to disk.  The caller specifies the

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -49,7 +49,8 @@ service EditorService {
 
   // Create a new editing session, optionally backed by an existing file.
   // Returns the assigned session ID, checkpoint directory, and (if a file was
-  // provided) the original file size.
+  // provided) the original file size. If the server is already draining
+  // existing sessions for graceful shutdown, this RPC fails with UNAVAILABLE.
   rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
 
   // Persist the session's computed content to disk.  The caller specifies the
@@ -326,6 +327,15 @@ enum ServerControlKind {
   SERVER_CONTROL_KIND_IMMEDIATE_SHUTDOWN = 2;
 }
 
+// Status reported after a server-control command is accepted.
+enum ServerControlStatus {
+  SERVER_CONTROL_STATUS_UNSPECIFIED = 0;
+  // The requested shutdown path has completed and the server is stopping.
+  SERVER_CONTROL_STATUS_COMPLETED = 1;
+  // Graceful shutdown was accepted, but the server is still draining sessions.
+  SERVER_CONTROL_STATUS_DRAINING = 2;
+}
+
 // ===========================================================================
 // Request / Response messages — Server info & management
 // ===========================================================================
@@ -359,7 +369,8 @@ message ServerControlRequest {
 message ServerControlResponse {
   ServerControlKind kind = 1; // The command that was executed.
   int32 pid = 2;              // Server process ID.
-  int32 response_code = 3;    // 0 for success, non-zero for failure.
+  int32 response_code = 3 [deprecated = true]; // Legacy field: 0 when the command was accepted, non-zero only for compatibility with older clients.
+  ServerControlStatus status = 4;              // Explicit shutdown progress for accepted commands.
 }
 
 // Client heartbeat request.  The client identifies itself and lists its

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -389,10 +389,8 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
                                                const ::omega_edit::v1::CreateSessionRequest *request,
                                                ::omega_edit::v1::CreateSessionResponse *response) {
     if (graceful_shutdown_.load()) {
-        // During graceful shutdown, refuse new sessions (return empty like previous server behavior)
-        response->set_session_id("");
-        response->set_checkpoint_directory("");
-        return grpc::Status::OK;
+        return grpc::Status(grpc::StatusCode::UNAVAILABLE,
+                            "server is draining existing sessions for graceful shutdown");
     }
 
     std::string file_path;
@@ -1236,17 +1234,20 @@ grpc::Status EditorServiceImpl::ServerControl(grpc::ServerContext * /*context*/,
             // Check if no sessions remain - if so, we can stop immediately
             if (session_manager_.session_count() == 0) {
                 response->set_response_code(0);
+                response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_COMPLETED);
                 if (shutdown_callback_) {
                     shutdown_callback_();
                 }
             } else {
-                response->set_response_code(1); // Sessions still active
+                response->set_response_code(0);
+                response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_DRAINING);
             }
             break;
 
         case ::omega_edit::v1::SERVER_CONTROL_KIND_IMMEDIATE_SHUTDOWN:
             session_manager_.destroy_all();
             response->set_response_code(0);
+            response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_COMPLETED);
             if (shutdown_callback_) {
                 shutdown_callback_();
             }

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -1245,6 +1245,7 @@ grpc::Status EditorServiceImpl::ServerControl(grpc::ServerContext * /*context*/,
             break;
 
         case ::omega_edit::v1::SERVER_CONTROL_KIND_IMMEDIATE_SHUTDOWN:
+            graceful_shutdown_.store(true);
             session_manager_.destroy_all();
             response->set_response_code(0);
             response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_COMPLETED);

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -389,8 +389,7 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
                                                const ::omega_edit::v1::CreateSessionRequest *request,
                                                ::omega_edit::v1::CreateSessionResponse *response) {
     if (graceful_shutdown_.load()) {
-        return grpc::Status(grpc::StatusCode::UNAVAILABLE,
-                            "server is draining existing sessions for graceful shutdown");
+        return grpc::Status(grpc::StatusCode::UNAVAILABLE, "server is shutting down");
     }
 
     std::string file_path;


### PR DESCRIPTION
## Summary\n- make graceful shutdown session refusal explicit with gRPC UNAVAILABLE\n- add a structured ServerControlStatus enum so draining vs completed is explicit on the wire\n- return structured shutdown results from the TS client and add lifecycle coverage for active sessions, no active sessions, and rejected creation\n\nCloses #1382\n\n## Testing\n- yarn workspace @omega-edit/client test:client\n- yarn workspace @omega-edit/client test:lifecycle\n- yarn lint