### PR TITLE
Refresh v2 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const main = async () => {
   const s = await createSession()      // empty session
   const id = s.getSessionId()
   await insert(id, 0, Buffer.from('Hello, Ωedit™!'))
-  await saveSession(id, 'output.dat', IOFlags.IO_FLAGS_OVERWRITE)
+  await saveSession(id, 'output.dat', IOFlags.OVERWRITE)
   await destroySession(id)
   await stopServerGraceful()
 }
@@ -61,6 +61,22 @@ main().catch(console.error)
 ```
 
 See the [Quick Start guide in the wiki](https://github.com/ctc-oss/omega-edit/wiki#quick-start) for C/C++ and VS Code extension paths, plus links to all examples.
+
+## Naming Conventions
+
+Use these naming rules in user-facing documentation:
+
+- **`Ωedit™`** is the project and product name in prose, headings, release notes, and other user-facing text.
+- **`omega-edit`** is the repository name, URL slug, release-asset stem, and Docker image stem.
+- **`@omega-edit/...`** is the npm package scope.
+- **`omega_edit`** is the C/C++ and protobuf identifier form used in symbols, include paths, and proto namespaces.
+
+Examples:
+
+- say "Build a VS Code extension powered by Ωedit™"
+- use `https://github.com/ctc-oss/omega-edit`
+- import `@omega-edit/client`
+- include `omega_edit/edit.h`
 
 ## AI Tooling
 
@@ -186,7 +202,7 @@ cmake -S . -B _build -DCMAKE_BUILD_TYPE=Debug -DBUILD_DOCS=NO -DBUILD_EXAMPLES=N
 
 #### Embedding the core library in another CMake project:
 
-If you want to consume Ωedit as a subproject, enable embed mode to automatically disable tests,
+If you want to consume Ωedit™ as a subproject, enable embed mode to automatically disable tests,
 documentation, examples, coverage instrumentation, and packaging:
 
 ```bash

--- a/UPGRADE-v1-to-v2.md
+++ b/UPGRADE-v1-to-v2.md
@@ -1,4 +1,4 @@
-# v1 to v2 Upgrade Guide
+# Ωedit™ v1 to v2 Upgrade Guide
 
 ## Why upgrade
 
@@ -9,7 +9,7 @@
 
 ## What changes
 
-- The protobuf import path remains `omega_edit/v1`; OmegaEdit 2.0 still includes intentional schema breaks where they materially simplify the API, and those breaks are documented here instead of through a package rename.
+- The protobuf import path remains `omega_edit/v1`; Ωedit™ 2.0 still includes intentional schema breaks where they materially simplify the API, and those breaks are documented here instead of through a package rename.
 - Most TypeScript consumers can upgrade by bumping package versions and rerunning their normal regression tests.
 - If you relied on the old Scala server scripts or deployment model, switch to the packaged C++ server (`@omega-edit/server` or `server/cpp`).
 - Server info and heartbeat responses now expose native-runtime metadata, while legacy JVM-shaped compatibility fields remain deprecated in the schema.

--- a/examples/vscode-extension/README.md
+++ b/examples/vscode-extension/README.md
@@ -46,8 +46,8 @@ Then open this folder in VS Code and press `F5`. A new Extension Development Hos
 
 In the new window:
 
-- Run `OmegaEdit: Open in Hex Editor` from the Command Palette to pick any file directly
-- Or right-click a file in the Explorer and choose `OmegaEdit: Open in Hex Editor`
+- Run `Ωedit™: Open in Hex Editor` from the Command Palette to pick any file directly
+- Or right-click a file in the Explorer and choose `Ωedit™: Open in Hex Editor`
 
 ## What Happens Under The Hood
 

--- a/examples/vscode-extension/README.md
+++ b/examples/vscode-extension/README.md
@@ -1,16 +1,16 @@
-# OmegaEdit Hex Editor - Reference VS Code Extension
+# Ωedit™ Hex Editor - Reference VS Code Extension
 
-A standalone reference VS Code extension that demonstrates how to use [OmegaEdit](https://github.com/ctc-oss/omega-edit) as a fast, usable data/hex editor. It is still intentionally smaller than a marketplace-grade product, but it now covers the core editing, navigation, save, replay, and testing paths needed to evaluate a serious integration.
+A standalone reference VS Code extension that demonstrates how to use [Ωedit™](https://github.com/ctc-oss/omega-edit) as a fast, usable data/hex editor. It is still intentionally smaller than a marketplace-grade product, but it now covers the core editing, navigation, save, replay, and testing paths needed to evaluate a serious integration.
 
-![OmegaEdit Hex Editor](./images/omega-hex.png)
+![Ωedit™ Hex Editor](./images/omega-hex.png)
 
 ## What This Demonstrates
 
 | Integration Point                                         | Where                                                                               |
 | --------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| Start OmegaEdit server on `activate()`                    | [extension.ts](src/extension.ts)                                                    |
+| Start Ωedit™ server on `activate()`                       | [extension.ts](src/extension.ts)                                                    |
 | Stop server on `deactivate()`                             | [extension.ts](src/extension.ts)                                                    |
-| `CustomReadonlyEditorProvider` wired to OmegaEdit         | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
+| `CustomReadonlyEditorProvider` wired to Ωedit™            | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
 | Direct open from command palette / explorer               | [extension.ts](src/extension.ts)                                                    |
 | Create session per opened file                            | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
 | Viewport to webview data flow                             | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
@@ -32,6 +32,8 @@ A standalone reference VS Code extension that demonstrates how to use [OmegaEdit
 
 The current VS Code floor is `1.110` because that is the oldest version exercised in CI and it matches the `@types/vscode` version used to compile the example. If the support range is widened later, the CI matrix should be widened with it.
 
+This reference extension intentionally depends on the in-repo `@omega-edit/client` package through a local `file:` dependency. That keeps the example and CI aligned with the current Ωedit™ 2.x client implementation in this checkout instead of a separately published npm version.
+
 ### Run With F5
 
 ```bash
@@ -50,7 +52,7 @@ In the new window:
 ## What Happens Under The Hood
 
 1. `activate()` reads the `omegaEdit.serverPort` setting and starts the bundled native server through `@omega-edit/client`.
-2. Opening a file creates an OmegaEdit session and viewport, then subscribes to viewport and session updates.
+2. Opening a file creates an Ωedit™ session and viewport, then subscribes to viewport and session updates.
 3. The native server now uses server-managed checkpoint directories under the host temp directory for auto-managed sessions, which keeps checkpoint artifacts out of the source file's folder and makes cleanup predictable.
 4. The webview drives edits, navigation, search, replace, save, and replay through the provider, and the provider pushes back reactive state updates for the viewport, undo/redo counts, dirty state, replace counts, and server health.
 5. `deactivate()` calls `stopServerGraceful()` so the server can shut down cleanly.
@@ -131,7 +133,7 @@ The repository's tagged release workflow also builds this extension and uploads 
                               | gRPC
                               v
 +--------------------------------------------------------------+
-| OmegaEdit native server                                      |
+| Ωedit™ native server                                         |
 |  - sessions, viewports, undo/redo                            |
 |  - checkpoint handling                                       |
 |  - save and replay support                                   |
@@ -151,6 +153,6 @@ This reference implementation is intentionally compact. A few natural next steps
 
 ## Related
 
-- [OmegaEdit TypeScript Examples](../typescript/) - Standalone Node.js examples using `@omega-edit/client`
+- [Ωedit™ TypeScript Examples](../typescript/) - Standalone Node.js examples using `@omega-edit/client`
 - [@omega-edit/client on npm](https://www.npmjs.com/package/@omega-edit/client) - The client package used here
-- [Apache Daffodil VS Code Extension](https://github.com/apache/daffodil-vscode) - Production extension using OmegaEdit
+- [Apache Daffodil VS Code Extension](https://github.com/apache/daffodil-vscode) - Production extension using Ωedit™

--- a/examples/vscode-extension/package.json
+++ b/examples/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit-hex-editor",
-  "displayName": "OmegaEdit Hex Editor",
-  "description": "A minimal reference hex/data editor VS Code extension powered by OmegaEdit",
+  "displayName": "Ωedit™ Hex Editor",
+  "description": "A minimal reference hex/data editor VS Code extension powered by Ωedit™",
   "version": "2.0.0-rc1",
   "publisher": "omega-edit-example",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     "customEditors": [
       {
         "viewType": "omegaEdit.hexEditor",
-        "displayName": "OmegaEdit Hex Editor",
+        "displayName": "Ωedit™ Hex Editor",
         "selector": [
           {
             "filenamePattern": "*"
@@ -41,7 +41,7 @@
       }
     ],
     "configuration": {
-      "title": "OmegaEdit Hex Editor",
+      "title": "Ωedit™ Hex Editor",
       "properties": {
         "omegaEdit.serverPort": {
           "type": "number",
@@ -76,19 +76,19 @@
     "commands": [
       {
         "command": "omegaEdit.openInHexEditor",
-        "title": "OmegaEdit: Open in Hex Editor"
+        "title": "Ωedit™: Open in Hex Editor"
       },
       {
         "command": "omegaEdit.goToOffset",
-        "title": "OmegaEdit: Go to Offset"
+        "title": "Ωedit™: Go to Offset"
       },
       {
         "command": "omegaEdit.exportChangeScript",
-        "title": "OmegaEdit: Export Change Script"
+        "title": "Ωedit™: Export Change Script"
       },
       {
         "command": "omegaEdit.replayChangeScript",
-        "title": "OmegaEdit: Replay Change Script"
+        "title": "Ωedit™: Replay Change Script"
       }
     ],
     "menus": {

--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -110,8 +110,8 @@ export async function activate(
               canSelectMany: false,
               canSelectFiles: true,
               canSelectFolders: false,
-              openLabel: 'Open in OmegaEdit Hex Editor',
-              title: 'Select a file to open in OmegaEdit Hex Editor',
+              openLabel: 'Open in Ωedit™ Hex Editor',
+              title: 'Select a file to open in Ωedit™ Hex Editor',
             })
           )?.[0]
         }

--- a/examples/vscode-extension/src/hexEditorProvider.ts
+++ b/examples/vscode-extension/src/hexEditorProvider.ts
@@ -1173,7 +1173,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         case 'saveAs': {
           const saveUri = await vscode.window.showSaveDialog({
             defaultUri: vscode.Uri.file(session.filePath),
-            title: 'Save OmegaEdit contents as',
+            title: 'Save Ωedit™ contents as',
           })
           if (!saveUri) {
             break

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -13,7 +13,7 @@
 
 <div align="center">
 <p>
-    <img alt="OmegaEdit Logo" src="https://raw.githubusercontent.com/ctc-oss/omega-edit/main/images/OmegaEditLogo.png" width=120>
+    <img alt="Ωedit™ Logo" src="https://raw.githubusercontent.com/ctc-oss/omega-edit/main/images/OmegaEditLogo.png" width=120>
 </p>
 
 <h1>@omega-edit/client</h1>
@@ -25,7 +25,7 @@
 
 </div>
 
-TypeScript/Node.js client for [OmegaEdit](https://github.com/ctc-oss/omega-edit) - a library for building editors that can handle massive files with multiple viewports, full undo/redo, and byte-level precision.
+TypeScript/Node.js client for [Ωedit™](https://github.com/ctc-oss/omega-edit) - a library for building editors that can handle massive files with multiple viewports, full undo/redo, and byte-level precision.
 
 > **Batteries included** - this package bundles the native gRPC server via its dependency on `@omega-edit/server`. No separate server install is needed.
 
@@ -62,7 +62,7 @@ const sessionResp = await createSession()
 const sessionId = sessionResp.getSessionId()
 
 // 4. Make edits
-await insert(sessionId, 0, new TextEncoder().encode('Hello, OmegaEdit!'))
+await insert(sessionId, 0, new TextEncoder().encode('Hello, Ωedit™!'))
 
 // 5. Save to disk
 await saveSession(sessionId, '/tmp/hello.txt', IOFlags.OVERWRITE)
@@ -224,7 +224,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for build, test, and contribution instructi
 Full documentation is published at <https://ctc-oss.github.io/omega-edit/>.
 
 ## Versioning
-OmegaEdit follows [Semantic Versioning](http://semver.org/).
+Ωedit™ follows [Semantic Versioning](http://semver.org/).
 
 ## License
 Apache 2.0 - see [LICENSE.txt](https://github.com/ctc-oss/omega-edit/blob/main/LICENSE.txt).

--- a/wiki/Embedding-OmegaEdit-Core.md
+++ b/wiki/Embedding-OmegaEdit-Core.md
@@ -1,14 +1,14 @@
-# Embedding OmegaEdit Core
+# Embedding Ωedit™ Core
 
-OmegaEdit core is already structured to be embedded directly into another native project. This page documents the three supported integration patterns and the runtime tradeoffs to think through before you ship.
+Ωedit™ core is already structured to be embedded directly into another native project. This page documents the three supported integration patterns and the runtime tradeoffs to think through before you ship.
 
 ## Choose an Integration Pattern
 
-Use one of these patterns depending on how much of the OmegaEdit repository you want to bring into your build:
+Use one of these patterns depending on how much of the Ωedit™ repository you want to bring into your build:
 
 1. `add_subdirectory(<omega-edit-repo>)`
 
-   Best when you vendor the full repository and want OmegaEdit to behave like a lean subproject.
+   Best when you vendor the full repository and want Ωedit™ to behave like a lean subproject.
 
 2. `add_subdirectory(<omega-edit-repo>/core)`
 
@@ -16,7 +16,7 @@ Use one of these patterns depending on how much of the OmegaEdit repository you 
 
 3. `find_package(omega_edit CONFIG REQUIRED)`
 
-   Best when OmegaEdit has already been installed to a prefix and you want consumers to link against the installed package.
+   Best when Ωedit™ has already been installed to a prefix and you want consumers to link against the installed package.
 
 In all three cases, the primary target is the same:
 
@@ -46,7 +46,7 @@ target_link_libraries(my_app PRIVATE omega_edit::omega_edit)
 
 Why this mode exists:
 
-- disables OmegaEdit tests
+- disables Ωedit™ tests
 - disables docs generation
 - disables examples
 - disables coverage instrumentation
@@ -70,13 +70,13 @@ This is the smallest CMake integration path. `core/CMakeLists.txt` intentionally
 
 Good fit for:
 
-- embedding OmegaEdit beneath another native engine
+- embedding Ωedit™ beneath another native engine
 - monorepos that already own their packaging story
 - projects that do not want the repo-root packaging/install targets
 
 ## Pattern 3: Link Against an Installed Package
 
-If OmegaEdit has already been installed to a prefix, use the exported package config:
+If Ωedit™ has already been installed to a prefix, use the exported package config:
 
 ```cmake
 find_package(omega_edit CONFIG REQUIRED)
@@ -93,7 +93,7 @@ find_package(omega_edit CONFIG REQUIRED COMPONENTS shared)
 target_link_libraries(my_app PRIVATE omega_edit::omega_edit)
 ```
 
-OmegaEdit's installed package config understands `static` and `shared` components and loads the matching exported target file for you.
+Ωedit™'s installed package config understands `static` and `shared` components and loads the matching exported target file for you.
 
 Typical install flow from this repo:
 
@@ -107,14 +107,14 @@ Then point your downstream project at that prefix using `CMAKE_PREFIX_PATH` or y
 
 ## Shared vs Static Linking
 
-OmegaEdit supports both shared and static builds. The right choice depends mostly on deployment constraints, not on API shape.
+Ωedit™ supports both shared and static builds. The right choice depends mostly on deployment constraints, not on API shape.
 
 ### Static linking
 
 Best when you want:
 
 - the simplest runtime deployment
-- no separate OmegaEdit DLL / `.so` / `.dylib`
+- no separate Ωedit™ DLL / `.so` / `.dylib`
 - easier shipping inside a single native executable or tightly controlled plugin package
 
 Tradeoffs:
@@ -128,7 +128,7 @@ Tradeoffs:
 Best when you want:
 
 - smaller application binaries
-- a separable OmegaEdit runtime artifact
+- a separable Ωedit™ runtime artifact
 - easier replacement of the core library without relinking the embedding app
 
 Tradeoffs:
@@ -138,7 +138,7 @@ Tradeoffs:
 
 ## Windows DLL and Runtime Placement
 
-If you build OmegaEdit as a shared library on Windows, make sure `omega_edit.dll` is deployed beside your executable, or otherwise available on `PATH`.
+If you build Ωedit™ as a shared library on Windows, make sure `omega_edit.dll` is deployed beside your executable, or otherwise available on `PATH`.
 
 The usual "works everywhere" rule is:
 
@@ -167,8 +167,8 @@ add_custom_command(TARGET my_app POST_BUILD
 
 Notes:
 
-- when OmegaEdit is built statically, no separate OmegaEdit DLL is needed at runtime
-- your C/C++ runtime deployment still follows your toolchain choice (`/MD` vs `/MT`, vcpkg triplet, etc.); OmegaEdit does not add a separate runtime policy beyond the one your build already uses
+- when Ωedit™ is built statically, no separate Ωedit™ DLL is needed at runtime
+- your C/C++ runtime deployment still follows your toolchain choice (`/MD` vs `/MT`, vcpkg triplet, etc.); Ωedit™ does not add a separate runtime policy beyond the one your build already uses
 
 ## Minimal Required Targets and Includes
 
@@ -188,12 +188,12 @@ Typical headers:
 - `omega_edit/search.h` if you want direct search contexts
 - `omega_edit/viewport.h` if your host application wants viewport-style reads
 
-## Using OmegaEdit as an Edit Backend
+## Using Ωedit™ as an Edit Backend
 
-OmegaEdit works well underneath another workflow engine, parser, editor shell, or rewrite system. A common pattern looks like this:
+Ωedit™ works well underneath another workflow engine, parser, editor shell, or rewrite system. A common pattern looks like this:
 
 1. Open a session from a file or in-memory bytes.
-2. Translate your engine's logical operations into OmegaEdit inserts, deletes, and overwrites.
+2. Translate your engine's logical operations into Ωedit™ inserts, deletes, and overwrites.
 3. Read computed data back through `omega_session_get_segment` when you need materialized bytes.
 4. Save to disk with `omega_edit_save` or keep working in-memory until your host decides to persist.
 5. Destroy the session when the workflow is complete.
@@ -228,8 +228,8 @@ int main(void) {
 
 Why this pattern is useful:
 
-- OmegaEdit gives your host system undo/redo, checkpointing, and large-file-safe edits without forcing you to design those primitives yourself.
-- Your application can keep its own higher-level transaction or workflow model while delegating byte-accurate edit bookkeeping to OmegaEdit.
+- Ωedit™ gives your host system undo/redo, checkpointing, and large-file-safe edits without forcing you to design those primitives yourself.
+- Your application can keep its own higher-level transaction or workflow model while delegating byte-accurate edit bookkeeping to Ωedit™.
 - You can adopt only the core session/edit APIs first and add search, viewports, profiling, or transforms later.
 
 ## Practical Recommendations
@@ -240,7 +240,7 @@ If you are choosing quickly:
 - use `core/` directly when you only want the native library as a subproject
 - use `find_package(omega_edit CONFIG REQUIRED COMPONENTS static)` when you want the simplest installed-package deployment story
 - prefer static linking first for embedded tools, plugins, and internal engines unless you have a strong reason to ship a shared runtime
-- prefer shared linking when multiple packaged components need to reuse the same OmegaEdit binary or when swapping the runtime independently matters
+- prefer shared linking when multiple packaged components need to reuse the same Ωedit™ binary or when swapping the runtime independently matters
 
 ## See Also
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -6,6 +6,15 @@
 
 Ωedit™ has a native library (written in C/C++), a native C++ gRPC server, and a TypeScript RPC client that uses HTTP/2 over TCP. Ωedit™ handles the editing bookkeeping and file I/O allowing the front-end to focus on presentation details. The front-end application creates one or more viewports that are subscribed to. Desired changes are then sent to the local Ωedit™ client, which communicates changes to the server, which then sends them into the library. Changes that affect the subscribed viewport(s) are communicated to the server, then to the client, and finally to the front-end which renders the data in the affected viewports. These round trips are fast and efficient (thousands of changes per second). This architecture allows for efficient (in both time and space) editing of very large files. Ωedit™ does not load the file being edited in memory, instead it keeps track of the changes, and can compute the changes for any given data segment or viewport on demand. This allows paging through the data with the edits applied, or have several viewports into the data all being kept up to date with all affecting changes being made.
 
+## Naming Conventions
+
+Use these naming rules in user-facing Ωedit™ documentation:
+
+- **`Ωedit™`** for the project and product name in prose, headings, and UI-facing explanations
+- **`omega-edit`** for repository names, URLs, release assets, and Docker image names
+- **`@omega-edit/...`** for npm package names
+- **`omega_edit`** for C/C++ identifiers, include paths, and protobuf namespaces
+
 ## Quick Start
 
 Choose the path that matches your use case. All five get you to a working edit in under five minutes.
@@ -42,7 +51,7 @@ async function main() {
   console.log(`Session size: ${size} bytes`)
 
   // 4. Save to disk
-  await saveSession(sessionId, 'hello-output.dat', IOFlags.IO_FLAGS_OVERWRITE)
+  await saveSession(sessionId, 'hello-output.dat', IOFlags.OVERWRITE)
   console.log('Saved to hello-output.dat')
 
   // 5. Clean up
@@ -87,7 +96,7 @@ FetchContent_MakeAvailable(omega_edit)
 target_link_libraries(my_app PRIVATE omega_edit::omega_edit)
 ```
 
-For a downstream-native integration guide covering subproject patterns, installed-package consumption, shared vs static tradeoffs, Windows DLL placement, and "use OmegaEdit as a backend" workflows, see [Embedding OmegaEdit Core](Embedding-OmegaEdit-Core).
+For a downstream-native integration guide covering subproject patterns, installed-package consumption, shared vs static tradeoffs, Windows DLL placement, and "use Ωedit™ as a backend" workflows, see [Embedding Ωedit™ Core](Embedding-OmegaEdit-Core).
 
 Minimal C example — open a file, insert bytes, save:
 
@@ -104,7 +113,7 @@ int main() {
 }
 ```
 
-> **Next steps:** See [`core/src/examples/`](https://github.com/ctc-oss/omega-edit/tree/main/core/src/examples) for 15+ C/C++ examples covering search, viewports, profiling, transforms, and record/replay. For embedding and deployment guidance, see [Embedding OmegaEdit Core](Embedding-OmegaEdit-Core).
+> **Next steps:** See [`core/src/examples/`](https://github.com/ctc-oss/omega-edit/tree/main/core/src/examples) for 15+ C/C++ examples covering search, viewports, profiling, transforms, and record/replay. For embedding and deployment guidance, see [Embedding Ωedit™ Core](Embedding-OmegaEdit-Core).
 
 ### Path 3 — VS Code Extension
 
@@ -113,7 +122,7 @@ Build a data/hex editor extension with a single npm dependency:
 ```json
 {
   "dependencies": {
-    "@omega-edit/client": "^1.0.1"
+    "@omega-edit/client": "^2.0.0"
   }
 }
 ```
@@ -133,6 +142,8 @@ npm install
 ```
 
 > **See also:** The [Apache Daffodil™ VS Code Extension](https://marketplace.visualstudio.com/items?itemName=asf.apache-daffodil-vscode) uses Ωedit™ as its data editor in production.
+
+> **Note:** The in-repo reference extension now depends on the local workspace client package so it always exercises the current Ωedit™ 2.x implementation in this repository. External extensions should consume the published `@omega-edit/client` package.
 
 ### Path 4 — Docker (zero-install server)
 


### PR DESCRIPTION
## What changed

This refreshes the user-facing Oedit� documentation for the 2.x line.

- adds an explicit naming-conventions section to the main README and wiki home page
- updates user-facing prose to consistently use `Oedit�` where we mean the project/product name
- fixes stale 2.x API examples such as `IOFlags.IO_FLAGS_OVERWRITE` to `IOFlags.OVERWRITE`
- updates the wiki's VS Code extension dependency example from `@omega-edit/client@^1.0.1` to the 2.x line
- clarifies that the in-repo reference VS Code extension now uses the local workspace client during repo development
- aligns the embedding guide and package README copy with the current branding and v2 messaging

## Why it changed

The repository still had a mix of v1-era examples, inconsistent naming, and missing guidance about how to refer to the project in user-facing documentation.

That caused a few problems:

- docs drifted away from the current 2.x API surface
- the project name appeared in multiple inconsistent forms in pages users are likely to copy from
- the previous naming-conventions guidance was no longer easy to find

## User and developer impact

- users should now see more consistent `Oedit�` branding across the main README, wiki, and extension docs
- copy-paste examples are better aligned with the 2.x TypeScript surface
- contributors have an explicit naming rule set again for future docs work
- downstream extension authors now get clearer guidance about the published package path versus the in-repo reference extension path

## Validation

- `git diff --check` on the edited doc set
- targeted repo-wide search for stale `OmegaEdit`, `^1.0.1`, and `IOFlags.IO_FLAGS_OVERWRITE` patterns in the touched user-facing docs

This is a documentation-only PR; no runtime code changed.
