### PR TITLE
Harden core arithmetic and session locking

### DIFF
--- a/core/src/lib/change.cpp
+++ b/core/src/lib/change.cpp
@@ -17,6 +17,11 @@
 #include "impl_/macros.h"
 #include <cassert>
 
+using omega_edit::internal::change_kind_t;
+using omega_edit::internal::omega_change_get_kind_;
+using omega_edit::internal::omega_change_get_transaction_bit_;
+using omega_edit::internal::omega_data_get_data_const_;
+
 static_assert(sizeof(omega_change_t) == sizeof(omega_change_struct), "omega_change_t size mismatch");
 static_assert(sizeof(omega_change_t) == 40);
 
@@ -37,8 +42,8 @@ int64_t omega_change_get_serial(const omega_change_t *change_ptr) {
 
 static inline const omega_byte_t *change_bytes_(const omega_change_t *change_ptr) {
     if (!change_ptr) { return nullptr; }
-    return (omega_change_get_kind(change_ptr) != change_kind_t::CHANGE_DELETE)
-           ? omega_data_get_data_const(&change_ptr->data, change_ptr->length)
+    return (omega_change_get_kind_(change_ptr) != change_kind_t::CHANGE_DELETE)
+           ? omega_data_get_data_const_(&change_ptr->data, change_ptr->length)
            : nullptr;
 }
 
@@ -49,7 +54,7 @@ const omega_byte_t *omega_change_get_bytes(const omega_change_t *change_ptr) {
 
 char omega_change_get_kind_as_char(const omega_change_t *change_ptr) {
     if (!change_ptr) { return '\0'; }
-    switch (omega_change_get_kind(change_ptr)) {
+    switch (omega_change_get_kind_(change_ptr)) {
         case change_kind_t::CHANGE_DELETE:
             return 'D';
         case change_kind_t::CHANGE_INSERT:

--- a/core/src/lib/check.cpp
+++ b/core/src/lib/check.cpp
@@ -17,8 +17,12 @@
 #include "impl_/change_def.hpp"
 #include "impl_/internal_fun.hpp"
 #include "impl_/macros.h"
+#include "impl_/safe_math.hpp"
 #include "impl_/session_def.hpp"
 #include <cassert>
+
+using omega_edit::internal::print_model_segments_;
+using omega_edit::internal::safe_add_int64_;
 
 int omega_check_model(const omega_session_t *session_ptr) {
     if (!session_ptr) { return -1; }
@@ -52,7 +56,9 @@ int omega_check_model(const omega_session_t *session_ptr) {
             }
 
             // Segment must not extend beyond its parent change data
-            if (segment->change_offset + segment->computed_length > segment->change_ptr->length) {
+            int64_t change_end = 0;
+            if (!safe_add_int64_(segment->change_offset, segment->computed_length, change_end) ||
+                change_end > segment->change_ptr->length) {
                 print_model_segments_(model_ptr.get(), CLOG);
                 return -1;
             }
@@ -63,7 +69,10 @@ int omega_check_model(const omega_session_t *session_ptr) {
                 return -1;
             }
 
-            expected_offset += segment->computed_length;
+            if (!safe_add_int64_(expected_offset, segment->computed_length, expected_offset)) {
+                print_model_segments_(model_ptr.get(), CLOG);
+                return -1;
+            }
         }
 
         // Checkpoint models (index > 0) must have a backing file
@@ -72,11 +81,15 @@ int omega_check_model(const omega_session_t *session_ptr) {
 
     // Cross-check: the back model's total segment length must match the session's computed file size
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0) { return -1; }
     const auto &back_model = session_ptr->models_.back();
-    const int64_t model_total_length = back_model->model_segments.empty()
-                                               ? 0
-                                               : back_model->model_segments.back()->computed_offset +
-                                                         back_model->model_segments.back()->computed_length;
+    int64_t model_total_length = 0;
+    if (!back_model->model_segments.empty() &&
+        !safe_add_int64_(back_model->model_segments.back()->computed_offset,
+                         back_model->model_segments.back()->computed_length,
+                         model_total_length)) {
+        return -1;
+    }
     if (model_total_length != computed_file_size) { return -1; }
 
     return 0;

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -23,20 +23,37 @@
 #include "impl_/macros.h"
 #include "impl_/model_def.hpp"
 #include "impl_/model_segment_def.hpp"
+#include "impl_/safe_math.hpp"
 #include "impl_/session_def.hpp"
 #include "impl_/viewport_def.hpp"
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
+#include <limits>
 #include <memory>
 #include <vector>
+
+using omega_edit::internal::add_overflows_int64_;
+using omega_edit::internal::change_kind_t;
+using omega_edit::internal::model_segment_kind_t;
+using omega_edit::internal::omega_change_get_kind_;
+using omega_edit::internal::omega_change_get_transaction_bit_;
+using omega_edit::internal::omega_data_create_;
+using omega_edit::internal::omega_data_destroy_;
+using omega_edit::internal::omega_model_segment_get_kind_;
+using omega_edit::internal::omega_session_begin_event_batch_;
+using omega_edit::internal::omega_session_end_event_batch_;
+using omega_edit::internal::omega_session_get_transaction_bit_;
+using omega_edit::internal::populate_data_segment_;
+using omega_edit::internal::print_model_segments_;
+using omega_edit::internal::safe_add_int64_;
+using omega_edit::internal::valid_nonnegative_range_;
 
 #ifdef OMEGA_BUILD_WINDOWS
 
 #include <io.h>
 
 #define close _close
-// Undefine Windows min/max macros to avoid conflicts with std::min/max
 #ifdef min
 #undef min
 #endif
@@ -50,29 +67,30 @@
 #endif
 
 namespace {
-    // 64KB I/O buffer for save and transform operations — reduces system-call overhead vs BUFSIZ (~8KB)
     constexpr int64_t OMEGA_IO_BUFFER_SIZE = 65536;
+
+    inline int64_t next_change_serial_(const omega_session_t *session_ptr) {
+        const auto change_count = omega_session_get_num_changes(session_ptr);
+        return change_count < (std::numeric_limits<int64_t>::max)() ? change_count + 1 : 0;
+    }
 
     void initialize_model_segments_(omega_model_segments_t &model_segments, int64_t length);
 
     auto resolve_checkpoint_directory_(const char *file_path, const char *checkpoint_directory,
                                        std::string &checkpoint_directory_str) -> bool {
         if (checkpoint_directory == nullptr) {
-            // First try to use the directory of the file being edited
             if ((file_path != nullptr) && file_path[0] != '\0') {
                 auto *const dirname = omega_util_dirname(file_path, nullptr);
                 if (dirname != nullptr) {
                     checkpoint_directory = checkpoint_directory_str.assign(dirname).c_str();
                 }
             }
-            // If that doesn't work, then try to use the system temp directory
             if (checkpoint_directory == nullptr) {
                 auto *const temp_dir = omega_util_get_temp_directory();
                 if (temp_dir != nullptr) {
                     checkpoint_directory = checkpoint_directory_str.assign(temp_dir).c_str();
                     free(temp_dir);
                 } else {
-                    // Finally, if that doesn't work, then use the current working directory
                     auto *const current_dir = omega_util_get_current_dir(nullptr);
                     if (current_dir != nullptr) {
                         checkpoint_directory = checkpoint_directory_str.assign(current_dir).c_str();
@@ -190,7 +208,6 @@ namespace {
     void initialize_model_segments_(omega_model_segments_t &model_segments, int64_t length) {
         model_segments.clear();
         if (0 < length) {
-            // Model begins with a single READ segment spanning the original file
             const auto change_ptr = std::make_shared<omega_change_t>();
             change_ptr->serial = 0;
             change_ptr->kind = (uint8_t) (change_kind_t::CHANGE_INSERT);
@@ -216,47 +233,45 @@ namespace {
         return change_ptr;
     }
 
+    inline auto populate_change_bytes_(omega_change_t *change_ptr, const omega_byte_t *bytes) -> bool {
+        if (change_ptr->length < DATA_T_SIZE) {
+            memcpy(change_ptr->data.sm_bytes, bytes, change_ptr->length);
+            change_ptr->data.sm_bytes[change_ptr->length] = '\0';
+            return true;
+        }
+        int64_t allocation_length = 0;
+        if (!safe_add_int64_(change_ptr->length, 1, allocation_length)) { return false; }
+        change_ptr->data.bytes_ptr = new omega_byte_t[allocation_length];
+        memcpy(change_ptr->data.bytes_ptr, bytes, change_ptr->length);
+        change_ptr->data.bytes_ptr[change_ptr->length] = '\0';
+        return true;
+    }
+
     inline auto ins_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
                      bool transaction_bit) -> const_omega_change_ptr_t {
         if (!bytes) { return nullptr; }
+        if (serial <= 0 || !valid_nonnegative_range_(offset, length)) { return nullptr; }
         auto change_ptr = std::make_shared<omega_change_t>();
         change_ptr->serial = serial;
         change_ptr->kind =
                 (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_INSERT;
         change_ptr->offset = offset;
         change_ptr->length = length;
-        if (change_ptr->length < DATA_T_SIZE) {
-            // small bytes optimization
-            memcpy(change_ptr->data.sm_bytes, bytes, change_ptr->length);
-            change_ptr->data.sm_bytes[change_ptr->length] = '\0';
-        } else {
-            // allocate its capacity plus one, so we can null-terminate it
-            change_ptr->data.bytes_ptr = new omega_byte_t[change_ptr->length + 1];
-            memcpy(change_ptr->data.bytes_ptr, bytes, change_ptr->length);
-            change_ptr->data.bytes_ptr[change_ptr->length] = '\0';
-        }
+        if (!populate_change_bytes_(change_ptr.get(), bytes)) { return nullptr; }
         return change_ptr;
     }
 
     inline auto ovr_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
                      bool transaction_bit) -> const_omega_change_ptr_t {
         if (!bytes) { return nullptr; }
+        if (serial <= 0 || !valid_nonnegative_range_(offset, length)) { return nullptr; }
         auto change_ptr = std::make_shared<omega_change_t>();
         change_ptr->serial = serial;
         change_ptr->kind =
                 (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_OVERWRITE;
         change_ptr->offset = offset;
         change_ptr->length = length;
-        if (change_ptr->length < DATA_T_SIZE) {
-            // small bytes optimization
-            memcpy(change_ptr->data.sm_bytes, bytes, change_ptr->length);
-            change_ptr->data.sm_bytes[change_ptr->length] = '\0';
-        } else {
-            // allocate its capacity plus one, so we can null-terminate it
-            change_ptr->data.bytes_ptr = new omega_byte_t[change_ptr->length + 1];
-            memcpy(change_ptr->data.bytes_ptr, bytes, change_ptr->length);
-            change_ptr->data.bytes_ptr[change_ptr->length] = '\0';
-        }
+        if (!populate_change_bytes_(change_ptr.get(), bytes)) { return nullptr; }
         return change_ptr;
     }
 
@@ -320,7 +335,7 @@ namespace {
     auto replace_bytes_impl_(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
                              const omega_byte_t *bytes, int64_t insert_length) -> int64_t {
         if (!session_ptr) { return -1; }
-        if (delete_length < 0 || insert_length < 0 || offset < 0) { return 0; }
+        if (!valid_nonnegative_range_(offset, delete_length) || insert_length < 0) { return 0; }
         if (!bytes && insert_length > 0) { return -1; }
         if (delete_length == 0 && insert_length == 0) { return 0; }
         if (delete_length == 0) { return omega_edit_insert_bytes(session_ptr, offset, bytes, insert_length); }
@@ -399,13 +414,7 @@ namespace {
 
         if (overwrite_only) {
             if (!replacement || replacement_length <= 0) { return; }
-            const omega_edit_script_op_t op{
-                    offset,
-                    replacement_length,
-                    OMEGA_EDIT_SCRIPT_OVERWRITE,
-                    replacement,
-                    replacement_length,
-            };
+            const omega_edit_script_op_t op{offset, replacement_length, OMEGA_EDIT_SCRIPT_OVERWRITE, replacement, replacement_length};
             ops.push_back(op);
             ++stats.overwrites;
             return;
@@ -430,54 +439,31 @@ namespace {
         if (remove_length == 0 && insert_length == 0) { return; }
 
         const auto *insert_bytes = (insert_length > 0) ? replacement + prefix_length : nullptr;
+        if (!valid_nonnegative_range_(offset, prefix_length)) { return; }
         const auto op_offset = offset + prefix_length;
 
         if (remove_length == 0) {
-            const omega_edit_script_op_t op{
-                    op_offset,
-                    0,
-                    OMEGA_EDIT_SCRIPT_INSERT,
-                    insert_bytes,
-                    insert_length,
-            };
+            const omega_edit_script_op_t op{op_offset, 0, OMEGA_EDIT_SCRIPT_INSERT, insert_bytes, insert_length};
             ops.push_back(op);
             ++stats.inserts;
             return;
         }
 
         if (insert_length == 0) {
-            const omega_edit_script_op_t op{
-                    op_offset,
-                    remove_length,
-                    OMEGA_EDIT_SCRIPT_DELETE,
-                    nullptr,
-                    0,
-            };
+            const omega_edit_script_op_t op{op_offset, remove_length, OMEGA_EDIT_SCRIPT_DELETE, nullptr, 0};
             ops.push_back(op);
             ++stats.deletes;
             return;
         }
 
         if (remove_length == insert_length) {
-            const omega_edit_script_op_t op{
-                    op_offset,
-                    remove_length,
-                    OMEGA_EDIT_SCRIPT_OVERWRITE,
-                    insert_bytes,
-                    insert_length,
-            };
+            const omega_edit_script_op_t op{op_offset, remove_length, OMEGA_EDIT_SCRIPT_OVERWRITE, insert_bytes, insert_length};
             ops.push_back(op);
             ++stats.overwrites;
             return;
         }
 
-        const omega_edit_script_op_t op{
-                op_offset,
-                remove_length,
-                OMEGA_EDIT_SCRIPT_REPLACE,
-                insert_bytes,
-                insert_length,
-        };
+        const omega_edit_script_op_t op{op_offset, remove_length, OMEGA_EDIT_SCRIPT_REPLACE, insert_bytes, insert_length};
         ops.push_back(op);
         ++stats.deletes;
         ++stats.inserts;
@@ -487,31 +473,46 @@ namespace {
                                                    const omega_change_t *change_ptr) {
         assert(0 < change_ptr->length);
         const auto offset = omega_viewport_get_offset(viewport_ptr);
-        // If the viewport is floating and a change happens before or at the start of the given viewport...
+        if (offset < 0) { return; }
         if ((omega_viewport_is_floating(viewport_ptr) != 0) && change_ptr->offset <= offset) {
-            // ...and the change is a delete, or insert, update the offset adjustment accordingly
-            if (change_kind_t::CHANGE_DELETE == omega_change_get_kind(change_ptr)) {
-                viewport_ptr->data_segment.offset_adjustment -= change_ptr->length;
-                // If the offset adjustment is now negative, adjust it to zero
-                if (offset < -viewport_ptr->data_segment.offset_adjustment) {
-                    viewport_ptr->data_segment.offset_adjustment = -offset;
+            if (change_kind_t::CHANGE_DELETE == omega_change_get_kind_(change_ptr)) {
+                int64_t adjusted = 0;
+                if (!safe_add_int64_(viewport_ptr->data_segment.offset_adjustment, -change_ptr->length, adjusted)) {
+                    adjusted = -viewport_ptr->data_segment.offset;
                 }
-            } else if (change_kind_t::CHANGE_INSERT == omega_change_get_kind(change_ptr)) {
-                viewport_ptr->data_segment.offset_adjustment += change_ptr->length;
+                int64_t adjusted_offset = 0;
+                if (!safe_add_int64_(viewport_ptr->data_segment.offset, adjusted, adjusted_offset) ||
+                    adjusted_offset < 0) {
+                    adjusted = -viewport_ptr->data_segment.offset;
+                }
+                viewport_ptr->data_segment.offset_adjustment = adjusted;
+            } else if (change_kind_t::CHANGE_INSERT == omega_change_get_kind_(change_ptr)) {
+                int64_t adjusted = 0;
+                int64_t adjusted_offset = 0;
+                if (safe_add_int64_(viewport_ptr->data_segment.offset_adjustment, change_ptr->length, adjusted) &&
+                    safe_add_int64_(viewport_ptr->data_segment.offset, adjusted, adjusted_offset)) {
+                    viewport_ptr->data_segment.offset_adjustment = adjusted;
+                } else {
+                    viewport_ptr->data_segment.offset_adjustment =
+                            (std::numeric_limits<int64_t>::max)() - viewport_ptr->data_segment.offset;
+                }
             }
         }
     }
 
     inline bool change_affects_viewport_(const omega_viewport_t *viewport_ptr, const omega_change_t *change_ptr) {
         assert(0 < change_ptr->length);
-        switch (omega_change_get_kind(change_ptr)) {
+        switch (omega_change_get_kind_(change_ptr)) {
             case change_kind_t::CHANGE_DELETE:// deliberate fall-through
             case change_kind_t::CHANGE_INSERT:
-                // INSERT and DELETE changes that happen before the viewport end offset affect the viewport
-                return (change_ptr->offset <=
-                        (omega_viewport_get_offset(viewport_ptr) + omega_viewport_get_capacity(viewport_ptr)));
+                {
+                    const auto viewport_offset = omega_viewport_get_offset(viewport_ptr);
+                    int64_t viewport_end = 0;
+                    return viewport_offset >= 0 &&
+                           safe_add_int64_(viewport_offset, omega_viewport_get_capacity(viewport_ptr), viewport_end) &&
+                           change_ptr->offset <= viewport_end;
+                }
             case change_kind_t::CHANGE_OVERWRITE:
-                // OVERWRITE changes that happen inside the viewport affect the viewport
                 return omega_viewport_in_segment(viewport_ptr, change_ptr->offset, change_ptr->length) != 0;
             default:
                 ABORT(LOG_ERROR("Unhandled change kind"););
@@ -520,7 +521,6 @@ namespace {
 
     auto update_viewports_(const omega_session_t *session_ptr, const omega_change_t *change_ptr) -> int {
         for (auto &&viewport_ptr: session_ptr->viewports_) {
-            // possibly adjust the viewport offset if it's floating and other criteria are met
             update_viewport_offset_adjustment_(viewport_ptr.get(), change_ptr);
             if (change_affects_viewport_(viewport_ptr.get(), change_ptr)) {
                 viewport_ptr->data_segment.capacity =
@@ -552,8 +552,8 @@ namespace {
     inline void free_model_changes_(omega_model_struct *model_ptr) {
         model_ptr->model_snapshots.clear();
         for (const auto &change_ptr: model_ptr->changes) {
-            if (omega_change_get_kind(change_ptr.get()) != change_kind_t::CHANGE_DELETE) {
-                omega_data_destroy(&const_cast<omega_change_t *>(change_ptr.get())->data, change_ptr->length);
+            if (omega_change_get_kind_(change_ptr.get()) != change_kind_t::CHANGE_DELETE) {
+                omega_data_destroy_(&const_cast<omega_change_t *>(change_ptr.get())->data, change_ptr->length);
             }
         }
         model_ptr->changes.clear();
@@ -561,8 +561,8 @@ namespace {
 
     inline void free_model_changes_undone_(omega_model_struct *model_ptr) {
         for (const auto &change_ptr: model_ptr->changes_undone) {
-            if (omega_change_get_kind(change_ptr.get()) != change_kind_t::CHANGE_DELETE) {
-                omega_data_destroy(&const_cast<omega_change_t *>(change_ptr.get())->data, change_ptr->length);
+            if (omega_change_get_kind_(change_ptr.get()) != change_kind_t::CHANGE_DELETE) {
+                omega_data_destroy_(&const_cast<omega_change_t *>(change_ptr.get())->data, change_ptr->length);
             }
         }
         model_ptr->changes_undone.clear();
@@ -576,19 +576,12 @@ namespace {
         for (auto &&model_ptr: session_ptr->models_) { free_model_changes_undone_(model_ptr.get()); }
     }
 
-/* --------------------------------------------------------------------------------------------------------------------
- The objective here is to model the edits using segments.  Essentially creating a contiguous model of the file by
- keeping track of what to do.  The verbs here are READ, INSERT, and OVERWRITE.  We don't need to model DELETE because
- that is covered by adjusting, or removing, the READ, INSERT, and OVERWRITE segments accordingly.  The model expects to
- take in changes with original offsets and lengths and the model will calculate computed offsets and lengths.
- -------------------------------------------------------------------------------------------------------------------- */
     auto update_model_helper_(omega_model_t *model_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
         assert(change_ptr->length > 0);
         int64_t read_offset = 0;
 
         if (model_ptr->model_segments.empty()) {
-            if (omega_change_get_kind(change_ptr.get()) != change_kind_t::CHANGE_DELETE) {
-                // The model is empty, and we have a change with content
+            if (omega_change_get_kind_(change_ptr.get()) != change_kind_t::CHANGE_DELETE) {
                 auto insert_segment_ptr = std::make_unique<omega_model_segment_t>();
                 insert_segment_ptr->computed_offset = change_ptr->offset;
                 insert_segment_ptr->computed_length = change_ptr->length;
@@ -599,53 +592,52 @@ namespace {
             return 0;
         }
         for (auto iter = model_ptr->model_segments.begin(); iter != model_ptr->model_segments.end(); ++iter) {
+            int64_t segment_end = 0;
+            if (!safe_add_int64_((*iter)->computed_offset, (*iter)->computed_length, segment_end)) { return -1; }
             if (read_offset != (*iter)->computed_offset) {
                 ABORT(print_model_segments_(model_ptr, CLOG);
                               LOG_ERROR("break in model continuity, expected: " << read_offset
                                                                                 << ", got: "
                                                                                 << (*iter)->computed_offset););
             }
-            if (change_ptr->offset >= read_offset && change_ptr->offset <= read_offset + (*iter)->computed_length) {
+            if (change_ptr->offset >= read_offset && change_ptr->offset <= segment_end) {
                 if (change_ptr->offset != read_offset) {
                     const auto delta = change_ptr->offset - (*iter)->computed_offset;
                     if (delta == (*iter)->computed_length) {
-                        // The update happens right at the end of the existing segment
                         ++iter;
                     } else {
-                        // The update site falls in the middle of an existing segment, so we need to split the segment at
-                        // the update site.  iter points to the segment on the left of the split and split_segment_ptr
-                        // points to a new duplicate segment on the right of the split.
                         auto split_segment_ptr = clone_model_segment_(*iter);
-                        split_segment_ptr->computed_offset += delta;
+                        if (!safe_add_int64_(split_segment_ptr->computed_offset, delta, split_segment_ptr->computed_offset) ||
+                            !safe_add_int64_(split_segment_ptr->change_offset, delta, split_segment_ptr->change_offset)) {
+                            return -1;
+                        }
                         split_segment_ptr->computed_length -= delta;
-                        split_segment_ptr->change_offset += delta;
                         (*iter)->computed_length = delta;
-                        // iter will now point to the new split segment inserted into the model and who's offset falls on
-                        // the update site
                         iter = model_ptr->model_segments.insert(iter + 1, std::move(split_segment_ptr));
                     }
                 }
-                switch (omega_change_get_kind(change_ptr.get())) {
+                switch (omega_change_get_kind_(change_ptr.get())) {
                     case change_kind_t::CHANGE_DELETE: {
                         auto delete_length = change_ptr->length;
                         while (delete_length && iter != model_ptr->model_segments.end()) {
                             if ((*iter)->computed_length <= delete_length) {
-                                // DELETE change spans the entire segment
                                 delete_length -= (*iter)->computed_length;
                                 iter = model_ptr->model_segments.erase(iter);
                             } else {
-                                // DELETE removes a portion of the beginning of the segment
                                 (*iter)->computed_length -= delete_length;
-                                (*iter)->computed_offset += delete_length - change_ptr->length;
-                                (*iter)->change_offset += delete_length;
+                                if (!safe_add_int64_((*iter)->computed_offset, delete_length - change_ptr->length, (*iter)->computed_offset) ||
+                                    !safe_add_int64_((*iter)->change_offset, delete_length, (*iter)->change_offset)) {
+                                    return -1;
+                                }
                                 assert((*iter)->change_offset < (*iter)->change_ptr->length);
                                 delete_length = 0;
                                 ++iter;// move to the next segment for adjusting
                             }
                         }
-                        // adjust the computed offsets for segments beyond the DELETE site
                         for (; iter != model_ptr->model_segments.end(); ++iter) {
-                            (*iter)->computed_offset -= change_ptr->length;
+                            if (!safe_add_int64_((*iter)->computed_offset, -change_ptr->length, (*iter)->computed_offset)) {
+                                return -1;
+                            }
                         }
                         break;
                     }
@@ -658,7 +650,9 @@ namespace {
                         insert_segment_ptr->change_ptr = change_ptr;
                         iter = model_ptr->model_segments.insert(iter, std::move(insert_segment_ptr));
                         for (++iter; iter != model_ptr->model_segments.end(); ++iter) {
-                            (*iter)->computed_offset += change_ptr->length;
+                            if (!safe_add_int64_((*iter)->computed_offset, change_ptr->length, (*iter)->computed_offset)) {
+                                return -1;
+                            }
                         }
                         break;
                     }
@@ -667,15 +661,14 @@ namespace {
                 }
                 return 0;
             }
-            read_offset += (*iter)->computed_length;
+            if (!safe_add_int64_(read_offset, (*iter)->computed_length, read_offset)) { return -1; }
         }
         return -1;
     }
 
     auto update_model_(omega_session_t *session_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
         const auto model_ptr = session_ptr->models_.back().get();
-        if (omega_change_get_kind(change_ptr.get()) == change_kind_t::CHANGE_OVERWRITE) {
-            // Overwrite will model just like a DELETE, followed by an INSERT
+        if (omega_change_get_kind_(change_ptr.get()) == change_kind_t::CHANGE_OVERWRITE) {
             const_omega_change_ptr_t const_change_ptr =
                     del_(0, change_ptr->offset, change_ptr->length, !omega_session_get_transaction_bit_(session_ptr));
             const auto rc = update_model_helper_(model_ptr, const_change_ptr);
@@ -723,17 +716,17 @@ namespace {
     }
 
     auto update_(omega_session_t *session_ptr, const const_omega_change_ptr_t &change_ptr) -> int64_t {
+        if (!change_ptr) { return -1; }
         if (change_ptr->offset <= omega_session_get_computed_file_size(session_ptr)) {
-            if (omega_change_get_serial(change_ptr.get()) < 0) {
-                // This is a previously undone change that is being redone, so flip the serial number back to positive
+            const auto change_serial = omega_change_get_serial(change_ptr.get());
+            if (change_serial == 0 || change_serial == (std::numeric_limits<int64_t>::min)()) { return -1; }
+            if (change_serial < 0) {
                 const_cast<omega_change_t *>(change_ptr.get())->serial *= -1;
             } else if (!session_ptr->models_.back()->changes_undone.empty()) {
-                // This is not a redo change, so any changes undone are now invalid and must be cleared
                 free_session_changes_undone_(session_ptr);
             }
             session_ptr->models_.back()->changes.push_back(change_ptr);
             if (0 != update_model_(session_ptr, change_ptr)) { return -1; }
-            // Take a periodic snapshot of model segments to accelerate future undo operations
             if (session_ptr->undo_snapshot_interval_ > 0) {
                 const auto count = static_cast<int64_t>(session_ptr->models_.back()->changes.size());
                 if (count % session_ptr->undo_snapshot_interval_ == 0) {
@@ -751,18 +744,13 @@ namespace {
     inline auto determine_change_transaction_bit_(omega_session_t *session_ptr) -> bool {
         switch (omega_session_get_transaction_state(session_ptr)) {
             case 0:
-                // No transaction in progress, use the flipped previous change transaction bit
                 return !omega_session_get_transaction_bit_(session_ptr);
             case 1:
-                // This is the first change in a transaction, use the flipped previous change transaction bit and set the
-                // transaction in progress flag
                 session_ptr->session_flags_ |= SESSION_FLAGS_SESSION_TRANSACTION_IN_PROGRESS;
                 return !omega_session_get_transaction_bit_(session_ptr);
             case 2:
-                // This is the second or later change in a transaction, use the previous change transaction bit
                 return omega_session_get_transaction_bit_(session_ptr);
             default:
-                // This should never happen
                 ABORT(LOG_ERROR("Invalid transaction state"););
                 return false;
         }
@@ -826,14 +814,17 @@ namespace {
         cursor.session_ptr = session_ptr;
         cursor.segment_end = segments.cend();
         cursor.offset = offset;
-        cursor.segment_iter = std::upper_bound(
-                segments.cbegin(), segments.cend(), offset,
-                [](int64_t logical_offset, const omega_model_segment_ptr_t &segment) {
-                    return logical_offset < segment->computed_offset;
-                });
+        cursor.segment_iter = std::upper_bound(segments.cbegin(), segments.cend(), offset,
+                                               [](int64_t logical_offset, const omega_model_segment_ptr_t &segment) {
+                                                   return logical_offset < segment->computed_offset;
+                                               });
         if (cursor.segment_iter != segments.cbegin()) { --cursor.segment_iter; }
-        while (cursor.segment_iter != cursor.segment_end &&
-               (*cursor.segment_iter)->computed_offset + (*cursor.segment_iter)->computed_length <= offset) {
+        while (cursor.segment_iter != cursor.segment_end) {
+            int64_t segment_end = 0;
+            if (!safe_add_int64_((*cursor.segment_iter)->computed_offset, (*cursor.segment_iter)->computed_length, segment_end)) {
+                return false;
+            }
+            if (segment_end > offset) { break; }
             ++cursor.segment_iter;
         }
         return true;
@@ -846,7 +837,9 @@ namespace {
         while (cursor.offset < end_offset) {
             if (cursor.segment_iter == cursor.segment_end) { return -1; }
             const auto &segment = *cursor.segment_iter;
-            if (segment->computed_offset + segment->computed_length <= cursor.offset) {
+            int64_t segment_end = 0;
+            if (!safe_add_int64_(segment->computed_offset, segment->computed_length, segment_end)) { return -1; }
+            if (segment_end <= cursor.offset) {
                 ++cursor.segment_iter;
                 continue;
             }
@@ -859,14 +852,15 @@ namespace {
             const auto segment_start = std::max(cursor.offset - segment->computed_offset, int64_t(0));
             const auto segment_length = std::min(end_offset - cursor.offset, segment->computed_length - segment_start);
             if (to_file_ptr != nullptr) {
-                switch (omega_model_segment_get_kind(segment.get())) {
+                switch (omega_model_segment_get_kind_(segment.get())) {
                     case model_segment_kind_t::SEGMENT_READ: {
                         if (cursor.session_ptr->models_.back()->file_ptr == nullptr) {
                             ABORT(LOG_ERROR("attempt to read segment from null file pointer"););
                             return -1;
                         }
-                        if (write_file_segment_(cursor.session_ptr->models_.back()->file_ptr,
-                                                segment->change_offset + segment_start, segment_length, to_file_ptr,
+                        int64_t source_offset = 0;
+                        if (!safe_add_int64_(segment->change_offset, segment_start, source_offset)) { return -1; }
+                        if (write_file_segment_(cursor.session_ptr->models_.back()->file_ptr, source_offset, segment_length, to_file_ptr,
                                                 io_buf) != segment_length) {
                             LOG_ERROR("write_file_segment_ failed");
                             return -1;
@@ -874,8 +868,9 @@ namespace {
                         break;
                     }
                     case model_segment_kind_t::SEGMENT_INSERT: {
-                        if (static_cast<int64_t>(fwrite(omega_change_get_bytes(segment->change_ptr.get()) +
-                                                        segment->change_offset + segment_start,
+                        int64_t source_offset = 0;
+                        if (!safe_add_int64_(segment->change_offset, segment_start, source_offset)) { return -1; }
+                        if (static_cast<int64_t>(fwrite(omega_change_get_bytes(segment->change_ptr.get()) + source_offset,
                                                         sizeof(omega_byte_t), segment_length,
                                                         to_file_ptr)) != segment_length) {
                             LOG_ERROR("fwrite failed");
@@ -889,9 +884,13 @@ namespace {
                 }
             }
 
-            cursor.offset += segment_length;
-            processed += segment_length;
-            if (segment_start + segment_length >= segment->computed_length) { ++cursor.segment_iter; }
+            if (!safe_add_int64_(cursor.offset, segment_length, cursor.offset) ||
+                !safe_add_int64_(processed, segment_length, processed)) {
+                return -1;
+            }
+            int64_t segment_consumed = 0;
+            if (!safe_add_int64_(segment_start, segment_length, segment_consumed)) { return -1; }
+            if (segment_consumed >= segment->computed_length) { ++cursor.segment_iter; }
         }
         return processed;
     }
@@ -902,7 +901,6 @@ namespace {
         return static_cast<int64_t>(fwrite(bytes, sizeof(omega_byte_t), length, file_ptr)) == length ? length : -1;
     }
 
-    // Write a file segment to the output file using the larger I/O buffer
     int64_t write_file_segment_(FILE *from_file_ptr, int64_t offset, int64_t byte_count, FILE *to_file_ptr,
                                 omega_byte_t *io_buf) {
         if (!from_file_ptr || !to_file_ptr) { return -1; }
@@ -917,9 +915,6 @@ namespace {
         return byte_count - remaining;
     }
 
-    // Write a segment from a source file to a destination file, applying a byte transform to bytes that
-    // fall within the transform range [transform_file_begin, transform_file_end). file_write_pos tracks the current
-    // position in the output file for range calculations.
     int64_t write_segment_to_file_transformed_(FILE *from_file_ptr, int64_t offset, int64_t byte_count,
                                                FILE *to_file_ptr, int64_t file_write_pos,
                                                omega_util_byte_transform_t transform, void *user_data_ptr,
@@ -932,9 +927,9 @@ namespace {
             const auto count = std::min(remaining, OMEGA_IO_BUFFER_SIZE);
             if (count != static_cast<int64_t>(fread(io_buf, sizeof(omega_byte_t), count, from_file_ptr))) { break; }
             if (transform) {
-                // Determine which portion of this buffer overlaps the transform range
                 const auto buf_begin = file_write_pos;
-                const auto buf_end = file_write_pos + count;
+                int64_t buf_end = 0;
+                if (!safe_add_int64_(file_write_pos, count, buf_end)) { break; }
                 if (buf_begin < transform_file_end && buf_end > transform_file_begin) {
                     const auto t_start = std::max(transform_file_begin - buf_begin, int64_t(0));
                     const auto t_end = std::min(transform_file_end - buf_begin, count);
@@ -943,24 +938,25 @@ namespace {
             }
             if (count != static_cast<int64_t>(fwrite(io_buf, sizeof(omega_byte_t), count, to_file_ptr))) { break; }
             remaining -= count;
-            file_write_pos += count;
+            if (!safe_add_int64_(file_write_pos, count, file_write_pos)) { break; }
         }
         return byte_count - remaining;
     }
 
-    // Save the current session model to a file, applying a byte transform to bytes in [transform_offset,
-    // transform_offset + transform_length). Returns 0 on success.
     int save_segment_transformed_(omega_session_t *session_ptr, const char *file_path,
                                   omega_util_byte_transform_t transform, void *user_data_ptr, int64_t transform_offset,
                                   int64_t transform_length) {
         if (!session_ptr || !file_path || !transform) { return -1; }
+        if (transform_offset < 0) { return -1; }
         const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+        if (computed_file_size < 0) { return -1; }
         const auto adjusted_transform_length =
                 transform_length <= 0 ? computed_file_size - transform_offset
                                       : std::min(transform_length, computed_file_size - transform_offset);
-        if (transform_offset < 0 || adjusted_transform_length < 0) { return -1; }
+        if (adjusted_transform_length < 0) { return -1; }
         const auto transform_file_begin = transform_offset;
-        const auto transform_file_end = transform_offset + adjusted_transform_length;
+        int64_t transform_file_end = 0;
+        if (!safe_add_int64_(transform_offset, adjusted_transform_length, transform_file_end)) { return -1; }
 
         const auto temp_fptr = FOPEN(file_path, "wb");
         if (!temp_fptr) {
@@ -975,16 +971,16 @@ namespace {
                 ABORT(LOG_ERROR("break in model continuity, expected: " << write_offset
                                                                         << ", got: " << segment->computed_offset););
             }
-            switch (omega_model_segment_get_kind(segment.get())) {
+            switch (omega_model_segment_get_kind_(segment.get())) {
                 case model_segment_kind_t::SEGMENT_READ: {
                     if (session_ptr->models_.back()->file_ptr == nullptr) {
                         ABORT(LOG_ERROR("attempt to read segment from null file pointer"););
                     }
-                    if (write_segment_to_file_transformed_(
-                                session_ptr->models_.back()->file_ptr,
-                                segment->change_offset, segment->computed_length, temp_fptr, file_write_pos, transform,
-                                user_data_ptr, transform_file_begin, transform_file_end,
-                                io_buf.get()) != segment->computed_length) {
+                    if (write_segment_to_file_transformed_(session_ptr->models_.back()->file_ptr,
+                                                           segment->change_offset, segment->computed_length, temp_fptr,
+                                                           file_write_pos, transform, user_data_ptr,
+                                                           transform_file_begin, transform_file_end,
+                                                           io_buf.get()) != segment->computed_length) {
                         FCLOSE(temp_fptr);
                         LOG_ERROR("write_segment_to_file_transformed_ failed");
                         return -1;
@@ -994,21 +990,31 @@ namespace {
                 case model_segment_kind_t::SEGMENT_INSERT: {
                     const auto *src = omega_change_get_bytes(segment->change_ptr.get()) + segment->change_offset;
                     const auto len = segment->computed_length;
-                    // Check if any part of this segment overlaps the transform range
-                    if (file_write_pos < transform_file_end && file_write_pos + len > transform_file_begin) {
-                        // Need a mutable copy so we can apply the transform in-place
+                    int64_t segment_file_end = 0;
+                    if (!safe_add_int64_(file_write_pos, len, segment_file_end)) {
+                        FCLOSE(temp_fptr);
+                        return -1;
+                    }
+                    if (file_write_pos < transform_file_end && segment_file_end > transform_file_begin) {
                         int64_t seg_remaining = len;
                         int64_t seg_offset = 0;
                         while (seg_remaining > 0) {
                             const auto chunk = std::min(seg_remaining, OMEGA_IO_BUFFER_SIZE);
                             memcpy(io_buf.get(), src + seg_offset, chunk);
-                            const auto buf_begin = file_write_pos + seg_offset;
-                            const auto buf_end = buf_begin + chunk;
+                            int64_t buf_begin = 0;
+                            if (!safe_add_int64_(file_write_pos, seg_offset, buf_begin)) {
+                                FCLOSE(temp_fptr);
+                                return -1;
+                            }
+                            int64_t buf_end = 0;
+                            if (!safe_add_int64_(buf_begin, chunk, buf_end)) {
+                                FCLOSE(temp_fptr);
+                                return -1;
+                            }
                             if (buf_begin < transform_file_end && buf_end > transform_file_begin) {
                                 const auto t_start = std::max(transform_file_begin - buf_begin, int64_t(0));
                                 const auto t_end = std::min(transform_file_end - buf_begin, chunk);
-                                omega_util_apply_byte_transform(io_buf.get() + t_start, t_end - t_start, transform,
-                                                                user_data_ptr);
+                                omega_util_apply_byte_transform(io_buf.get() + t_start, t_end - t_start, transform, user_data_ptr);
                             }
                             if (static_cast<int64_t>(fwrite(io_buf.get(), 1, chunk, temp_fptr)) != chunk) {
                                 FCLOSE(temp_fptr);
@@ -1016,10 +1022,12 @@ namespace {
                                 return -1;
                             }
                             seg_remaining -= chunk;
-                            seg_offset += chunk;
+                            if (!safe_add_int64_(seg_offset, chunk, seg_offset)) {
+                                FCLOSE(temp_fptr);
+                                return -1;
+                            }
                         }
                     } else {
-                        // Entirely outside the transform range — write verbatim
                         if (static_cast<int64_t>(fwrite(src, 1, len, temp_fptr)) != len) {
                             FCLOSE(temp_fptr);
                             LOG_ERROR("fwrite failed");
@@ -1031,8 +1039,11 @@ namespace {
                 default:
                     ABORT(LOG_ERROR("Unhandled segment kind"););
             }
-            file_write_pos += segment->computed_length;
-            write_offset += segment->computed_length;
+            if (!safe_add_int64_(file_write_pos, segment->computed_length, file_write_pos) ||
+                !safe_add_int64_(write_offset, segment->computed_length, write_offset)) {
+                FCLOSE(temp_fptr);
+                return -1;
+            }
         }
         FCLOSE(temp_fptr);
         if (file_write_pos != computed_file_size) {
@@ -1048,9 +1059,8 @@ omega_session_t *omega_edit_create_session(const char *file_path, omega_session_
     std::string checkpoint_directory_str;
     if (!resolve_checkpoint_directory_(file_path, checkpoint_directory, checkpoint_directory_str)) { return nullptr; }
     FILE *file_ptr = nullptr;
-    char checkpoint_filename[FILENAME_MAX + 1]; // +1 for null terminator
+    char checkpoint_filename[FILENAME_MAX + 1];
     if ((file_path != nullptr) && file_path[0] != '\0') {
-        // Copy the original file to a checkpoint file to handle out of band changes to the original file
         if (FILENAME_MAX <=
             snprintf(static_cast<char *>(checkpoint_filename), FILENAME_MAX, "%s%c.OmegaEdit-orig.XXXXXX",
                      checkpoint_directory_str.c_str(), omega_util_directory_separator())) {
@@ -1069,10 +1079,14 @@ omega_session_t *omega_edit_create_session(const char *file_path, omega_session_
             LOG_ERROR("failed to copy original file '" << file_path << "' to checkpoint file '"
                                                        << static_cast<char *>(checkpoint_filename)
                                                        << "'");
+            omega_util_remove_file(checkpoint_filename);
             return nullptr;
         }
         file_ptr = FOPEN(checkpoint_filename, "rb");
-        if (file_ptr == nullptr) { return nullptr; }
+        if (file_ptr == nullptr) {
+            omega_util_remove_file(checkpoint_filename);
+            return nullptr;
+        }
     }
     return create_session_with_backing_file_(file_ptr, file_path, checkpoint_filename, checkpoint_directory_str, cbk,
                                              user_data_ptr, event_interest);
@@ -1126,38 +1140,32 @@ omega_session_t *omega_edit_create_session_from_bytes(const omega_byte_t *data_p
 
 void omega_edit_destroy_session(omega_session_t *session_ptr) {
     if (!session_ptr) { return; }
-    // Close all open files in the models
     for (const auto &model_ptr: session_ptr->models_) {
         if (model_ptr->file_ptr) { FCLOSE(model_ptr->file_ptr); }
     }
-    // Destroy all search contexts
     while (!session_ptr->search_contexts_.empty()) {
         omega_search_destroy_context(session_ptr->search_contexts_.back().get());
     }
-    // Destroy all viewports
     while (!session_ptr->viewports_.empty()) { omega_edit_destroy_viewport(session_ptr->viewports_.back().get()); }
-    // Destroy all changes
     free_session_changes_(session_ptr);
-    // Destroy all undone changes
     free_session_changes_undone_(session_ptr);
-    // Remove all checkpoint files
     while (omega_session_get_num_checkpoints(session_ptr) != 0) {
         if (0 != omega_util_remove_file(session_ptr->models_.back()->file_path.c_str())) { LOG_ERRNO(); }
         session_ptr->models_.pop_back();
     }
-    // Remove the session checkpoint file if it exists
     if (!session_ptr->checkpoint_file_name_.empty() &&
         0 != omega_util_remove_file(session_ptr->checkpoint_file_name_.c_str())) {
         LOG_ERRNO();
     }
-    // Delete the session pointer
     delete session_ptr;
 }
 
 omega_viewport_t *omega_edit_create_viewport(omega_session_t *session_ptr, int64_t offset, int64_t capacity,
                                              int is_floating, omega_viewport_event_cbk_t cbk, void *user_data_ptr,
                                              int32_t event_interest) {
-    if (capacity > 0 && capacity <= OMEGA_VIEWPORT_CAPACITY_LIMIT) {
+    int64_t viewport_end = 0;
+    if (session_ptr && offset >= 0 && capacity > 0 && capacity <= OMEGA_VIEWPORT_CAPACITY_LIMIT &&
+        safe_add_int64_(offset, capacity, viewport_end)) {
         const auto viewport_ptr = std::make_shared<omega_viewport_t>();
         viewport_ptr->session_ptr = session_ptr;
         viewport_ptr->data_segment.offset = offset;
@@ -1165,7 +1173,7 @@ omega_viewport_t *omega_edit_create_viewport(omega_session_t *session_ptr, int64
         viewport_ptr->data_segment.is_floating = (bool) is_floating;
         viewport_ptr->data_segment.capacity = -1 * capacity;// Negative capacity indicates dirty read
         viewport_ptr->data_segment.length = 0;
-        omega_data_create(&viewport_ptr->data_segment.data, capacity);
+        omega_data_create_(&viewport_ptr->data_segment.data, capacity);
         viewport_ptr->event_handler = cbk;
         viewport_ptr->user_data_ptr = user_data_ptr;
         viewport_ptr->event_interest_ = event_interest;
@@ -1184,7 +1192,7 @@ void omega_edit_destroy_viewport(omega_viewport_t *viewport_ptr) {
          iter != viewport_ptr->session_ptr->viewports_.rend(); ++iter) {
         if (viewport_ptr == iter->get()) {
             auto *const session_ptr = viewport_ptr->session_ptr;
-            omega_data_destroy(&(*iter)->data_segment.data, omega_viewport_get_capacity(iter->get()));
+            omega_data_destroy_(&(*iter)->data_segment.data, omega_viewport_get_capacity(iter->get()));
             session_ptr->viewports_.erase(std::next(iter).base());
             omega_session_notify(session_ptr, SESSION_EVT_DESTROY_VIEWPORT, viewport_ptr);
             break;
@@ -1194,26 +1202,34 @@ void omega_edit_destroy_viewport(omega_viewport_t *viewport_ptr) {
 
 int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t length) {
     if (!session_ptr) { return -1; }
-    if (offset < 0 || length < 0) { return -1; }
+    if (!valid_nonnegative_range_(offset, length)) { return -1; }
     if (length == 0) { return 0; }
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0) { return -1; }
+    const auto serial = next_change_serial_(session_ptr);
+    if (serial <= 0) { return -1; }
     return (omega_session_changes_paused(session_ptr) == 0) && 0 < length && offset < computed_file_size
-           ? update_(session_ptr, del_(1 + omega_session_get_num_changes(session_ptr), offset,
-                                       std::min(length, static_cast<int64_t>(computed_file_size) - offset),
-                                       determine_change_transaction_bit_(session_ptr)))
+           ? update_(session_ptr, del_(serial, offset,
+                                        std::min(length, static_cast<int64_t>(computed_file_size) - offset),
+                                        determine_change_transaction_bit_(session_ptr)))
            : 0;
 }
 
 int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                 int64_t length) {
     if (!session_ptr) { return -1; }
-    if (offset < 0 || length < 0) { return -1; }
+    if (!valid_nonnegative_range_(offset, length)) { return -1; }
     if (length == 0) { return 0; }
     if (!bytes) { return -1; }
+    const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0) { return -1; }
+    if (add_overflows_int64_(computed_file_size, length)) { return -1; }
+    const auto serial = next_change_serial_(session_ptr);
+    if (serial <= 0) { return -1; }
     return (omega_session_changes_paused(session_ptr) == 0) &&
-           offset <= omega_session_get_computed_file_size(session_ptr)
-           ? update_(session_ptr, ins_(1 + omega_session_get_num_changes(session_ptr), offset, bytes, length,
-                                       determine_change_transaction_bit_(session_ptr)))
+           offset <= computed_file_size
+           ? update_(session_ptr, ins_(serial, offset, bytes, length,
+                                        determine_change_transaction_bit_(session_ptr)))
            : 0;
 }
 
@@ -1226,13 +1242,17 @@ int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const ch
 int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                    int64_t length) {
     if (!session_ptr) { return -1; }
-    if (offset < 0 || length < 0) { return -1; }
+    if (!valid_nonnegative_range_(offset, length)) { return -1; }
     if (length == 0) { return 0; }
     if (!bytes) { return -1; }
+    const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0) { return -1; }
+    const auto serial = next_change_serial_(session_ptr);
+    if (serial <= 0) { return -1; }
     return (omega_session_changes_paused(session_ptr) == 0) &&
-           offset <= omega_session_get_computed_file_size(session_ptr)
-           ? update_(session_ptr, ovr_(1 + omega_session_get_num_changes(session_ptr), offset, bytes, length,
-                                       determine_change_transaction_bit_(session_ptr)))
+           offset <= computed_file_size
+           ? update_(session_ptr, ovr_(serial, offset, bytes, length,
+                                        determine_change_transaction_bit_(session_ptr)))
            : 0;
 }
 
@@ -1277,6 +1297,7 @@ int omega_edit_replace_matches_bytes(omega_session_t *session_ptr, const omega_b
     if (omega_session_changes_paused(session_ptr) != 0) { return -1; }
 
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0) { return -1; }
     if (offset > computed_file_size) { return -1; }
     const auto adjusted_length =
             length <= 0 ? computed_file_size - offset : std::min(length, computed_file_size - offset);
@@ -1293,10 +1314,18 @@ int omega_edit_replace_matches_bytes(omega_session_t *session_ptr, const omega_b
     while ((limit <= 0 || static_cast<int64_t>(match_offsets.size()) < limit) &&
            omega_search_next_match(search_context, 1) > 0) {
         const auto match_offset = omega_search_context_get_match_offset(search_context);
+        int64_t match_end = 0;
+        int64_t last_accepted_end = 0;
+        if (!safe_add_int64_(match_offset, pattern_length, match_end) ||
+            (!match_offsets.empty() &&
+             !safe_add_int64_(last_accepted_offset, pattern_length, last_accepted_end))) {
+            omega_search_destroy_context(search_context);
+            return -1;
+        }
         const bool overlaps_prior =
                 !match_offsets.empty() &&
-                (is_reverse ? (match_offset + pattern_length > last_accepted_offset)
-                            : (match_offset < last_accepted_offset + pattern_length));
+                (is_reverse ? (match_end > last_accepted_offset)
+                            : (match_offset < last_accepted_end));
         if (overlaps_prior) { continue; }
         match_offsets.push_back(match_offset);
         last_accepted_offset = match_offset;
@@ -1311,12 +1340,17 @@ int omega_edit_replace_matches_bytes(omega_session_t *session_ptr, const omega_b
     std::vector<omega_edit_script_op_t> ops;
     ops.reserve(match_offsets.size());
     replace_match_stats_t stats;
-    // overwrite_only emits a pure OVERWRITE so the file size never changes; its effective per-replacement
-    // offset delta is always zero regardless of the difference in pattern/replacement lengths.
     const auto replacement_delta = (overwrite_only != 0) ? 0LL : (replacement_length - pattern_length);
     for (size_t i = 0; i < match_offsets.size(); ++i) {
-        const auto base_offset = front_to_back ? match_offsets[i] + replacement_delta * static_cast<int64_t>(i)
-                                               : match_offsets[i];
+        int64_t base_offset = match_offsets[i];
+        if (front_to_back) {
+            const auto match_index = static_cast<int64_t>(i);
+            if (replacement_delta != 0 &&
+                (match_index > (std::numeric_limits<int64_t>::max)() / std::llabs(replacement_delta))) {
+                return -1;
+            }
+            if (!safe_add_int64_(match_offsets[i], replacement_delta * match_index, base_offset)) { return -1; }
+        }
         append_optimized_replace_ops_(ops, stats, base_offset, pattern, pattern_length, replacement,
                                       replacement_length, overwrite_only != 0);
     }
@@ -1366,6 +1400,8 @@ int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_
     if (omega_session_changes_paused(session_ptr) != 0) { return -1; }
 
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0) { return -1; }
+    if (offset > computed_file_size) { return -1; }
     const auto adjusted_length = length <= 0 ? computed_file_size - offset : std::min(length, computed_file_size - offset);
     if (adjusted_length < 0) { return -1; }
     if (pattern_length > adjusted_length) { return 0; }
@@ -1402,7 +1438,13 @@ int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_
     }
 
     auto io_buf = std::make_unique<omega_byte_t[]>(OMEGA_IO_BUFFER_SIZE);
-    const auto replace_end = offset + adjusted_length;
+    int64_t replace_end = 0;
+    if (!safe_add_int64_(offset, adjusted_length, replace_end)) {
+        omega_search_destroy_context(search_context);
+        FCLOSE(checkpoint_fptr);
+        omega_util_remove_file(checkpoint_filename);
+        return -1;
+    }
     int64_t replacement_count = 0;
     auto rc = 0;
 
@@ -1428,7 +1470,9 @@ int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_
                 rc = -1;
                 break;
             }
-            if (stream_session_range_(cursor, match_offset + pattern_length, nullptr, io_buf.get()) != pattern_length) {
+            int64_t match_end = 0;
+            if (!safe_add_int64_(match_offset, pattern_length, match_end) ||
+                stream_session_range_(cursor, match_end, nullptr, io_buf.get()) != pattern_length) {
                 rc = -1;
                 break;
             }
@@ -1531,36 +1575,15 @@ int omega_edit_apply_transform(omega_session_t *session_ptr, omega_util_byte_tra
     if (!session_ptr || !transform) { return -1; }
     if (omega_session_changes_paused(session_ptr) != 0) { return -1; }
 
-    // Create the checkpoint file path
-    const auto *const checkpoint_directory = omega_session_get_checkpoint_directory(session_ptr);
-    if (omega_util_directory_exists(checkpoint_directory) == 0) {
-        LOG_ERROR("checkpoint directory '" << checkpoint_directory << "' does not exist");
-        return -1;
-    }
     char checkpoint_filename[FILENAME_MAX + 1];
-    const auto snprintf_result_transform =
-            snprintf(checkpoint_filename, sizeof(checkpoint_filename), "%s%c.OmegaEdit-chk.%zu.XXXXXX",
-                     checkpoint_directory, omega_util_directory_separator(), session_ptr->models_.size());
-    if (snprintf_result_transform < 0 ||
-        static_cast<size_t>(snprintf_result_transform) >= sizeof(checkpoint_filename)) {
-        LOG_ERROR("failed to create checkpoint filename template");
-        return -1;
-    }
-    const auto checkpoint_fd = omega_util_mkstemp(checkpoint_filename, 0600);// S_IRUSR | S_IWUSR
-    if (checkpoint_fd < 0) {
-        LOG_ERROR("omega_util_mkstemp failed for checkpoint file '" << checkpoint_filename << "'");
-        return -1;
-    }
-    close(checkpoint_fd);
+    if (0 != create_checkpoint_file_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename))) { return -1; }
 
-    // Single-pass: walk the segment model and write the transformed content directly to the checkpoint file
     if (0 != save_segment_transformed_(session_ptr, checkpoint_filename, transform, user_data_ptr, offset, length)) {
         LOG_ERROR("save_segment_transformed_ failed");
         omega_util_remove_file(checkpoint_filename);
         return -1;
     }
 
-    // Push the new checkpoint model (same as omega_edit_create_checkpoint does after saving)
     const auto file_size = omega_session_get_computed_file_size(session_ptr);
     session_ptr->num_changes_adjustment_ = omega_session_get_num_changes(session_ptr);
     session_ptr->models_.push_back(std::make_unique<omega_model_t>());
@@ -1575,7 +1598,6 @@ int omega_edit_apply_transform(omega_session_t *session_ptr, omega_util_byte_tra
     initialize_model_segments_(session_ptr->models_.back()->model_segments, file_size);
     omega_session_notify(session_ptr, SESSION_EVT_CREATE_CHECKPOINT, nullptr);
 
-    // Notify viewports and session of the transform
     for (const auto &viewport_ptr: session_ptr->viewports_) {
         viewport_ptr->data_segment.capacity =
                 -1 * std::abs(viewport_ptr->data_segment.capacity);// indicate dirty read
@@ -1589,6 +1611,7 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
                             int64_t offset, int64_t length) {
     if (!session_ptr || !file_path || !*file_path || offset < 0) { return -1; }
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0) { return -1; }
     const auto adjusted_length = length <= 0 ? computed_file_size - offset : std::min(length, computed_file_size - offset);
     if (adjusted_length < 0) {
         LOG_ERROR("invalid offset: " << offset << ", length: " << length << ", adjusted_length: " << adjusted_length
@@ -1604,14 +1627,10 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
     const auto mode = omega_util_compute_mode(0666);// S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
     if (saved_file_path != nullptr) { saved_file_path[0] = '\0'; }
 
-    // If overwrite is requested and the file path is the same as the original session file, then overwrite_original
-    // will be true
     const auto overwrite_original = (overwrite && (session_file_path != nullptr) &&
                                      (omega_util_file_exists(file_path) != 0) &&
                                      (omega_util_paths_equivalent(file_path, session_file_path) != 0));
 
-    // If the original file is going to be overwritten, and the file has been modified since the session was opened, and
-    // the IO_FLG_FORCE_OVERWRITE flag is not set, then return an error
     if (overwrite_original && (force_overwrite == 0) &&
         1 == omega_util_compare_modification_times(session_file_path, checkpoint_file)) {
         LOG_ERROR("original file '" << session_file_path
@@ -1667,9 +1686,14 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
     }
     const auto io_buf = std::make_unique<omega_byte_t[]>(OMEGA_IO_BUFFER_SIZE);
     int64_t bytes_written = 0;
+    auto close_and_cleanup_output = [&]() {
+        if (temp_fptr != nullptr) {
+            FCLOSE(temp_fptr);
+            temp_fptr = nullptr;
+        }
+        if (cleanup_output) { omega_util_remove_file(output_path); }
+    };
 
-    // Binary search for the first segment that could contain data at 'offset'.
-    // Segments are contiguous and sorted by computed_offset.
     const auto &segments = session_ptr->models_.back()->model_segments;
     auto seg_iter = std::upper_bound(
             segments.cbegin(), segments.cend(), offset,
@@ -1678,34 +1702,46 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
 
     for (; seg_iter != segments.cend() && bytes_written < adjusted_length; ++seg_iter) {
         const auto &segment = *seg_iter;
-        // Skip this iteration if the segment is entirely before the start offset
-        if (segment->computed_offset + segment->computed_length <= offset) { continue; }
+        int64_t segment_end = 0;
+        if (!safe_add_int64_(segment->computed_offset, segment->computed_length, segment_end)) {
+            close_and_cleanup_output();
+            LOG_ERROR("segment offset overflow");
+            return -6;
+        }
+        if (segment_end <= offset) { continue; }
 
-        // Calculate how much to write from this segment
         const auto segment_start = std::max(offset - segment->computed_offset, int64_t(0));
         const auto segment_length = std::min(adjusted_length - bytes_written, segment->computed_length - segment_start);
 
-        switch (omega_model_segment_get_kind(segment.get())) {
+        switch (omega_model_segment_get_kind_(segment.get())) {
             case model_segment_kind_t::SEGMENT_READ: {
                 if (session_ptr->models_.back()->file_ptr == nullptr) {
                     ABORT(LOG_ERROR("attempt to read segment from null file pointer"););
                 }
+                int64_t source_offset = 0;
+                if (!safe_add_int64_(segment->change_offset, segment_start, source_offset)) {
+                    close_and_cleanup_output();
+                    return -6;
+                }
                 if (write_file_segment_(session_ptr->models_.back()->file_ptr,
-                                        segment->change_offset + segment_start, segment_length,
+                                        source_offset, segment_length,
                                         temp_fptr, io_buf.get()) != segment_length) {
-                    FCLOSE(temp_fptr);
-                    if (cleanup_output) { omega_util_remove_file(output_path); }
+                    close_and_cleanup_output();
                     LOG_ERROR("write_file_segment_ failed");
                     return -6;
                 }
                 break;
             }
             case model_segment_kind_t::SEGMENT_INSERT: {
+                int64_t source_offset = 0;
+                if (!safe_add_int64_(segment->change_offset, segment_start, source_offset)) {
+                    close_and_cleanup_output();
+                    return -7;
+                }
                 if (static_cast<int64_t>(fwrite(omega_change_get_bytes(segment->change_ptr.get()) +
-                                                segment->change_offset + segment_start,
+                                                source_offset,
                                                 1, segment_length, temp_fptr)) != segment_length) {
-                    FCLOSE(temp_fptr);
-                    if (cleanup_output) { omega_util_remove_file(output_path); }
+                    close_and_cleanup_output();
                     LOG_ERROR("fwrite failed");
                     return -7;
                 }
@@ -1714,18 +1750,22 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
             default:
                 ABORT(LOG_ERROR("Unhandled segment kind"););
         }
-        bytes_written += segment_length;
+        if (!safe_add_int64_(bytes_written, segment_length, bytes_written)) {
+            close_and_cleanup_output();
+            return -8;
+        }
     }
     FCLOSE(temp_fptr);
+    temp_fptr = nullptr;
     if (bytes_written != adjusted_length) {
         LOG_ERROR("failed to write all requested bytes, expected: " << adjusted_length << ", got: " << bytes_written);
-        if (cleanup_output) { omega_util_remove_file(output_path); }
+        close_and_cleanup_output();
         return -8;
     }
     if (bytes_written != omega_util_file_size(output_path)) {
         LOG_ERROR("failed to write all requested bytes to '" << output_path << "', expected: " << bytes_written
                                                              << ", got: " << omega_util_file_size(output_path));
-        if (cleanup_output) { omega_util_remove_file(output_path); }
+        close_and_cleanup_output();
         return -9;
     }
     if (overwrite && omega_util_file_exists(file_path)) {
@@ -1744,9 +1784,6 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
     }
     cleanup_output = false;
     output_path = overwrite ? file_path : output_path;
-    // If required, touch the checkpoint file after the original file has been overwritten, so that the checkpoint file
-    // appears to be newer than the original file, otherwise the original file will be considered newer than the
-    // checkpoint and a force overwrite will be required to save the session next time.
     if (overwrite_original) {
         if (0 != omega_util_touch(checkpoint_file, 0)) {
             LOG_ERROR("failed to touch checkpoint file: " << checkpoint_file);
@@ -1774,6 +1811,7 @@ int omega_edit_save_segment_to_bytes(const omega_session_t *session_ptr, omega_b
     *length_out = 0;
 
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0) { return -1; }
     if (offset > computed_file_size) { return -1; }
 
     const auto remaining_length = computed_file_size - offset;
@@ -1799,7 +1837,9 @@ int omega_edit_save_segment_to_bytes(const omega_session_t *session_ptr, omega_b
 
     int64_t bytes_copied = 0;
     while (bytes_copied < requested_length) {
-        if (0 != omega_session_get_segment(session_ptr, segment, offset + bytes_copied)) {
+        int64_t read_offset = 0;
+        if (!safe_add_int64_(offset, bytes_copied, read_offset) ||
+            0 != omega_session_get_segment(session_ptr, segment, read_offset)) {
             omega_segment_destroy(segment);
             free(data_ptr);
             return -1;
@@ -1811,7 +1851,11 @@ int omega_edit_save_segment_to_bytes(const omega_session_t *session_ptr, omega_b
             return -1;
         }
         memcpy(data_ptr + bytes_copied, omega_segment_get_data(segment), static_cast<size_t>(segment_length));
-        bytes_copied += segment_length;
+        if (!safe_add_int64_(bytes_copied, segment_length, bytes_copied)) {
+            omega_segment_destroy(segment);
+            free(data_ptr);
+            return -1;
+        }
     }
 
     omega_segment_destroy(segment);
@@ -1863,6 +1907,7 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr) {
 
         for (const auto &change_ptr: undone_changes) {
             auto *const undone_change_ptr = const_cast<omega_change_t *>(change_ptr.get());
+            if (undone_change_ptr->serial <= 0) { return -1; }
             undone_change_ptr->serial *= -1;
 
             model_ptr->changes_undone.push_back(change_ptr);
@@ -1884,11 +1929,9 @@ int64_t omega_edit_redo_last_undo(omega_session_t *session_ptr) {
         const auto change_ptr = session_ptr->models_.back()->changes_undone.back();
         rc = update_(session_ptr, change_ptr);
         if (rc < 0) {
-            // On failure, leave the change in changes_undone and return the error code to the caller
             return rc;
         }
         session_ptr->models_.back()->changes_undone.pop_back();
-        // If the redone change is part of a transaction, continue redoing the entire transaction
         if (!session_ptr->models_.back()->changes_undone.empty() &&
             omega_change_get_transaction_bit_(change_ptr.get()) ==
             omega_change_get_transaction_bit_(session_ptr->models_.back()->changes_undone.back().get())) {
@@ -1901,27 +1944,8 @@ int64_t omega_edit_redo_last_undo(omega_session_t *session_ptr) {
 
 int omega_edit_create_checkpoint(omega_session_t *session_ptr) {
     if (!session_ptr) { return -1; }
-    const auto *const checkpoint_directory = omega_session_get_checkpoint_directory(session_ptr);
-    // make sure the checkpoint directory exists
-    if (omega_util_directory_exists(checkpoint_directory) == 0) {
-        LOG_ERROR("checkpoint directory '" << checkpoint_directory << "' does not exist");
-        return -1;
-    }
     char checkpoint_filename[FILENAME_MAX + 1];
-    const auto snprintf_result_checkpoint =
-            snprintf(checkpoint_filename, sizeof(checkpoint_filename), "%s%c.OmegaEdit-chk.%zu.XXXXXX",
-                     checkpoint_directory, omega_util_directory_separator(), session_ptr->models_.size());
-    if (snprintf_result_checkpoint < 0 ||
-        static_cast<size_t>(snprintf_result_checkpoint) >= sizeof(checkpoint_filename)) {
-        LOG_ERROR("failed to create checkpoint filename template");
-        return -1;
-    }
-    const auto checkpoint_fd = omega_util_mkstemp(checkpoint_filename, 0600);// S_IRUSR | S_IWUSR
-    if (checkpoint_fd < 0) {
-        LOG_ERROR("omega_util_mkstemp failed for checkpoint file '" << checkpoint_filename << "'");
-        return -1;
-    }
-    close(checkpoint_fd);
+    if (0 != create_checkpoint_file_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename))) { return -1; }
     if (0 != omega_edit_save(session_ptr, checkpoint_filename, IO_FLG_OVERWRITE, nullptr)) {
         LOG_ERROR("failed to save checkpoint to '" << checkpoint_filename << "'");
         return -1;

--- a/core/src/lib/impl_/change_def.hpp
+++ b/core/src/lib/impl_/change_def.hpp
@@ -19,9 +19,14 @@
 #include "data_def.hpp"
 #include <cstdint>
 
+namespace omega_edit::internal {
+
 enum class change_kind_t {
     CHANGE_DELETE = 0, CHANGE_INSERT = 1, CHANGE_OVERWRITE = 2
 };
+
+}// namespace omega_edit::internal
+
 #define OMEGA_CHANGE_KIND_MASK 0x03
 #define OMEGA_CHANGE_TRANSACTION_BIT 0x04
 
@@ -33,12 +38,14 @@ struct omega_change_struct {
     uint8_t kind{};     ///< Change kind
 };
 
+namespace omega_edit::internal {
+
 /**
  * @brief Get the kind of change
  * @param change_ptr change to get the kind from
  * @return change kind
  */
-inline change_kind_t omega_change_get_kind(const omega_change_t *change_ptr) {
+inline change_kind_t omega_change_get_kind_(const omega_change_t *change_ptr) {
     return static_cast<change_kind_t>(change_ptr->kind & OMEGA_CHANGE_KIND_MASK);
 }
 
@@ -46,8 +53,10 @@ inline bool omega_change_get_transaction_bit_(const omega_change_t *change_ptr) 
     return change_ptr->kind & OMEGA_CHANGE_TRANSACTION_BIT;
 }
 
-inline void omega_change_toggle_transaction_bit(omega_change_t *change_ptr) {
+inline void omega_change_toggle_transaction_bit_(omega_change_t *change_ptr) {
     change_ptr->kind ^= OMEGA_CHANGE_TRANSACTION_BIT;// Toggle the transaction bit
 }
+
+}// namespace omega_edit::internal
 
 #endif//OMEGA_EDIT_CHANGE_DEF_HPP

--- a/core/src/lib/impl_/data_def.hpp
+++ b/core/src/lib/impl_/data_def.hpp
@@ -16,7 +16,10 @@
 #define OMEGA_EDIT_DATA_DEF_HPP
 
 #include "../../include/omega_edit/byte.h"
+#include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <new>
 
 #define DATA_T_SIZE (8)
 
@@ -32,31 +35,39 @@ using omega_data_t = union omega_data_union {
 
 static_assert(DATA_T_SIZE == sizeof(omega_data_t), "size of omega_data_t is expected to be 8 bytes");
 
-inline omega_byte_t *omega_data_get_data(omega_data_t *data_ptr, int64_t capacity) {
+namespace omega_edit::internal {
+
+inline omega_byte_t *omega_data_get_data_(omega_data_t *data_ptr, int64_t capacity) {
     return (capacity < static_cast<int64_t>(sizeof(omega_data_t))) ? data_ptr->sm_bytes : data_ptr->bytes_ptr;
 }
 
-inline const omega_byte_t *omega_data_get_data_const(const omega_data_t *data_ptr, int64_t capacity) {
+inline const omega_byte_t *omega_data_get_data_const_(const omega_data_t *data_ptr, int64_t capacity) {
     return (capacity < static_cast<int64_t>(sizeof(omega_data_t))) ? data_ptr->sm_bytes : data_ptr->bytes_ptr;
 }
 
-inline void omega_data_create(omega_data_t *data_ptr, int64_t capacity) {
+inline void omega_data_create_(omega_data_t *data_ptr, int64_t capacity) {
+    if (capacity < 0 || capacity == (std::numeric_limits<int64_t>::max)() ||
+        static_cast<uint64_t>(capacity) > static_cast<uint64_t>((std::numeric_limits<size_t>::max)() - 1U)) {
+        throw std::bad_array_new_length();
+    }
     if (static_cast<int64_t>(sizeof(omega_data_t)) - 1 < capacity) {
         // allocate space for the data segment
-        data_ptr->bytes_ptr = new omega_byte_t[capacity + 1];
+        data_ptr->bytes_ptr = new omega_byte_t[static_cast<size_t>(capacity) + 1U];
     } else {
         // data segment is small enough to fit in the 8 byte union
         data_ptr->bytes_ptr = nullptr;
     }
     // data segment allocation is its capacity plus one, so we can null-terminate it
-    omega_data_get_data(data_ptr, capacity)[capacity] = '\0';
+    omega_data_get_data_(data_ptr, capacity)[capacity] = '\0';
 }
 
-inline void omega_data_destroy(omega_data_t *data_ptr, int64_t capacity) {
+inline void omega_data_destroy_(omega_data_t *data_ptr, int64_t capacity) {
     if (data_ptr->bytes_ptr && static_cast<int64_t>(sizeof(omega_data_t)) - 1 < capacity) {
         delete[] data_ptr->bytes_ptr;
     }
     data_ptr->bytes_ptr = nullptr;
 }
+
+}// namespace omega_edit::internal
 
 #endif//OMEGA_EDIT_DATA_DEF_HPP

--- a/core/src/lib/impl_/internal_fun.cpp
+++ b/core/src/lib/impl_/internal_fun.cpp
@@ -19,10 +19,13 @@
 #include "macros.h"
 #include "model_def.hpp"
 #include "model_segment_def.hpp"
+#include "safe_math.hpp"
 #include "session_def.hpp"
 #include "viewport_def.hpp"
 #include <algorithm>
 #include <cassert>
+
+namespace omega_edit::internal {
 
 /**********************************************************************************************************************
  * Data segment functions
@@ -47,7 +50,11 @@ int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *
     if (model_ptr->model_segments.empty()) { return 0; }
     assert(0 <= data_segment_ptr->capacity);
     const auto data_segment_capacity = data_segment_ptr->capacity;
-    const auto data_segment_offset = data_segment_ptr->offset + data_segment_ptr->offset_adjustment;
+    int64_t data_segment_offset = 0;
+    if (!safe_add_int64_(data_segment_ptr->offset, data_segment_ptr->offset_adjustment, data_segment_offset)) {
+        return -1;
+    }
+    if (data_segment_offset < 0) { return -1; }
     // Binary search for the first segment that could contain data_segment_offset.
     // Segments are contiguous and sorted by computed_offset, so upper_bound finds the first segment
     // with computed_offset > data_segment_offset, and we step back one to get the containing segment.
@@ -57,7 +64,11 @@ int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *
     if (iter != model_ptr->model_segments.cbegin()) { --iter; }
 
     // Verify the found segment contains the target offset
-    if (data_segment_offset > (*iter)->computed_offset + (*iter)->computed_length) { return -1; }
+    int64_t segment_end = 0;
+    if (!safe_add_int64_((*iter)->computed_offset, (*iter)->computed_length, segment_end) ||
+        data_segment_offset < (*iter)->computed_offset || data_segment_offset > segment_end) {
+        return -1;
+    }
 
     auto delta = data_segment_offset - (*iter)->computed_offset;
     const auto data_segment_buffer = omega_segment_get_data(data_segment_ptr);
@@ -66,17 +77,19 @@ int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *
         const auto remaining_capacity = data_segment_capacity - data_segment_ptr->length;
         auto amount = (*iter)->computed_length - delta;
         amount = (amount > remaining_capacity) ? remaining_capacity : amount;
-        switch (omega_model_segment_get_kind(iter->get())) {
+        switch (omega_model_segment_get_kind_(iter->get())) {
             case model_segment_kind_t::SEGMENT_READ: {
                 // For read segments, we're reading a segment, or portion thereof, from the input file and
                 // writing it into the data segment.
                 // Coalesce with consecutive READ segments that are contiguous in the source file to reduce
                 // the number of fread system calls.
-                auto file_offset = (*iter)->change_offset + delta;
+                int64_t file_offset = 0;
+                if (!safe_add_int64_((*iter)->change_offset, delta, file_offset)) { return -1; }
                 auto coalesced = amount;
                 auto peek = iter;
                 while (coalesced < remaining_capacity && ++peek != model_ptr->model_segments.end() &&
-                       omega_model_segment_get_kind(peek->get()) == model_segment_kind_t::SEGMENT_READ &&
+                       omega_model_segment_get_kind_(peek->get()) == model_segment_kind_t::SEGMENT_READ &&
+                       !add_overflows_int64_(file_offset, coalesced) &&
                        (*peek)->change_offset == file_offset + coalesced) {
                     const auto peek_amount = (std::min)(remaining_capacity - coalesced, (*peek)->computed_length);
                     coalesced += peek_amount;
@@ -95,18 +108,21 @@ int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *
                 amount = coalesced;
                 break;
             }
-            case model_segment_kind_t::SEGMENT_INSERT:
+            case model_segment_kind_t::SEGMENT_INSERT: {
                 // For insert segments, we're writing the change byte buffer, or portion thereof, into the data
                 // segment
+                int64_t change_offset = 0;
+                if (!safe_add_int64_((*iter)->change_offset, delta, change_offset)) { return -1; }
                 memcpy(data_segment_buffer + data_segment_ptr->length,
-                       omega_change_get_bytes((*iter)->change_ptr.get()) + (*iter)->change_offset + delta,
+                       omega_change_get_bytes((*iter)->change_ptr.get()) + change_offset,
                        amount);
                 break;
+            }
             default:
                 ABORT(LOG_ERROR("Unhandled model segment kind"););
         }
         // Add the amount written to the data segment length
-        data_segment_ptr->length += amount;
+        if (!safe_add_int64_(data_segment_ptr->length, amount, data_segment_ptr->length)) { return -1; }
         // After the first segment is written, the delta should be zero from that point on
         delta = 0;
         // Keep writing segments until we run out of viewport capacity or run out of segments
@@ -135,7 +151,7 @@ static inline void print_change_(const omega_change_t *change_ptr, std::ostream 
 
 static inline void print_model_segment_(const omega_model_segment_ptr_t &segment_ptr,
                                         std::ostream &out_stream) noexcept {
-    out_stream << R"({"kind": ")" << omega_model_segment_kind_as_char(omega_model_segment_get_kind(segment_ptr.get()))
+    out_stream << R"({"kind": ")" << omega_model_segment_kind_as_char_(omega_model_segment_get_kind_(segment_ptr.get()))
                << R"(", "computed_offset": )" << segment_ptr->computed_offset << R"(, "computed_length": )"
                << segment_ptr->computed_length << R"(, "change_offset": )" << segment_ptr->change_offset
                << R"(, "change": )";
@@ -147,3 +163,5 @@ void print_model_segments_(const omega_model_t *model_ptr, std::ostream &out_str
     assert(model_ptr);
     for (const auto &segment: model_ptr->model_segments) { print_model_segment_(segment, out_stream); }
 }
+
+}// namespace omega_edit::internal

--- a/core/src/lib/impl_/model_segment_def.hpp
+++ b/core/src/lib/impl_/model_segment_def.hpp
@@ -18,9 +18,13 @@
 #include "../../include/omega_edit/change.h"
 #include "internal_fwd_defs.hpp"
 
+namespace omega_edit::internal {
+
 enum class model_segment_kind_t {
     SEGMENT_READ, SEGMENT_INSERT
 };
+
+}// namespace omega_edit::internal
 
 // NOTE: omega_model_segment_struct is used in internal_fwd_defs.hpp despite what sonarlint says
 struct omega_model_segment_struct {
@@ -30,12 +34,14 @@ struct omega_model_segment_struct {
     const_omega_change_ptr_t change_ptr{};///< Reference to parent change
 };
 
-inline model_segment_kind_t omega_model_segment_get_kind(const omega_model_segment_t *model_segment_ptr) {
+namespace omega_edit::internal {
+
+inline model_segment_kind_t omega_model_segment_get_kind_(const omega_model_segment_t *model_segment_ptr) {
     return (0 == omega_change_get_serial(model_segment_ptr->change_ptr.get())) ? model_segment_kind_t::SEGMENT_READ
                                                                                : model_segment_kind_t::SEGMENT_INSERT;
 }
 
-inline char omega_model_segment_kind_as_char(const model_segment_kind_t segment_kind) {
+inline char omega_model_segment_kind_as_char_(const model_segment_kind_t segment_kind) {
     switch (segment_kind) {
         case model_segment_kind_t::SEGMENT_READ:
             return 'R';
@@ -45,5 +51,7 @@ inline char omega_model_segment_kind_as_char(const model_segment_kind_t segment_
             return '?';
     }
 }
+
+}// namespace omega_edit::internal
 
 #endif//OMEGA_EDIT_MODEL_SEGMENT_DEF_HPP

--- a/core/src/lib/impl_/safe_math.hpp
+++ b/core/src/lib/impl_/safe_math.hpp
@@ -12,26 +12,30 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#ifndef OMEGA_EDIT_INTERNAL_FUN_HPP
-#define OMEGA_EDIT_INTERNAL_FUN_HPP
+#ifndef OMEGA_EDIT_SAFE_MATH_HPP
+#define OMEGA_EDIT_SAFE_MATH_HPP
 
-#include "../../include/omega_edit/byte.h"
-#include "../../include/omega_edit/fwd_defs.h"
-#include "internal_fwd_defs.hpp"
-#include <iosfwd>
+#include <cstdint>
+#include <limits>
 
 namespace omega_edit::internal {
 
-// Data segment functions
-int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr)
+inline bool add_overflows_int64_(int64_t lhs, int64_t rhs) {
+    return (rhs > 0 && lhs > (std::numeric_limits<int64_t>::max)() - rhs) ||
+           (rhs < 0 && lhs < (std::numeric_limits<int64_t>::min)() - rhs);
+}
 
-noexcept;
+inline bool safe_add_int64_(int64_t lhs, int64_t rhs, int64_t &result) {
+    if (add_overflows_int64_(lhs, rhs)) { return false; }
+    result = lhs + rhs;
+    return true;
+}
 
-// Model segment functions
-void print_model_segments_(const omega_model_t *model_ptr, std::ostream &out_stream)
-
-noexcept;
+inline bool valid_nonnegative_range_(int64_t offset, int64_t length) {
+    int64_t end = 0;
+    return offset >= 0 && length >= 0 && safe_add_int64_(offset, length, end);
+}
 
 }// namespace omega_edit::internal
 
-#endif//OMEGA_EDIT_INTERNAL_FUN_HPP
+#endif//OMEGA_EDIT_SAFE_MATH_HPP

--- a/core/src/lib/impl_/session_def.hpp
+++ b/core/src/lib/impl_/session_def.hpp
@@ -51,8 +51,12 @@ struct omega_session_struct {
     std::string checkpoint_file_name_{};       ///< Name of session checkpoint file
 };
 
+namespace omega_edit::internal {
+
 bool omega_session_get_transaction_bit_(const omega_session_t *session_ptr);
 void omega_session_begin_event_batch_(omega_session_t *session_ptr, omega_session_event_t session_event);
 void omega_session_end_event_batch_(omega_session_t *session_ptr);
+
+}// namespace omega_edit::internal
 
 #endif//OMEGA_EDIT_SESSION_DEF_HPP

--- a/core/src/lib/search.cpp
+++ b/core/src/lib/search.cpp
@@ -18,6 +18,7 @@
 #include "../include/omega_edit/utility.h"
 #include "impl_/find.h"
 #include "impl_/internal_fun.hpp"
+#include "impl_/safe_math.hpp"
 #include "impl_/search_context_def.h"
 #include "impl_/segment_def.hpp"
 #include "impl_/session_def.hpp"
@@ -26,6 +27,12 @@
 #include <cctype>
 #include <cstring>
 #include <memory>
+
+using omega_edit::internal::omega_data_create_;
+using omega_edit::internal::omega_data_destroy_;
+using omega_edit::internal::omega_data_get_data_;
+using omega_edit::internal::populate_data_segment_;
+using omega_edit::internal::safe_add_int64_;
 
 constexpr auto MAX_SEGMENT_LENGTH = static_cast<int64_t>(OMEGA_SEARCH_PATTERN_LENGTH_LIMIT) << 1;
 
@@ -40,8 +47,12 @@ omega_search_context_t *omega_search_create_context_bytes(omega_session_t *sessi
     if (!session_ptr || !pattern || session_offset < 0) { return nullptr; }
     if (pattern_length <= 0) { return nullptr; }
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0 || session_offset > computed_file_size) { return nullptr; }
     const auto session_length_computed = session_length ? session_length : computed_file_size - session_offset;
-    if (session_length_computed < 0 || session_offset + session_length_computed > computed_file_size) {
+    int64_t session_end = 0;
+    if (session_length_computed < 0 ||
+        !safe_add_int64_(session_offset, session_length_computed, session_end) ||
+        session_end > computed_file_size) {
         return nullptr;
     }
     if (pattern_length < OMEGA_SEARCH_PATTERN_LENGTH_LIMIT && pattern_length <= session_length_computed) {
@@ -51,10 +62,10 @@ omega_search_context_t *omega_search_create_context_bytes(omega_session_t *sessi
         match_context_ptr->pattern_length = pattern_length;
         match_context_ptr->session_offset = session_offset;
         match_context_ptr->session_length = session_length_computed;
-        match_context_ptr->match_offset = session_offset + session_length_computed;
+        match_context_ptr->match_offset = session_end;
         match_context_ptr->byte_transform = case_insensitive ? &to_lower_ : nullptr;
-        omega_data_create(&match_context_ptr->pattern, pattern_length);
-        const auto pattern_data_ptr = omega_data_get_data(&match_context_ptr->pattern, pattern_length);
+        omega_data_create_(&match_context_ptr->pattern, pattern_length);
+        const auto pattern_data_ptr = omega_data_get_data_(&match_context_ptr->pattern, pattern_length);
         memcpy(pattern_data_ptr, pattern, pattern_length);
         if (match_context_ptr->byte_transform) {
             omega_util_apply_byte_transform(pattern_data_ptr, pattern_length, match_context_ptr->byte_transform,
@@ -65,7 +76,7 @@ omega_search_context_t *omega_search_create_context_bytes(omega_session_t *sessi
         match_context_ptr->skip_table_ptr =
                 omega_find_create_skip_table(pattern_data_ptr, pattern_length, is_reverse_search);
         if (!match_context_ptr->skip_table_ptr) {
-            omega_data_destroy(&match_context_ptr->pattern, pattern_length);
+            omega_data_destroy_(&match_context_ptr->pattern, pattern_length);
             return nullptr;
         }
         session_ptr->search_contexts_.push_back(match_context_ptr);
@@ -123,7 +134,10 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
     if (!search_context_ptr || !search_context_ptr->session_ptr || advance_context < 0) { return 0; }
 
     // Calculate the last offset in the session. If we have no match, then this will be the match offset.
-    const auto last_offset = search_context_ptr->session_offset + search_context_ptr->session_length;
+    int64_t last_offset = 0;
+    if (!safe_add_int64_(search_context_ptr->session_offset, search_context_ptr->session_length, last_offset)) {
+        return 0;
+    }
 
     // Check if we are going to begin the search at the session offset.
     const auto is_begin = search_context_ptr->match_offset == last_offset;
@@ -148,7 +162,7 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
     // Only start searching if the pattern length is less than the search length.
     if (search_context_ptr->pattern_length <= search_length) {
         // Extract the pattern to search for.
-        const auto *pattern = omega_data_get_data(&search_context_ptr->pattern, search_context_ptr->pattern_length);
+        const auto *pattern = omega_data_get_data_(&search_context_ptr->pattern, search_context_ptr->pattern_length);
 
         // The data segment to search.
         omega_segment_t data_segment;
@@ -161,18 +175,36 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
         const auto stride_size = 1 + data_segment.capacity - search_context_ptr->pattern_length;
 
         // Initialize the data segment to search.
-        omega_data_create(&data_segment.data, data_segment.capacity);
+        omega_data_create_(&data_segment.data, data_segment.capacity);
 
         // Determine the offset to start the search from. It depends on the direction of the search and
         // whether we are beginning a new search or continuing an old one.
         if (is_reverse) {
-            data_segment.offset =
-                    is_begin ? (search_context_ptr->session_offset + search_context_ptr->session_length -
-                                data_segment.capacity)
-                             : search_context_ptr->match_offset - data_segment.capacity - advance_context + 1;
+            int64_t session_end = 0;
+            if (!safe_add_int64_(search_context_ptr->session_offset, search_context_ptr->session_length,
+                                 session_end)) {
+                omega_data_destroy_(&data_segment.data, data_segment.capacity);
+                return 0;
+            }
+            if (is_begin) {
+                data_segment.offset = session_end - data_segment.capacity;
+            } else {
+                int64_t rewind = 0;
+                if (!safe_add_int64_(data_segment.capacity, advance_context, rewind) ||
+                    !safe_add_int64_(search_context_ptr->match_offset, -rewind, data_segment.offset) ||
+                    !safe_add_int64_(data_segment.offset, 1, data_segment.offset)) {
+                    omega_data_destroy_(&data_segment.data, data_segment.capacity);
+                    return 0;
+                }
+            }
         } else {
+            int64_t next_offset = 0;
+            if (!is_begin && !safe_add_int64_(search_context_ptr->match_offset, advance_context, next_offset)) {
+                omega_data_destroy_(&data_segment.data, data_segment.capacity);
+                return 0;
+            }
             data_segment.offset =
-                    is_begin ? search_context_ptr->session_offset : search_context_ptr->match_offset + advance_context;
+                    is_begin ? search_context_ptr->session_offset : next_offset;
         }
 
         // Loop until a match is found, or we have searched the entire segment.
@@ -193,19 +225,26 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
             if (auto *found = omega_find(segment_data_ptr, data_segment.length, search_context_ptr->skip_table_ptr,
                                          pattern, search_context_ptr->pattern_length)) {
                 // If a match is found, destroy the data segment and update the match offset in the search context.
-                omega_data_destroy(&data_segment.data, data_segment.capacity);
-                search_context_ptr->match_offset = data_segment.offset + (found - segment_data_ptr);
+                const auto found_offset = static_cast<int64_t>(found - segment_data_ptr);
+                if (!safe_add_int64_(data_segment.offset, found_offset, search_context_ptr->match_offset)) {
+                    omega_data_destroy_(&data_segment.data, data_segment.capacity);
+                    return 0;
+                }
+                omega_data_destroy_(&data_segment.data, data_segment.capacity);
                 return 1;
             }
 
             // If no match was found, move the search window by the stride size.
             search_length -= stride_size;
-            data_segment.offset += is_reverse ? -stride_size : stride_size;
+            if (!safe_add_int64_(data_segment.offset, is_reverse ? -stride_size : stride_size,
+                                 data_segment.offset)) {
+                break;
+            }
 
         } while (MAX_SEGMENT_LENGTH == data_segment.length);
 
         // Destroy the data segment if no match was found.
-        omega_data_destroy(&data_segment.data, data_segment.capacity);
+        omega_data_destroy_(&data_segment.data, data_segment.capacity);
     }
 
     // If no match was found after searching the entire length, set the match offset to the last offset.
@@ -220,7 +259,7 @@ void omega_search_destroy_context(omega_search_context_t *const search_context_p
         for (auto iter = search_context_ptr->session_ptr->search_contexts_.rbegin();
              iter != search_context_ptr->session_ptr->search_contexts_.rend(); ++iter) {
             if (search_context_ptr == iter->get()) {
-                omega_data_destroy(&search_context_ptr->pattern, search_context_ptr->pattern_length);
+                omega_data_destroy_(&search_context_ptr->pattern, search_context_ptr->pattern_length);
                 if (search_context_ptr->skip_table_ptr) {
                     omega_find_destroy_skip_table(search_context_ptr->skip_table_ptr);
                     search_context_ptr->skip_table_ptr = nullptr;

--- a/core/src/lib/segment.cpp
+++ b/core/src/lib/segment.cpp
@@ -15,17 +15,25 @@
 #include "../include/omega_edit/segment.h"
 #include "impl_/segment_def.hpp"
 #include <cassert>
+#include <new>
+
+using omega_edit::internal::omega_data_create_;
+using omega_edit::internal::omega_data_destroy_;
+using omega_edit::internal::omega_data_get_data_;
 
 omega_segment_t *omega_segment_create(int64_t capacity) {
     if (capacity < 0) { return nullptr; }
     auto *segment_ptr = new omega_segment_t();
-    segment_ptr->data.bytes_ptr =
-            static_cast<int64_t>(sizeof(omega_data_t)) - 1 < capacity ? new omega_byte_t[capacity + 1] : nullptr;
+    try {
+        omega_data_create_(&segment_ptr->data, capacity);
+    } catch (const std::bad_alloc &) {
+        delete segment_ptr;
+        return nullptr;
+    }
     segment_ptr->capacity = capacity;
     segment_ptr->length = 0;
     segment_ptr->offset = -1;
     segment_ptr->offset_adjustment = 0;
-    omega_segment_get_data(segment_ptr)[capacity] = '\0';// null terminate, this does not exceed the upper limit
     return segment_ptr;
 }
 
@@ -51,15 +59,13 @@ int64_t omega_segment_get_offset_adjustment(const omega_segment_t *segment_ptr) 
 
 omega_byte_t *omega_segment_get_data(omega_segment_t *segment_ptr) {
     if (!segment_ptr) { return nullptr; }
-    return 0 <= segment_ptr->length ? omega_data_get_data(&segment_ptr->data, std::abs(segment_ptr->capacity))
+    return 0 <= segment_ptr->length ? omega_data_get_data_(&segment_ptr->data, std::abs(segment_ptr->capacity))
                                     : nullptr;
 }
 
 void omega_segment_destroy(omega_segment_t *segment_ptr) {
     if (segment_ptr) {
-        if (static_cast<int64_t>(sizeof(omega_data_t)) - 1 < omega_segment_get_capacity(segment_ptr)) {
-            delete[] segment_ptr->data.bytes_ptr;
-        }
+        omega_data_destroy_(&segment_ptr->data, omega_segment_get_capacity(segment_ptr));
         delete segment_ptr;
     }
 }

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -17,6 +17,7 @@
 #include "impl_/character_counts_def.h"
 #include "impl_/internal_fun.hpp"
 #include "impl_/model_def.hpp"
+#include "impl_/safe_math.hpp"
 #include "impl_/segment_def.hpp"
 #include "impl_/session_def.hpp"
 #include "omega_edit/character_counts.h"
@@ -26,6 +27,10 @@
 #include <cassert>
 #include <cstring>
 
+using omega_edit::internal::omega_change_get_transaction_bit_;
+using omega_edit::internal::omega_session_end_event_batch_;
+using omega_edit::internal::populate_data_segment_;
+using omega_edit::internal::safe_add_int64_;
 
 int omega_session_byte_frequency_profile_size() { return OMEGA_EDIT_BYTE_FREQUENCY_PROFILE_SIZE; }
 
@@ -37,7 +42,7 @@ void *omega_session_get_user_data_ptr(const omega_session_t *session_ptr) {
 }
 
 int omega_session_get_segment(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr, int64_t offset) {
-    if (!session_ptr || !data_segment_ptr) { return -1; }
+    if (!session_ptr || !data_segment_ptr || offset < 0 || data_segment_ptr->capacity < 0) { return -1; }
     data_segment_ptr->offset = offset;
     return populate_data_segment_(session_ptr, data_segment_ptr);
 }
@@ -55,12 +60,17 @@ int64_t omega_session_get_num_search_contexts(const omega_session_t *session_ptr
 int64_t omega_session_get_computed_file_size(const omega_session_t *session_ptr) {
     if (!session_ptr) { return 0; }
     assert(session_ptr->models_.back());
+    int64_t last_segment_end = 0;
+    if (!session_ptr->models_.back()->model_segments.empty() &&
+        !safe_add_int64_(session_ptr->models_.back()->model_segments.back()->computed_offset,
+                         session_ptr->models_.back()->model_segments.back()->computed_length,
+                         last_segment_end)) {
+        return -1;
+    }
     const auto computed_file_size =
             session_ptr->models_.back()->model_segments.empty()
                 ? 0
-                : session_ptr->models_.back()->model_segments.back()->computed_offset +
-                  session_ptr->models_.back()->model_segments.back()->computed_length;
-    assert(0 <= computed_file_size);
+                : last_segment_end;
     return computed_file_size;
 }
 
@@ -265,14 +275,15 @@ int64_t omega_session_get_num_checkpoints(const omega_session_t *session_ptr) {
     return static_cast<int64_t>(session_ptr->models_.size()) - 1;
 }
 
-void omega_session_begin_event_batch_(omega_session_t *session_ptr, omega_session_event_t session_event) {
+void omega_edit::internal::omega_session_begin_event_batch_(omega_session_t *session_ptr,
+                                                           omega_session_event_t session_event) {
     if (!session_ptr) { return; }
     session_ptr->batched_session_event_kind_ = session_event;
     session_ptr->pending_session_event_kind_ = SESSION_EVT_UNDEFINED;
     session_ptr->pending_session_event_ptr_ = nullptr;
 }
 
-void omega_session_end_event_batch_(omega_session_t *session_ptr) {
+void omega_edit::internal::omega_session_end_event_batch_(omega_session_t *session_ptr) {
     if (!session_ptr) { return; }
     const auto pending_event = session_ptr->pending_session_event_kind_;
     const auto pending_ptr = session_ptr->pending_session_event_ptr_;
@@ -320,7 +331,11 @@ int omega_session_byte_frequency_profile(const omega_session_t *session_ptr,
                                          omega_byte_frequency_profile_t *profile_ptr, int64_t offset, int64_t length) {
     if (!session_ptr || !profile_ptr || offset < 0) { return -1; }
     length = 0 == length ? omega_session_get_computed_file_size(session_ptr) - offset : length;
-    if (length < 0 || offset + length > omega_session_get_computed_file_size(session_ptr)) { return -1; }
+    int64_t end_offset = 0;
+    if (length < 0 || !safe_add_int64_(offset, length, end_offset) ||
+        end_offset > omega_session_get_computed_file_size(session_ptr)) {
+        return -1;
+    }
     memset(profile_ptr, 0, sizeof(omega_byte_frequency_profile_t));
     if (0 < length) {
         const auto segment_ptr = omega_segment_create(std::min(length, static_cast<int64_t>(BUFSIZ)));
@@ -335,7 +350,10 @@ int omega_session_byte_frequency_profile(const omega_session_t *session_ptr,
                 if (last_profiled_byte == '\r' && segment_data[i] == '\n') { ++dos_eol_count; }
                 ++(*profile_ptr)[last_profiled_byte = segment_data[i]];
             }
-            offset += profile_length;
+            if (!safe_add_int64_(offset, profile_length, offset)) {
+                omega_segment_destroy(segment_ptr);
+                return -1;
+            }
             length -= profile_length;
         }
         omega_segment_destroy(segment_ptr);
@@ -348,7 +366,11 @@ int omega_session_character_counts(const omega_session_t *session_ptr, omega_cha
                                    int64_t offset, int64_t length, omega_bom_t bom) {
     if (!session_ptr || !counts_ptr || offset < 0) { return -1; }
     length = length ? length : omega_session_get_computed_file_size(session_ptr) - offset;
-    if (length < 0 || offset + length > omega_session_get_computed_file_size(session_ptr)) { return -1; }
+    int64_t end_offset = 0;
+    if (length < 0 || !safe_add_int64_(offset, length, end_offset) ||
+        end_offset > omega_session_get_computed_file_size(session_ptr)) {
+        return -1;
+    }
     omega_character_counts_set_BOM(omega_character_counts_reset(counts_ptr), bom);
     const auto segment_ptr = omega_segment_create(std::min(length, static_cast<int64_t>(BUFSIZ)));
     while (length) {
@@ -357,7 +379,10 @@ int omega_session_character_counts(const omega_session_t *session_ptr, omega_cha
         const auto segment_data = omega_segment_get_data(segment_ptr);
         const auto count_length = std::min(length, omega_segment_get_length(segment_ptr));
         omega_util_count_characters(segment_data, count_length, counts_ptr);
-        offset += count_length;
+        if (!safe_add_int64_(offset, count_length, offset)) {
+            omega_segment_destroy(segment_ptr);
+            return -1;
+        }
         length -= count_length;
     }
     omega_segment_destroy(segment_ptr);
@@ -385,7 +410,7 @@ int64_t omega_session_set_undo_snapshot_interval(omega_session_t *session_ptr, i
     return session_ptr->undo_snapshot_interval_;
 }
 
-bool omega_session_get_transaction_bit_(const omega_session_t *session_ptr) {
+bool omega_edit::internal::omega_session_get_transaction_bit_(const omega_session_t *session_ptr) {
     return (session_ptr->models_.back()->changes.empty()) ||
            omega_change_get_transaction_bit_(session_ptr->models_.back()->changes.back().get());
 }

--- a/core/src/lib/viewport.cpp
+++ b/core/src/lib/viewport.cpp
@@ -16,10 +16,16 @@
 #include "../include/omega_edit/segment.h"
 #include "../include/omega_edit/session.h"
 #include "impl_/internal_fun.hpp"
+#include "impl_/safe_math.hpp"
 #include "impl_/session_def.hpp"
 #include "impl_/viewport_def.hpp"
 #include <cassert>
 #include <cstdlib>
+
+using omega_edit::internal::omega_data_create_;
+using omega_edit::internal::omega_data_destroy_;
+using omega_edit::internal::populate_data_segment_;
+using omega_edit::internal::safe_add_int64_;
 
 const omega_session_t *omega_viewport_get_session(const omega_viewport_t *viewport_ptr) {
     if (!viewport_ptr) { return nullptr; }
@@ -37,16 +43,22 @@ int64_t omega_viewport_get_length(const omega_viewport_t *viewport_ptr) {
     if (!viewport_ptr) { return 0; }
     if (0 == omega_viewport_has_changes(viewport_ptr)) { return viewport_ptr->data_segment.length; }
     auto const capacity = omega_viewport_get_capacity(viewport_ptr);
-    auto const remaining_file_size =
-            std::max(omega_session_get_computed_file_size(omega_viewport_get_session(viewport_ptr)) -
-                     omega_viewport_get_offset(viewport_ptr),
-                     static_cast<int64_t>(0));
+    auto const viewport_offset = omega_viewport_get_offset(viewport_ptr);
+    if (viewport_offset < 0) { return 0; }
+    auto const computed_file_size = omega_session_get_computed_file_size(omega_viewport_get_session(viewport_ptr));
+    if (computed_file_size < 0) { return 0; }
+    int64_t remaining_file_size = 0;
+    if (!safe_add_int64_(computed_file_size, -viewport_offset, remaining_file_size)) { return 0; }
+    remaining_file_size = std::max(remaining_file_size, static_cast<int64_t>(0));
     return capacity < remaining_file_size ? capacity : remaining_file_size;
 }
 
 int64_t omega_viewport_get_offset(const omega_viewport_t *viewport_ptr) {
     if (!viewport_ptr) { return -1; }
-    return viewport_ptr->data_segment.offset + viewport_ptr->data_segment.offset_adjustment;
+    int64_t offset = 0;
+    return safe_add_int64_(viewport_ptr->data_segment.offset, viewport_ptr->data_segment.offset_adjustment, offset)
+           ? offset
+           : -1;
 }
 
 void *omega_viewport_get_user_data_ptr(const omega_viewport_t *viewport_ptr) {
@@ -77,22 +89,33 @@ int omega_viewport_is_floating(const omega_viewport_t *viewport_ptr) {
 
 int64_t omega_viewport_get_following_byte_count(const omega_viewport_t *viewport_ptr) {
     if (!viewport_ptr) { return 0; }
-    return omega_session_get_computed_file_size(omega_viewport_get_session(viewport_ptr)) -
-           (omega_viewport_get_offset(viewport_ptr) + omega_viewport_get_length(viewport_ptr));
+    const auto viewport_offset = omega_viewport_get_offset(viewport_ptr);
+    if (viewport_offset < 0) { return 0; }
+    int64_t viewport_end = 0;
+    if (!safe_add_int64_(viewport_offset, omega_viewport_get_length(viewport_ptr), viewport_end)) {
+        return 0;
+    }
+    if (viewport_end < 0) { return 0; }
+    const auto computed_file_size = omega_session_get_computed_file_size(omega_viewport_get_session(viewport_ptr));
+    if (computed_file_size < 0) { return 0; }
+    // Negative result is intentional when viewport_end > computed_file_size (viewport past EOF).
+    return computed_file_size - viewport_end;
 }
 
 int omega_viewport_modify(omega_viewport_t *viewport_ptr, int64_t offset, int64_t capacity, int is_floating) {
     if (!viewport_ptr) { return -1; }
-    if (capacity > 0 && capacity <= OMEGA_VIEWPORT_CAPACITY_LIMIT) {
+    int64_t viewport_end = 0;
+    if (offset >= 0 && capacity > 0 && capacity <= OMEGA_VIEWPORT_CAPACITY_LIMIT &&
+        safe_add_int64_(offset, capacity, viewport_end)) {
         // only change settings if they are different
         if (viewport_ptr->data_segment.offset != offset || omega_viewport_get_capacity(viewport_ptr) != capacity ||
             viewport_ptr->data_segment.is_floating != (bool) is_floating) {
-            omega_data_destroy(&viewport_ptr->data_segment.data, omega_viewport_get_capacity(viewport_ptr));
+            omega_data_destroy_(&viewport_ptr->data_segment.data, omega_viewport_get_capacity(viewport_ptr));
             viewport_ptr->data_segment.offset = offset;
             viewport_ptr->data_segment.is_floating = (bool) is_floating;
             viewport_ptr->data_segment.offset_adjustment = 0;
             viewport_ptr->data_segment.capacity = -1 * capacity;// Negative capacity indicates dirty read
-            omega_data_create(&viewport_ptr->data_segment.data, capacity);
+            omega_data_create_(&viewport_ptr->data_segment.data, capacity);
             omega_viewport_notify(viewport_ptr, VIEWPORT_EVT_MODIFY, nullptr);
         }
         return 0;
@@ -120,8 +143,15 @@ int omega_viewport_has_changes(const omega_viewport_t *viewport_ptr) {
 }
 
 int omega_viewport_in_segment(const omega_viewport_t *viewport_ptr, int64_t offset, int64_t length) {
-    return (offset + length) >= omega_viewport_get_offset(viewport_ptr) &&
-           offset <= omega_viewport_get_offset(viewport_ptr) + omega_viewport_get_capacity(viewport_ptr)
+    if (!viewport_ptr) { return 0; }
+    const auto viewport_offset = omega_viewport_get_offset(viewport_ptr);
+    if (viewport_offset < 0) { return 0; }
+    int64_t segment_end = 0;
+    int64_t viewport_end = 0;
+    return safe_add_int64_(offset, length, segment_end) &&
+           safe_add_int64_(viewport_offset, omega_viewport_get_capacity(viewport_ptr), viewport_end) &&
+           segment_end >= viewport_offset &&
+           offset <= viewport_end
            ? 1
            : 0;
 }

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -13,9 +13,14 @@
  **********************************************************************************************************************/
 
 #include "omega_edit.h"
+#include "omega_edit/character_counts.h"
 #include "omega_edit/check.h"
 #include "omega_edit/stl_string_adaptor.hpp"
 #include "omega_edit/utility.h"
+#include "../lib/impl_/safe_math.hpp"
+#include "../lib/impl_/data_def.hpp"
+#include "../lib/impl_/session_def.hpp"
+#include "../lib/impl_/viewport_def.hpp"
 
 #include <test_util.hpp>
 
@@ -25,6 +30,8 @@
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <limits>
+#include <new>
 #include <string>
 
 using namespace std;
@@ -503,6 +510,218 @@ TEST_CASE("Negative Edit Parameters Are Rejected", "[EdgeCase][InvalidInput]") {
 }
 
 // ─── Viewport Notify ─────────────────────────────────────────────────────────
+
+TEST_CASE("Safe Int64 Math Helpers Detect Boundary Overflow", "[EdgeCase][Overflow]") {
+    const auto max = (std::numeric_limits<int64_t>::max)();
+    const auto min = (std::numeric_limits<int64_t>::min)();
+    int64_t result = 0;
+
+    REQUIRE_FALSE(omega_edit::internal::add_overflows_int64_(40, 2));
+    REQUIRE(omega_edit::internal::add_overflows_int64_(max, 1));
+    REQUIRE(omega_edit::internal::add_overflows_int64_(min, -1));
+
+    REQUIRE(omega_edit::internal::safe_add_int64_(40, 2, result));
+    REQUIRE(42 == result);
+    REQUIRE_FALSE(omega_edit::internal::safe_add_int64_(max, 1, result));
+    REQUIRE_FALSE(omega_edit::internal::safe_add_int64_(min, -1, result));
+
+    REQUIRE(omega_edit::internal::valid_nonnegative_range_(0, max));
+    REQUIRE_FALSE(omega_edit::internal::valid_nonnegative_range_(-1, 1));
+    REQUIRE_FALSE(omega_edit::internal::valid_nonnegative_range_(1, -1));
+    REQUIRE_FALSE(omega_edit::internal::valid_nonnegative_range_(max, 1));
+}
+
+TEST_CASE("Overflow Sized Edit Ranges Are Rejected Without Mutating Session", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+
+    const auto max = (std::numeric_limits<int64_t>::max)();
+    const omega_byte_t byte = 'x';
+
+    REQUIRE(-1 == omega_edit_delete(session_ptr, max, 1));
+    REQUIRE(-1 == omega_edit_insert_bytes(session_ptr, max, &byte, 1));
+    REQUIRE(-1 == omega_edit_insert_bytes(session_ptr, 0, &byte, max));
+    REQUIRE(-1 == omega_edit_overwrite_bytes(session_ptr, max, &byte, 1));
+    REQUIRE(-1 == omega_edit_overwrite_bytes(session_ptr, 0, &byte, max));
+
+    REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(0 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Computed File Size Returns -1 On Segment Overflow", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+    REQUIRE(3 == omega_session_get_computed_file_size(session_ptr));
+
+    // Directly corrupt the last segment so computed_offset + computed_length overflows int64.
+    auto &seg = session_ptr->models_.back()->model_segments.back();
+    seg->computed_offset = (std::numeric_limits<int64_t>::max)();
+    seg->computed_length = 1;
+
+    REQUIRE(-1 == omega_session_get_computed_file_size(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Viewport Offset Overflow Returns Safe Sentinels", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+
+    auto *vp = omega_edit_create_viewport(session_ptr, 0, 3, 0, nullptr, nullptr, NO_EVENTS);
+    REQUIRE(vp);
+    // Viewport is created dirty (capacity < 0). Force offset + offset_adjustment to overflow int64.
+    vp->data_segment.offset = (std::numeric_limits<int64_t>::max)();
+    vp->data_segment.offset_adjustment = 1;
+    vp->data_segment.capacity = -omega_viewport_get_capacity(vp);
+
+    REQUIRE(-1 == omega_viewport_get_offset(vp));
+    // omega_viewport_get_length detects viewport_offset < 0 and returns 0.
+    REQUIRE(0 == omega_viewport_get_length(vp));
+
+    omega_edit_destroy_viewport(vp);
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Viewport Negative Offset Sentinels Do Not Overflow Range Helpers", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+
+    auto *vp = omega_edit_create_viewport(session_ptr, 0, 3, 0, nullptr, nullptr, NO_EVENTS);
+    REQUIRE(vp);
+    vp->data_segment.offset = (std::numeric_limits<int64_t>::min)();
+    vp->data_segment.offset_adjustment = 0;
+    vp->data_segment.capacity = -omega_viewport_get_capacity(vp);
+
+    REQUIRE((std::numeric_limits<int64_t>::min)() == omega_viewport_get_offset(vp));
+    REQUIRE(0 == omega_viewport_get_length(vp));
+    REQUIRE(0 == omega_viewport_get_following_byte_count(vp));
+    REQUIRE_FALSE(omega_viewport_in_segment(vp, 0, 1));
+
+    omega_edit_destroy_viewport(vp);
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Data Segment Allocation Rejects Unrepresentable Null Terminator Capacity", "[EdgeCase][Overflow]") {
+    omega_data_t data{};
+
+    REQUIRE_THROWS_AS(omega_edit::internal::omega_data_create_(
+                              &data, (std::numeric_limits<int64_t>::max)()),
+                      std::bad_array_new_length);
+}
+
+TEST_CASE("Segment Allocation Rejects Unrepresentable Null Terminator Capacity", "[EdgeCase][Overflow]") {
+    REQUIRE(nullptr == omega_segment_create((std::numeric_limits<int64_t>::max)()));
+}
+
+TEST_CASE("Negative Segment Offsets Are Rejected Before Population", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+
+    auto *segment_ptr = omega_segment_create(2);
+    REQUIRE(segment_ptr);
+
+    REQUIRE(-1 == omega_session_get_segment(session_ptr, segment_ptr, -1));
+    REQUIRE(-1 == omega_segment_get_offset(segment_ptr));
+    REQUIRE(0 == omega_segment_get_length(segment_ptr));
+
+    omega_segment_destroy(segment_ptr);
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Viewport Creation And Modification Reject Invalid Ranges", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+
+    const auto max = (std::numeric_limits<int64_t>::max)();
+    REQUIRE(nullptr == omega_edit_create_viewport(nullptr, 0, 1, 0, nullptr, nullptr, NO_EVENTS));
+    REQUIRE(nullptr == omega_edit_create_viewport(session_ptr, -1, 1, 0, nullptr, nullptr, NO_EVENTS));
+    REQUIRE(nullptr == omega_edit_create_viewport(session_ptr, max, 1, 0, nullptr, nullptr, NO_EVENTS));
+
+    auto *viewport_ptr = omega_edit_create_viewport(session_ptr, 0, 2, 0, nullptr, nullptr, NO_EVENTS);
+    REQUIRE(viewport_ptr);
+    REQUIRE(-1 == omega_viewport_modify(viewport_ptr, -1, 2, 0));
+    REQUIRE(-1 == omega_viewport_modify(viewport_ptr, max, 1, 0));
+
+    omega_edit_destroy_viewport(viewport_ptr);
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Floating Viewport Adjustment Overflow Is Rejected Without Undefined Arithmetic", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+
+    auto *viewport_ptr = omega_edit_create_viewport(
+            session_ptr, (std::numeric_limits<int64_t>::max)() - 1, 1, 1, nullptr, nullptr, NO_EVENTS);
+    REQUIRE(viewport_ptr);
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "x"));
+    REQUIRE((std::numeric_limits<int64_t>::max)() == omega_viewport_get_offset(viewport_ptr));
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "y"));
+    REQUIRE((std::numeric_limits<int64_t>::max)() == omega_viewport_get_offset(viewport_ptr));
+
+    omega_edit_destroy_viewport(viewport_ptr);
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Model Check Rejects Arithmetic Overflow In Segment Bounds", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+
+    auto &seg = session_ptr->models_.back()->model_segments.back();
+    seg->change_offset = (std::numeric_limits<int64_t>::max)();
+    seg->computed_length = 1;
+
+    REQUIRE(-1 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Transform Rejects Negative Offsets Before Range Arithmetic", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+
+    REQUIRE(-1 == omega_edit_apply_transform(session_ptr, to_upper, nullptr,
+                                             (std::numeric_limits<int64_t>::min)(), 0));
+    REQUIRE("abc" == omega_session_get_segment_string(session_ptr, 0, 3));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Overflow Sized Read Ranges Are Rejected", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+
+    const auto max = (std::numeric_limits<int64_t>::max)();
+
+    REQUIRE(nullptr == omega_search_create_context_string(session_ptr, "b", 1, max, false, false));
+
+    omega_byte_frequency_profile_t profile;
+    REQUIRE(-1 == omega_session_byte_frequency_profile(session_ptr, &profile, 1, max));
+
+    auto *counts = omega_character_counts_create();
+    REQUIRE(counts);
+    REQUIRE(-1 == omega_session_character_counts(session_ptr, counts, 1, max, BOM_NONE));
+    omega_character_counts_destroy(counts);
+
+    auto *viewport_ptr = omega_edit_create_viewport(session_ptr, 0, 2, 0, nullptr, nullptr, NO_EVENTS);
+    REQUIRE(viewport_ptr);
+    REQUIRE(0 == omega_viewport_in_segment(viewport_ptr, max, 1));
+    REQUIRE(0 == omega_viewport_in_segment(viewport_ptr, 1, max));
+    omega_edit_destroy_viewport(viewport_ptr);
+
+    REQUIRE(0 == omega_check_model(session_ptr));
+    omega_edit_destroy_session(session_ptr);
+}
 
 static int viewport_notify_count = 0;
 

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -23,9 +23,11 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <thread>
+#include <vector>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -306,6 +308,19 @@ static grpc::Status validate_replace_payload_sizes(const std::string &pattern, c
     return grpc::Status::OK;
 }
 
+static grpc::Status validate_viewport_range(int64_t offset, int64_t capacity) {
+    if (offset < 0 || capacity <= 0) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                            "viewport offset must be non-negative and capacity must be positive");
+    }
+    if (capacity > OMEGA_VIEWPORT_CAPACITY_LIMIT ||
+        offset > (std::numeric_limits<int64_t>::max)() - capacity) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                            "viewport range is invalid or exceeds configured capacity limit");
+    }
+    return grpc::Status::OK;
+}
+
 EditorServiceImpl::EditorServiceImpl(HeartbeatConfig heartbeat_config, ResourceLimits resource_limits,
                                      std::function<void()> shutdown_callback)
     : session_manager_(resource_limits), start_time_(std::chrono::steady_clock::now()),
@@ -405,10 +420,11 @@ template <typename T>
 grpc::Status EditorServiceImpl::fill_viewport_data(const std::string &session_id, const std::string &viewport_id,
                                                     const std::string &fqid,
                                                     T *response) {
-    auto *vp = session_manager_.get_viewport(session_id, viewport_id);
-    if (!vp) {
+    auto locked_viewport = session_manager_.lock_viewport(session_id, viewport_id);
+    if (!locked_viewport) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + fqid);
     }
+    auto *vp = locked_viewport.viewport();
     const auto *data = omega_viewport_get_data(vp);
     auto length = omega_viewport_get_length(vp);
 
@@ -519,12 +535,12 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::SaveSession(grpc::ServerContext * /*context*/,
                                              const ::omega_edit::v1::SaveSessionRequest *request,
                                              ::omega_edit::v1::SaveSessionResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->session_id());
     char saved_file_path[FILENAME_MAX] = {};
     int64_t offset = request->has_offset() ? request->offset() : 0;
     int64_t length = request->has_length() ? request->length() : 0;
@@ -568,12 +584,12 @@ grpc::Status EditorServiceImpl::DestroySession(grpc::ServerContext * /*context*/
 grpc::Status EditorServiceImpl::SubmitChange(grpc::ServerContext * /*context*/,
                                               const ::omega_edit::v1::SubmitChangeRequest *request,
                                               ::omega_edit::v1::SubmitChangeResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->session_id());
     const grpc::Status payload_status =
         validate_change_payload_size(request, resource_limits_.max_change_bytes);
     if (!payload_status.ok()) {
@@ -627,17 +643,17 @@ grpc::Status EditorServiceImpl::SubmitChange(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::UndoLastChange(grpc::ServerContext * /*context*/,
                                                 const ::omega_edit::v1::UndoLastChangeRequest *request,
                                                 ::omega_edit::v1::UndoLastChangeResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     int64_t serial = omega_edit_undo_last_change(session);
     if (serial == 0) {
         return grpc::Status(grpc::StatusCode::UNKNOWN, "undo failed or nothing to undo");
     }
 
-    session_manager_.touch_session(request->id());
     response->set_session_id(request->id());
     response->set_serial(serial);
     return grpc::Status::OK;
@@ -646,17 +662,17 @@ grpc::Status EditorServiceImpl::UndoLastChange(grpc::ServerContext * /*context*/
 grpc::Status EditorServiceImpl::RedoLastUndo(grpc::ServerContext * /*context*/,
                                               const ::omega_edit::v1::RedoLastUndoRequest *request,
                                               ::omega_edit::v1::RedoLastUndoResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     int64_t serial = omega_edit_redo_last_undo(session);
     if (serial == 0) {
         return grpc::Status(grpc::StatusCode::UNKNOWN, "redo failed or nothing to redo");
     }
 
-    session_manager_.touch_session(request->id());
     response->set_session_id(request->id());
     response->set_serial(serial);
     return grpc::Status::OK;
@@ -665,17 +681,17 @@ grpc::Status EditorServiceImpl::RedoLastUndo(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::ClearChanges(grpc::ServerContext * /*context*/,
                                               const ::omega_edit::v1::ClearChangesRequest *request,
                                               ::omega_edit::v1::ClearChangesResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     int result = omega_edit_clear_changes(session);
     if (result != 0) {
         return grpc::Status(grpc::StatusCode::UNKNOWN, "clear changes failed");
     }
 
-    session_manager_.touch_session(request->id());
     response->set_id(request->id());
     return grpc::Status::OK;
 }
@@ -685,10 +701,11 @@ grpc::Status EditorServiceImpl::ClearChanges(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::PauseSessionChanges(grpc::ServerContext * /*context*/,
                                                      const ::omega_edit::v1::PauseSessionChangesRequest *request,
                                                      ::omega_edit::v1::PauseSessionChangesResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     omega_session_pause_changes(session);
     response->set_id(request->id());
@@ -698,10 +715,11 @@ grpc::Status EditorServiceImpl::PauseSessionChanges(grpc::ServerContext * /*cont
 grpc::Status EditorServiceImpl::ResumeSessionChanges(grpc::ServerContext * /*context*/,
                                                       const ::omega_edit::v1::ResumeSessionChangesRequest *request,
                                                       ::omega_edit::v1::ResumeSessionChangesResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     omega_session_resume_changes(session);
     response->set_id(request->id());
@@ -711,10 +729,11 @@ grpc::Status EditorServiceImpl::ResumeSessionChanges(grpc::ServerContext * /*con
 grpc::Status EditorServiceImpl::PauseViewportEvents(grpc::ServerContext * /*context*/,
                                                      const ::omega_edit::v1::PauseViewportEventsRequest *request,
                                                      ::omega_edit::v1::PauseViewportEventsResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     omega_session_pause_viewport_event_callbacks(session);
     response->set_id(request->id());
@@ -724,10 +743,11 @@ grpc::Status EditorServiceImpl::PauseViewportEvents(grpc::ServerContext * /*cont
 grpc::Status EditorServiceImpl::ResumeViewportEvents(grpc::ServerContext * /*context*/,
                                                       const ::omega_edit::v1::ResumeViewportEventsRequest *request,
                                                       ::omega_edit::v1::ResumeViewportEventsResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     omega_session_resume_viewport_event_callbacks(session);
     response->set_id(request->id());
@@ -737,10 +757,11 @@ grpc::Status EditorServiceImpl::ResumeViewportEvents(grpc::ServerContext * /*con
 grpc::Status EditorServiceImpl::SessionBeginTransaction(grpc::ServerContext * /*context*/,
                                                          const ::omega_edit::v1::SessionBeginTransactionRequest *request,
                                                          ::omega_edit::v1::SessionBeginTransactionResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     // Tolerate nested begin-transaction calls (no-op if already in a transaction)
     // to match the server behaviour used by the TypeScript client's
@@ -748,7 +769,6 @@ grpc::Status EditorServiceImpl::SessionBeginTransaction(grpc::ServerContext * /*
     // outer transaction is already open.
     omega_session_begin_transaction(session);
 
-    session_manager_.touch_session(request->id());
     response->set_id(request->id());
     return grpc::Status::OK;
 }
@@ -756,15 +776,15 @@ grpc::Status EditorServiceImpl::SessionBeginTransaction(grpc::ServerContext * /*
 grpc::Status EditorServiceImpl::SessionEndTransaction(grpc::ServerContext * /*context*/,
                                                        const ::omega_edit::v1::SessionEndTransactionRequest *request,
                                                        ::omega_edit::v1::SessionEndTransactionResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     // Tolerate end-transaction when no transaction is open (no-op).
     omega_session_end_transaction(session);
 
-    session_manager_.touch_session(request->id());
     response->set_id(request->id());
     return grpc::Status::OK;
 }
@@ -772,10 +792,11 @@ grpc::Status EditorServiceImpl::SessionEndTransaction(grpc::ServerContext * /*co
 grpc::Status EditorServiceImpl::NotifyChangedViewports(grpc::ServerContext * /*context*/,
                                                         const ::omega_edit::v1::NotifyChangedViewportsRequest *request,
                                                         ::omega_edit::v1::NotifyChangedViewportsResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
     int count = omega_session_notify_changed_viewports(session);
     response->set_count(count);
@@ -787,6 +808,9 @@ grpc::Status EditorServiceImpl::NotifyChangedViewports(grpc::ServerContext * /*c
 grpc::Status EditorServiceImpl::CreateViewport(grpc::ServerContext * /*context*/,
                                                 const ::omega_edit::v1::CreateViewportRequest *request,
                                                 ::omega_edit::v1::CreateViewportResponse *response) {
+    auto viewport_status = validate_viewport_range(request->offset(), request->capacity());
+    if (!viewport_status.ok()) { return viewport_status; }
+
     std::string desired_vp_id;
     if (request->has_viewport_id_desired()) {
         desired_vp_id = request->viewport_id_desired();
@@ -827,23 +851,37 @@ grpc::Status EditorServiceImpl::CreateViewport(grpc::ServerContext * /*context*/
 grpc::Status EditorServiceImpl::ModifyViewport(grpc::ServerContext * /*context*/,
                                                 const ::omega_edit::v1::ModifyViewportRequest *request,
                                                 ::omega_edit::v1::ModifyViewportResponse *response) {
+    auto viewport_status = validate_viewport_range(request->offset(), request->capacity());
+    if (!viewport_status.ok()) { return viewport_status; }
+
     std::string sid, vid;
     if (!parse_viewport_id(request->viewport_id(), sid, vid)) {
         return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->viewport_id());
     }
 
-    auto *vp = session_manager_.get_viewport(sid, vid);
-    if (!vp) {
+    auto locked_viewport = session_manager_.lock_viewport(sid, vid);
+    if (!locked_viewport) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->viewport_id());
     }
+    auto *vp = locked_viewport.viewport();
 
     int result = omega_viewport_modify(vp, request->offset(), request->capacity(), request->is_floating() ? 1 : 0);
     if (result != 0) {
         return grpc::Status(grpc::StatusCode::UNKNOWN, "modify viewport failed");
     }
 
-    session_manager_.touch_session(sid);
-    return fill_viewport_data(sid, vid, request->viewport_id(), response);
+    // Keep the existing core lock while returning the refreshed viewport data. Calling fill_viewport_data here would
+    // attempt to acquire the same per-session lock again.
+    const auto *data = omega_viewport_get_data(vp);
+    auto length = omega_viewport_get_length(vp);
+    response->set_viewport_id(request->viewport_id());
+    response->set_offset(omega_viewport_get_offset(vp));
+    response->set_length(length);
+    if (data && length > 0) {
+        response->set_data(data, static_cast<size_t>(length));
+    }
+    response->set_following_byte_count(omega_viewport_get_following_byte_count(vp));
+    return grpc::Status::OK;
 }
 
 grpc::Status EditorServiceImpl::ViewportHasChanges(grpc::ServerContext * /*context*/,
@@ -854,13 +892,13 @@ grpc::Status EditorServiceImpl::ViewportHasChanges(grpc::ServerContext * /*conte
         return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
     }
 
-    auto *vp = session_manager_.get_viewport(sid, vid);
-    if (!vp) {
+    auto locked_viewport = session_manager_.lock_viewport(sid, vid);
+    if (!locked_viewport) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->id());
     }
+    auto *vp = locked_viewport.viewport();
 
     response->set_result(omega_viewport_has_changes(vp) != 0);
-    session_manager_.touch_session(sid);
     return grpc::Status::OK;
 }
 
@@ -901,12 +939,12 @@ grpc::Status EditorServiceImpl::GetChangeDetails(grpc::ServerContext * /*context
         return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "change serial id required");
     }
 
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->session_id());
     const auto *change = omega_session_get_change(session, request->serial());
     if (!change) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "change not found");
@@ -919,12 +957,12 @@ grpc::Status EditorServiceImpl::GetChangeDetails(grpc::ServerContext * /*context
 grpc::Status EditorServiceImpl::GetLastChange(grpc::ServerContext * /*context*/,
                                                const ::omega_edit::v1::GetLastChangeRequest *request,
                                                ::omega_edit::v1::GetLastChangeResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->id());
     const auto *change = omega_session_get_last_change(session);
     if (!change) {
         return grpc::Status(grpc::StatusCode::UNKNOWN, "no changes available");
@@ -937,12 +975,12 @@ grpc::Status EditorServiceImpl::GetLastChange(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::GetLastUndo(grpc::ServerContext * /*context*/,
                                              const ::omega_edit::v1::GetLastUndoRequest *request,
                                              ::omega_edit::v1::GetLastUndoResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->id());
     const auto *change = omega_session_get_last_undo(session);
     if (!change) {
         return grpc::Status(grpc::StatusCode::UNKNOWN, "no undone changes available");
@@ -957,14 +995,18 @@ grpc::Status EditorServiceImpl::GetLastUndo(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::GetComputedFileSize(grpc::ServerContext * /*context*/,
                                                      const ::omega_edit::v1::GetComputedFileSizeRequest *request,
                                                      ::omega_edit::v1::GetComputedFileSizeResponse *response) {
-    auto *session = session_manager_.get_session(request->id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->id());
+    const auto computed_file_size = omega_session_get_computed_file_size(session);
+    if (computed_file_size < 0) {
+        return grpc::Status(grpc::StatusCode::INTERNAL, "computed file size overflow");
+    }
     response->set_session_id(request->id());
-    response->set_computed_file_size(omega_session_get_computed_file_size(session));
+    response->set_computed_file_size(computed_file_size);
     return grpc::Status::OK;
 }
 
@@ -973,12 +1015,12 @@ grpc::Status EditorServiceImpl::GetComputedFileSize(grpc::ServerContext * /*cont
 grpc::Status EditorServiceImpl::GetByteOrderMark(grpc::ServerContext * /*context*/,
                                                   const ::omega_edit::v1::GetByteOrderMarkRequest *request,
                                                   ::omega_edit::v1::GetByteOrderMarkResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->session_id());
     omega_bom_t bom = omega_session_detect_BOM(session, request->offset());
     const char *bom_str = omega_util_BOM_to_cstring(bom);
     auto bom_size = static_cast<int64_t>(omega_util_BOM_size(bom));
@@ -993,12 +1035,16 @@ grpc::Status EditorServiceImpl::GetByteOrderMark(grpc::ServerContext * /*context
 grpc::Status EditorServiceImpl::GetContentType(grpc::ServerContext * /*context*/,
                                                 const ::omega_edit::v1::GetContentTypeRequest *request,
                                                 ::omega_edit::v1::GetContentTypeResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    if (request->offset() < 0) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
     }
 
-    session_manager_.touch_session(request->session_id());
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
+        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    }
+    auto *session = locked_session.session();
+
     if (request->length() <= 0) {
         response->set_session_id(request->session_id());
         response->set_offset(request->offset());
@@ -1033,12 +1079,16 @@ grpc::Status EditorServiceImpl::GetContentType(grpc::ServerContext * /*context*/
 grpc::Status EditorServiceImpl::GetLanguage(grpc::ServerContext * /*context*/,
                                              const ::omega_edit::v1::GetLanguageRequest *request,
                                              ::omega_edit::v1::GetLanguageResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    if (request->offset() < 0) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
     }
 
-    session_manager_.touch_session(request->session_id());
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
+        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    }
+    auto *session = locked_session.session();
+
     if (request->length() <= 0) {
         response->set_session_id(request->session_id());
         response->set_offset(request->offset());
@@ -1076,12 +1126,12 @@ grpc::Status EditorServiceImpl::GetLanguage(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::GetCount(grpc::ServerContext * /*context*/,
                                           const ::omega_edit::v1::GetCountRequest *request,
                                           ::omega_edit::v1::GetCountResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->session_id());
     response->set_session_id(request->session_id());
 
     for (int i = 0; i < request->kind_size(); ++i) {
@@ -1090,6 +1140,9 @@ grpc::Status EditorServiceImpl::GetCount(grpc::ServerContext * /*context*/,
         switch (kind) {
             case ::omega_edit::v1::COUNT_KIND_COMPUTED_FILE_SIZE:
                 count_value = omega_session_get_computed_file_size(session);
+                if (count_value < 0) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL, "computed file size overflow");
+                }
                 break;
             case ::omega_edit::v1::COUNT_KIND_CHANGES:
                 count_value = omega_session_get_num_changes(session);
@@ -1135,12 +1188,16 @@ grpc::Status EditorServiceImpl::GetSessionCount(grpc::ServerContext * /*context*
 grpc::Status EditorServiceImpl::GetSegment(grpc::ServerContext * /*context*/,
                                             const ::omega_edit::v1::GetSegmentRequest *request,
                                             ::omega_edit::v1::GetSegmentResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    if (request->offset() < 0) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
     }
 
-    session_manager_.touch_session(request->session_id());
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
+        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    }
+    auto *session = locked_session.session();
+
     if (request->length() <= 0) {
         response->set_session_id(request->session_id());
         response->set_offset(request->offset());
@@ -1175,22 +1232,34 @@ grpc::Status EditorServiceImpl::GetSegment(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::SearchSession(grpc::ServerContext * /*context*/,
                                                const ::omega_edit::v1::SearchSessionRequest *request,
                                                ::omega_edit::v1::SearchSessionResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-
-    session_manager_.touch_session(request->session_id());
     bool case_insensitive = request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
     bool is_reverse = request->has_is_reverse() ? request->is_reverse() : false;
     int64_t offset = request->has_offset() ? request->offset() : 0;
     int64_t length = request->has_length() ? request->length() : 0;
     int64_t limit = request->has_limit() ? request->limit() : 0; // 0 = no limit
+    std::vector<int64_t> match_offsets;
 
-    auto *ctx = omega_search_create_context_bytes(
-        session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
-        static_cast<int64_t>(request->pattern().size()), offset, length, case_insensitive ? 1 : 0,
-        is_reverse ? 1 : 0);
+    {
+        auto locked_session = session_manager_.lock_session(request->session_id());
+        if (!locked_session) {
+            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+        }
+        auto *session = locked_session.session();
+
+        auto *ctx = omega_search_create_context_bytes(
+            session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+            static_cast<int64_t>(request->pattern().size()), offset, length, case_insensitive ? 1 : 0,
+            is_reverse ? 1 : 0);
+
+        if (ctx) {
+            int64_t num_matches = 0;
+            while ((limit <= 0 || num_matches < limit) && omega_search_next_match(ctx, 1) > 0) {
+                match_offsets.push_back(omega_search_context_get_match_offset(ctx));
+                ++num_matches;
+            }
+            omega_search_destroy_context(ctx);
+        }
+    }
 
     response->set_session_id(request->session_id());
     response->set_pattern(request->pattern());
@@ -1198,14 +1267,8 @@ grpc::Status EditorServiceImpl::SearchSession(grpc::ServerContext * /*context*/,
     response->set_is_reverse(is_reverse);
     response->set_offset(offset);
     response->set_length(length);
-
-    if (ctx) {
-        int64_t num_matches = 0;
-        while ((limit <= 0 || num_matches < limit) && omega_search_next_match(ctx, 1) > 0) {
-            response->add_match_offset(omega_search_context_get_match_offset(ctx));
-            ++num_matches;
-        }
-        omega_search_destroy_context(ctx);
+    for (const auto match_offset : match_offsets) {
+        response->add_match_offset(match_offset);
     }
 
     return grpc::Status::OK;
@@ -1214,12 +1277,16 @@ grpc::Status EditorServiceImpl::SearchSession(grpc::ServerContext * /*context*/,
 grpc::Status EditorServiceImpl::ReplaceSession(grpc::ServerContext * /*context*/,
                                                const ::omega_edit::v1::ReplaceSessionRequest *request,
                                                ::omega_edit::v1::ReplaceSessionResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    {
+        auto locked_session = session_manager_.lock_session(request->session_id());
+        if (!locked_session) {
+            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+        }
     }
+    // Lock released intentionally: validation runs without holding core_mutex to avoid blocking other
+    // handlers during potentially long payload and size checks. The second lock_session below
+    // re-acquires for mutation and returns NOT_FOUND if the session was destroyed in this window.
 
-    session_manager_.touch_session(request->session_id());
     const bool case_insensitive =
             request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
     const bool is_reverse = request->has_is_reverse() ? request->is_reverse() : false;
@@ -1232,14 +1299,6 @@ grpc::Status EditorServiceImpl::ReplaceSession(grpc::ServerContext * /*context*/
     if (offset < 0 || length < 0 || limit < 0) {
         return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                             "replace offset, length, and limit must be non-negative");
-    }
-
-    const auto session_size = omega_session_get_computed_file_size(session);
-    if (offset > session_size) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "replace offset " + std::to_string(offset) +
-                                    " exceeds session size " + std::to_string(session_size) +
-                                    " for session: " + request->session_id());
     }
 
     const auto payload_status = validate_replace_payload_sizes(request->pattern(), request->replacement(),
@@ -1264,25 +1323,46 @@ grpc::Status EditorServiceImpl::ReplaceSession(grpc::ServerContext * /*context*/
                             "replace pattern must not be empty for session: " + request->session_id());
     }
 
-    if (omega_session_changes_paused(session) != 0) {
-        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                            "replace requires active session changes for session: " + request->session_id());
-    }
-
     int64_t replacement_count = 0;
     int64_t delete_count = 0;
     int64_t insert_count = 0;
     int64_t overwrite_count = 0;
-    const auto rc = omega_edit_replace_matches_bytes(
-            session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
-            static_cast<int64_t>(request->pattern().size()),
-            reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
-            static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0,
-            is_reverse ? 1 : 0, offset, length, limit, front_to_back ? 1 : 0, overwrite_only ? 1 : 0,
-            &replacement_count, &delete_count, &insert_count, &overwrite_count);
-    if (rc != 0) {
-        return grpc::Status(grpc::StatusCode::INTERNAL,
-                            "replace failed for session: " + request->session_id());
+
+    {
+        auto locked_session = session_manager_.lock_session(request->session_id());
+        if (!locked_session) {
+            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+        }
+        auto *session = locked_session.session();
+
+        const auto session_size = omega_session_get_computed_file_size(session);
+        if (session_size < 0) {
+            return grpc::Status(grpc::StatusCode::INTERNAL,
+                                "failed to compute session size for session: " + request->session_id());
+        }
+        if (offset > session_size) {
+            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                "replace offset " + std::to_string(offset) +
+                                        " exceeds session size " + std::to_string(session_size) +
+                                        " for session: " + request->session_id());
+        }
+
+        if (omega_session_changes_paused(session) != 0) {
+            return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                "replace requires active session changes for session: " + request->session_id());
+        }
+
+        const auto rc = omega_edit_replace_matches_bytes(
+                session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+                static_cast<int64_t>(request->pattern().size()),
+                reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
+                static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0,
+                is_reverse ? 1 : 0, offset, length, limit, front_to_back ? 1 : 0, overwrite_only ? 1 : 0,
+                &replacement_count, &delete_count, &insert_count, &overwrite_count);
+        if (rc != 0) {
+            return grpc::Status(grpc::StatusCode::INTERNAL,
+                                "replace failed for session: " + request->session_id());
+        }
     }
 
     response->set_replacement_count(replacement_count);
@@ -1296,12 +1376,16 @@ grpc::Status EditorServiceImpl::ReplaceSessionCheckpointed(
         grpc::ServerContext * /*context*/,
         const ::omega_edit::v1::ReplaceSessionCheckpointedRequest *request,
         ::omega_edit::v1::ReplaceSessionCheckpointedResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    {
+        auto locked_session = session_manager_.lock_session(request->session_id());
+        if (!locked_session) {
+            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+        }
     }
+    // Lock released intentionally: validation runs without holding core_mutex to avoid blocking other
+    // handlers during potentially long payload and size checks. The second lock_session below
+    // re-acquires for mutation and returns NOT_FOUND if the session was destroyed in this window.
 
-    session_manager_.touch_session(request->session_id());
     const bool case_insensitive =
             request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
     const int64_t offset = request->has_offset() ? request->offset() : 0;
@@ -1312,47 +1396,59 @@ grpc::Status EditorServiceImpl::ReplaceSessionCheckpointed(
                             "checkpointed replace offset and length must be non-negative");
     }
 
-    const auto session_size = omega_session_get_computed_file_size(session);
-    if (offset > session_size) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "checkpointed replace offset " + std::to_string(offset) +
-                                    " exceeds session size " + std::to_string(session_size) +
-                                    " for session: " + request->session_id());
-    }
-
     const auto payload_status =
             validate_replace_checkpointed_payload_sizes(request, resource_limits_.max_change_bytes);
     if (!payload_status.ok()) {
         return payload_status;
     }
 
-    if (request->pattern().empty()) {
-        response->set_session_id(request->session_id());
-        response->set_pattern(request->pattern());
-        response->set_replacement(request->replacement());
-        response->set_is_case_insensitive(case_insensitive);
-        response->set_offset(offset);
-        response->set_length(length);
-        response->set_replacement_count(0);
-        return grpc::Status::OK;
-    }
-
-    if (omega_session_changes_paused(session) != 0) {
-        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                            "checkpointed replace requires active session changes for session: " +
-                                    request->session_id());
-    }
-
     int64_t replacement_count = 0;
-    const auto rc = omega_edit_replace_all_bytes(
-            session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
-            static_cast<int64_t>(request->pattern().size()),
-            reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
-            static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0, offset, length,
-            &replacement_count);
-    if (rc != 0) {
-        return grpc::Status(grpc::StatusCode::INTERNAL,
-                            "checkpointed replace failed for session: " + request->session_id());
+    {
+        auto locked_session = session_manager_.lock_session(request->session_id());
+        if (!locked_session) {
+            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+        }
+        auto *session = locked_session.session();
+
+        const auto session_size = omega_session_get_computed_file_size(session);
+        if (session_size < 0) {
+            return grpc::Status(grpc::StatusCode::INTERNAL,
+                                "failed to compute session size for session: " + request->session_id());
+        }
+        if (offset > session_size) {
+            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                "checkpointed replace offset " + std::to_string(offset) +
+                                        " exceeds session size " + std::to_string(session_size) +
+                                        " for session: " + request->session_id());
+        }
+
+        if (request->pattern().empty()) {
+            response->set_session_id(request->session_id());
+            response->set_pattern(request->pattern());
+            response->set_replacement(request->replacement());
+            response->set_is_case_insensitive(case_insensitive);
+            response->set_offset(offset);
+            response->set_length(length);
+            response->set_replacement_count(0);
+            return grpc::Status::OK;
+        }
+
+        if (omega_session_changes_paused(session) != 0) {
+            return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                "checkpointed replace requires active session changes for session: " +
+                                        request->session_id());
+        }
+
+        const auto rc = omega_edit_replace_all_bytes(
+                session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+                static_cast<int64_t>(request->pattern().size()),
+                reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
+                static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0, offset, length,
+                &replacement_count);
+        if (rc != 0) {
+            return grpc::Status(grpc::StatusCode::INTERNAL,
+                                "checkpointed replace failed for session: " + request->session_id());
+        }
     }
 
     response->set_session_id(request->session_id());
@@ -1369,12 +1465,12 @@ grpc::Status EditorServiceImpl::DestroyLastCheckpoint(
         grpc::ServerContext * /*context*/,
         const ::omega_edit::v1::DestroyLastCheckpointRequest *request,
         ::omega_edit::v1::DestroyLastCheckpointResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
     }
+    auto *session = locked_session.session();
 
-    session_manager_.touch_session(request->session_id());
     if (0 != omega_edit_destroy_last_checkpoint(session)) {
         return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "no checkpoint available to destroy");
     }
@@ -1389,19 +1485,21 @@ grpc::Status EditorServiceImpl::DestroyLastCheckpoint(
 grpc::Status EditorServiceImpl::GetByteFrequencyProfile(grpc::ServerContext * /*context*/,
                                                          const ::omega_edit::v1::GetByteFrequencyProfileRequest *request,
                                                          ::omega_edit::v1::GetByteFrequencyProfileResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-
-    session_manager_.touch_session(request->session_id());
     omega_byte_frequency_profile_t profile;
     std::memset(profile, 0, sizeof(profile));
 
-    int result = omega_session_byte_frequency_profile(session, &profile, request->offset(), request->length());
-    if (result != 0) {
-        return grpc::Status(grpc::StatusCode::UNKNOWN,
-                            "Profile function failed with error code: " + std::to_string(result));
+    {
+        auto locked_session = session_manager_.lock_session(request->session_id());
+        if (!locked_session) {
+            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+        }
+        auto *session = locked_session.session();
+
+        int result = omega_session_byte_frequency_profile(session, &profile, request->offset(), request->length());
+        if (result != 0) {
+            return grpc::Status(grpc::StatusCode::UNKNOWN,
+                                "Profile function failed with error code: " + std::to_string(result));
+        }
     }
 
     response->set_session_id(request->session_id());
@@ -1420,21 +1518,24 @@ grpc::Status EditorServiceImpl::GetByteFrequencyProfile(grpc::ServerContext * /*
 grpc::Status EditorServiceImpl::GetCharacterCounts(grpc::ServerContext * /*context*/,
                                                     const ::omega_edit::v1::GetCharacterCountsRequest *request,
                                                     ::omega_edit::v1::GetCharacterCountsResponse *response) {
-    auto *session = session_manager_.get_session(request->session_id());
-    if (!session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-
-    session_manager_.touch_session(request->session_id());
     omega_bom_t bom = omega_util_cstring_to_BOM(request->byte_order_mark().c_str());
     auto *counts = omega_character_counts_create();
     omega_character_counts_set_BOM(counts, bom);
 
-    int result = omega_session_character_counts(session, counts, request->offset(), request->length(), bom);
-    if (result != 0) {
-        omega_character_counts_destroy(counts);
-        return grpc::Status(grpc::StatusCode::UNKNOWN,
-                            "CharCount function failed with error code: " + std::to_string(result));
+    {
+        auto locked_session = session_manager_.lock_session(request->session_id());
+        if (!locked_session) {
+            omega_character_counts_destroy(counts);
+            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+        }
+        auto *session = locked_session.session();
+
+        int result = omega_session_character_counts(session, counts, request->offset(), request->length(), bom);
+        if (result != 0) {
+            omega_character_counts_destroy(counts);
+            return grpc::Status(grpc::StatusCode::UNKNOWN,
+                                "CharCount function failed with error code: " + std::to_string(result));
+        }
     }
 
     response->set_session_id(request->session_id());

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -495,9 +495,15 @@ std::string SessionManager::create_session(const std::string &file_path, const s
                 file_sessions_by_path_.erase(existing_file_session);
             } else if (checkpoint_directory.empty() || checkpoint_directory == existing->second->checkpoint_directory) {
                 auto &info = existing->second;
+                std::lock_guard<std::mutex> core_lock(info->core_mutex);
+                const auto computed_size = info->session ? omega_session_get_computed_file_size(info->session) : 0;
+                if (computed_size < 0) {
+                    if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                    return "";
+                }
                 ++info->attachment_count;
                 info->last_activity = std::chrono::steady_clock::now();
-                file_size_out = omega_session_get_computed_file_size(info->session);
+                file_size_out = computed_size;
                 checkpoint_dir_out = info->checkpoint_directory;
                 return info->session_id;
             } else {
@@ -571,6 +577,17 @@ std::string SessionManager::create_session(const std::string &file_path, const s
 
     info->session = session;
     file_size_out = omega_session_get_computed_file_size(session);
+    if (file_size_out < 0) {
+        omega_edit_destroy_session(session);
+        info->session = nullptr;
+        if (info->owns_checkpoint_directory) {
+            cleanup_directory_best_effort(info->checkpoint_directory);
+        }
+        sessions_.erase(session_id);
+        cleanup_managed_server_root_if_empty();
+        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+        return "";
+    }
 
     const char *chkpt = omega_session_get_checkpoint_directory(session);
     checkpoint_dir_out = chkpt ? chkpt : "";
@@ -587,6 +604,7 @@ std::string SessionManager::create_session(const std::string &file_path, const s
 
 bool SessionManager::destroy_session_locked(const std::map<std::string, std::shared_ptr<SessionInfo>>::iterator &it) {
     auto &info = it->second;
+    std::lock_guard<std::mutex> core_lock(info->core_mutex);
 
     // Close event queues
     {
@@ -604,11 +622,15 @@ bool SessionManager::destroy_session_locked(const std::map<std::string, std::sha
         if (vp.second->event_queue) {
             vp.second->event_queue->close();
         }
+        vp.second->viewport = nullptr;
         // Viewports are destroyed when session is destroyed
     }
 
     // Destroy the session (this also destroys all viewports)
-    omega_edit_destroy_session(info->session);
+    if (info->session) {
+        omega_edit_destroy_session(info->session);
+        info->session = nullptr;
+    }
     if (info->owns_checkpoint_directory) {
         cleanup_directory_best_effort(info->checkpoint_directory);
     }
@@ -655,6 +677,21 @@ omega_session_t *SessionManager::get_session(const std::string &session_id) {
     return (it != sessions_.end()) ? it->second->session : nullptr;
 }
 
+LockedSession SessionManager::lock_session(const std::string &session_id) {
+    std::shared_ptr<SessionInfo> info;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = sessions_.find(session_id);
+        if (it == sessions_.end()) { return {}; }
+        info = it->second;
+        info->last_activity = std::chrono::steady_clock::now();
+    }
+
+    std::unique_lock<std::mutex> core_lock(info->core_mutex);
+    if (info->session == nullptr) { return {}; }
+    return LockedSession{std::move(info), std::move(core_lock)};
+}
+
 int64_t SessionManager::session_count() const {
     std::lock_guard<std::mutex> lock(mutex_);
     return static_cast<int64_t>(sessions_.size());
@@ -679,6 +716,7 @@ std::string SessionManager::create_viewport(const std::string &session_id, int64
     }
 
     auto &session_info = sit->second;
+    session_info->last_activity = std::chrono::steady_clock::now();
     std::string viewport_id = desired_viewport_id;
     if (viewport_id.empty()) {
         do {
@@ -706,9 +744,16 @@ std::string SessionManager::create_viewport(const std::string &session_id, int64
         "viewport subscription '" + make_viewport_fqid(session_id, viewport_id) + "'");
     vp_info->event_interest = 0;
 
-    // Store first so callback has access
+    // Store first so the viewport CREATE callback can find its queue. lock_viewport treats a null viewport as missing
+    // until omega_edit_create_viewport publishes the core pointer below.
     session_info->viewports[viewport_id] = vp_info;
 
+    std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
+    if (session_info->session == nullptr) {
+        session_info->viewports.erase(viewport_id);
+        if (error_out) *error_out = ViewportCreateError::SESSION_NOT_FOUND;
+        return "";
+    }
     omega_viewport_t *viewport = omega_edit_create_viewport(session_info->session, offset, capacity,
                                                             is_floating ? 1 : 0, viewport_event_callback,
                                                             vp_info.get(), 0);
@@ -731,15 +776,18 @@ bool SessionManager::destroy_viewport(const std::string &session_id, const std::
     if (sit == sessions_.end()) return false;
 
     auto &session_info = sit->second;
+    session_info->last_activity = std::chrono::steady_clock::now();
     auto vit = session_info->viewports.find(viewport_id);
     if (vit == session_info->viewports.end()) return false;
 
     auto &vp_info = vit->second;
+    std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
     if (vp_info->event_queue) {
         vp_info->event_queue->close();
     }
 
-    omega_edit_destroy_viewport(vp_info->viewport);
+    if (vp_info->viewport) { omega_edit_destroy_viewport(vp_info->viewport); }
+    vp_info->viewport = nullptr;
     session_info->viewports.erase(vit);
     return true;
 }
@@ -755,6 +803,27 @@ omega_viewport_t *SessionManager::get_viewport(const std::string &session_id, co
 }
 
 // ── Event subscription ───────────────────────────────────────────────────────
+LockedViewport SessionManager::lock_viewport(const std::string &session_id, const std::string &viewport_id) {
+    std::shared_ptr<SessionInfo> info;
+    std::shared_ptr<ViewportInfo> viewport_info;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto sit = sessions_.find(session_id);
+        if (sit == sessions_.end()) { return {}; }
+
+        auto vit = sit->second->viewports.find(viewport_id);
+        if (vit == sit->second->viewports.end()) { return {}; }
+
+        info = sit->second;
+        viewport_info = vit->second;
+        info->last_activity = std::chrono::steady_clock::now();
+    }
+
+    std::unique_lock<std::mutex> core_lock(info->core_mutex);
+    if (info->session == nullptr || viewport_info->viewport == nullptr) { return {}; }
+    return LockedViewport{std::move(info), std::move(viewport_info), std::move(core_lock)};
+}
+
 std::shared_ptr<EventQueue<SessionEventData>>
 SessionManager::subscribe_session_events(const std::string &session_id, int32_t interest) {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -766,11 +835,14 @@ SessionManager::subscribe_session_events(const std::string &session_id, int32_t 
     auto queue = std::make_shared<EventQueue<SessionEventData>>(
         limits_.session_event_queue_capacity,
         "session subscription '" + session_id + "#" + generate_subscription_id() + "'");
+    int32_t combined_interest = 0;
     {
         std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
         info->session_subscriptions.push_back({queue, interest});
-        omega_session_set_event_interest(info->session, combine_session_event_interest(info->session_subscriptions));
+        combined_interest = combine_session_event_interest(info->session_subscriptions);
     }
+    std::lock_guard<std::mutex> core_lock(info->core_mutex);
+    if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
     return queue;
 }
 
@@ -790,8 +862,9 @@ void SessionManager::unsubscribe_session_events(const std::string &session_id) {
             }
         }
         info->session_subscriptions.clear();
-        omega_session_set_event_interest(info->session, 0);
     }
+    std::lock_guard<std::mutex> core_lock(info->core_mutex);
+    if (info->session) { omega_session_set_event_interest(info->session, 0); }
 
     for (const auto &queue : removed_queues) {
         queue->clear();
@@ -808,6 +881,7 @@ void SessionManager::unsubscribe_session_events(const std::string &session_id,
 
     auto &info = it->second;
     bool removed = false;
+    int32_t combined_interest = 0;
     {
         std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
         auto &subscriptions = info->session_subscriptions;
@@ -816,10 +890,12 @@ void SessionManager::unsubscribe_session_events(const std::string &session_id,
                                                const bool matches = subscription.event_queue == queue;
                                                removed = removed || matches;
                                                return matches;
-                                           }),
+                                            }),
                             subscriptions.end());
-        omega_session_set_event_interest(info->session, combine_session_event_interest(subscriptions));
+        combined_interest = combine_session_event_interest(subscriptions);
     }
+    std::lock_guard<std::mutex> core_lock(info->core_mutex);
+    if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
 
     if (removed) {
         queue->clear();
@@ -840,7 +916,8 @@ SessionManager::subscribe_viewport_events(const std::string &session_id, const s
 
     auto &vp_info = vit->second;
     vp_info->event_interest = interest;
-    omega_viewport_set_event_interest(vp_info->viewport, interest);
+    std::lock_guard<std::mutex> core_lock(sit->second->core_mutex);
+    if (vp_info->viewport) { omega_viewport_set_event_interest(vp_info->viewport, interest); }
     return vp_info->event_queue;
 }
 
@@ -855,7 +932,8 @@ void SessionManager::unsubscribe_viewport_events(const std::string &session_id, 
 
     auto &vp_info = vit->second;
     vp_info->event_interest = 0;
-    omega_viewport_set_event_interest(vp_info->viewport, 0);
+    std::lock_guard<std::mutex> core_lock(sit->second->core_mutex);
+    if (vp_info->viewport) { omega_viewport_set_event_interest(vp_info->viewport, 0); }
     if (vp_info->event_queue) {
         vp_info->event_queue->clear();
     }
@@ -866,6 +944,7 @@ void SessionManager::destroy_all() {
 
     for (auto &pair : sessions_) {
         auto &info = pair.second;
+        std::lock_guard<std::mutex> core_lock(info->core_mutex);
         {
             std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
             for (auto &subscription : info->session_subscriptions) {
@@ -875,8 +954,12 @@ void SessionManager::destroy_all() {
         }
         for (auto &vp : info->viewports) {
             if (vp.second->event_queue) vp.second->event_queue->close();
+            vp.second->viewport = nullptr;
         }
-        omega_edit_destroy_session(info->session);
+        if (info->session) {
+            omega_edit_destroy_session(info->session);
+            info->session = nullptr;
+        }
         if (info->owns_checkpoint_directory) {
             cleanup_directory_best_effort(info->checkpoint_directory);
         }

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -147,7 +147,7 @@ struct SessionEventSubscriptionInfo {
 
 /// Information about a viewport managed by the session manager
 struct ViewportInfo {
-    omega_viewport_t *viewport;
+    omega_viewport_t *viewport{};
     std::string session_id;
     std::string viewport_id;
     std::shared_ptr<EventQueue<ViewportEventData>> event_queue;
@@ -156,7 +156,7 @@ struct ViewportInfo {
 
 /// Information about a session managed by the session manager
 struct SessionInfo {
-    omega_session_t *session;
+    omega_session_t *session{};
     std::string session_id;
     std::string canonical_file_path;
     std::string checkpoint_directory;
@@ -165,9 +165,28 @@ struct SessionInfo {
     // after the last attachment detaches.
     size_t attachment_count{0};
     std::map<std::string, std::shared_ptr<ViewportInfo>> viewports;
+    // Serializes all access to the underlying non-thread-safe omega_session_t and its viewports.
+    std::mutex core_mutex;
     std::mutex session_subscription_mutex;
     std::vector<SessionEventSubscriptionInfo> session_subscriptions;
     std::chrono::steady_clock::time_point last_activity;
+};
+
+struct LockedSession {
+    std::shared_ptr<SessionInfo> info;
+    std::unique_lock<std::mutex> lock;
+
+    omega_session_t *session() const { return info ? info->session : nullptr; }
+    explicit operator bool() const { return session() != nullptr; }
+};
+
+struct LockedViewport {
+    std::shared_ptr<SessionInfo> info;
+    std::shared_ptr<ViewportInfo> viewport_info;
+    std::unique_lock<std::mutex> lock;
+
+    omega_viewport_t *viewport() const { return viewport_info ? viewport_info->viewport : nullptr; }
+    explicit operator bool() const { return viewport() != nullptr; }
 };
 
 /// Error codes returned by SessionManager::create_session
@@ -203,6 +222,7 @@ public:
     bool destroy_session(const std::string &session_id);
     bool detach_session(const std::string &session_id);
     omega_session_t *get_session(const std::string &session_id);
+    LockedSession lock_session(const std::string &session_id);
     int64_t session_count() const;
 
     // Viewport lifecycle
@@ -211,6 +231,7 @@ public:
                                 ViewportCreateError *error_out = nullptr);
     bool destroy_viewport(const std::string &session_id, const std::string &viewport_id);
     omega_viewport_t *get_viewport(const std::string &session_id, const std::string &viewport_id);
+    LockedViewport lock_viewport(const std::string &session_id, const std::string &viewport_id);
 
     // Event subscription
     std::shared_ptr<EventQueue<SessionEventData>> subscribe_session_events(const std::string &session_id,


### PR DESCRIPTION
## Summary

This PR hardens the core edit model and the C++ gRPC server concurrency path.

- Adds shared `omega_edit::internal` safe int64 arithmetic helpers and applies overflow checks across segment/model/search/viewport/save paths.
- Guards computed file size overflow responses in the server instead of returning `-1` to clients.
- Cleans up checkpoint/output file failure handling.
- Serializes non-thread-safe core session access behind per-session RAII locks in the gRPC server.
- Narrows lock scopes for search, replace, byte-frequency, and character-count handlers where results can be copied before response construction.
- Fixes session event subscription interest-mask calculation under the subscription mutex.
- Replaces the previous `length >= INT64_MAX` insert/overwrite guard with an explicit `length + 1` allocation overflow check.
- Adds overflow-boundary regression tests for safe math, edit, search, session analysis, and viewport range handling.

## Why

The core library was already designed around large-file editing, but several offset and length additions could overflow in extreme cases. The gRPC server also exposed one `omega_session_t` to concurrent requests for the same session without serializing access to the non-thread-safe core structures.

## Validation

- Built `omega_edit` Debug target.
- Built `edge_case_tests` Debug target.
- Built `omega-edit-grpc-server` Release target.
- Ran `build\core\src\tests\Debug\edge_case_tests.exe`.
- Ran `build\core\src\tests\Debug\session_tests.exe`.
- Ran `build\core\src\tests\Debug\omegaEdit_tests.exe`.
- Ran `build\core\src\tests\Debug\viewport_stress_tests.exe`.
- Ran `git diff --check`.

MSVC still reports existing int64-to-long warnings in file I/O call sites; no build failures.