### PR TITLE
More efficient memory management for search performance

### DIFF
--- a/core/src/lib/impl_/search_context_def.h
+++ b/core/src/lib/impl_/search_context_def.h
@@ -27,6 +27,8 @@ struct omega_search_context_struct {
     int64_t match_offset{};
     omega_util_byte_transform_t byte_transform{};
     omega_data_t pattern{};
+    omega_data_t scratch_buffer{};
+    int64_t scratch_capacity{};
 };
 
 #endif//OMEGA_EDIT_SEARCH_CONTEXT_DEF_H

--- a/core/src/lib/search.cpp
+++ b/core/src/lib/search.cpp
@@ -188,7 +188,6 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
             int64_t session_end = 0;
             if (!safe_add_int64_(search_context_ptr->session_offset, search_context_ptr->session_length,
                                  session_end)) {
-                omega_data_destroy_(&data_segment.data, data_segment.capacity);
                 return 0;
             }
             if (is_begin) {
@@ -198,14 +197,12 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
                 if (!safe_add_int64_(data_segment.capacity, advance_context, rewind) ||
                     !safe_add_int64_(search_context_ptr->match_offset, -rewind, data_segment.offset) ||
                     !safe_add_int64_(data_segment.offset, 1, data_segment.offset)) {
-                    omega_data_destroy_(&data_segment.data, data_segment.capacity);
                     return 0;
                 }
             }
         } else {
             int64_t next_offset = 0;
             if (!is_begin && !safe_add_int64_(search_context_ptr->match_offset, advance_context, next_offset)) {
-                omega_data_destroy_(&data_segment.data, data_segment.capacity);
                 return 0;
             }
             data_segment.offset =

--- a/core/src/lib/search.cpp
+++ b/core/src/lib/search.cpp
@@ -174,8 +174,13 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
         // Stride size is how far we can slide the search window after the previous window has been searched.
         const auto stride_size = 1 + data_segment.capacity - search_context_ptr->pattern_length;
 
-        // Initialize the data segment to search.
-        omega_data_create_(&data_segment.data, data_segment.capacity);
+        // Reuse scratch buffer if available and large enough
+        if (search_context_ptr->scratch_capacity < data_segment.capacity) {
+            omega_data_destroy_(&search_context_ptr->scratch_buffer, search_context_ptr->scratch_capacity);
+            omega_data_create_(&search_context_ptr->scratch_buffer, data_segment.capacity);
+            search_context_ptr->scratch_capacity = data_segment.capacity;
+        }
+        data_segment.data = search_context_ptr->scratch_buffer;
 
         // Determine the offset to start the search from. It depends on the direction of the search and
         // whether we are beginning a new search or continuing an old one.
@@ -224,13 +229,11 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
             // Try to find the pattern in the current segment.
             if (auto *found = omega_find(segment_data_ptr, data_segment.length, search_context_ptr->skip_table_ptr,
                                          pattern, search_context_ptr->pattern_length)) {
-                // If a match is found, destroy the data segment and update the match offset in the search context.
+                // If a match is found, update the match offset in the search context.
                 const auto found_offset = static_cast<int64_t>(found - segment_data_ptr);
                 if (!safe_add_int64_(data_segment.offset, found_offset, search_context_ptr->match_offset)) {
-                    omega_data_destroy_(&data_segment.data, data_segment.capacity);
                     return 0;
                 }
-                omega_data_destroy_(&data_segment.data, data_segment.capacity);
                 return 1;
             }
 
@@ -241,10 +244,9 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
                 break;
             }
 
-        } while (MAX_SEGMENT_LENGTH == data_segment.length);
-
-        // Destroy the data segment if no match was found.
-        omega_data_destroy_(&data_segment.data, data_segment.capacity);
+                } while (MAX_SEGMENT_LENGTH == data_segment.length);
+ 
+        // Scratch buffer is managed by the context and destroyed in omega_search_destroy_context.
     }
 
     // If no match was found after searching the entire length, set the match offset to the last offset.
@@ -264,6 +266,7 @@ void omega_search_destroy_context(omega_search_context_t *const search_context_p
                     omega_find_destroy_skip_table(search_context_ptr->skip_table_ptr);
                     search_context_ptr->skip_table_ptr = nullptr;
                 }
+                omega_data_destroy_(&search_context_ptr->scratch_buffer, search_context_ptr->scratch_capacity);
                 search_context_ptr->session_ptr->search_contexts_.erase(std::next(iter).base());
                 break;
             }

--- a/core/src/lib/search.cpp
+++ b/core/src/lib/search.cpp
@@ -174,10 +174,12 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
         // Stride size is how far we can slide the search window after the previous window has been searched.
         const auto stride_size = 1 + data_segment.capacity - search_context_ptr->pattern_length;
 
-        // Reuse scratch buffer if available and large enough
+        // Reuse scratch buffer if available and large enough.
         if (search_context_ptr->scratch_capacity < data_segment.capacity) {
+            omega_data_t scratch_buffer{};
+            omega_data_create_(&scratch_buffer, data_segment.capacity);
             omega_data_destroy_(&search_context_ptr->scratch_buffer, search_context_ptr->scratch_capacity);
-            omega_data_create_(&search_context_ptr->scratch_buffer, data_segment.capacity);
+            search_context_ptr->scratch_buffer = scratch_buffer;
             search_context_ptr->scratch_capacity = data_segment.capacity;
         }
         data_segment.data = search_context_ptr->scratch_buffer;
@@ -241,8 +243,8 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
                 break;
             }
 
-                } while (MAX_SEGMENT_LENGTH == data_segment.length);
- 
+        } while (MAX_SEGMENT_LENGTH == data_segment.length);
+
         // Scratch buffer is managed by the context and destroyed in omega_search_destroy_context.
     }
 
@@ -251,7 +253,6 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
 
     return 0;
 }
-
 
 void omega_search_destroy_context(omega_search_context_t *const search_context_ptr) {
     if (search_context_ptr) {


### PR DESCRIPTION
- [x] Inspect the linked review comment and identify the exact requested suggestion
- [x] Run existing build/test commands to establish baseline before edits
- [x] Apply only the requested change from the review suggestion
- [x] Run targeted validation for the changed area
- [x] Run final automated validation and report completion