### PR TITLE
Simplify heartbeat request contract

### DIFF
--- a/UPGRADE-v1-to-v2.md
+++ b/UPGRADE-v1-to-v2.md
@@ -13,6 +13,7 @@
 - Most TypeScript consumers can upgrade by bumping package versions and rerunning their normal regression tests.
 - If you relied on the old Scala server scripts or deployment model, switch to the packaged C++ server (`@omega-edit/server` or `server/cpp`).
 - Server info and heartbeat responses now expose native-runtime metadata, while legacy JVM-shaped compatibility fields remain deprecated in the schema.
+- The heartbeat request contract is now session-centric. `GetHeartbeatRequest` only carries `session_ids`, and `@omega-edit/client` now exposes `getServerHeartbeat(sessionIds)` without the old hostname / PID / interval request fields.
 - Caller-chosen `session_id_desired` values and caller-chosen `viewport_id_desired` values are now explicit uniqueness requests: duplicates are rejected with `ALREADY_EXISTS` instead of being remapped to a different ID.
 
 ## Quick path

--- a/UPGRADE-v1-to-v2.md
+++ b/UPGRADE-v1-to-v2.md
@@ -9,11 +9,11 @@
 
 ## What changes
 
-- The protobuf namespace remains `omega_edit/v1`; this is a platform and packaging major release, not a wire-format reset.
+- The protobuf import path remains `omega_edit/v1`; OmegaEdit 2.0 still includes intentional schema breaks where they materially simplify the API, and those breaks are documented here instead of through a package rename.
 - Most TypeScript consumers can upgrade by bumping package versions and rerunning their normal regression tests.
 - If you relied on the old Scala server scripts or deployment model, switch to the packaged C++ server (`@omega-edit/server` or `server/cpp`).
 - Server info and heartbeat responses now expose native-runtime metadata, while legacy JVM-shaped compatibility fields remain deprecated in the schema.
-- The heartbeat request contract is now session-centric. `GetHeartbeatRequest` only carries `session_ids`, and `@omega-edit/client` now exposes `getServerHeartbeat(sessionIds)` without the old hostname / PID / interval request fields.
+- The heartbeat request contract is now session-centric. `GetHeartbeatRequest` only carries `session_ids`, the old hostname / PID / interval request fields are removed, and `@omega-edit/client` now exposes `getServerHeartbeat(sessionIds)`.
 - Caller-chosen `session_id_desired` values and caller-chosen `viewport_id_desired` values are now explicit uniqueness requests: duplicates are rejected with `ALREADY_EXISTS` instead of being remapped to a different ID.
 
 ## Quick path

--- a/examples/vscode-extension/src/hexEditorProvider.ts
+++ b/examples/vscode-extension/src/hexEditorProvider.ts
@@ -563,8 +563,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
       const [serverInfo, heartbeat] = await Promise.all([
         getServerInfo(),
         getServerHeartbeat(
-          Array.from(this.sessions.values(), (session) => session.sessionId),
-          1000
+          Array.from(this.sessions.values(), (session) => session.sessionId)
         ),
       ])
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -83,7 +83,7 @@ await stopServerGraceful()
 | `stopServerGraceful()`                            | Graceful shutdown                         |
 | `stopServerImmediate()`                           | Immediate shutdown                        |
 | `getServerInfo()`                                 | Runtime metadata for the native server    |
-| `getServerHeartbeat(sessions, interval?)`         | Heartbeat and process health              |
+| `getServerHeartbeat(sessions)`                    | Heartbeat and process health              |
 
 ### Server Health API Migration
 

--- a/packages/client/src/omega_edit_pb.ts
+++ b/packages/client/src/omega_edit_pb.ts
@@ -95,37 +95,7 @@ export class EventSubscriptionRequest {
 
 export class HeartbeatRequest {
   private request_: RawGetHeartbeatRequest = {
-    hostname: '',
-    processId: 0,
-    heartbeatInterval: 0,
     sessionIds: [],
-  }
-
-  setHostname(value: string): this {
-    this.request_.hostname = value
-    return this
-  }
-
-  getHostname(): string {
-    return this.request_.hostname
-  }
-
-  setProcessId(value: number): this {
-    this.request_.processId = value
-    return this
-  }
-
-  getProcessId(): number {
-    return this.request_.processId
-  }
-
-  setHeartbeatInterval(value: number): this {
-    this.request_.heartbeatInterval = value
-    return this
-  }
-
-  getHeartbeatInterval(): number {
-    return this.request_.heartbeatInterval
   }
 
   setSessionIdsList(value: string[]): this {

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -1423,8 +1423,8 @@ export interface IEditorServiceClient {
     ) => void
   ): grpc.ClientUnaryCall
   /**
-   * Exchange a heartbeat with the server.  The client sends its hostname,
-   * PID, and active session IDs; the server responds with resource metrics.
+   * Exchange a heartbeat with the server. The client sends the session IDs it
+   * still holds so the server can keep them alive and return resource metrics.
    *
    * @generated from protobuf rpc: GetHeartbeat
    */
@@ -2953,8 +2953,8 @@ export class EditorServiceClient
     )
   }
   /**
-   * Exchange a heartbeat with the server.  The client sends its hostname,
-   * PID, and active session IDs; the server responds with resource metrics.
+   * Exchange a heartbeat with the server. The client sends the session IDs it
+   * still holds so the server can keep them alive and return resource metrics.
    *
    * @generated from protobuf rpc: GetHeartbeat
    */

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -98,6 +98,10 @@ import type { CreateSessionRequest } from './omega_edit'
 import type { GetServerInfoResponse } from './omega_edit'
 import type { GetServerInfoRequest } from './omega_edit'
 import * as grpc from '@grpc/grpc-js'
+// The omega_edit/v1 import path remains the canonical schema location for the
+// OmegaEdit 2.x line. Major-release API breaks are documented in the upgrade
+// guide rather than expressed through a package rename.
+
 /**
  * EditorService is the primary gRPC service for the Ωedit library.  It provides
  * byte-level editing of arbitrarily large files through a session/viewport
@@ -1570,6 +1574,10 @@ export interface IEditorServiceClient {
     ) => void
   ): grpc.ClientUnaryCall
 }
+// The omega_edit/v1 import path remains the canonical schema location for the
+// OmegaEdit 2.x line. Major-release API breaks are documented in the upgrade
+// guide rather than expressed through a package rename.
+
 /**
  * EditorService is the primary gRPC service for the Ωedit library.  It provides
  * byte-level editing of arbitrarily large files through a session/viewport

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -129,26 +129,14 @@ export interface ServerControlResponse {
   responseCode: number // 0 for success, non-zero for failure.
 }
 /**
- * Client heartbeat request.  The client identifies itself and lists its
- * active sessions so the server can track liveness.
+ * Client heartbeat request. The client lists the session IDs it still holds so
+ * the server can track liveness.
  *
  * @generated from protobuf message omega_edit.v1.GetHeartbeatRequest
  */
 export interface GetHeartbeatRequest {
   /**
-   * @generated from protobuf field: string hostname = 1
-   */
-  hostname: string // Client hostname.
-  /**
-   * @generated from protobuf field: int32 process_id = 2
-   */
-  processId: number // Client OS process ID.
-  /**
-   * @generated from protobuf field: int32 heartbeat_interval = 3
-   */
-  heartbeatInterval: number // Interval in milliseconds between heartbeats.
-  /**
-   * @generated from protobuf field: repeated string session_ids = 4
+   * @generated from protobuf field: repeated string session_ids = 1
    */
   sessionIds: string[] // Session IDs the client currently holds.
 }
@@ -2275,16 +2263,8 @@ export const ServerControlResponse = new ServerControlResponse$Type()
 class GetHeartbeatRequest$Type extends MessageType<GetHeartbeatRequest> {
   constructor() {
     super('omega_edit.v1.GetHeartbeatRequest', [
-      { no: 1, name: 'hostname', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
-      { no: 2, name: 'process_id', kind: 'scalar', T: 5 /*ScalarType.INT32*/ },
       {
-        no: 3,
-        name: 'heartbeat_interval',
-        kind: 'scalar',
-        T: 5 /*ScalarType.INT32*/,
-      },
-      {
-        no: 4,
+        no: 1,
         name: 'session_ids',
         kind: 'scalar',
         repeat: 2 /*RepeatType.UNPACKED*/,
@@ -2294,9 +2274,6 @@ class GetHeartbeatRequest$Type extends MessageType<GetHeartbeatRequest> {
   }
   create(value?: PartialMessage<GetHeartbeatRequest>): GetHeartbeatRequest {
     const message = globalThis.Object.create(this.messagePrototype!)
-    message.hostname = ''
-    message.processId = 0
-    message.heartbeatInterval = 0
     message.sessionIds = []
     if (value !== undefined)
       reflectionMergePartial<GetHeartbeatRequest>(this, message, value)
@@ -2313,16 +2290,7 @@ class GetHeartbeatRequest$Type extends MessageType<GetHeartbeatRequest> {
     while (reader.pos < end) {
       let [fieldNo, wireType] = reader.tag()
       switch (fieldNo) {
-        case /* string hostname */ 1:
-          message.hostname = reader.string()
-          break
-        case /* int32 process_id */ 2:
-          message.processId = reader.int32()
-          break
-        case /* int32 heartbeat_interval */ 3:
-          message.heartbeatInterval = reader.int32()
-          break
-        case /* repeated string session_ids */ 4:
+        case /* repeated string session_ids */ 1:
           message.sessionIds.push(reader.string())
           break
         default:
@@ -2349,18 +2317,9 @@ class GetHeartbeatRequest$Type extends MessageType<GetHeartbeatRequest> {
     writer: IBinaryWriter,
     options: BinaryWriteOptions
   ): IBinaryWriter {
-    /* string hostname = 1; */
-    if (message.hostname !== '')
-      writer.tag(1, WireType.LengthDelimited).string(message.hostname)
-    /* int32 process_id = 2; */
-    if (message.processId !== 0)
-      writer.tag(2, WireType.Varint).int32(message.processId)
-    /* int32 heartbeat_interval = 3; */
-    if (message.heartbeatInterval !== 0)
-      writer.tag(3, WireType.Varint).int32(message.heartbeatInterval)
-    /* repeated string session_ids = 4; */
+    /* repeated string session_ids = 1; */
     for (let i = 0; i < message.sessionIds.length; i++)
-      writer.tag(4, WireType.LengthDelimited).string(message.sessionIds[i])
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionIds[i])
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -20,7 +20,6 @@
 import { getLogger } from './logger'
 import { getClient } from './client'
 import * as fs from 'fs'
-import * as os from 'os'
 import * as path from 'path'
 import { createServer, Server, createConnection } from 'net'
 import * as omegaEditServerModule from '@omega-edit/server'
@@ -1182,24 +1181,18 @@ export interface IServerHeartbeat {
 /**
  * Get the server heartbeat
  * @param activeSessions list of active sessions
- * @param heartbeatInterval heartbeat interval in ms
  * @returns a promise that resolves to the server heartbeat
  */
 export async function getServerHeartbeat(
-  activeSessions: string[],
-  heartbeatInterval: number = 1000
+  activeSessions: string[]
 ): Promise<IServerHeartbeat> {
   const log = getLogger()
   const client = await getClient()
-  const hostname = os.hostname()
   const startTime: number = Date.now()
 
   return new Promise<IServerHeartbeat>((resolve, reject) => {
     client.getHeartbeat(
       {
-        hostname,
-        processId: process.pid,
-        heartbeatInterval,
         sessionIds: activeSessions,
       },
       (err, heartbeatResponse) => {

--- a/packages/client/tests/specs/protoCompatibility.spec.ts
+++ b/packages/client/tests/specs/protoCompatibility.spec.ts
@@ -124,19 +124,12 @@ describe('Proto Compatibility', () => {
       interest: 7,
     })
 
-    const heartbeatRequest = new HeartbeatRequest()
-      .setHostname('host')
-      .setProcessId(42)
-      .setHeartbeatInterval(250)
-      .setSessionIdsList(['a', 'b'])
-    expect(heartbeatRequest.getHostname()).to.equal('host')
-    expect(heartbeatRequest.getProcessId()).to.equal(42)
-    expect(heartbeatRequest.getHeartbeatInterval()).to.equal(250)
+    const heartbeatRequest = new HeartbeatRequest().setSessionIdsList([
+      'a',
+      'b',
+    ])
     expect(heartbeatRequest.getSessionIdsList()).to.deep.equal(['a', 'b'])
     expect(heartbeatRequest.toRaw()).to.deep.equal({
-      hostname: 'host',
-      processId: 42,
-      heartbeatInterval: 250,
       sessionIds: ['a', 'b'],
     })
 

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -299,9 +299,9 @@ describe('Server Heartbeat Timeout', () => {
 
     // Send a heartbeat to keep it alive.
     await delay(50)
-    await getServerHeartbeat([session_id], 50)
+    await getServerHeartbeat([session_id])
     await delay(100)
-    await getServerHeartbeat([session_id], 50)
+    await getServerHeartbeat([session_id])
     await delay(100)
     expect(await getSessionCount()).to.equal(1)
 
@@ -493,9 +493,9 @@ describe('Server Shutdown When No Sessions', () => {
     expect(session_id.length).to.equal(36)
 
     await delay(50)
-    await getServerHeartbeat([session_id], 50)
+    await getServerHeartbeat([session_id])
     await delay(100)
-    await getServerHeartbeat([session_id], 50)
+    await getServerHeartbeat([session_id])
 
     await waitForSessionCount(0, 2000, true)
     await waitForPidToExit(pid as number, 15000)

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -133,7 +133,7 @@ describe('Server Edge Cases', () => {
       expect(serverInfo.buildType).to.be.a('string').and.not.be.empty
       expect(serverInfo.cppStandard).to.be.a('string').and.not.be.empty
 
-      const heartbeat = await getServerHeartbeat([], 250)
+      const heartbeat = await getServerHeartbeat([])
       expect(heartbeat.latency).to.be.greaterThanOrEqual(0)
       expect(heartbeat.sessionCount).to.equal(0)
       expect(heartbeat.serverCpuCount).to.be.greaterThanOrEqual(0)
@@ -208,9 +208,6 @@ describe('Server Edge Cases', () => {
         (resolve, reject) => {
           client.getHeartbeat(
             {
-              hostname: os.hostname(),
-              processId: process.pid,
-              heartbeatInterval: 250,
               sessionIds: [],
             },
             (err, response) => {
@@ -223,7 +220,7 @@ describe('Server Edge Cases', () => {
           )
         }
       )
-      const wrappedHeartbeat = await getServerHeartbeat([], 250)
+      const wrappedHeartbeat = await getServerHeartbeat([])
 
       expect(heartbeat.maxMemory).to.equal(0)
       expect(heartbeat.committedMemory).to.equal(0)
@@ -412,7 +409,7 @@ describe('Server Edge Cases', () => {
     )
 
     try {
-      await serverModule.getServerHeartbeat([], 100)
+      await serverModule.getServerHeartbeat([])
       expect.fail(
         'getServerHeartbeat should reject when the RPC returns an error'
       )
@@ -423,7 +420,7 @@ describe('Server Edge Cases', () => {
     mode = 'empty'
 
     try {
-      await serverModule.getServerHeartbeat([], 100)
+      await serverModule.getServerHeartbeat([])
       expect.fail(
         'getServerHeartbeat should reject when the RPC response is empty'
       )

--- a/proto/README.md
+++ b/proto/README.md
@@ -6,6 +6,10 @@ This directory contains the gRPC service definition for Ωedit™.
 
 Defines the `Editor` service with RPCs for:
 
+The `omega_edit/v1` import path is the canonical schema location for the
+OmegaEdit 2.x line. Major-release API breaks are documented in the repo's
+upgrade guide rather than expressed through a package rename.
+
 - **Session management** — create, save, destroy editing sessions
 - **Editing** — insert, delete, overwrite with unlimited undo/redo
 - **Viewports** — sliding windows into session data
@@ -25,6 +29,8 @@ Consumers migrating from older JVM-oriented fields should treat missing optional
 heartbeat metrics as "unavailable" rather than `0`.
 `virtual_memory_bytes` is best-effort and may be unset on platforms where an
 equivalent process metric is not consistently available.
+`GetHeartbeatRequest` is intentionally session-centric in 2.x: the unused
+hostname / process / interval request fields were removed outright.
 The legacy JVM-shaped fields remain in the schema as deprecated compatibility
 fields so existing protobuf consumers do not break on the wire. The native C++
 server leaves deprecated JVM-only fields unset rather than fabricating placeholder

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -194,8 +194,8 @@ service EditorService {
   // Send a control command to the server (graceful or immediate shutdown).
   rpc ServerControl(ServerControlRequest) returns (ServerControlResponse);
 
-  // Exchange a heartbeat with the server.  The client sends its hostname,
-  // PID, and active session IDs; the server responds with resource metrics.
+  // Exchange a heartbeat with the server. The client sends the session IDs it
+  // still holds so the server can keep them alive and return resource metrics.
   rpc GetHeartbeat(GetHeartbeatRequest) returns (GetHeartbeatResponse);
 
   // ---------------------------------------------------------------------------
@@ -362,13 +362,10 @@ message ServerControlResponse {
   int32 response_code = 3;    // 0 for success, non-zero for failure.
 }
 
-// Client heartbeat request.  The client identifies itself and lists its
-// active sessions so the server can track liveness.
+// Client heartbeat request. The client lists the session IDs it still holds so
+// the server can track liveness.
 message GetHeartbeatRequest {
-  string hostname = 1;            // Client hostname.
-  int32 process_id = 2;           // Client OS process ID.
-  int32 heartbeat_interval = 3;   // Interval in milliseconds between heartbeats.
-  repeated string session_ids = 4; // Session IDs the client currently holds.
+  repeated string session_ids = 1; // Session IDs the client currently holds.
 }
 
 // Server heartbeat response with resource metrics.

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -18,6 +18,10 @@ package omega_edit.v1;
 
 option cc_enable_arenas = true;
 
+// The omega_edit/v1 import path remains the canonical schema location for the
+// OmegaEdit 2.x line. Major-release API breaks are documented in the upgrade
+// guide rather than expressed through a package rename.
+
 // EditorService is the primary gRPC service for the Ωedit library.  It provides
 // byte-level editing of arbitrarily large files through a session/viewport
 // model with unlimited, serialised undo/redo.


### PR DESCRIPTION
## Summary
- simplify `GetHeartbeatRequest` so it only carries `session_ids`
- remove the unused hostname / PID / interval fields from the TS compatibility wrapper and end-user client API
- update docs and tests to match the session-centric heartbeat contract

## Why
The native C++ server only uses heartbeat session IDs to refresh session liveness. The extra request fields made the wire and client APIs look richer than the real contract, which is exactly the kind of mismatch that gets frozen into downstream integrations.

## What changed
- removed `hostname`, `process_id`, and `heartbeat_interval` from `GetHeartbeatRequest`
- changed `getServerHeartbeat(...)` to take only the session ID list
- updated the compatibility `HeartbeatRequest` wrapper and proto-compat tests
- regenerated the protobuf-ts client artifacts from the canonical proto
- documented the 2.x heartbeat request simplification in the upgrade guide and client README

## Validation
- `yarn workspace @omega-edit/client test:client`
- `yarn lint`

Closes #1394.
