### PR TITLE
Clarify desired ID collision contract

### DIFF
--- a/UPGRADE-v1-to-v2.md
+++ b/UPGRADE-v1-to-v2.md
@@ -13,6 +13,7 @@
 - Most TypeScript consumers can upgrade by bumping package versions and rerunning their normal regression tests.
 - If you relied on the old Scala server scripts or deployment model, switch to the packaged C++ server (`@omega-edit/server` or `server/cpp`).
 - Server info and heartbeat responses now expose native-runtime metadata, while legacy JVM-shaped compatibility fields remain deprecated in the schema.
+- Caller-chosen `session_id_desired` values and caller-chosen `viewport_id_desired` values are now explicit uniqueness requests: duplicates are rejected with `ALREADY_EXISTS` instead of being remapped to a different ID.
 
 ## Quick path
 

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -228,8 +228,8 @@ export interface CreateSessionRequest {
    */
   filePath?: string
   /**
-   * Caller-chosen session ID.  The server may assign a different ID if this
-   * one is already in use.
+   * Caller-chosen session ID. Must be unique; duplicates are rejected with
+   * ALREADY_EXISTS rather than being silently reassigned.
    *
    * @generated from protobuf field: optional string session_id_desired = 2
    */
@@ -573,9 +573,12 @@ export interface CreateViewportRequest {
    */
   isFloating: boolean // When true, the viewport follows edits automatically.
   /**
+   * Optional caller-chosen viewport ID. Must be unique within the session;
+   * duplicates are rejected with ALREADY_EXISTS.
+   *
    * @generated from protobuf field: optional string viewport_id_desired = 5
    */
-  viewportIdDesired?: string // Optional caller-chosen viewport ID.
+  viewportIdDesired?: string
 }
 /**
  * Response carrying a viewport's content.

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -1190,6 +1190,57 @@ describe('Sessions', () => {
     expect(await getSessionCount()).to.equal(initialCount)
   })
 
+  it('Should reject duplicate desired session IDs', async () => {
+    const initialCount = await getSessionCount()
+    const desiredSessionId = 'desired-session-id'
+    const session = await createSession('', desiredSessionId)
+    const sessionId = session.getSessionId()
+
+    expect(sessionId).to.equal(desiredSessionId)
+    expect(await getSessionCount()).to.equal(initialCount + 1)
+
+    try {
+      await createSession('', desiredSessionId)
+      expect.fail('createSession should reject duplicate desired session IDs')
+    } catch (err) {
+      expect((err as Error).message).to.include('ALREADY_EXISTS')
+      expect((err as Error).message).to.include(
+        `session already exists: ${desiredSessionId}`
+      )
+    } finally {
+      await destroySession(sessionId)
+    }
+
+    expect(await getSessionCount()).to.equal(initialCount)
+  })
+
+  it('Should reject duplicate desired viewport IDs within a session', async () => {
+    const session = await createSession()
+    const sessionId = session.getSessionId()
+    const desiredViewportId = 'desired-viewport-id'
+
+    try {
+      const viewport = await createViewport(desiredViewportId, sessionId, 0, 16)
+      expect(viewport.getViewportId()).to.equal(
+        `${sessionId}:${desiredViewportId}`
+      )
+
+      try {
+        await createViewport(desiredViewportId, sessionId, 0, 16)
+        expect.fail(
+          'createViewport should reject duplicate desired viewport IDs'
+        )
+      } catch (err) {
+        expect((err as Error).message).to.include('ALREADY_EXISTS')
+        expect((err as Error).message).to.include(
+          `viewport already exists: ${desiredViewportId}`
+        )
+      }
+    } finally {
+      await destroySession(sessionId)
+    }
+  })
+
   it('Should reject invalid and nonexistent sessions', async () => {
     try {
       await getComputedFileSize('nonexistent-session-id-12345')

--- a/proto/omega_edit.proto
+++ b/proto/omega_edit.proto
@@ -174,6 +174,8 @@ message CreateViewportRequest {
   int64 capacity = 2;
   int64 offset = 3;
   bool is_floating = 4;
+  // Optional caller-chosen viewport ID. Must be unique within the session;
+  // duplicates are rejected with ALREADY_EXISTS.
   optional string viewport_id_desired = 5;
 }
 
@@ -198,6 +200,8 @@ message ViewportDataResponse {
 
 message CreateSessionRequest {
   optional string file_path = 1;
+  // Caller-chosen session ID. Must be unique; duplicates are rejected with
+  // ALREADY_EXISTS rather than being silently reassigned.
   optional string session_id_desired = 2;
   optional string checkpoint_directory = 3;
   optional bytes initial_data = 4;

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -395,8 +395,8 @@ message GetHeartbeatResponse {
 message CreateSessionRequest {
   // Path to the file to load.  Omit to create an empty session.
   optional string file_path = 1;
-  // Caller-chosen session ID.  The server may assign a different ID if this
-  // one is already in use.
+  // Caller-chosen session ID. Must be unique; duplicates are rejected with
+  // ALREADY_EXISTS rather than being silently reassigned.
   optional string session_id_desired = 2;
   // Directory for checkpoint files.  Defaults to a system temp directory.
   optional string checkpoint_directory = 3;
@@ -542,7 +542,9 @@ message CreateViewportRequest {
   int64 capacity = 2;                   // Maximum number of bytes the viewport holds.
   int64 offset = 3;                     // Starting byte offset in the session.
   bool is_floating = 4;                 // When true, the viewport follows edits automatically.
-  optional string viewport_id_desired = 5; // Optional caller-chosen viewport ID.
+  // Optional caller-chosen viewport ID. Must be unique within the session;
+  // duplicates are rejected with ALREADY_EXISTS.
+  optional string viewport_id_desired = 5;
 }
 
 // Response carrying a viewport's content.


### PR DESCRIPTION
## Summary
- make the desired-ID contract explicit for session and viewport creation
- document that duplicate caller-chosen IDs are rejected with `ALREADY_EXISTS`
- add regression coverage for duplicate desired session IDs and duplicate desired viewport IDs

Closes #1384

## Why
The native server already rejects duplicate `session_id_desired` values, but the canonical `omega_edit/v1` protobuf comment still said the server might silently assign a different session ID. That mismatch makes the schema an unreliable source of truth for generated clients and external integrators.

## What changed
- updated both proto schemas so `session_id_desired` is documented as a uniqueness request that fails with `ALREADY_EXISTS` when reused
- clarified that `viewport_id_desired` must be unique within a session and also fails with `ALREADY_EXISTS` on duplicates
- added client regression tests that lock down both duplicate-ID cases in CI
- added a note to the v1-to-v2 upgrade guide so the release-era contract is explicit in the migration docs

## Impact
Integrators now get one consistent contract across the native server, the protobuf schema, and the client test suite: caller-chosen IDs are honored when free and rejected when already taken. The server does not silently mint a fallback ID.

## Validation
- `yarn workspace @omega-edit/client test:client`
- `yarn lint`

## Notes
- This PR targets `codex/release-2-0-0-rc1` because the 2.0 release branch is where we are finalizing the contract before the 2.x line freezes.