### PR TITLE
Require explicit lengths for byte APIs

### DIFF
--- a/UPGRADE-v1-to-v2.md
+++ b/UPGRADE-v1-to-v2.md
@@ -14,6 +14,7 @@
 - If you relied on the old Scala server scripts or deployment model, switch to the packaged C++ server (`@omega-edit/server` or `server/cpp`).
 - Server info and heartbeat responses now expose native-runtime metadata, while legacy JVM-shaped compatibility fields remain deprecated in the schema.
 - Caller-chosen `session_id_desired` values and caller-chosen `viewport_id_desired` values are now explicit uniqueness requests: duplicates are rejected with `ALREADY_EXISTS` instead of being remapped to a different ID.
+- Byte-oriented core edit/search APIs now require explicit lengths. `omega_edit_insert_bytes`, `omega_edit_overwrite_bytes`, and `omega_search_create_context_bytes` no longer treat `0` as `strlen(...)`; keep that convenience by using the C-string helpers instead.
 
 ## Quick path
 

--- a/core/src/examples/play.cpp
+++ b/core/src/examples/play.cpp
@@ -213,10 +213,10 @@ int main(int /*argc*/, char ** /*argv*/) {
     omega_edit_delete(session_ptr.get(), 70, 2);
     view_mode.display_mode = display_mode_t::CHAR_MODE;
     omega_edit_insert_string(session_ptr.get(), 10, "++++");
-    omega_edit_overwrite_bytes(session_ptr.get(), 12, (const omega_byte_t *) ".", 0);
-    omega_edit_insert_bytes(session_ptr.get(), 0, (const omega_byte_t *) "+++", 0);
-    omega_edit_overwrite_bytes(session_ptr.get(), 1, (const omega_byte_t *) ".", 0);
-    omega_edit_overwrite_bytes(session_ptr.get(), 77, (const omega_byte_t *) ".", 0);
+    omega_edit_overwrite_bytes(session_ptr.get(), 12, (const omega_byte_t *) ".", 1);
+    omega_edit_insert_bytes(session_ptr.get(), 0, (const omega_byte_t *) "+++", 3);
+    omega_edit_overwrite_bytes(session_ptr.get(), 1, (const omega_byte_t *) ".", 1);
+    omega_edit_overwrite_bytes(session_ptr.get(), 77, (const omega_byte_t *) ".", 1);
     omega_edit_delete(session_ptr.get(), 50, 3);
     omega_edit_insert_bytes(session_ptr.get(), 50, (const omega_byte_t *) "***", 3);
     omega_edit_delete(session_ptr.get(), 1, 50);

--- a/core/src/examples/replay.cpp
+++ b/core/src/examples/replay.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
                 ++inserts;
                 break;
             case 'O':
-                omega_edit_overwrite_bytes(session_ptr.get(), offset, bytes, 0);
+                omega_edit_overwrite_bytes(session_ptr.get(), offset, bytes, length);
                 ++overwrites;
                 break;
             default:

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -203,7 +203,8 @@ typedef struct {
  * @param session_ptr session to make the change in
  * @param offset location offset to make the change
  * @param length number of bytes to delete
- * @return positive change serial number on success, zero otherwise
+ * @return positive change serial number on success, 0 when the request is rejected without error, or -1 for invalid
+ * arguments
  */
 int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t length);
 
@@ -213,7 +214,8 @@ int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t 
  * @param offset location offset to make the change
  * @param bytes bytes to insert at the given offset
  * @param length explicit number of bytes to insert
- * @return positive change serial number on success, zero otherwise
+ * @return positive change serial number on success, 0 for a no-op when length is 0 or when the request is rejected
+ * without error, or -1 for invalid arguments
  * @warning This byte-oriented API never infers a length from strlen. Use omega_edit_insert for null-terminated C
  * strings. Passing length 0 is treated as a no-op.
  */
@@ -227,7 +229,8 @@ int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, co
  * @param cstr C string to insert at the given offset
  * @param length length of the C string to insert (if 0, strlen will be used to calculate the length of null-terminated
  * bytes)
- * @return positive change serial number on success, zero otherwise
+ * @return positive change serial number on success, 0 when the request is rejected without error, or -1 for invalid
+ * arguments
  * @warning This helper is for null-terminated text inputs. For binary data or buffers that may contain embedded nulls,
  * use omega_edit_insert_bytes and pass an explicit byte length.
  */
@@ -239,7 +242,8 @@ int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const ch
  * @param offset location offset to make the change
  * @param bytes new bytes to overwrite the old bytes with
  * @param length explicit number of new bytes
- * @return positive change serial number on success, zero otherwise
+ * @return positive change serial number on success, 0 for a no-op when length is 0 or when the request is rejected
+ * without error, or -1 for invalid arguments
  * @warning This byte-oriented API never infers a length from strlen. Use omega_edit_overwrite for null-terminated C
  * strings. Passing length 0 is treated as a no-op.
  */
@@ -252,7 +256,8 @@ int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset,
  * @param offset location offset to make the change
  * @param cstr new C string to overwrite the old bytes with
  * @param length length of the new C string (if 0, strlen will be used to calculate the length of null-terminated bytes)
- * @return positive change serial number on success, zero otherwise
+ * @return positive change serial number on success, 0 when the request is rejected without error, or -1 for invalid
+ * arguments
  * @warning This helper is for null-terminated text inputs. For binary data or buffers that may contain embedded nulls,
  * use omega_edit_overwrite_bytes and pass an explicit byte length.
  */

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -212,11 +212,10 @@ int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t 
  * @param session_ptr session to make the change in
  * @param offset location offset to make the change
  * @param bytes bytes to insert at the given offset
- * @param length number of bytes to insert (if 0, strlen will be used to calculate the length of null-terminated bytes)
+ * @param length explicit number of bytes to insert
  * @return positive change serial number on success, zero otherwise
- * @warning If editing data that could have embedded nulls, do not rely on setting the length to 0 and have this
- * function compute the length using strlen, because it will be wrong.  Passing length 0 is a convenience for testing
- * and should not be used in production code.  In production code, explicitly pass in the length.
+ * @warning This byte-oriented API never infers a length from strlen. Use omega_edit_insert for null-terminated C
+ * strings. Passing length 0 is treated as a no-op.
  */
 int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                 int64_t length);
@@ -229,9 +228,8 @@ int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, co
  * @param length length of the C string to insert (if 0, strlen will be used to calculate the length of null-terminated
  * bytes)
  * @return positive change serial number on success, zero otherwise
- * @warning If editing data that could have embedded nulls, do not rely on setting the length to 0 and have this
- * function compute the length using strlen, because it will be wrong.  Passing length 0 is a convenience for testing
- * and should not be used in production code.  In production code, explicitly pass in the length.
+ * @warning This helper is for null-terminated text inputs. For binary data or buffers that may contain embedded nulls,
+ * use omega_edit_insert_bytes and pass an explicit byte length.
  */
 int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length);
 
@@ -240,11 +238,10 @@ int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const ch
  * @param session_ptr session to make the change in
  * @param offset location offset to make the change
  * @param bytes new bytes to overwrite the old bytes with
- * @param length number of new bytes (if 0, strlen will be used to calculate the length of null-terminated bytes)
+ * @param length explicit number of new bytes
  * @return positive change serial number on success, zero otherwise
- * @warning If editing data that could have embedded nulls, do not rely on setting the length to 0 and have this
- * function compute the length using strlen, because it will be wrong.  Passing length 0 is a convenience for testing
- * and should not be used in production code.  In production code, explicitly pass in the length.
+ * @warning This byte-oriented API never infers a length from strlen. Use omega_edit_overwrite for null-terminated C
+ * strings. Passing length 0 is treated as a no-op.
  */
 int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                    int64_t length);
@@ -256,9 +253,8 @@ int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset,
  * @param cstr new C string to overwrite the old bytes with
  * @param length length of the new C string (if 0, strlen will be used to calculate the length of null-terminated bytes)
  * @return positive change serial number on success, zero otherwise
- * @warning If editing data that could have embedded nulls, do not rely on setting the length to 0 and have this
- * function compute the length using strlen, because it will be wrong.  Passing length 0 is a convenience for testing
- * and should not be used in production code.  In production code, explicitly pass in the length.
+ * @warning This helper is for null-terminated text inputs. For binary data or buffers that may contain embedded nulls,
+ * use omega_edit_overwrite_bytes and pass an explicit byte length.
  */
 int64_t omega_edit_overwrite(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length);
 
@@ -273,7 +269,7 @@ int64_t omega_edit_overwrite(omega_session_t *session_ptr, int64_t offset, const
  * @param offset location offset to make the change
  * @param delete_length number of original bytes to remove
  * @param bytes replacement bytes, or null if `insert_length` is zero
- * @param insert_length number of replacement bytes to insert
+ * @param insert_length explicit number of replacement bytes to insert
  * @return positive change serial number on success, zero otherwise
  */
 int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
@@ -285,7 +281,7 @@ int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, i
  * @param offset location offset to make the change
  * @param delete_length number of original bytes to remove
  * @param cstr replacement C string, or null if `insert_length` is zero
- * @param insert_length length of the replacement string (if 0, strlen will be used)
+ * @param insert_length length of the replacement string (if 0, strlen will be used for null-terminated text)
  * @return positive change serial number on success, zero otherwise
  */
 int64_t omega_edit_replace(omega_session_t *session_ptr, int64_t offset, int64_t delete_length, const char *cstr,

--- a/core/src/include/omega_edit/search.h
+++ b/core/src/include/omega_edit/search.h
@@ -38,18 +38,15 @@ extern "C" {
  * Create a search context
  * @param session_ptr session to find patterns in
  * @param pattern pointer to the pattern to find (as a sequence of bytes)
- * @param pattern_length length of the pattern (if 0, strlen will be used to calculate the length of null-terminated
- * bytes)
+ * @param pattern_length explicit length of the pattern in bytes
  * @param session_offset start searching at this offset within the session
  * @param session_length search from the starting offset within the session up to this many bytes, if set to zero, it
  * will track the computed session length
  * @param case_insensitive zero for case sensitive match and non-zero otherwise
  * @param is_reverse_search zero for forward search and non-zero for reverse search
  * @return search context
- * @warning If searching for pattern data that could have embedded nulls, do not rely on setting the length to 0 and
- * have this function compute the length using strlen, because it will be wrong. Passing pattern length 0 is a
- * convenience for testing and should not be used in production code. In production code, explicitly pass in the pattern
- * length.
+ * @warning This byte-oriented API never infers a pattern length from strlen. Use omega_search_create_context for
+ * null-terminated C strings. Passing pattern_length 0 is invalid and returns null.
  * @warning Ensure that the pattern_length does not exceed the session_length - session_offset.  This is considered an
  * error and a null pointer will be returned.
  */
@@ -70,9 +67,8 @@ omega_search_context_t *omega_search_create_context_bytes(omega_session_t *sessi
  * @param case_insensitive zero for case-sensitive matching and non-zero for case-insensitive matching
  * @param is_reverse_search zero for forward search and non-zero for reverse search
  * @return search context
- * @warning If searching for pattern data that could have embedded nulls, do not rely on setting the length to 0 and
- * have this function compute the length using strlen, because it will be wrong. Passing length 0 is a convenience for
- * testing and should not be used in production code. In production code, explicitly pass in the length.
+ * @warning This helper is for null-terminated text patterns. For binary data or patterns that may contain embedded
+ * nulls, use omega_search_create_context_bytes and pass an explicit pattern_length.
  * @warning Ensure that the pattern_length does not exceed the session_length - session_offset.  This is considered an
  * error and a null pointer will be returned.
  */

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -884,8 +884,9 @@ int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t 
 
 int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                 int64_t length) {
-    if (!session_ptr || !bytes) { return -1; }
+    if (!session_ptr) { return -1; }
     if (length == 0) { return 0; }
+    if (!bytes) { return -1; }
     return (omega_session_changes_paused(session_ptr) == 0) && 0 <= length &&
            offset <= omega_session_get_computed_file_size(session_ptr)
            ? update_(session_ptr, ins_(1 + omega_session_get_num_changes(session_ptr), offset, bytes, length,
@@ -901,8 +902,9 @@ int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const ch
 
 int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                    int64_t length) {
-    if (!session_ptr || !bytes) { return -1; }
+    if (!session_ptr) { return -1; }
     if (length == 0) { return 0; }
+    if (!bytes) { return -1; }
     return (omega_session_changes_paused(session_ptr) == 0) && 0 <= length &&
            offset <= omega_session_get_computed_file_size(session_ptr)
            ? update_(session_ptr, ovr_(1 + omega_session_get_num_changes(session_ptr), offset, bytes, length,

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -874,6 +874,8 @@ void omega_edit_destroy_viewport(omega_viewport_t *viewport_ptr) {
 
 int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t length) {
     if (!session_ptr) { return -1; }
+    if (offset < 0 || length < 0) { return -1; }
+    if (length == 0) { return 0; }
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
     return (omega_session_changes_paused(session_ptr) == 0) && 0 < length && offset < computed_file_size
            ? update_(session_ptr, del_(1 + omega_session_get_num_changes(session_ptr), offset,
@@ -885,6 +887,7 @@ int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t 
 int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                 int64_t length) {
     if (!session_ptr) { return -1; }
+    if (offset < 0 || length < 0) { return -1; }
     if (length == 0) { return 0; }
     if (!bytes) { return -1; }
     return (omega_session_changes_paused(session_ptr) == 0) && 0 <= length &&
@@ -903,6 +906,7 @@ int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const ch
 int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                    int64_t length) {
     if (!session_ptr) { return -1; }
+    if (offset < 0 || length < 0) { return -1; }
     if (length == 0) { return 0; }
     if (!bytes) { return -1; }
     return (omega_session_changes_paused(session_ptr) == 0) && 0 <= length &&

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -925,7 +925,7 @@ int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, i
 
 int64_t omega_edit_replace(omega_session_t *session_ptr, int64_t offset, int64_t delete_length, const char *cstr,
                            int64_t insert_length) {
-    if (!cstr) { return omega_edit_replace_bytes(session_ptr, offset, delete_length, nullptr, insert_length); }
+    if (!cstr) { return (insert_length == 0) ? omega_edit_replace_bytes(session_ptr, offset, delete_length, nullptr, 0) : -1; }
     const auto cstr_length = (insert_length == 0) ? static_cast<int64_t>(strlen(cstr)) : insert_length;
     return omega_edit_replace_bytes(session_ptr, offset, delete_length, (const omega_byte_t *) cstr, cstr_length);
 }

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -223,7 +223,7 @@ namespace {
         change_ptr->kind =
                 (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_INSERT;
         change_ptr->offset = offset;
-        change_ptr->length = length ? length : static_cast<int64_t>(strlen((const char *) bytes));
+        change_ptr->length = length;
         if (change_ptr->length < DATA_T_SIZE) {
             // small bytes optimization
             memcpy(change_ptr->data.sm_bytes, bytes, change_ptr->length);
@@ -245,7 +245,7 @@ namespace {
         change_ptr->kind =
                 (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_OVERWRITE;
         change_ptr->offset = offset;
-        change_ptr->length = length ? length : static_cast<int64_t>(strlen((const char *) bytes));
+        change_ptr->length = length;
         if (change_ptr->length < DATA_T_SIZE) {
             // small bytes optimization
             memcpy(change_ptr->data.sm_bytes, bytes, change_ptr->length);
@@ -885,6 +885,7 @@ int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t 
 int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                 int64_t length) {
     if (!session_ptr || !bytes) { return -1; }
+    if (length == 0) { return 0; }
     return (omega_session_changes_paused(session_ptr) == 0) && 0 <= length &&
            offset <= omega_session_get_computed_file_size(session_ptr)
            ? update_(session_ptr, ins_(1 + omega_session_get_num_changes(session_ptr), offset, bytes, length,
@@ -893,12 +894,15 @@ int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, co
 }
 
 int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length) {
-    return omega_edit_insert_bytes(session_ptr, offset, (const omega_byte_t *) cstr, length);
+    if (!cstr) { return -1; }
+    const auto cstr_length = (length == 0) ? static_cast<int64_t>(strlen(cstr)) : length;
+    return omega_edit_insert_bytes(session_ptr, offset, (const omega_byte_t *) cstr, cstr_length);
 }
 
 int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                    int64_t length) {
     if (!session_ptr || !bytes) { return -1; }
+    if (length == 0) { return 0; }
     return (omega_session_changes_paused(session_ptr) == 0) && 0 <= length &&
            offset <= omega_session_get_computed_file_size(session_ptr)
            ? update_(session_ptr, ovr_(1 + omega_session_get_num_changes(session_ptr), offset, bytes, length,
@@ -907,7 +911,9 @@ int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset,
 }
 
 int64_t omega_edit_overwrite(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length) {
-    return omega_edit_overwrite_bytes(session_ptr, offset, (const omega_byte_t *) cstr, length);
+    if (!cstr) { return -1; }
+    const auto cstr_length = (length == 0) ? static_cast<int64_t>(strlen(cstr)) : length;
+    return omega_edit_overwrite_bytes(session_ptr, offset, (const omega_byte_t *) cstr, cstr_length);
 }
 
 int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
@@ -917,7 +923,9 @@ int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, i
 
 int64_t omega_edit_replace(omega_session_t *session_ptr, int64_t offset, int64_t delete_length, const char *cstr,
                            int64_t insert_length) {
-    return omega_edit_replace_bytes(session_ptr, offset, delete_length, (const omega_byte_t *) cstr, insert_length);
+    if (!cstr) { return omega_edit_replace_bytes(session_ptr, offset, delete_length, nullptr, insert_length); }
+    const auto cstr_length = (insert_length == 0) ? static_cast<int64_t>(strlen(cstr)) : insert_length;
+    return omega_edit_replace_bytes(session_ptr, offset, delete_length, (const omega_byte_t *) cstr, cstr_length);
 }
 
 int omega_edit_apply_script(omega_session_t *session_ptr, const omega_edit_script_op_t *ops, size_t op_count) {

--- a/core/src/lib/search.cpp
+++ b/core/src/lib/search.cpp
@@ -38,8 +38,6 @@ omega_search_context_t *omega_search_create_context_bytes(omega_session_t *sessi
                                                           int64_t session_length, int case_insensitive,
                                                           int is_reverse_search) {
     if (!session_ptr || !pattern || session_offset < 0) { return nullptr; }
-    pattern_length =
-            pattern_length ? pattern_length : static_cast<int64_t>(strlen(reinterpret_cast<const char *>(pattern)));
     if (pattern_length <= 0) { return nullptr; }
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
     const auto session_length_computed = session_length ? session_length : computed_file_size - session_offset;
@@ -80,6 +78,8 @@ omega_search_context_t *omega_search_create_context(omega_session_t *session_ptr
                                                     int64_t pattern_length, int64_t session_offset,
                                                     int64_t session_length, int case_insensitive,
                                                     int is_reverse_search) {
+    if (!pattern) { return nullptr; }
+    pattern_length = pattern_length ? pattern_length : static_cast<int64_t>(strlen(pattern));
     return omega_search_create_context_bytes(session_ptr, (const omega_byte_t *) pattern, pattern_length,
                                              session_offset, session_length, case_insensitive, is_reverse_search);
 }

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -481,13 +481,17 @@ TEST_CASE("Null Pointer Operations Rejected", "[EdgeCase][InvalidInput]") {
     omega_edit_destroy_session(session_ptr);
 }
 
-TEST_CASE("Negative Length Delete Rejected", "[EdgeCase][InvalidInput]") {
+TEST_CASE("Negative Edit Parameters Are Rejected", "[EdgeCase][InvalidInput]") {
     const auto session_ptr = omega_edit_create_session(MAKE_PATH("test1.dat"), nullptr, nullptr, 0, nullptr);
     REQUIRE(session_ptr);
     const auto original_size = omega_session_get_computed_file_size(session_ptr);
 
-    // Negative length delete should be rejected (returns 0)
-    REQUIRE(0 == omega_edit_delete(session_ptr, 0, -5));
+    REQUIRE(-1 == omega_edit_delete(session_ptr, 0, -5));
+    REQUIRE(-1 == omega_edit_delete(session_ptr, -1, 5));
+    REQUIRE(-1 == omega_edit_insert_bytes(session_ptr, 0, reinterpret_cast<const omega_byte_t *>("x"), -1));
+    REQUIRE(-1 == omega_edit_insert_bytes(session_ptr, -1, reinterpret_cast<const omega_byte_t *>("x"), 1));
+    REQUIRE(-1 == omega_edit_overwrite_bytes(session_ptr, 0, reinterpret_cast<const omega_byte_t *>("x"), -1));
+    REQUIRE(-1 == omega_edit_overwrite_bytes(session_ptr, -1, reinterpret_cast<const omega_byte_t *>("x"), 1));
     REQUIRE(omega_session_get_computed_file_size(session_ptr) == original_size);
     REQUIRE(0 == omega_session_get_num_changes(session_ptr));
     REQUIRE(0 == omega_check_model(session_ptr));

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -116,12 +116,14 @@ TEST_CASE("Byte APIs treat zero-length inputs as empty and keep string helpers c
 
     const omega_byte_t bytes[] = {'A', '\0', 'B'};
     REQUIRE(0 == omega_edit_insert_bytes(session_ptr, 0, bytes, 0));
+    REQUIRE(0 == omega_edit_insert_bytes(session_ptr, 0, nullptr, 0));
     REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
     REQUIRE(0 == omega_session_get_num_changes(session_ptr));
 
     REQUIRE(0 < omega_edit_insert(session_ptr, 0, "text", 0));
     REQUIRE("text" == omega_session_get_segment_string(session_ptr, 0, 4));
     REQUIRE(0 == omega_edit_overwrite_bytes(session_ptr, 1, bytes, 0));
+    REQUIRE(0 == omega_edit_overwrite_bytes(session_ptr, 1, nullptr, 0));
     REQUIRE("text" == omega_session_get_segment_string(session_ptr, 0, 4));
 
     REQUIRE(0 < omega_edit_overwrite(session_ptr, 1, "A", 0));

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -76,6 +76,70 @@ TEST_CASE("Insert on Empty Session", "[EdgeCase][EmptyInsert]") {
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Byte APIs preserve embedded nulls with explicit lengths", "[EdgeCase][BinaryLengths]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+
+    const omega_byte_t inserted[] = {'A', '\0', 'B'};
+    REQUIRE(0 < omega_edit_insert_bytes(session_ptr, 0, inserted, static_cast<int64_t>(sizeof(inserted))));
+    REQUIRE(3 == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(1 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(std::string(reinterpret_cast<const char *>(inserted), sizeof(inserted)) ==
+            omega_session_get_segment_string(session_ptr, 0, 3));
+
+    const omega_byte_t overwritten[] = {'X', '\0', 'Y'};
+    REQUIRE(0 < omega_edit_overwrite_bytes(session_ptr, 0, overwritten, static_cast<int64_t>(sizeof(overwritten))));
+    REQUIRE(std::string(reinterpret_cast<const char *>(overwritten), sizeof(overwritten)) ==
+            omega_session_get_segment_string(session_ptr, 0, 3));
+
+    const omega_byte_t replaced[] = {'Q', '\0', 'R', '\0'};
+    REQUIRE(0 < omega_edit_replace_bytes(session_ptr, 0, 3, replaced, static_cast<int64_t>(sizeof(replaced))));
+    REQUIRE(4 == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(std::string(reinterpret_cast<const char *>(replaced), sizeof(replaced)) ==
+            omega_session_get_segment_string(session_ptr, 0, 4));
+
+    const omega_byte_t pattern[] = {'\0', 'R'};
+    const auto search_context =
+            omega_search_create_context_bytes(session_ptr, pattern, static_cast<int64_t>(sizeof(pattern)), 0, 0, 0, 0);
+    REQUIRE(search_context);
+    REQUIRE(1 == omega_search_next_match(search_context, 1));
+    REQUIRE(1 == omega_search_context_get_match_offset(search_context));
+    omega_search_destroy_context(search_context);
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Byte APIs treat zero-length inputs as empty and keep string helpers convenient",
+          "[EdgeCase][BinaryLengths]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+
+    const omega_byte_t bytes[] = {'A', '\0', 'B'};
+    REQUIRE(0 == omega_edit_insert_bytes(session_ptr, 0, bytes, 0));
+    REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(0 == omega_session_get_num_changes(session_ptr));
+
+    REQUIRE(0 < omega_edit_insert(session_ptr, 0, "text", 0));
+    REQUIRE("text" == omega_session_get_segment_string(session_ptr, 0, 4));
+    REQUIRE(0 == omega_edit_overwrite_bytes(session_ptr, 1, bytes, 0));
+    REQUIRE("text" == omega_session_get_segment_string(session_ptr, 0, 4));
+
+    REQUIRE(0 < omega_edit_overwrite(session_ptr, 1, "A", 0));
+    REQUIRE("tAxt" == omega_session_get_segment_string(session_ptr, 0, 4));
+    REQUIRE(0 < omega_edit_replace(session_ptr, 1, 2, "BCD", 0));
+    REQUIRE("tBCDt" == omega_session_get_segment_string(session_ptr, 0, 5));
+
+    const auto cstring_search = omega_search_create_context(session_ptr, "BCD", 0, 0, 0, 0, 0);
+    REQUIRE(cstring_search);
+    REQUIRE(1 == omega_search_next_match(cstring_search, 1));
+    REQUIRE(1 == omega_search_context_get_match_offset(cstring_search));
+    omega_search_destroy_context(cstring_search);
+
+    REQUIRE(nullptr == omega_search_create_context_bytes(session_ptr, bytes, 0, 0, 0, 0, 0));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Delete Entire File Content", "[EdgeCase][DeleteAll]") {
     const auto session_ptr = omega_edit_create_session(MAKE_PATH("test1.dat"), nullptr, nullptr, 0, nullptr);
     REQUIRE(session_ptr);

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -130,6 +130,8 @@ TEST_CASE("Byte APIs treat zero-length inputs as empty and keep string helpers c
     REQUIRE("tAxt" == omega_session_get_segment_string(session_ptr, 0, 4));
     REQUIRE(0 < omega_edit_replace(session_ptr, 1, 2, "BCD", 0));
     REQUIRE("tBCDt" == omega_session_get_segment_string(session_ptr, 0, 5));
+    REQUIRE(-1 == omega_edit_replace(session_ptr, 0, 0, nullptr, 1));
+    REQUIRE("tBCDt" == omega_session_get_segment_string(session_ptr, 0, 5));
 
     const auto cstring_search = omega_search_create_context(session_ptr, "BCD", 0, 0, 0, 0, 0);
     REQUIRE(cstring_search);

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -161,7 +161,7 @@ TEST_CASE("Model Tests", "[ModelTests]") {
     REQUIRE(0 ==
         omega_util_compare_files(MAKE_PATH("model-test.expected.2.dat"), MAKE_PATH("model-test.actual.2.dat")));
     REQUIRE(omega_util_paths_equivalent(MAKE_PATH("model-test.actual.2.dat"), saved_filename));
-    REQUIRE(0 < omega_edit_insert_bytes(session_ptr, 5, reinterpret_cast<const omega_byte_t *>("xxx"), 0));
+    REQUIRE(0 < omega_edit_insert_bytes(session_ptr, 5, reinterpret_cast<const omega_byte_t *>("xxx"), 3));
     file_size += 3;
     REQUIRE(omega_session_get_computed_file_size(session_ptr) == file_size);
     REQUIRE(0 == omega_edit_save(session_ptr, MAKE_PATH("model-test.actual.3.dat"), omega_io_flags_t::IO_FLG_OVERWRITE,
@@ -197,7 +197,7 @@ TEST_CASE("Model Tests", "[ModelTests]") {
     REQUIRE(0 < omega_edit_delete(session_ptr, 7, 4));
     REQUIRE((last_change = omega_session_get_last_change(session_ptr)));
     REQUIRE('D' == omega_change_get_kind_as_char(last_change));
-    REQUIRE(0 < omega_edit_overwrite_bytes(session_ptr, 6, reinterpret_cast<const omega_byte_t *>("O"), 0));
+    REQUIRE(0 < omega_edit_overwrite_bytes(session_ptr, 6, reinterpret_cast<const omega_byte_t *>("O"), 1));
     REQUIRE((last_change = omega_session_get_last_change(session_ptr)));
     REQUIRE('O' == omega_change_get_kind_as_char(last_change));
     REQUIRE(1 == omega_change_get_length(last_change));
@@ -434,7 +434,7 @@ TEST_CASE("Hanoi insert", "[ModelTests]") {
     // Hanoi test
     int64_t change_serial;
     REQUIRE(0 <
-        (change_serial = omega_edit_insert_bytes(session_ptr, 0, reinterpret_cast<const omega_byte_t *>("00"), 0)));
+        (change_serial = omega_edit_insert_bytes(session_ptr, 0, reinterpret_cast<const omega_byte_t *>("00"), 2)));
     auto change_ptr = omega_session_get_change(session_ptr, change_serial);
     REQUIRE(change_ptr);
     REQUIRE('I' == omega_change_get_kind_as_char(change_ptr));
@@ -446,7 +446,7 @@ TEST_CASE("Hanoi insert", "[ModelTests]") {
     REQUIRE(1 == omega_session_get_num_changes(session_ptr));
     REQUIRE(1 == omega_change_get_serial(omega_session_get_last_change(session_ptr)));
     REQUIRE(2 == omega_session_get_computed_file_size(session_ptr));
-    REQUIRE(0 < omega_edit_insert_bytes(session_ptr, 1, reinterpret_cast<const omega_byte_t *>("11"), 0));
+    REQUIRE(0 < omega_edit_insert_bytes(session_ptr, 1, reinterpret_cast<const omega_byte_t *>("11"), 2));
     REQUIRE(2 == omega_session_get_num_changes(session_ptr));
     REQUIRE(2 == omega_change_get_serial(omega_session_get_last_change(session_ptr)));
     REQUIRE(4 == omega_session_get_computed_file_size(session_ptr));
@@ -566,7 +566,7 @@ TEST_CASE("Check initialization", "[InitTests]") {
             REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "+++"));
             REQUIRE(1 + num_changes == omega_session_get_num_changes(session_ptr));
             REQUIRE(70 == omega_session_get_computed_file_size(session_ptr));
-            REQUIRE(0 < omega_edit_overwrite_bytes(session_ptr, 1, reinterpret_cast<const omega_byte_t *>("."), 0));
+            REQUIRE(0 < omega_edit_overwrite_bytes(session_ptr, 1, reinterpret_cast<const omega_byte_t *>("."), 1));
             REQUIRE(70 == omega_session_get_computed_file_size(session_ptr));
             REQUIRE(0 < omega_edit_overwrite_string(session_ptr, 15, "*"));
             REQUIRE(70 == omega_session_get_computed_file_size(session_ptr));

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Empty Session File Tests", "[EmptySessionFileTests]") {
     REQUIRE(0 == omega_session_get_num_change_transactions(session_ptr));
     REQUIRE(0 == omega_edit_undo_last_change(session_ptr));
     auto change_serial =
-            omega_edit_insert_bytes(session_ptr, 0, reinterpret_cast<const omega_byte_t *>("1234567890"), 0);
+            omega_edit_insert_bytes(session_ptr, 0, reinterpret_cast<const omega_byte_t *>("1234567890"), 10);
     REQUIRE(0 < change_serial);
     REQUIRE(1 == omega_session_get_num_change_transactions(session_ptr));
     file_size += 10;


### PR DESCRIPTION
## Summary
- require explicit lengths for byte-oriented core edit/search APIs instead of treating `0` as `strlen(...)`
- keep the convenience path on the C-string wrappers and update in-repo examples/tests to use the intended API layer
- add embedded-null and zero-length regression coverage for the core library

## Why
The byte-oriented APIs were still mixing binary and C-string semantics. Passing `length == 0` to functions like `omega_edit_insert_bytes`, `omega_edit_overwrite_bytes`, and `omega_search_create_context_bytes` would silently fall back to `strlen(...)`, which breaks for embedded-null data and is the wrong long-term contract for a binary editor core.

## Developer impact
- byte-oriented callers must now pass explicit lengths
- zero-length byte inserts/overwrites are treated as no-ops, and zero-length byte search patterns are rejected
- null-terminated text callers can keep using `omega_edit_insert`, `omega_edit_overwrite`, `omega_edit_replace`, and `omega_search_create_context` with `0` length as a convenience

## Root cause
Length inference lived inside the byte-oriented core helpers themselves, so even callers that intentionally chose the binary APIs could still get C-string behavior.

## Validation
- `cmake --build build --config Release --target edge_case_tests omegaEdit_tests session_tests`
- `ctest --test-dir build/core/src/tests -C Release --output-on-failure -R "(edge_case_tests|omegaEdit_tests|session_tests)"`

Closes #1383.
