### PR TITLE
Add native server logging compatibility

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -86,6 +86,8 @@ await stopServerGraceful()
 | `getServerHeartbeat(sessions)`                    | Heartbeat and process health              |
 | `startServerHeartbeatLoop(options)`               | Managed liveness heartbeat loop           |
 
+`startServer(..., heartbeat)` and `startServerUnixSocket(..., heartbeat)` accept the same `HeartbeatOptions` bag exported from `@omega-edit/server`, including native logging fields such as `logFile`, `logLevel`, and `logConfigFile`.
+
 Shutdown migration note:
 
 - In the 2.x line, `stopServerGraceful()` and `stopServerImmediate()` return a structured result object with `responseCode`, `serverProcessId`, and `status` instead of returning only a numeric response code.
@@ -257,6 +259,8 @@ Distributed as both **ESM** and **CommonJS** with full TypeScript source maps an
 | ----------------------------- | ----------- | --------------------- |
 | `OMEGA_EDIT_SERVER_HOST`      | `127.0.0.1` | Server bind address   |
 | `OMEGA_EDIT_SERVER_PORT`      | `9000`      | Server port           |
+| `OMEGA_EDIT_SERVER_LOG_FILE`  | -           | Native server log file |
+| `OMEGA_EDIT_SERVER_LOG_LEVEL` | -           | Native server log level |
 | `OMEGA_EDIT_CLIENT_LOG_LEVEL` | -           | Client-side log level |
 
 ## Examples

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -257,11 +257,12 @@ Distributed as both **ESM** and **CommonJS** with full TypeScript source maps an
 
 | Variable                      | Default     | Description           |
 | ----------------------------- | ----------- | --------------------- |
-| `OMEGA_EDIT_SERVER_HOST`      | `127.0.0.1` | Server bind address   |
-| `OMEGA_EDIT_SERVER_PORT`      | `9000`      | Server port           |
-| `OMEGA_EDIT_SERVER_LOG_FILE`  | -           | Native server log file |
-| `OMEGA_EDIT_SERVER_LOG_LEVEL` | -           | Native server log level |
-| `OMEGA_EDIT_CLIENT_LOG_LEVEL` | -           | Client-side log level |
+| `OMEGA_EDIT_SERVER_HOST`        | `127.0.0.1` | Server bind address                       |
+| `OMEGA_EDIT_SERVER_PORT`        | `9000`      | Server port                               |
+| `OMEGA_EDIT_SERVER_LOG_CONFIG`  | -           | Native server logback-style XML config    |
+| `OMEGA_EDIT_SERVER_LOG_FILE`    | -           | Native server log file                    |
+| `OMEGA_EDIT_SERVER_LOG_LEVEL`   | -           | Native server log level                   |
+| `OMEGA_EDIT_CLIENT_LOG_LEVEL`   | -           | Client-side log level                     |
 
 ## Examples
 

--- a/packages/client/src/shims/omega-edit-server.ts
+++ b/packages/client/src/shims/omega-edit-server.ts
@@ -36,6 +36,9 @@ export interface HeartbeatOptions {
   viewportEventQueueCapacity?: number
   maxChangeBytes?: number
   maxViewportsPerSession?: number
+  logFile?: string
+  logLevel?: string
+  logConfigFile?: string
 }
 
 export declare function runServer(

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -762,6 +762,159 @@ describe('Server Resource Limits', () => {
   })
 })
 
+describe('Server Logging', () => {
+  let pid: number | undefined
+  const tempDirs: string[] = []
+  const serverTestPort = testPort + 4
+  const isUds = testTransport === 'uds'
+  const socketPath = path.join(
+    rootPath,
+    `.server-logging-${serverTestPort}.sock`
+  )
+
+  const waitForLogText = async (
+    logPath: string,
+    expectedText: string,
+    timeoutMs: number = 5000
+  ): Promise<void> => {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const contents = await fsPromises.readFile(logPath, 'utf8')
+        if (contents.includes(expectedText)) {
+          return
+        }
+      } catch {
+        // keep polling until timeout
+      }
+      await delay(100)
+    }
+
+    expect(await fsPromises.readFile(logPath, 'utf8')).to.include(expectedText)
+  }
+
+  afterEach(`cleanup logging server on port ${serverTestPort}`, async () => {
+    if (pid !== undefined && pidIsRunning(pid)) {
+      if (isUds) {
+        expect(await stopProcessUsingPID(pid)).to.be.true
+      } else {
+        expect(await stopServiceOnPort(serverTestPort)).to.be.true
+      }
+    }
+
+    if (isUds) {
+      try {
+        fs.unlinkSync(socketPath)
+      } catch {
+        // ignore
+      }
+    }
+
+    while (tempDirs.length > 0) {
+      await fsPromises.rm(tempDirs.pop() as string, {
+        recursive: true,
+        force: true,
+      })
+    }
+
+    pid = undefined
+  })
+
+  it(`on port ${serverTestPort} should write native lifecycle logs to a configured log file`, async () => {
+    const tempDir = await fsPromises.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-server-log-')
+    )
+    tempDirs.push(tempDir)
+    const serverLogPath = path.join(tempDir, 'omega-edit-server.log')
+
+    if (isUds) {
+      const udsJavaHome = process.env.OMEGA_EDIT_TEST_JAVA_HOME
+      if (udsJavaHome) {
+        process.env.JAVA_HOME = udsJavaHome
+        const currentPath = process.env.PATH || ''
+        if (!currentPath.includes(`${udsJavaHome}/bin`)) {
+          process.env.PATH = `${udsJavaHome}/bin:${currentPath}`
+        }
+      }
+
+      process.env.OMEGA_EDIT_SERVER_SOCKET = socketPath
+      delete process.env.OMEGA_EDIT_SERVER_URI
+      pid = await startServerUnixSocket(
+        socketPath,
+        undefined,
+        false,
+        serverTestPort,
+        testHost,
+        { logFile: serverLogPath, logLevel: 'info' }
+      )
+    } else {
+      delete process.env.OMEGA_EDIT_SERVER_SOCKET
+      delete process.env.OMEGA_EDIT_SERVER_URI
+      expect(await stopServiceOnPort(serverTestPort)).to.be.true
+      pid = await startServer(serverTestPort, undefined, undefined, {
+        logFile: serverLogPath,
+        logLevel: 'info',
+      })
+    }
+
+    expect(pid).to.be.a('number').greaterThan(0)
+    await waitForLogText(serverLogPath, 'ready...')
+  })
+
+  it(`on port ${serverTestPort} should accept a logback-style config file for native logging`, async () => {
+    const tempDir = await fsPromises.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-server-log-config-')
+    )
+    tempDirs.push(tempDir)
+    const serverLogPath = path.join(tempDir, 'omega-edit-server.log')
+    const logConfigPath = path.join(tempDir, 'server-log.xml')
+    const logConfig = `<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${serverLogPath}</file>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>
+`
+
+    await fsPromises.writeFile(logConfigPath, logConfig, 'utf8')
+
+    if (isUds) {
+      const udsJavaHome = process.env.OMEGA_EDIT_TEST_JAVA_HOME
+      if (udsJavaHome) {
+        process.env.JAVA_HOME = udsJavaHome
+        const currentPath = process.env.PATH || ''
+        if (!currentPath.includes(`${udsJavaHome}/bin`)) {
+          process.env.PATH = `${udsJavaHome}/bin:${currentPath}`
+        }
+      }
+
+      process.env.OMEGA_EDIT_SERVER_SOCKET = socketPath
+      delete process.env.OMEGA_EDIT_SERVER_URI
+      pid = await startServerUnixSocket(
+        socketPath,
+        undefined,
+        false,
+        serverTestPort,
+        testHost,
+        { logConfigFile: logConfigPath }
+      )
+    } else {
+      delete process.env.OMEGA_EDIT_SERVER_SOCKET
+      delete process.env.OMEGA_EDIT_SERVER_URI
+      expect(await stopServiceOnPort(serverTestPort)).to.be.true
+      pid = await startServer(serverTestPort, undefined, undefined, {
+        logConfigFile: logConfigPath,
+      })
+    }
+
+    expect(pid).to.be.a('number').greaterThan(0)
+    await waitForLogText(serverLogPath, 'ready...')
+  })
+})
+
 // Tests involving running the server
 // Created for investigating https://github.com/apache/daffodil-vscode/pull/1277 and https://github.com/apache/daffodil-vscode/issues/1075
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -63,6 +63,8 @@ const proc = await runServer(9000, '127.0.0.1', '/tmp/server.pid', {
   shutdownWhenNoSessions: true,
   maxChangeBytes: 16 * 1024 * 1024,
   maxViewportsPerSession: 64,
+  logFile: '/tmp/omega-edit-server.log',
+  logLevel: 'info',
 })
 
 // Or pass raw CLI arguments
@@ -113,6 +115,9 @@ interface HeartbeatOptions {
   viewportEventQueueCapacity?: number // Buffered viewport events per subscription (0 = unbounded)
   maxChangeBytes?: number        // Insert/overwrite payload limit in bytes (0 = unbounded)
   maxViewportsPerSession?: number // Viewport cap per session (0 = unbounded)
+  logFile?: string               // Append native server lifecycle logs to this file
+  logLevel?: string              // Native log level: debug, info, warn, error
+  logConfigFile?: string         // Compatibility shim for logback-style XML config
 }
 ```
 
@@ -136,6 +141,9 @@ The native binary supports:
 | `--viewport-event-queue-capacity` | Buffered viewport events per subscription |
 | `--max-change-bytes` | Limit insert/overwrite payload size |
 | `--max-viewports-per-session` | Limit open viewports per session |
+| `--log-file` | Append native server logs to a file |
+| `--log-level` | Set native server log verbosity |
+| `--log-config` | Read log file/level from a logback-style XML config |
 
 ## Platform Support
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -47,6 +47,12 @@ export interface HeartbeatOptions {
   maxChangeBytes?: number
   /** Limit concurrently open viewports per session (0 = unbounded). */
   maxViewportsPerSession?: number
+  /** Append native server lifecycle logs to this file. */
+  logFile?: string
+  /** Native server log level. */
+  logLevel?: string
+  /** Compatibility shim: read native log file/level from a logback-style XML config. */
+  logConfigFile?: string
 }
 
 /**
@@ -191,6 +197,15 @@ function heartbeatToArgs(opts?: HeartbeatOptions): string[] {
   }
   if (opts.maxViewportsPerSession !== undefined) {
     args.push(`--max-viewports-per-session=${opts.maxViewportsPerSession}`)
+  }
+  if (opts.logFile !== undefined) {
+    args.push(`--log-file=${opts.logFile}`)
+  }
+  if (opts.logLevel !== undefined) {
+    args.push(`--log-level=${opts.logLevel}`)
+  }
+  if (opts.logConfigFile !== undefined) {
+    args.push(`--log-config=${opts.logConfigFile}`)
   }
   return args
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -198,14 +198,14 @@ function heartbeatToArgs(opts?: HeartbeatOptions): string[] {
   if (opts.maxViewportsPerSession !== undefined) {
     args.push(`--max-viewports-per-session=${opts.maxViewportsPerSession}`)
   }
+  if (opts.logConfigFile !== undefined) {
+    args.push(`--log-config=${opts.logConfigFile}`)
+  }
   if (opts.logFile !== undefined) {
     args.push(`--log-file=${opts.logFile}`)
   }
   if (opts.logLevel !== undefined) {
     args.push(`--log-level=${opts.logLevel}`)
-  }
-  if (opts.logConfigFile !== undefined) {
-    args.push(`--log-config=${opts.logConfigFile}`)
   }
   return args
 }

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -148,8 +148,6 @@ static bool configure_log_output(const std::string &log_file) {
         return false;
     }
     g_log_stream = &g_log_file_stream;
-    std::cerr.rdbuf(g_log_file_stream.rdbuf());
-    std::clog.rdbuf(g_log_file_stream.rdbuf());
     return true;
 }
 
@@ -321,12 +319,12 @@ int main(int argc, char **argv) {
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_PIDFILE")) {
         pidfile = env;
     }
-    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_FILE")) {
-        log_file = env;
-    }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_CONFIG")) {
         log_config_file = env;
         if (!apply_log_config_file(log_config_file, log_file, log_level)) return 1;
+    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_FILE")) {
+        log_file = env;
     }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_LEVEL")) {
         if (!parse_log_level(env, "OMEGA_EDIT_SERVER_LOG_LEVEL", log_level)) return 1;
@@ -433,7 +431,27 @@ int main(int argc, char **argv) {
                     return 1;
                 }
                 log_config_file = value;
-                if (!apply_log_config_file(log_config_file, log_file, log_level)) return 1;
+                // Pre-scan for explicit --log-file / --log-level flags so that they
+                // always win over the config file regardless of argument order.
+                bool has_explicit_log_file = false;
+                bool has_explicit_log_level = false;
+                for (int j = 1; j < argc; ++j) {
+                    const std::string a = argv[j];
+                    if (a == "--log-file" || a.rfind("--log-file=", 0) == 0) {
+                        has_explicit_log_file = true;
+                    } else if (a == "--log-level" || a.rfind("--log-level=", 0) == 0) {
+                        has_explicit_log_level = true;
+                    }
+                }
+                std::string config_log_file = log_file;
+                LogLevel config_log_level = log_level;
+                if (!apply_log_config_file(log_config_file, config_log_file, config_log_level)) return 1;
+                if (!has_explicit_log_file) {
+                    log_file = config_log_file;
+                }
+                if (!has_explicit_log_level) {
+                    log_level = config_log_level;
+                }
             } else if (key == "--session-timeout") {
                 if (value.empty()) {
                     std::cerr << "Error: " << key << " requires a value\n";

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -436,10 +436,10 @@ int main(int argc, char **argv) {
                 bool has_explicit_log_file = false;
                 bool has_explicit_log_level = false;
                 for (int j = 1; j < argc; ++j) {
-                    const std::string a = argv[j];
-                    if (a == "--log-file" || a.rfind("--log-file=", 0) == 0) {
+                    const char *a = argv[j];
+                    if (std::strcmp(a, "--log-file") == 0 || std::strncmp(a, "--log-file=", 11) == 0) {
                         has_explicit_log_file = true;
-                    } else if (a == "--log-level" || a.rfind("--log-level=", 0) == 0) {
+                    } else if (std::strcmp(a, "--log-level") == 0 || std::strncmp(a, "--log-level=", 12) == 0) {
                         has_explicit_log_level = true;
                     }
                 }

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -554,20 +554,20 @@ int main(int argc, char **argv) {
         }
         std::string unix_addr = "unix:" + unix_socket;
         builder.AddListeningPort(unix_addr, grpc::InsecureServerCredentials());
-        std::cerr << "Ωedit gRPC server (v" << SERVER_VERSION << ") with PID " << pid << " bound to " << unix_addr
-                  << ": ready..." << std::endl;
+        log_message(LogLevel::Info, std::string("Ωedit gRPC server (v") + SERVER_VERSION + ") with PID " +
+                                         std::to_string(pid) + " bound to " + unix_addr + ": ready...");
 #endif
     } else {
         std::string server_address = interface_addr + ":" + std::to_string(port);
         builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-        std::cerr << "Ωedit gRPC server (v" << SERVER_VERSION << ") with PID " << pid << " bound to "
-                  << server_address << ": ready..." << std::endl;
+        log_message(LogLevel::Info, std::string("Ωedit gRPC server (v") + SERVER_VERSION + ") with PID " +
+                                         std::to_string(pid) + " bound to " + server_address + ": ready...");
 
 #ifndef _WIN32
         if (!unix_socket.empty()) {
             std::string unix_addr = "unix:" + unix_socket;
             builder.AddListeningPort(unix_addr, grpc::InsecureServerCredentials());
-            std::cerr << "Ωedit gRPC server additionally exposed via " << unix_addr << std::endl;
+            log_message(LogLevel::Info, "Ωedit gRPC server additionally exposed via " + unix_addr);
         }
 #endif
     }

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -25,9 +25,17 @@
 #include <cstdio>
 #include <cstdlib>
 #include <atomic>
+#include <chrono>
+#include <cctype>
+#include <ctime>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <limits>
+#include <memory>
+#include <mutex>
+#include <regex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -42,9 +50,137 @@
 static std::unique_ptr<grpc::Server> g_server;
 static std::atomic<bool> g_shutdown_requested{false};
 
+enum class LogLevel {
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+};
+
+static std::mutex g_log_mutex;
+static LogLevel g_log_level = LogLevel::Info;
+static std::ofstream g_log_file_stream;
+static std::ostream *g_log_stream = &std::cerr;
+
 // Signal handler — only sets an atomic flag (async-signal-safe).
 // The main thread polls this flag and performs the actual shutdown.
 static void signal_handler(int /*signum*/) { g_shutdown_requested.store(true, std::memory_order_relaxed); }
+
+static const char *log_level_name(LogLevel level) {
+    switch (level) {
+        case LogLevel::Debug: return "DEBUG";
+        case LogLevel::Info: return "INFO";
+        case LogLevel::Warn: return "WARN";
+        case LogLevel::Error: return "ERROR";
+    }
+    return "INFO";
+}
+
+static bool try_parse_log_level(const std::string &value, LogLevel &out) {
+    std::string normalized;
+    normalized.reserve(value.size());
+    for (char ch : value) {
+        normalized.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
+    }
+    if (normalized == "trace" || normalized == "debug") {
+        out = LogLevel::Debug;
+        return true;
+    }
+    if (normalized == "info") {
+        out = LogLevel::Info;
+        return true;
+    }
+    if (normalized == "warn" || normalized == "warning") {
+        out = LogLevel::Warn;
+        return true;
+    }
+    if (normalized == "error" || normalized == "fatal" || normalized == "critical") {
+        out = LogLevel::Error;
+        return true;
+    }
+    return false;
+}
+
+static bool parse_log_level(const std::string &value, const std::string &name, LogLevel &out) {
+    if (!try_parse_log_level(value, out)) {
+        std::cerr << "Error: " << name
+                  << " must be one of trace, debug, info, warn, warning, error, fatal, critical; got: "
+                  << value << "\n";
+        return false;
+    }
+    return true;
+}
+
+static std::string current_timestamp() {
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_snapshot{};
+#ifdef _WIN32
+    localtime_s(&tm_snapshot, &now_time);
+#else
+    localtime_r(&now_time, &tm_snapshot);
+#endif
+    std::ostringstream stream;
+    stream << std::put_time(&tm_snapshot, "%Y-%m-%d %H:%M:%S");
+    return stream.str();
+}
+
+static void log_message(LogLevel level, const std::string &message) {
+    if (static_cast<int>(level) < static_cast<int>(g_log_level)) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+    (*g_log_stream) << "[" << current_timestamp() << "] "
+                    << "[" << log_level_name(level) << "] "
+                    << message << std::endl;
+}
+
+static bool configure_log_output(const std::string &log_file) {
+    if (log_file.empty()) {
+        g_log_stream = &std::cerr;
+        return true;
+    }
+
+    g_log_file_stream.open(log_file, std::ios::out | std::ios::app);
+    if (!g_log_file_stream.is_open()) {
+        std::cerr << "Error: could not open log file: " << log_file << "\n";
+        return false;
+    }
+    g_log_stream = &g_log_file_stream;
+    std::cerr.rdbuf(g_log_file_stream.rdbuf());
+    std::clog.rdbuf(g_log_file_stream.rdbuf());
+    return true;
+}
+
+static bool apply_log_config_file(const std::string &config_path, std::string &log_file, LogLevel &log_level) {
+    std::ifstream file(config_path);
+    if (!file.is_open()) {
+        std::cerr << "Error: could not open log config file: " << config_path << "\n";
+        return false;
+    }
+
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    const std::string contents = buffer.str();
+
+    const std::regex file_regex(R"OMEGA(<file>\s*([^<]+?)\s*</file>)OMEGA", std::regex::icase);
+    const std::regex root_level_regex(R"OMEGA(<root[^>]*level\s*=\s*"([^"]+)")OMEGA", std::regex::icase);
+    std::smatch match;
+
+    if (std::regex_search(contents, match, file_regex)) {
+        log_file = match[1].str();
+    }
+    if (std::regex_search(contents, match, root_level_regex)) {
+        LogLevel parsed_level;
+        if (!parse_log_level(match[1].str(), "--log-config root level", parsed_level)) {
+            return false;
+        }
+        log_level = parsed_level;
+    }
+
+    return true;
+}
 
 /// Parse a string as an integer in [min_val, max_val], writing the result to out.
 /// Returns true on success; on failure prints a message to stderr and returns false.
@@ -126,6 +262,10 @@ static void print_usage(const char *progname) {
               << "  -f, --pidfile <path>             Write PID to file\n"
               << "  -u, --unix-socket <path>         Unix domain socket path (Linux/macOS only)\n"
               << "      --unix-socket-only           Bind only to Unix domain socket\n"
+              << "\nLogging options:\n"
+              << "      --log-file <path>            Append native server logs to file\n"
+              << "      --log-level <level>          Native log level (debug, info, warn, error)\n"
+              << "      --log-config <path>          Compatibility shim: read log file/level from logback-style XML\n"
               << "\nHeartbeat / session-reaping options:\n"
               << "      --session-timeout <ms>       Idle session timeout in milliseconds (0 = disabled)\n"
               << "      --cleanup-interval <ms>      Reaper sweep interval in milliseconds (0 = disabled)\n"
@@ -148,7 +288,10 @@ int main(int argc, char **argv) {
     int port = 9000;
     std::string pidfile;
     std::string unix_socket;
+    std::string log_file;
+    std::string log_config_file;
     bool unix_socket_only = false;
+    LogLevel log_level = LogLevel::Info;
 
     // Heartbeat / session-reaping defaults (0 = disabled)
     int session_timeout_ms = 0;
@@ -177,6 +320,18 @@ int main(int argc, char **argv) {
     }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_PIDFILE")) {
         pidfile = env;
+    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_FILE")) {
+        log_file = env;
+    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_CONFIG")) {
+        log_config_file = env;
+        if (!apply_log_config_file(log_config_file, log_file, log_level)) return 1;
+    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_LEVEL")) {
+        if (!parse_log_level(env, "OMEGA_EDIT_SERVER_LOG_LEVEL", log_level)) return 1;
+    } else if (const char *env = std::getenv("OMEGA_EDIT_LOG_LEVEL")) {
+        if (!parse_log_level(env, "OMEGA_EDIT_LOG_LEVEL", log_level)) return 1;
     }
 
     // Native heartbeat environment variables
@@ -260,6 +415,25 @@ int main(int argc, char **argv) {
                     return 1;
                 }
                 unix_socket = value;
+            } else if (key == "--log-file") {
+                if (value.empty()) {
+                    std::cerr << "Error: " << key << " requires a value\n";
+                    return 1;
+                }
+                log_file = value;
+            } else if (key == "--log-level") {
+                if (value.empty()) {
+                    std::cerr << "Error: " << key << " requires a value\n";
+                    return 1;
+                }
+                if (!parse_log_level(value, "--log-level", log_level)) return 1;
+            } else if (key == "--log-config") {
+                if (value.empty()) {
+                    std::cerr << "Error: " << key << " requires a value\n";
+                    return 1;
+                }
+                log_config_file = value;
+                if (!apply_log_config_file(log_config_file, log_file, log_level)) return 1;
             } else if (key == "--session-timeout") {
                 if (value.empty()) {
                     std::cerr << "Error: " << key << " requires a value\n";
@@ -305,6 +479,12 @@ int main(int argc, char **argv) {
         }
     }
 
+    g_log_level = log_level;
+    if (!configure_log_output(log_file)) return 1;
+    if (!log_file.empty()) {
+        log_message(LogLevel::Info, "native server logging redirected to " + log_file);
+    }
+
     // Write PID file
     int pid = getpid();
     if (!pidfile.empty()) {
@@ -313,7 +493,7 @@ int main(int argc, char **argv) {
             pf << pid;
             pf.close();
         } else {
-            std::cerr << "Warning: could not write pidfile: " << pidfile << std::endl;
+            log_message(LogLevel::Warn, "could not write pidfile: " + pidfile);
         }
     }
 
@@ -347,11 +527,11 @@ int main(int argc, char **argv) {
 
     if (unix_socket_only) {
 #ifdef _WIN32
-        std::cerr << "Unix domain sockets are not supported on Windows" << std::endl;
+        log_message(LogLevel::Error, "Unix domain sockets are not supported on Windows");
         return 1;
 #else
         if (unix_socket.empty()) {
-            std::cerr << "--unix-socket-only requires --unix-socket" << std::endl;
+            log_message(LogLevel::Error, "--unix-socket-only requires --unix-socket");
             return 1;
         }
         std::string unix_addr = "unix:" + unix_socket;


### PR DESCRIPTION
## Summary
- add native server logging options for `--log-file`, `--log-level`, and `--log-config`
- pass the new logging options through the Node launcher and client-facing `HeartbeatOptions` surface
- document the native logging flow and add lifecycle coverage for direct log-file output plus logback-style XML compatibility

## Why
The old Scala-backed server accepted logback-style configuration, but the native C++ server did not have a comparable CLI surface. That left downstream integrations like the Apache Daffodil VS Code extension with a logging migration gap even though the functional editor integration worked.

## Impact
Consumers can now configure native server lifecycle logging directly, and existing JVM-era launchers can migrate incrementally by handing the native server a logback-style XML file that provides the log file path and root level.

## Validation
- `yarn workspace @omega-edit/server build`
- `yarn workspace @omega-edit/client build`
- `yarn workspace @omega-edit/client test:lifecycle`
- `yarn workspace @omega-edit/server lint`
- `yarn workspace @omega-edit/client lint`
