### PR TITLE
Fix VS Code extension health branding

### DIFF
--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -67,12 +67,12 @@ export async function activate(
     serverPid = await startServer(port)
     if (serverPid && !isTestRuntime()) {
       void vscode.window.showInformationMessage(
-        `OmegaEdit server started on port ${port} (pid ${serverPid})`
+        `Ωedit™ server started on port ${port} (pid ${serverPid})`
       )
     }
   } catch (err) {
     reportActivationError(
-      `Failed to start OmegaEdit server: ${err instanceof Error ? err.message : String(err)}`
+      `Failed to start Ωedit™ server: ${err instanceof Error ? err.message : String(err)}`
     )
     return
   }
@@ -80,7 +80,7 @@ export async function activate(
   try {
     await getClient(port)
   } catch {
-    reportActivationError('OmegaEdit server started but is not reachable')
+    reportActivationError('Ωedit™ server started but is not reachable')
     return
   }
 

--- a/examples/vscode-extension/src/hexEditorProvider.ts
+++ b/examples/vscode-extension/src/hexEditorProvider.ts
@@ -663,14 +663,14 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         { label: 'Sessions', value: String(heartbeat.sessionCount) },
         { label: 'Uptime', value: `${uptimeSeconds}s` },
         { label: 'CPU', value: `${heartbeat.serverCpuCount} cores` },
-        {
-          label: 'Load',
-          value:
-            heartbeat.serverCpuLoadAverage === undefined
-              ? 'n/a'
-              : heartbeat.serverCpuLoadAverage.toFixed(2),
-        },
       ]
+
+      if (heartbeat.serverCpuLoadAverage !== undefined) {
+        metrics.push({
+          label: 'Load Avg',
+          value: heartbeat.serverCpuLoadAverage.toFixed(2),
+        })
+      }
 
       if (availableProcessors !== undefined) {
         metrics.push({
@@ -719,7 +719,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
       this.broadcastServerHealth({
         type: 'serverHealth',
         ok: true,
-        summary: `Î©editâ„¢ ${heartbeat.latency} ms`,
+        summary: `Ωedit™ ${heartbeat.latency} ms`,
         detail: metrics
           .map((metric) => `${metric.label}: ${metric.value}`)
           .join('\n'),
@@ -731,7 +731,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
       this.broadcastServerHealth({
         type: 'serverHealth',
         ok: false,
-        summary: 'Î©editâ„¢ unavailable',
+        summary: 'Ωedit™ unavailable',
         detail: message,
         severity: 'down',
         metrics: [{ label: 'Error', value: message }],


### PR DESCRIPTION
## What changed
- updated the VS Code extension startup toast and related activation errors to use the `Oedit�` branding
- fixed the server health hover text so the summary is no longer garbled
- renamed the optional CPU load metric to `Load Avg` and only show it when the server actually reports a value

## Why
The extension UI still had a few inconsistent or mojibake user-facing strings after the RC sweep, especially around server startup and the Health status area.

## Impact
The reference extension now presents consistent branded copy and a cleaner Health hover on platforms where load average is unavailable.

## Validation
- `npm run compile`
