### PR TITLE
Add transform plugin foundation

### DIFF
--- a/.github/workflows/build-middleware/action.yml
+++ b/.github/workflows/build-middleware/action.yml
@@ -50,12 +50,13 @@ runs:
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_SHARED_LIBS=OFF \
           -DBUILD_DOCS=OFF \
-          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_EXAMPLES=ON \
           -DBUILD_TESTS=OFF
         cmake --build _build_core --config Release
         cmake --install _build_core/packages/core --prefix "$(pwd)/_install_core" --config Release
         echo "OE_LIB_DIR=$(pwd)/_install_core/lib" >> $GITHUB_ENV
         echo "OE_PREFIX=$(pwd)/_install_core" >> $GITHUB_ENV
+        echo "OMEGA_EDIT_TEST_PLUGIN_DIR=$(pwd)/_build_core/packages/core/src/tests/plugins" >> $GITHUB_ENV
 
     - name: Setup Python 🐍
       uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,10 +222,11 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_DOCS=OFF \
-            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_EXAMPLES=ON \
             -DBUILD_TESTS=OFF
           cmake --build _build_core --config Release
           cmake --install _build_core/packages/core --prefix "$(pwd)/_install_core" --config Release
+          echo "OMEGA_EDIT_TEST_PLUGIN_DIR=$(pwd)/_build_core/packages/core/src/tests/plugins" >> $GITHUB_ENV
           export OE_LIB_DIR="$(pwd)/_install_core/lib"
           export OE_PREFIX="$(pwd)/_install_core"
           cd server/cpp

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ For an installed package instead of a source checkout, use the Codex MCP format 
 - machine-readable CLI and MCP responses are easier for agents to consume than terminal scraping
 - the same primitives work for both human-operated scripts and agent-hosted tool calls
 
+## Transform Plugins
+
+OmegaEdit can discover native transform plugins from `.so`, `.dylib`, and `.dll` files. Plugins can replace a selected range, expand or shrink content, or inspect a range and return a result such as a checksum or hash. The shipped examples include one-for-one transforms, base64 encode/decode, zlib stored-block compress/decompress, expansion/shrink behavior, and inspect-only results. See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the ABI, SDK helpers, plugin directory layout, server registration options, and exemplar plugins.
+
 ## User documentation
 
 User documentation is published to https://ctc-oss.github.io/omega-edit/.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -80,7 +80,7 @@ set_target_properties(omega_edit PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION
 target_include_directories(omega_edit PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>")
 target_compile_definitions(omega_edit PUBLIC "$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:OMEGA_EDIT_STATIC_DEFINE>")
 target_compile_definitions(omega_edit PRIVATE "$<$<CONFIG:Debug>:DEBUG>")
-target_link_libraries(omega_edit PRIVATE ${FILESYSTEM_LIB})
+target_link_libraries(omega_edit PRIVATE ${FILESYSTEM_LIB} ${CMAKE_DL_LIBS})
 
 # Version definitions
 string(TOUPPER "${PROJECT_NAME}" PREFIX)
@@ -96,6 +96,41 @@ if (BUILD_EXAMPLES)
         add_executable(${example_name} ${example_src})
         target_link_libraries(${example_name} PRIVATE omega_edit::omega_edit ${FILESYSTEM_LIB})
     endforeach ()
+endif ()
+
+if (BUILD_EXAMPLES OR BUILD_TESTS)
+    set(OMEGA_EDIT_TRANSFORM_PLUGIN_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/src/tests/plugins")
+    set(OMEGA_EDIT_TRANSFORM_PLUGIN_TARGETS)
+    foreach (plugin_src
+            src/plugins/base64_decode.c
+            src/plugins/base64_encode.c
+            src/plugins/fnv1a64.c
+            src/plugins/zlib_compress.c
+            src/plugins/zlib_decompress.c
+            src/plugins/xor_ff.c
+            src/plugins/repeat.c
+            src/plugins/checksum8.c)
+        get_filename_component(plugin_name ${plugin_src} NAME_WE)
+        set(plugin_target "omega_transform_${plugin_name}")
+        add_library(${plugin_target} MODULE ${plugin_src})
+        target_include_directories(${plugin_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/include")
+        set_target_properties(
+                ${plugin_target} PROPERTIES
+                PREFIX ""
+                RUNTIME_OUTPUT_DIRECTORY "${OMEGA_EDIT_TRANSFORM_PLUGIN_OUTPUT_DIR}"
+                LIBRARY_OUTPUT_DIRECTORY "${OMEGA_EDIT_TRANSFORM_PLUGIN_OUTPUT_DIR}"
+                RUNTIME_OUTPUT_DIRECTORY_DEBUG "${OMEGA_EDIT_TRANSFORM_PLUGIN_OUTPUT_DIR}"
+                LIBRARY_OUTPUT_DIRECTORY_DEBUG "${OMEGA_EDIT_TRANSFORM_PLUGIN_OUTPUT_DIR}"
+                RUNTIME_OUTPUT_DIRECTORY_RELEASE "${OMEGA_EDIT_TRANSFORM_PLUGIN_OUTPUT_DIR}"
+                LIBRARY_OUTPUT_DIRECTORY_RELEASE "${OMEGA_EDIT_TRANSFORM_PLUGIN_OUTPUT_DIR}"
+        )
+        list(APPEND OMEGA_EDIT_TRANSFORM_PLUGIN_TARGETS ${plugin_target})
+    endforeach ()
+    add_custom_target(omega_edit_transform_plugins DEPENDS ${OMEGA_EDIT_TRANSFORM_PLUGIN_TARGETS})
+
+    add_executable(omega-transform-plugin-harness src/tools/transform_plugin_harness.cpp)
+    target_link_libraries(omega-transform-plugin-harness PRIVATE omega_edit::omega_edit ${FILESYSTEM_LIB})
+    add_dependencies(omega-transform-plugin-harness omega_edit_transform_plugins)
 endif ()
 
 # Tests

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -199,6 +199,27 @@ typedef struct {
 } omega_edit_script_op_t;
 
 /**
+ * Built-in byte transform kinds.
+ */
+typedef enum {
+    OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER = 1,
+    OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER = 2,
+    OMEGA_EDIT_TRANSFORM_BITWISE_AND = 3,
+    OMEGA_EDIT_TRANSFORM_BITWISE_OR = 4,
+    OMEGA_EDIT_TRANSFORM_BITWISE_XOR = 5
+} omega_edit_transform_kind_t;
+
+/**
+ * A built-in byte transform description.
+ *
+ * `operand` is used by bitwise transform kinds and ignored by ASCII case transform kinds.
+ */
+typedef struct {
+    omega_edit_transform_kind_t kind;
+    omega_byte_t operand;
+} omega_edit_transform_t;
+
+/**
  * Delete a number of bytes at the given offset
  * @param session_ptr session to make the change in
  * @param offset location offset to make the change
@@ -422,6 +443,21 @@ int omega_edit_replace_all(omega_session_t *session_ptr, const char *pattern, in
  * @return zero on success and non-zero otherwise
  */
 int omega_edit_apply_script(omega_session_t *session_ptr, const omega_edit_script_op_t *ops, size_t op_count);
+
+/**
+ * Checkpoint and apply a built-in transform to bytes starting at the given offset up to the given length.
+ *
+ * This is a stable C API layer for common transform operations that higher-level clients and services can expose
+ * without requiring process-local callback functions. Use omega_edit_apply_transform for custom callback transforms.
+ *
+ * @param session_ptr session to transform
+ * @param transform built-in transform descriptor
+ * @param offset location offset to begin transforming bytes
+ * @param length number of bytes from the given offset to transform, or zero to transform through the end of session
+ * @return zero on success, non-zero otherwise
+ */
+int omega_edit_apply_builtin_transform(omega_session_t *session_ptr, omega_edit_transform_t transform, int64_t offset,
+                                       int64_t length);
 
 /**
  * Checkpoint and apply the given mask of the given mask type to the bytes starting at the given offset up to the given

--- a/core/src/include/omega_edit/transform.h
+++ b/core/src/include/omega_edit/transform.h
@@ -1,0 +1,134 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+ * implied.  See the License for the specific language governing permissions and limitations under the License.       *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+/**
+ * @file transform.h
+ * @brief Dynamic transform plugin ABI and registry functions.
+ */
+
+#ifndef OMEGA_EDIT_TRANSFORM_H
+#define OMEGA_EDIT_TRANSFORM_H
+
+#include "byte.h"
+#include "fwd_defs.h"
+
+#ifdef __cplusplus
+
+#include <cstddef>
+#include <cstdint>
+
+extern "C" {
+#else
+
+#include <stddef.h>
+#include <stdint.h>
+
+#endif
+
+#define OMEGA_TRANSFORM_PLUGIN_ABI_VERSION 1
+
+typedef enum {
+    OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE = 1,
+    OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT = 2,
+    OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT = 3
+} omega_transform_plugin_operation_t;
+
+typedef enum {
+    OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE = 1,
+    OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND = 1 << 1,
+    OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK = 1 << 2,
+    OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT = 1 << 3,
+    OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE = 1 << 4
+} omega_transform_plugin_flags_t;
+
+typedef struct {
+    uint32_t abi_version;
+    const char *id;
+    const char *name;
+    const char *description;
+    omega_transform_plugin_operation_t operation;
+    uint32_t flags;
+} omega_transform_plugin_info_t;
+
+typedef void *(*omega_transform_plugin_alloc_t)(size_t size, void *user_data_ptr);
+
+typedef struct {
+    /** Bytes from the requested session range. */
+    const omega_byte_t *input_bytes;
+    /** Length of input_bytes. */
+    int64_t input_length;
+    /** Start offset of input_bytes within the session. */
+    int64_t session_offset;
+    /** Requested range length after clamping to the session end. */
+    int64_t session_length;
+    /** Optional plugin-specific JSON options supplied by the caller. */
+    const char *options_json;
+    /** Allocator plugins must use for response buffers and strings. */
+    omega_transform_plugin_alloc_t alloc;
+    void *allocator_user_data_ptr;
+} omega_transform_plugin_request_t;
+
+/**
+ * Response buffers and strings are owned by the caller after a successful plugin call.
+ * Plugins must allocate them with omega_transform_plugin_request_t::alloc, and callers must
+ * release them with omega_transform_plugin_response_clear().
+ */
+typedef struct {
+    omega_byte_t *replacement_bytes;
+    int64_t replacement_length;
+    omega_byte_t *result_bytes;
+    int64_t result_length;
+    char *result_label;
+    char *result_mime_type;
+} omega_transform_plugin_response_t;
+
+typedef int (*omega_transform_plugin_get_info_fn)(omega_transform_plugin_info_t *info_ptr);
+typedef int (*omega_transform_plugin_apply_fn)(const omega_transform_plugin_request_t *request_ptr,
+                                               omega_transform_plugin_response_t *response_ptr);
+
+typedef struct omega_transform_plugin_registry_struct omega_transform_plugin_registry_t;
+
+omega_transform_plugin_registry_t *omega_transform_plugin_registry_create(void);
+
+void omega_transform_plugin_registry_destroy(omega_transform_plugin_registry_t *registry_ptr);
+
+int omega_transform_plugin_registry_register_plugin(omega_transform_plugin_registry_t *registry_ptr,
+                                                   const char *plugin_path);
+
+int omega_transform_plugin_registry_register_directory(omega_transform_plugin_registry_t *registry_ptr,
+                                                      const char *plugin_directory);
+
+int64_t omega_transform_plugin_registry_get_count(const omega_transform_plugin_registry_t *registry_ptr);
+
+const omega_transform_plugin_info_t *omega_transform_plugin_registry_get_info(
+        const omega_transform_plugin_registry_t *registry_ptr, int64_t index);
+
+const omega_transform_plugin_info_t *omega_transform_plugin_registry_find_info(
+        const omega_transform_plugin_registry_t *registry_ptr, const char *plugin_id);
+
+int omega_transform_plugin_registry_apply_to_session(omega_transform_plugin_registry_t *registry_ptr,
+                                                    const char *plugin_id, omega_session_t *session_ptr,
+                                                    int64_t offset, int64_t length, const char *options_json,
+                                                    omega_transform_plugin_response_t *response_ptr);
+
+/**
+ * Release response-owned replacement/result buffers and reset all fields to zero/null.
+ */
+void omega_transform_plugin_response_clear(omega_transform_plugin_response_t *response_ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif//OMEGA_EDIT_TRANSFORM_H

--- a/core/src/include/omega_edit/transform_plugin_sdk.h
+++ b/core/src/include/omega_edit/transform_plugin_sdk.h
@@ -1,0 +1,87 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+/**
+ * @file transform_plugin_sdk.h
+ * @brief Helper macros and allocation helpers for Omega Edit transform plugins.
+ */
+
+#ifndef OMEGA_EDIT_TRANSFORM_PLUGIN_SDK_H
+#define OMEGA_EDIT_TRANSFORM_PLUGIN_SDK_H
+
+#include "transform.h"
+
+#include <string.h>
+
+#ifdef _WIN32
+#define OMEGA_TRANSFORM_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define OMEGA_TRANSFORM_PLUGIN_EXPORT __attribute__((visibility("default")))
+#endif
+
+static inline void *omega_transform_plugin_sdk_alloc(const omega_transform_plugin_request_t *request_ptr, size_t size) {
+    if (!request_ptr || !request_ptr->alloc) { return NULL; }
+    return request_ptr->alloc(size == 0 ? 1 : size, request_ptr->allocator_user_data_ptr);
+}
+
+static inline omega_byte_t *omega_transform_plugin_sdk_copy_bytes(
+        const omega_transform_plugin_request_t *request_ptr, const omega_byte_t *bytes, int64_t length) {
+    if (!request_ptr || length < 0 || (length > 0 && !bytes)) { return NULL; }
+    omega_byte_t *copy = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, (size_t) length);
+    if (!copy) { return NULL; }
+    if (length > 0) { memcpy(copy, bytes, (size_t) length); }
+    return copy;
+}
+
+static inline char *omega_transform_plugin_sdk_copy_cstring(const omega_transform_plugin_request_t *request_ptr,
+                                                           const char *value) {
+    if (!value) { return NULL; }
+    const size_t length = strlen(value);
+    char *copy = (char *) omega_transform_plugin_sdk_alloc(request_ptr, length + 1);
+    if (!copy) { return NULL; }
+    memcpy(copy, value, length + 1);
+    return copy;
+}
+
+static inline int omega_transform_plugin_sdk_set_replacement(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr,
+        const omega_byte_t *bytes, int64_t length) {
+    if (!request_ptr || !response_ptr || length < 0 || (length > 0 && !bytes)) { return -1; }
+    response_ptr->replacement_length = length;
+    if (length == 0) { return 0; }
+    response_ptr->replacement_bytes = omega_transform_plugin_sdk_copy_bytes(request_ptr, bytes, length);
+    return response_ptr->replacement_bytes ? 0 : -1;
+}
+
+static inline int omega_transform_plugin_sdk_set_text_result(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr,
+        const char *label, const char *value, const char *mime_type) {
+    if (!request_ptr || !response_ptr || !value) { return -1; }
+    const size_t value_length = strlen(value);
+    response_ptr->result_bytes = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, value_length);
+    if (!response_ptr->result_bytes) { return -1; }
+    memcpy(response_ptr->result_bytes, value, value_length);
+    response_ptr->result_length = (int64_t) value_length;
+    if (label) {
+        response_ptr->result_label = omega_transform_plugin_sdk_copy_cstring(request_ptr, label);
+        if (!response_ptr->result_label) { return -1; }
+    }
+    if (mime_type) {
+        response_ptr->result_mime_type = omega_transform_plugin_sdk_copy_cstring(request_ptr, mime_type);
+        if (!response_ptr->result_mime_type) { return -1; }
+    }
+    return 0;
+}
+
+#endif//OMEGA_EDIT_TRANSFORM_PLUGIN_SDK_H

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -223,6 +223,8 @@ namespace {
     }
 
     inline auto del_(int64_t serial, int64_t offset, int64_t length, bool transaction_bit) -> const_omega_change_ptr_t {
+        // serial == 0 is used internally while decomposing OVERWRITE into DELETE+INSERT model updates.
+        // Public delete entry points validate serial/range before creating DELETE changes.
         const auto change_ptr = std::make_shared<omega_change_t>();
         change_ptr->serial = serial;
         change_ptr->kind =
@@ -396,6 +398,37 @@ namespace {
                 return replace_bytes_impl_(session_ptr, op.offset, op.length, op.bytes, op.bytes_length);
             default:
                 return -1;
+        }
+    }
+
+    auto is_builtin_transform_kind_(omega_edit_transform_kind_t kind) -> bool {
+        switch (kind) {
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER:
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER:
+            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
+            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
+            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    omega_byte_t apply_builtin_transform_(omega_byte_t byte, void *user_data_ptr) {
+        const auto *const transform_ptr = reinterpret_cast<const omega_edit_transform_t *>(user_data_ptr);
+        switch (transform_ptr->kind) {
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER:
+                return (byte >= 'a' && byte <= 'z') ? static_cast<omega_byte_t>(byte - ('a' - 'A')) : byte;
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER:
+                return (byte >= 'A' && byte <= 'Z') ? static_cast<omega_byte_t>(byte + ('a' - 'A')) : byte;
+            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
+                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_AND);
+            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
+                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_OR);
+            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR:
+                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_XOR);
+            default:
+                return byte;
         }
     }
 
@@ -1568,6 +1601,12 @@ int omega_edit_apply_script(omega_session_t *session_ptr, const omega_edit_scrip
 
     restore_viewport_callbacks_(session_ptr, callbacks_were_paused, changed);
     return rc;
+}
+
+int omega_edit_apply_builtin_transform(omega_session_t *session_ptr, omega_edit_transform_t transform, int64_t offset,
+                                       int64_t length) {
+    if (!is_builtin_transform_kind_(transform.kind)) { return -1; }
+    return omega_edit_apply_transform(session_ptr, apply_builtin_transform_, &transform, offset, length);
 }
 
 int omega_edit_apply_transform(omega_session_t *session_ptr, omega_util_byte_transform_t transform, void *user_data_ptr,

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -1,0 +1,305 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+ * implied.  See the License for the specific language governing permissions and limitations under the License.       *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include "../include/omega_edit/transform.h"
+#include "../include/omega_edit/edit.h"
+#include "../include/omega_edit/segment.h"
+#include "../include/omega_edit/session.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+#else
+#include <dlfcn.h>
+#endif
+
+namespace {
+    struct dynamic_library_t {
+#ifdef _WIN32
+        HMODULE handle{};
+#else
+        void *handle{};
+#endif
+
+        dynamic_library_t() = default;
+        explicit dynamic_library_t(const char *path) {
+#ifdef _WIN32
+            handle = LoadLibraryA(path);
+#else
+            handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+#endif
+        }
+
+        dynamic_library_t(const dynamic_library_t &) = delete;
+        auto operator=(const dynamic_library_t &) -> dynamic_library_t & = delete;
+
+        dynamic_library_t(dynamic_library_t &&other) noexcept : handle(other.handle) { other.handle = nullptr; }
+
+        auto operator=(dynamic_library_t &&other) noexcept -> dynamic_library_t & {
+            if (this != &other) {
+                close();
+                handle = other.handle;
+                other.handle = nullptr;
+            }
+            return *this;
+        }
+
+        ~dynamic_library_t() { close(); }
+
+        auto ok() const -> bool { return handle != nullptr; }
+
+        auto symbol(const char *name) const -> void * {
+            if (!handle) { return nullptr; }
+#ifdef _WIN32
+            return reinterpret_cast<void *>(GetProcAddress(handle, name));
+#else
+            return dlsym(handle, name);
+#endif
+        }
+
+    private:
+        void close() {
+            if (!handle) { return; }
+#ifdef _WIN32
+            FreeLibrary(handle);
+#else
+            dlclose(handle);
+#endif
+            handle = nullptr;
+        }
+    };
+
+    struct loaded_plugin_t {
+        dynamic_library_t library;
+        omega_transform_plugin_info_t info{};
+        omega_transform_plugin_apply_fn apply{};
+        std::string path;
+    };
+
+    auto plugin_operation_is_valid_(omega_transform_plugin_operation_t operation) -> bool {
+        return operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE ||
+               operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
+               operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT;
+    }
+
+    auto plugin_buffer_is_valid_(const omega_byte_t *bytes, int64_t length) -> bool {
+        return length >= 0 && (length == 0 || bytes != nullptr);
+    }
+
+    auto plugin_extension_is_supported_(const std::filesystem::path &path) -> bool {
+        const auto extension = path.extension().string();
+#ifdef _WIN32
+        return extension == ".dll";
+#elif defined(__APPLE__)
+        return extension == ".dylib" || extension == ".so";
+#else
+        return extension == ".so";
+#endif
+    }
+
+    void *plugin_malloc_(size_t size, void *) { return std::malloc(size == 0 ? 1 : size); }
+
+    // Transfers plugin-owned response buffers to the caller. If no caller response is supplied,
+    // the temporary response is cleared here so plugins never leak allocator-owned memory.
+    void move_plugin_response_(omega_transform_plugin_response_t *response_ptr,
+                               omega_transform_plugin_response_t &plugin_response) {
+        if (!response_ptr) {
+            omega_transform_plugin_response_clear(&plugin_response);
+            return;
+        }
+        omega_transform_plugin_response_clear(response_ptr);
+        *response_ptr = plugin_response;
+        plugin_response = {};
+    }
+
+    auto read_session_range_(const omega_session_t *session_ptr, int64_t offset, int64_t length,
+                             std::vector<omega_byte_t> &bytes) -> int {
+        if (!session_ptr || offset < 0 || length < 0) { return -1; }
+
+        const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+        if (computed_file_size < 0 || offset > computed_file_size) { return -1; }
+        const auto remaining = computed_file_size - offset;
+        const auto requested_length = (length == 0 || length > remaining) ? remaining : length;
+        if (requested_length < 0) { return -1; }
+        if (requested_length == 0) {
+            bytes.clear();
+            return 0;
+        }
+
+        omega_byte_t *data_ptr = nullptr;
+        int64_t copied_length = 0;
+        const auto rc = omega_edit_save_segment_to_bytes(session_ptr, &data_ptr, &copied_length, offset, requested_length);
+        if (rc != 0) {
+            std::free(data_ptr);
+            return rc;
+        }
+        bytes.assign(data_ptr, data_ptr + copied_length);
+        std::free(data_ptr);
+        return 0;
+    }
+}
+
+struct omega_transform_plugin_registry_struct {
+    std::vector<std::unique_ptr<loaded_plugin_t>> plugins;
+};
+
+omega_transform_plugin_registry_t *omega_transform_plugin_registry_create(void) {
+    return new omega_transform_plugin_registry_t();
+}
+
+void omega_transform_plugin_registry_destroy(omega_transform_plugin_registry_t *registry_ptr) {
+    delete registry_ptr;
+}
+
+int omega_transform_plugin_registry_register_plugin(omega_transform_plugin_registry_t *registry_ptr,
+                                                   const char *plugin_path) {
+    if (!registry_ptr || !plugin_path || !*plugin_path) { return -1; }
+
+    auto plugin = std::make_unique<loaded_plugin_t>();
+    plugin->path = plugin_path;
+    plugin->library = dynamic_library_t(plugin_path);
+    if (!plugin->library.ok()) { return -1; }
+
+    const auto get_info = reinterpret_cast<omega_transform_plugin_get_info_fn>(
+            plugin->library.symbol("omega_transform_plugin_get_info"));
+    plugin->apply = reinterpret_cast<omega_transform_plugin_apply_fn>(
+            plugin->library.symbol("omega_transform_plugin_apply"));
+    if (!get_info || !plugin->apply) { return -1; }
+    if (0 != get_info(&plugin->info)) { return -1; }
+    if (plugin->info.abi_version != OMEGA_TRANSFORM_PLUGIN_ABI_VERSION || !plugin->info.id || !*plugin->info.id ||
+        !plugin_operation_is_valid_(plugin->info.operation)) {
+        return -1;
+    }
+    if (omega_transform_plugin_registry_find_info(registry_ptr, plugin->info.id) != nullptr) { return -1; }
+
+    registry_ptr->plugins.push_back(std::move(plugin));
+    return 0;
+}
+
+int omega_transform_plugin_registry_register_directory(omega_transform_plugin_registry_t *registry_ptr,
+                                                      const char *plugin_directory) {
+    if (!registry_ptr || !plugin_directory || !*plugin_directory) { return -1; }
+    const std::filesystem::path directory(plugin_directory);
+
+    int loaded_count = 0;
+    try {
+        if (!std::filesystem::is_directory(directory)) { return -1; }
+        for (const auto &entry: std::filesystem::directory_iterator(directory)) {
+            if (!entry.is_regular_file() || !plugin_extension_is_supported_(entry.path())) { continue; }
+            const auto path = entry.path().string();
+            if (0 == omega_transform_plugin_registry_register_plugin(registry_ptr, path.c_str())) { ++loaded_count; }
+        }
+    } catch (const std::filesystem::filesystem_error &) {
+        return loaded_count > 0 ? loaded_count : -1;
+    }
+    return loaded_count;
+}
+
+int64_t omega_transform_plugin_registry_get_count(const omega_transform_plugin_registry_t *registry_ptr) {
+    if (!registry_ptr) { return 0; }
+    return static_cast<int64_t>(registry_ptr->plugins.size());
+}
+
+const omega_transform_plugin_info_t *omega_transform_plugin_registry_get_info(
+        const omega_transform_plugin_registry_t *registry_ptr, int64_t index) {
+    if (!registry_ptr || index < 0 || index >= static_cast<int64_t>(registry_ptr->plugins.size())) { return nullptr; }
+    return &registry_ptr->plugins[static_cast<size_t>(index)]->info;
+}
+
+const omega_transform_plugin_info_t *omega_transform_plugin_registry_find_info(
+        const omega_transform_plugin_registry_t *registry_ptr, const char *plugin_id) {
+    if (!registry_ptr || !plugin_id || !*plugin_id) { return nullptr; }
+    const auto iter = std::find_if(registry_ptr->plugins.cbegin(), registry_ptr->plugins.cend(),
+                                   [plugin_id](const auto &plugin) { return plugin->info.id == std::string(plugin_id); });
+    return iter != registry_ptr->plugins.cend() ? &(*iter)->info : nullptr;
+}
+
+int omega_transform_plugin_registry_apply_to_session(omega_transform_plugin_registry_t *registry_ptr,
+                                                    const char *plugin_id, omega_session_t *session_ptr,
+                                                    int64_t offset, int64_t length, const char *options_json,
+                                                    omega_transform_plugin_response_t *response_ptr) {
+    if (response_ptr) { omega_transform_plugin_response_clear(response_ptr); }
+    if (!registry_ptr || !plugin_id || !*plugin_id || !session_ptr || offset < 0 || length < 0) { return -1; }
+
+    // The registry owns plugin lookup/lifetime, but omega_session_t itself is not thread-safe.
+    // Callers that share sessions across threads must hold their session/core lock across this call.
+    auto iter = std::find_if(registry_ptr->plugins.begin(), registry_ptr->plugins.end(),
+                             [plugin_id](const auto &plugin) { return plugin->info.id == std::string(plugin_id); });
+    if (iter == registry_ptr->plugins.end()) { return -1; }
+
+    std::vector<omega_byte_t> input_bytes;
+    if (0 != read_session_range_(session_ptr, offset, length, input_bytes)) { return -1; }
+
+    const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    const auto requested_length = length == 0 ? computed_file_size - offset
+                                              : std::min(length, computed_file_size - offset);
+    if (requested_length < 0) { return -1; }
+
+    omega_transform_plugin_request_t request{};
+    request.input_bytes = input_bytes.empty() ? nullptr : input_bytes.data();
+    request.input_length = static_cast<int64_t>(input_bytes.size());
+    request.session_offset = offset;
+    request.session_length = requested_length;
+    request.options_json = options_json;
+    request.alloc = plugin_malloc_;
+    request.allocator_user_data_ptr = nullptr;
+
+    omega_transform_plugin_response_t plugin_response{};
+    if (0 != (*iter)->apply(&request, &plugin_response)) {
+        omega_transform_plugin_response_clear(&plugin_response);
+        return -1;
+    }
+    if (!plugin_buffer_is_valid_(plugin_response.replacement_bytes, plugin_response.replacement_length) ||
+        !plugin_buffer_is_valid_(plugin_response.result_bytes, plugin_response.result_length)) {
+        omega_transform_plugin_response_clear(&plugin_response);
+        return -1;
+    }
+
+    const auto operation = (*iter)->info.operation;
+    if (operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE ||
+        operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT) {
+        const auto serial = omega_edit_replace_bytes(session_ptr, offset, requested_length,
+                                                     plugin_response.replacement_bytes,
+                                                     plugin_response.replacement_length);
+        if (serial < 0 || (serial == 0 && (requested_length > 0 || plugin_response.replacement_length > 0))) {
+            omega_transform_plugin_response_clear(&plugin_response);
+            return -1;
+        }
+    }
+
+    move_plugin_response_(response_ptr, plugin_response);
+    return 0;
+}
+
+void omega_transform_plugin_response_clear(omega_transform_plugin_response_t *response_ptr) {
+    if (!response_ptr) { return; }
+    std::free(response_ptr->replacement_bytes);
+    std::free(response_ptr->result_bytes);
+    std::free(response_ptr->result_label);
+    std::free(response_ptr->result_mime_type);
+    *response_ptr = {};
+}

--- a/core/src/plugins/base64_decode.c
+++ b/core/src/plugins/base64_decode.c
@@ -1,0 +1,112 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit/transform_plugin_sdk.h>
+
+static int is_base64_whitespace_(omega_byte_t byte) {
+    return byte == ' ' || byte == '\t' || byte == '\n' || byte == '\r';
+}
+
+/* RFC 4648 base64 with MIME-style whitespace tolerance. Non-whitespace invalid bytes fail validation. */
+static int decode_base64_value_(omega_byte_t byte) {
+    if (byte >= 'A' && byte <= 'Z') { return byte - 'A'; }
+    if (byte >= 'a' && byte <= 'z') { return byte - 'a' + 26; }
+    if (byte >= '0' && byte <= '9') { return byte - '0' + 52; }
+    if (byte == '+') { return 62; }
+    if (byte == '/') { return 63; }
+    if (byte == '=') { return -2; }
+    return -1;
+}
+
+static int validate_base64_(const omega_transform_plugin_request_t *request_ptr, int64_t *encoded_length_ptr,
+                            int *padding_ptr) {
+    int64_t encoded_length = 0;
+    int padding = 0;
+    int saw_padding = 0;
+
+    for (int64_t i = 0; i < request_ptr->input_length; ++i) {
+        const omega_byte_t byte = request_ptr->input_bytes[i];
+        if (is_base64_whitespace_(byte)) { continue; }
+        const int value = decode_base64_value_(byte);
+        if (value == -1) { return -1; }
+
+        const int quartet_position = (int) (encoded_length % 4);
+        if (value == -2) {
+            if (quartet_position < 2) { return -1; }
+            saw_padding = 1;
+            ++padding;
+        } else if (saw_padding) {
+            return -1;
+        }
+        ++encoded_length;
+    }
+
+    if (encoded_length == 0) {
+        *encoded_length_ptr = 0;
+        *padding_ptr = 0;
+        return 0;
+    }
+    if ((encoded_length % 4) != 0 || padding > 2) { return -1; }
+
+    *encoded_length_ptr = encoded_length;
+    *padding_ptr = padding;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "omega.example.base64_decode";
+    info_ptr->name = "Base64 Decode";
+    info_ptr->description = "Decode RFC 4648 base64 text from the selected range.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
+
+    int64_t encoded_length = 0;
+    int padding = 0;
+    if (0 != validate_base64_(request_ptr, &encoded_length, &padding)) { return -1; }
+    if (encoded_length == 0) { return omega_transform_plugin_sdk_set_replacement(request_ptr, response_ptr, NULL, 0); }
+
+    const int64_t output_length = (encoded_length / 4) * 3 - padding;
+    omega_byte_t *output = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, (size_t) output_length);
+    if (!output) { return -1; }
+
+    int quartet[4] = {0, 0, 0, 0};
+    int quartet_index = 0;
+    int64_t output_index = 0;
+    for (int64_t i = 0; i < request_ptr->input_length; ++i) {
+        const omega_byte_t byte = request_ptr->input_bytes[i];
+        if (is_base64_whitespace_(byte)) { continue; }
+        const int value = decode_base64_value_(byte);
+        quartet[quartet_index++] = value == -2 ? 0 : value;
+        if (quartet_index < 4) { continue; }
+
+        const unsigned int triple = ((unsigned int) quartet[0] << 18) | ((unsigned int) quartet[1] << 12) |
+                                    ((unsigned int) quartet[2] << 6) | (unsigned int) quartet[3];
+        if (output_index < output_length) { output[output_index++] = (omega_byte_t) ((triple >> 16) & 0xFF); }
+        if (output_index < output_length) { output[output_index++] = (omega_byte_t) ((triple >> 8) & 0xFF); }
+        if (output_index < output_length) { output[output_index++] = (omega_byte_t) (triple & 0xFF); }
+        quartet_index = 0;
+    }
+
+    response_ptr->replacement_bytes = output;
+    response_ptr->replacement_length = output_length;
+    return 0;
+}

--- a/core/src/plugins/base64_encode.c
+++ b/core/src/plugins/base64_encode.c
@@ -1,0 +1,59 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit/transform_plugin_sdk.h>
+
+static const char BASE64_ALPHABET[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "omega.example.base64_encode";
+    info_ptr->name = "Base64 Encode";
+    info_ptr->description = "Encode the selected range as RFC 4648 base64 text.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
+    if (request_ptr->input_length == 0) { return omega_transform_plugin_sdk_set_replacement(request_ptr, response_ptr, NULL, 0); }
+    if (request_ptr->input_length > ((INT64_MAX / 4) - 1) * 3) { return -1; }
+
+    const int64_t output_length = ((request_ptr->input_length + 2) / 3) * 4;
+    omega_byte_t *output = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, (size_t) output_length);
+    if (!output) { return -1; }
+
+    int64_t input_index = 0;
+    int64_t output_index = 0;
+    while (input_index < request_ptr->input_length) {
+        const unsigned int octet_a = request_ptr->input_bytes[input_index++];
+        const int has_b = input_index < request_ptr->input_length;
+        const unsigned int octet_b = has_b ? request_ptr->input_bytes[input_index++] : 0;
+        const int has_c = input_index < request_ptr->input_length;
+        const unsigned int octet_c = has_c ? request_ptr->input_bytes[input_index++] : 0;
+        const unsigned int triple = (octet_a << 16) | (octet_b << 8) | octet_c;
+
+        output[output_index++] = (omega_byte_t) BASE64_ALPHABET[(triple >> 18) & 0x3F];
+        output[output_index++] = (omega_byte_t) BASE64_ALPHABET[(triple >> 12) & 0x3F];
+        output[output_index++] = (omega_byte_t) (has_b ? BASE64_ALPHABET[(triple >> 6) & 0x3F] : '=');
+        output[output_index++] = (omega_byte_t) (has_c ? BASE64_ALPHABET[triple & 0x3F] : '=');
+    }
+
+    response_ptr->replacement_bytes = output;
+    response_ptr->replacement_length = output_length;
+    return 0;
+}

--- a/core/src/plugins/checksum8.c
+++ b/core/src/plugins/checksum8.c
@@ -1,0 +1,38 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit/transform_plugin_sdk.h>
+#include <stdio.h>
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "omega.example.checksum8";
+    info_ptr->name = "Checksum-8";
+    info_ptr->description = "Calculate an 8-bit additive checksum over the selected range.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
+    unsigned int checksum = 0;
+    for (int64_t i = 0; i < request_ptr->input_length; ++i) { checksum = (checksum + request_ptr->input_bytes[i]) & 0xFF; }
+
+    char result[16];
+    snprintf(result, sizeof(result), "0x%02X", checksum);
+    return omega_transform_plugin_sdk_set_text_result(request_ptr, response_ptr, "checksum8", result, "text/plain");
+}

--- a/core/src/plugins/fnv1a64.c
+++ b/core/src/plugins/fnv1a64.c
@@ -1,0 +1,43 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit/transform_plugin_sdk.h>
+#include <inttypes.h>
+#include <stdio.h>
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "omega.example.fnv1a64";
+    info_ptr->name = "FNV-1a 64-bit Hash";
+    info_ptr->description = "Calculate an FNV-1a 64-bit hash over the selected range.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
+
+    uint64_t hash = UINT64_C(14695981039346656037);
+    for (int64_t i = 0; i < request_ptr->input_length; ++i) {
+        hash ^= request_ptr->input_bytes[i];
+        hash *= UINT64_C(1099511628211);
+    }
+
+    char result[32];
+    snprintf(result, sizeof(result), "0x%016" PRIX64, hash);
+    return omega_transform_plugin_sdk_set_text_result(request_ptr, response_ptr, "fnv1a64", result, "text/plain");
+}

--- a/core/src/plugins/repeat.c
+++ b/core/src/plugins/repeat.c
@@ -1,0 +1,43 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit/transform_plugin_sdk.h>
+#include <string.h>
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "omega.example.repeat";
+    info_ptr->name = "Repeat Range";
+    info_ptr->description = "Replace the selected range with two copies of itself.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
+    if (request_ptr->input_length > INT64_MAX / 2) { return -1; }
+    const int64_t replacement_length = request_ptr->input_length * 2;
+    response_ptr->replacement_length = replacement_length;
+    if (replacement_length == 0) { return 0; }
+    response_ptr->replacement_bytes = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr,
+                                                                                       (size_t) replacement_length);
+    if (!response_ptr->replacement_bytes) { return -1; }
+    memcpy(response_ptr->replacement_bytes, request_ptr->input_bytes, (size_t) request_ptr->input_length);
+    memcpy(response_ptr->replacement_bytes + request_ptr->input_length, request_ptr->input_bytes,
+           (size_t) request_ptr->input_length);
+    return 0;
+}

--- a/core/src/plugins/xor_ff.c
+++ b/core/src/plugins/xor_ff.c
@@ -12,24 +12,29 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-/**
- * @file omega_edit.h
- * @brief Convenience meta header that includes the omega-edit canon of header files.
- */
+#include <omega_edit/transform_plugin_sdk.h>
 
-#ifndef OMEGA_OMEGA_EDIT_H
-#define OMEGA_OMEGA_EDIT_H
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "omega.example.xor_ff";
+    info_ptr->name = "XOR 0xFF";
+    info_ptr->description = "Invert every byte in the selected range.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
 
-#include "omega_edit/change.h"
-#include "omega_edit/edit.h"
-#include "omega_edit/license.h"
-#include "omega_edit/search.h"
-#include "omega_edit/segment.h"
-#include "omega_edit/session.h"
-#include "omega_edit/transform.h"
-#include "omega_edit/transform_plugin_sdk.h"
-#include "omega_edit/version.h"
-#include "omega_edit/viewport.h"
-#include "omega_edit/visit.h"
-
-#endif//OMEGA_OMEGA_EDIT_H
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
+    omega_byte_t *bytes = omega_transform_plugin_sdk_copy_bytes(request_ptr, request_ptr->input_bytes,
+                                                                request_ptr->input_length);
+    if (!bytes) { return -1; }
+    for (int64_t i = 0; i < request_ptr->input_length; ++i) {
+        bytes[i] = request_ptr->input_bytes[i] ^ 0xFF;
+    }
+    response_ptr->replacement_bytes = bytes;
+    response_ptr->replacement_length = request_ptr->input_length;
+    return 0;
+}

--- a/core/src/plugins/zlib_compress.c
+++ b/core/src/plugins/zlib_compress.c
@@ -1,0 +1,87 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit/transform_plugin_sdk.h>
+
+#define ZLIB_STORED_BLOCK_MAX 65535
+
+static uint32_t adler32_(const omega_byte_t *bytes, int64_t length) {
+    uint32_t s1 = 1;
+    uint32_t s2 = 0;
+    for (int64_t i = 0; i < length; ++i) {
+        s1 = (s1 + bytes[i]) % 65521;
+        s2 = (s2 + s1) % 65521;
+    }
+    return (s2 << 16) | s1;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "omega.example.zlib_compress";
+    info_ptr->name = "Zlib Compress";
+    info_ptr->description = "Wrap the selected range in a valid zlib stream using stored DEFLATE blocks.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
+
+    /* This exemplar emits stored blocks only, so options_json/compression-level settings are intentionally ignored. */
+    const int64_t block_count = request_ptr->input_length == 0
+                                        ? 1
+                                        : (request_ptr->input_length + ZLIB_STORED_BLOCK_MAX - 1) /
+                                                  ZLIB_STORED_BLOCK_MAX;
+    if (block_count > (INT64_MAX - request_ptr->input_length - 6) / 5) { return -1; }
+    const int64_t output_length = 2 + request_ptr->input_length + (block_count * 5) + 4;
+    omega_byte_t *output = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, (size_t) output_length);
+    if (!output) { return -1; }
+
+    int64_t output_index = 0;
+    output[output_index++] = 0x78;
+    output[output_index++] = 0x01;
+
+    int64_t input_index = 0;
+    for (int64_t block_index = 0; block_index < block_count; ++block_index) {
+        const int is_final_block = block_index == block_count - 1;
+        const int64_t remaining = request_ptr->input_length - input_index;
+        const uint16_t block_length =
+                (uint16_t) (remaining > ZLIB_STORED_BLOCK_MAX ? ZLIB_STORED_BLOCK_MAX : remaining);
+        const uint16_t nlen = (uint16_t) ~block_length;
+
+        output[output_index++] = (omega_byte_t) (is_final_block ? 0x01 : 0x00);
+        output[output_index++] = (omega_byte_t) (block_length & 0xFF);
+        output[output_index++] = (omega_byte_t) ((block_length >> 8) & 0xFF);
+        output[output_index++] = (omega_byte_t) (nlen & 0xFF);
+        output[output_index++] = (omega_byte_t) ((nlen >> 8) & 0xFF);
+        if (block_length > 0) {
+            memcpy(output + output_index, request_ptr->input_bytes + input_index, block_length);
+            output_index += block_length;
+            input_index += block_length;
+        }
+    }
+
+    const uint32_t checksum = adler32_(request_ptr->input_bytes, request_ptr->input_length);
+    output[output_index++] = (omega_byte_t) ((checksum >> 24) & 0xFF);
+    output[output_index++] = (omega_byte_t) ((checksum >> 16) & 0xFF);
+    output[output_index++] = (omega_byte_t) ((checksum >> 8) & 0xFF);
+    output[output_index++] = (omega_byte_t) (checksum & 0xFF);
+
+    response_ptr->replacement_bytes = output;
+    response_ptr->replacement_length = output_length;
+    return output_index == output_length ? 0 : -1;
+}

--- a/core/src/plugins/zlib_decompress.c
+++ b/core/src/plugins/zlib_decompress.c
@@ -1,0 +1,99 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit/transform_plugin_sdk.h>
+
+static uint32_t adler32_(const omega_byte_t *bytes, int64_t length) {
+    uint32_t s1 = 1;
+    uint32_t s2 = 0;
+    for (int64_t i = 0; i < length; ++i) {
+        s1 = (s1 + bytes[i]) % 65521;
+        s2 = (s2 + s1) % 65521;
+    }
+    return (s2 << 16) | s1;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "omega.example.zlib_decompress";
+    info_ptr->name = "Zlib Decompress";
+    info_ptr->description = "Decode zlib streams that use stored DEFLATE blocks.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
+    if (request_ptr->input_length < 6) { return -1; }
+
+    const omega_byte_t *input = request_ptr->input_bytes;
+    const int64_t input_length = request_ptr->input_length;
+    const uint16_t zlib_header = (uint16_t) ((input[0] << 8) | input[1]);
+    if ((input[0] & 0x0F) != 8 || (input[0] >> 4) > 7 || (zlib_header % 31) != 0 || (input[1] & 0x20) != 0) {
+        return -1;
+    }
+
+    int64_t input_index = 2;
+    int saw_final_block = 0;
+    int64_t output_length = 0;
+
+    while (!saw_final_block) {
+        if (input_index + 5 > input_length - 4) { return -1; }
+        const omega_byte_t block_header = input[input_index++];
+        saw_final_block = (block_header & 0x01) != 0;
+        if (((block_header >> 1) & 0x03) != 0 || (block_header & 0xF8) != 0) { return -1; }
+
+        const uint16_t block_length = (uint16_t) (input[input_index] | (input[input_index + 1] << 8));
+        const uint16_t nlen = (uint16_t) (input[input_index + 2] | (input[input_index + 3] << 8));
+        input_index += 4;
+        if ((uint16_t) ~block_length != nlen || input_index + block_length > input_length - 4) { return -1; }
+        if (output_length > INT64_MAX - block_length) { return -1; }
+        output_length += block_length;
+        input_index += block_length;
+    }
+
+    if (input_index != input_length - 4) { return -1; }
+    omega_byte_t *output =
+            output_length == 0 ? NULL : (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr,
+                                                                                          (size_t) output_length);
+    if (output_length > 0 && !output) { return -1; }
+
+    input_index = 2;
+    int64_t output_index = 0;
+    saw_final_block = 0;
+    while (!saw_final_block) {
+        const omega_byte_t block_header = input[input_index++];
+        saw_final_block = (block_header & 0x01) != 0;
+        const uint16_t block_length = (uint16_t) (input[input_index] | (input[input_index + 1] << 8));
+        input_index += 4;
+        if (block_length > 0) {
+            memcpy(output + output_index, input + input_index, block_length);
+            output_index += block_length;
+            input_index += block_length;
+        }
+    }
+
+    const uint32_t expected_checksum = ((uint32_t) input[input_index] << 24) |
+                                       ((uint32_t) input[input_index + 1] << 16) |
+                                       ((uint32_t) input[input_index + 2] << 8) |
+                                       (uint32_t) input[input_index + 3];
+    if (expected_checksum != adler32_(output, output_length)) { return -1; }
+
+    response_ptr->replacement_bytes = output;
+    response_ptr->replacement_length = output_length;
+    return 0;
+}

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ include(Catch)
 
 set(OMEGA_EDIT_TEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(OMEGA_EDIT_TEST_DATA_DIR ${OMEGA_EDIT_TEST_BINARY_DIR}/data)
+set(OMEGA_EDIT_TEST_PLUGIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/plugins)
 
 file(COPY ./data DESTINATION ${CMAKE_CURRENT_BINARY_DIR} USE_SOURCE_PERMISSIONS)
 configure_file(
@@ -81,4 +82,7 @@ foreach (test_src ${omega_test_srcs})
         message(STATUS "Using catch_discover_tests for ${testname}")
         catch_discover_tests(${testname} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     endif()
+    if (TARGET omega_edit_transform_plugins)
+        add_dependencies(${testname} omega_edit_transform_plugins)
+    endif ()
 endforeach ()

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -109,6 +109,153 @@ TEST_CASE("Apply Script", "[EditScript]") {
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Apply Builtin Transform", "[EditTransform]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "Abc xyz 09!"));
+
+    const omega_edit_transform_t lower_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER, 0};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, lower_transform, 0, 3));
+    REQUIRE("abc xyz 09!" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    const omega_edit_transform_t upper_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, upper_transform, 4, 3));
+    REQUIRE("abc XYZ 09!" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    const omega_edit_transform_t invalid_transform{static_cast<omega_edit_transform_kind_t>(999), 0};
+    REQUIRE(-1 == omega_edit_apply_builtin_transform(session_ptr, invalid_transform, 0, 0));
+    REQUIRE(-1 == omega_edit_apply_builtin_transform(nullptr, upper_transform, 0, 0));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Apply Builtin Bitwise Transform", "[EditTransform]") {
+    const omega_byte_t input[] = {0x0F, 0xF0, 0x55};
+    const auto session_ptr =
+            omega_edit_create_session_from_bytes(input, static_cast<int64_t>(sizeof(input)), nullptr, nullptr,
+                                                 NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    const omega_edit_transform_t xor_transform{OMEGA_EDIT_TRANSFORM_BITWISE_XOR, 0xFF};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, xor_transform, 0, 2));
+    REQUIRE(std::string({static_cast<char>(0xF0), static_cast<char>(0x0F), static_cast<char>(0x55)}) ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    const omega_edit_transform_t and_transform{OMEGA_EDIT_TRANSFORM_BITWISE_AND, 0x0F};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, and_transform, 0, 0));
+    REQUIRE(std::string({static_cast<char>(0x00), static_cast<char>(0x0F), static_cast<char>(0x05)}) ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    const omega_edit_transform_t or_transform{OMEGA_EDIT_TRANSFORM_BITWISE_OR, 0xA0};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, or_transform, 1, 2));
+    REQUIRE(std::string({static_cast<char>(0x00), static_cast<char>(0xAF), static_cast<char>(0xA5)}) ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Transform Plugin Registry", "[EditTransform][Plugin]") {
+    const auto registry_ptr = omega_transform_plugin_registry_create();
+    REQUIRE(registry_ptr);
+    REQUIRE(0 < omega_transform_plugin_registry_register_directory(registry_ptr, PLUGIN_DIR.string().c_str()));
+    REQUIRE(8 <= omega_transform_plugin_registry_get_count(registry_ptr));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.base64_decode"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.base64_encode"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.fnv1a64"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib_compress"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib_decompress"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.xor_ff"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.repeat"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.checksum8"));
+
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "ABCD"));
+
+    omega_transform_plugin_response_t response{};
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.repeat", session_ptr,
+                                                                  1, 2, nullptr, &response));
+    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
+                                                         omega_session_get_computed_file_size(session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.checksum8", session_ptr,
+                                                                  0, 0, nullptr, &response));
+    REQUIRE(4 == response.result_length);
+    REQUIRE("0x8F" == std::string(reinterpret_cast<const char *>(response.result_bytes),
+                                  static_cast<size_t>(response.result_length)));
+    REQUIRE("checksum8" == std::string(response.result_label));
+    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
+                                                         omega_session_get_computed_file_size(session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.xor_ff", session_ptr,
+                                                                  0, 1, nullptr, &response));
+    REQUIRE(std::string({static_cast<char>(0xBE), 'B', 'C', 'B', 'C', 'D'}) ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+
+    const auto codec_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(codec_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(codec_session_ptr, 0, "hello"));
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64_encode",
+                                                                  codec_session_ptr, 0, 5, nullptr, &response));
+    REQUIRE("aGVsbG8=" == omega_session_get_segment_string(codec_session_ptr, 0,
+                                                          omega_session_get_computed_file_size(codec_session_ptr)));
+    REQUIRE(8 == response.replacement_length);
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64_decode",
+                                                                  codec_session_ptr, 0, 0, nullptr, &response));
+    REQUIRE("hello" == omega_session_get_segment_string(codec_session_ptr, 0,
+                                                        omega_session_get_computed_file_size(codec_session_ptr)));
+    REQUIRE(5 == response.replacement_length);
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.fnv1a64",
+                                                                  codec_session_ptr, 0, 5, nullptr, &response));
+    REQUIRE(18 == response.result_length);
+    REQUIRE("0xA430D84680AABD0B" == std::string(reinterpret_cast<const char *>(response.result_bytes),
+                                               static_cast<size_t>(response.result_length)));
+    REQUIRE("fnv1a64" == std::string(response.result_label));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib_compress",
+                                                                  codec_session_ptr, 0, 5, nullptr, &response));
+    REQUIRE(16 == response.replacement_length);
+    {
+        const auto compressed = omega_session_get_segment_string(codec_session_ptr, 0,
+                                                                omega_session_get_computed_file_size(codec_session_ptr));
+        REQUIRE(16 == compressed.size());
+        REQUIRE(static_cast<char>(0x78) == compressed[0]);
+        REQUIRE(static_cast<char>(0x01) == compressed[1]);
+    }
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib_decompress",
+                                                                  codec_session_ptr, 0, 0, nullptr, &response));
+    REQUIRE("hello" == omega_session_get_segment_string(codec_session_ptr, 0,
+                                                        omega_session_get_computed_file_size(codec_session_ptr)));
+    REQUIRE(5 == response.replacement_length);
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 < omega_edit_insert_string(codec_session_ptr, omega_session_get_computed_file_size(codec_session_ptr),
+                                         "!"));
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64_decode",
+                                                                   codec_session_ptr, 0, 0, nullptr, &response));
+    omega_edit_destroy_session(codec_session_ptr);
+
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.missing", session_ptr,
+                                                                   0, 0, nullptr, nullptr));
+
+    omega_edit_destroy_session(session_ptr);
+    omega_transform_plugin_registry_destroy(registry_ptr);
+}
+
 TEST_CASE("Model Tests", "[ModelTests]") {
     file_info_t file_info;
     file_info.num_changes = 0;

--- a/core/src/tests/test_util.hpp.in
+++ b/core/src/tests/test_util.hpp.in
@@ -32,8 +32,10 @@ using file_info_t = struct file_info_struct {
 
 // The template parameter is replaced by cmake at configure time with the appropriate value for the platform.
 static const std::filesystem::path DATA_DIR = "@OMEGA_EDIT_TEST_DATA_DIR@";
+static const std::filesystem::path PLUGIN_DIR = "@OMEGA_EDIT_TEST_PLUGIN_DIR@";
 
 #define MAKE_PATH(path) (DATA_DIR / (path)).string().c_str()
+#define MAKE_PLUGIN_PATH(path) (PLUGIN_DIR / (path)).string().c_str()
 
 static inline FILE *fill_file(const char *f1, int64_t file_size, const char *fill, int64_t fill_length) {
     const auto f1_ptr = FOPEN(f1, "w+");

--- a/core/src/tools/transform_plugin_harness.cpp
+++ b/core/src/tools/transform_plugin_harness.cpp
@@ -1,0 +1,324 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+    struct options_t {
+        std::vector<std::string> plugin_dirs;
+        std::vector<std::string> plugin_paths;
+        bool list = false;
+        std::string run_id;
+        std::optional<std::vector<omega_byte_t>> input;
+        int64_t offset = 0;
+        int64_t length = 0;
+        std::string options_json;
+        std::optional<std::vector<omega_byte_t>> expect_output;
+        std::optional<std::string> expect_result;
+    };
+
+    void print_usage(const char *argv0) {
+        std::cerr
+                << "Usage:\n"
+                << "  " << argv0 << " --plugin-dir DIR --list\n"
+                << "  " << argv0 << " --plugin PATH --run ID --input TEXT [--expect-output TEXT]\n"
+                << "  " << argv0 << " --plugin-dir DIR --run ID --input-hex HEX [--offset N] [--length N]\n"
+                << "       [--options JSON] [--expect-output-hex HEX] [--expect-result TEXT]\n";
+    }
+
+    auto parse_i64(const char *value, int64_t &out) -> bool {
+        if (!value || !*value) { return false; }
+        char *end_ptr = nullptr;
+        const auto parsed = std::strtoll(value, &end_ptr, 10);
+        if (!end_ptr || *end_ptr != '\0') { return false; }
+        out = static_cast<int64_t>(parsed);
+        return true;
+    }
+
+    auto hex_nibble(char ch, omega_byte_t &value) -> bool {
+        if (ch >= '0' && ch <= '9') {
+            value = static_cast<omega_byte_t>(ch - '0');
+            return true;
+        }
+        if (ch >= 'a' && ch <= 'f') {
+            value = static_cast<omega_byte_t>(10 + ch - 'a');
+            return true;
+        }
+        if (ch >= 'A' && ch <= 'F') {
+            value = static_cast<omega_byte_t>(10 + ch - 'A');
+            return true;
+        }
+        return false;
+    }
+
+    auto parse_hex(std::string hex, std::vector<omega_byte_t> &bytes) -> bool {
+        hex.erase(std::remove_if(hex.begin(), hex.end(), [](unsigned char ch) {
+            return std::isspace(ch) != 0 || ch == ':' || ch == '-';
+        }), hex.end());
+        if ((hex.size() % 2) != 0) { return false; }
+        bytes.clear();
+        bytes.reserve(hex.size() / 2);
+        for (size_t i = 0; i < hex.size(); i += 2) {
+            omega_byte_t high = 0;
+            omega_byte_t low = 0;
+            if (!hex_nibble(hex[i], high) || !hex_nibble(hex[i + 1], low)) { return false; }
+            bytes.push_back(static_cast<omega_byte_t>((high << 4) | low));
+        }
+        return true;
+    }
+
+    auto to_hex(const omega_byte_t *bytes, int64_t length) -> std::string {
+        static constexpr char digits[] = "0123456789abcdef";
+        std::string result;
+        if (length <= 0) { return result; }
+        result.reserve(static_cast<size_t>(length) * 2);
+        for (int64_t i = 0; i < length; ++i) {
+            result.push_back(digits[(bytes[i] >> 4) & 0x0F]);
+            result.push_back(digits[bytes[i] & 0x0F]);
+        }
+        return result;
+    }
+
+    auto bytes_from_string(const std::string &value) -> std::vector<omega_byte_t> {
+        return {reinterpret_cast<const omega_byte_t *>(value.data()),
+                reinterpret_cast<const omega_byte_t *>(value.data()) + value.size()};
+    }
+
+    auto parse_options(int argc, char **argv, options_t &options) -> bool {
+        for (int i = 1; i < argc; ++i) {
+            const std::string arg = argv[i];
+            auto require_value = [&](const char *name) -> const char * {
+                if (i + 1 >= argc) {
+                    std::cerr << name << " requires a value\n";
+                    return nullptr;
+                }
+                return argv[++i];
+            };
+
+            if (arg == "--plugin-dir") {
+                const auto value = require_value("--plugin-dir");
+                if (!value) { return false; }
+                options.plugin_dirs.emplace_back(value);
+            } else if (arg == "--plugin") {
+                const auto value = require_value("--plugin");
+                if (!value) { return false; }
+                options.plugin_paths.emplace_back(value);
+            } else if (arg == "--list") {
+                options.list = true;
+            } else if (arg == "--run") {
+                const auto value = require_value("--run");
+                if (!value) { return false; }
+                options.run_id = value;
+            } else if (arg == "--input") {
+                const auto value = require_value("--input");
+                if (!value) { return false; }
+                options.input = bytes_from_string(value);
+            } else if (arg == "--input-hex") {
+                const auto value = require_value("--input-hex");
+                if (!value) { return false; }
+                std::vector<omega_byte_t> bytes;
+                if (!parse_hex(value, bytes)) {
+                    std::cerr << "invalid --input-hex value\n";
+                    return false;
+                }
+                options.input = bytes;
+            } else if (arg == "--offset") {
+                const auto value = require_value("--offset");
+                if (!value || !parse_i64(value, options.offset)) { return false; }
+            } else if (arg == "--length") {
+                const auto value = require_value("--length");
+                if (!value || !parse_i64(value, options.length)) { return false; }
+            } else if (arg == "--options") {
+                const auto value = require_value("--options");
+                if (!value) { return false; }
+                options.options_json = value;
+            } else if (arg == "--expect-output") {
+                const auto value = require_value("--expect-output");
+                if (!value) { return false; }
+                options.expect_output = bytes_from_string(value);
+            } else if (arg == "--expect-output-hex") {
+                const auto value = require_value("--expect-output-hex");
+                if (!value) { return false; }
+                std::vector<omega_byte_t> bytes;
+                if (!parse_hex(value, bytes)) {
+                    std::cerr << "invalid --expect-output-hex value\n";
+                    return false;
+                }
+                options.expect_output = bytes;
+            } else if (arg == "--expect-result") {
+                const auto value = require_value("--expect-result");
+                if (!value) { return false; }
+                options.expect_result = value;
+            } else if (arg == "--help" || arg == "-h") {
+                return false;
+            } else {
+                std::cerr << "unknown option: " << arg << "\n";
+                return false;
+            }
+        }
+        return true;
+    }
+
+    auto operation_name(omega_transform_plugin_operation_t operation) -> const char * {
+        switch (operation) {
+            case OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE:
+                return "replace";
+            case OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT:
+                return "inspect";
+            case OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT:
+                return "replace_and_inspect";
+            default:
+                return "unknown";
+        }
+    }
+
+    auto register_plugins(omega_transform_plugin_registry_t *registry_ptr, const options_t &options) -> bool {
+        for (const auto &path: options.plugin_paths) {
+            if (0 != omega_transform_plugin_registry_register_plugin(registry_ptr, path.c_str())) {
+                std::cerr << "failed to register plugin: " << path << "\n";
+                return false;
+            }
+        }
+        for (const auto &dir: options.plugin_dirs) {
+            if (0 > omega_transform_plugin_registry_register_directory(registry_ptr, dir.c_str())) {
+                std::cerr << "failed to register plugin directory: " << dir << "\n";
+                return false;
+            }
+        }
+        return true;
+    }
+
+    auto list_plugins(const omega_transform_plugin_registry_t *registry_ptr) -> int {
+        const auto count = omega_transform_plugin_registry_get_count(registry_ptr);
+        std::cout << "plugins=" << count << "\n";
+        for (int64_t i = 0; i < count; ++i) {
+            const auto *info = omega_transform_plugin_registry_get_info(registry_ptr, i);
+            if (!info) { continue; }
+            std::cout << info->id << "\t" << (info->name ? info->name : "") << "\t"
+                      << operation_name(info->operation) << "\t" << info->flags << "\t"
+                      << (info->description ? info->description : "") << "\n";
+        }
+        return 0;
+    }
+
+    auto run_plugin(omega_transform_plugin_registry_t *registry_ptr, const options_t &options) -> int {
+        if (options.run_id.empty()) {
+            std::cerr << "--run is required unless --list is used\n";
+            return 2;
+        }
+        if (!options.input.has_value()) {
+            std::cerr << "--input or --input-hex is required with --run\n";
+            return 2;
+        }
+
+        const auto &input = *options.input;
+        auto *session_ptr = omega_edit_create_session_from_bytes(
+                input.empty() ? nullptr : input.data(), static_cast<int64_t>(input.size()), nullptr, nullptr,
+                NO_EVENTS, nullptr);
+        if (!session_ptr) {
+            std::cerr << "failed to create session\n";
+            return 1;
+        }
+
+        omega_transform_plugin_response_t response{};
+        const auto options_json = options.options_json.empty() ? nullptr : options.options_json.c_str();
+        const auto rc = omega_transform_plugin_registry_apply_to_session(registry_ptr, options.run_id.c_str(),
+                                                                         session_ptr, options.offset, options.length,
+                                                                         options_json, &response);
+        if (rc != 0) {
+            omega_edit_destroy_session(session_ptr);
+            std::cerr << "plugin apply failed\n";
+            return 1;
+        }
+
+        omega_byte_t *output_ptr = nullptr;
+        int64_t output_length = 0;
+        if (0 != omega_edit_save_to_bytes(session_ptr, &output_ptr, &output_length)) {
+            omega_transform_plugin_response_clear(&response);
+            omega_edit_destroy_session(session_ptr);
+            std::cerr << "failed to read output session bytes\n";
+            return 1;
+        }
+
+        std::cout << "output_hex=" << to_hex(output_ptr, output_length) << "\n";
+        if (response.result_length > 0 && response.result_bytes != nullptr) {
+            std::cout << "result_label=" << (response.result_label ? response.result_label : "") << "\n";
+            std::cout << "result_mime_type=" << (response.result_mime_type ? response.result_mime_type : "") << "\n";
+            std::cout << "result_text="
+                      << std::string(reinterpret_cast<const char *>(response.result_bytes),
+                                     static_cast<size_t>(response.result_length))
+                      << "\n";
+            std::cout << "result_hex=" << to_hex(response.result_bytes, response.result_length) << "\n";
+        }
+
+        int result = 0;
+        if (options.expect_output.has_value()) {
+            const auto &expected = *options.expect_output;
+            if (expected.size() != static_cast<size_t>(output_length) ||
+                std::memcmp(expected.data(), output_ptr, expected.size()) != 0) {
+                std::cerr << "output mismatch: expected " << to_hex(expected.data(), static_cast<int64_t>(expected.size()))
+                          << " got " << to_hex(output_ptr, output_length) << "\n";
+                result = 1;
+            }
+        }
+        if (options.expect_result.has_value()) {
+            const std::string actual = response.result_length > 0 && response.result_bytes != nullptr
+                                       ? std::string(reinterpret_cast<const char *>(response.result_bytes),
+                                                     static_cast<size_t>(response.result_length))
+                                       : std::string();
+            if (*options.expect_result != actual) {
+                std::cerr << "result mismatch: expected '" << *options.expect_result << "' got '" << actual << "'\n";
+                result = 1;
+            }
+        }
+
+        std::free(output_ptr);
+        omega_transform_plugin_response_clear(&response);
+        omega_edit_destroy_session(session_ptr);
+        return result;
+    }
+}
+
+int main(int argc, char **argv) {
+    options_t options;
+    if (!parse_options(argc, argv, options) || (options.plugin_dirs.empty() && options.plugin_paths.empty())) {
+        print_usage(argv[0]);
+        return 2;
+    }
+
+    auto *registry_ptr = omega_transform_plugin_registry_create();
+    if (!registry_ptr) {
+        std::cerr << "failed to create plugin registry\n";
+        return 1;
+    }
+
+    if (!register_plugins(registry_ptr, options)) {
+        omega_transform_plugin_registry_destroy(registry_ptr);
+        return 1;
+    }
+
+    const auto rc = options.list ? list_plugins(registry_ptr) : run_plugin(registry_ptr, options);
+    omega_transform_plugin_registry_destroy(registry_ptr);
+    return rc;
+}

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -47,6 +47,12 @@ oe search --session <session-id> --hex 89504E47 --limit 10
 oe patch --session <session-id> --offset 8 --hex 0000000d --dry-run
 oe patch --session <session-id> --offset 8 --hex 0000000d
 
+# Discover and run native transform plugins
+oe list-transform-plugins
+oe apply-transform-plugin --session <session-id> --plugin omega.example.checksum8 --offset 0 --length 128
+oe apply-transform-plugin --session <session-id> --plugin omega.example.base64_encode --offset 0 --length 128
+oe apply-transform-plugin --session <session-id> --plugin omega.example.zlib_compress --offset 0 --length 128
+
 # Save or export a slice
 oe save-session --session <session-id> --output ./patched.bin --overwrite
 oe export-range --session <session-id> --offset 0 --length 128 --output ./header.bin --overwrite
@@ -54,6 +60,10 @@ oe export-range --session <session-id> --offset 0 --length 128 --output ./header
 # Undo if needed
 oe undo --session <session-id>
 ```
+
+Transform plugins are registered when the native server starts. See the
+[Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins)
+for the ABI, SDK helpers, plugin directory layout, and exemplar plugin IDs.
 
 All CLI commands emit JSON to stdout and return non-zero exit codes on failure.
 
@@ -96,6 +106,9 @@ Available tools:
 - `omega_edit_session_status`
 - `omega_edit_read_range`
 - `omega_edit_search`
+- `omega_edit_replace_session`
+- `omega_edit_list_transform_plugins`
+- `omega_edit_apply_transform_plugin`
 - `omega_edit_preview_patch`
 - `omega_edit_apply_patch`
 - `omega_edit_undo`

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -38,6 +38,8 @@ function usage(): string {
     '  search --session <id> (--text <value> | --hex <value> | --base64 <value>) [--limit <n>]',
     '  patch --session <id> --offset <n> [--operation <insert|overwrite|delete|replace>]',
     '        [--text <value> | --hex <value> | --base64 <value>] [--delete-length <n>] [--dry-run]',
+    '  list-transform-plugins',
+    '  apply-transform-plugin --session <id> --plugin <id> [--offset <n>] [--length <n>] [--options-json <json>]',
     '  undo --session <id>',
     '  redo --session <id>',
     '  save-session --session <id> --output <path> [--overwrite]',
@@ -351,6 +353,49 @@ async function runCommand(
           64
         ),
         dryRun: Boolean(parsed.values['dry-run']),
+      })
+    }
+    case 'list-transform-plugins': {
+      const parsed = parseArgs({
+        args,
+        options: commonOptions,
+        allowPositionals: false,
+      })
+      return { plugins: await getToolkit(parsed.values).listTransformPlugins() }
+    }
+    case 'apply-transform-plugin': {
+      const parsed = parseArgs({
+        args,
+        options: {
+          ...commonOptions,
+          session: { type: 'string' as const },
+          plugin: { type: 'string' as const },
+          offset: { type: 'string' as const },
+          length: { type: 'string' as const },
+          'options-json': { type: 'string' as const },
+        },
+        allowPositionals: false,
+      })
+      return await getToolkit(parsed.values).applyTransformPlugin({
+        sessionId: requireStringOption(
+          parsed.values.session as string | undefined,
+          'session'
+        ),
+        pluginId: requireStringOption(
+          parsed.values.plugin as string | undefined,
+          'plugin'
+        ),
+        offset: parseIntegerOption(
+          parsed.values.offset as string | undefined,
+          'offset',
+          0
+        ),
+        length: parseIntegerOption(
+          parsed.values.length as string | undefined,
+          'length',
+          0
+        ),
+        optionsJson: parsed.values['options-json'] as string | undefined,
       })
     }
     case 'undo': {

--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -380,6 +380,45 @@ function buildTools(toolkit: OmegaEditToolkit): ToolDefinition[] {
       },
     },
     {
+      name: 'omega_edit_list_transform_plugins',
+      description:
+        'List transform plugins registered with the OmegaEdit server.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      run: async () => {
+        return {
+          plugins: await toolkit.listTransformPlugins(),
+        }
+      },
+    },
+    {
+      name: 'omega_edit_apply_transform_plugin',
+      description:
+        'Apply a registered transform plugin to a session range and return replacement/inspection metadata.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          pluginId: { type: 'string' },
+          offset: { type: 'integer' },
+          length: { type: 'integer' },
+          optionsJson: { type: 'string' },
+        },
+        required: ['sessionId', 'pluginId'],
+      },
+      run: async (argumentsObject) => {
+        return await toolkit.applyTransformPlugin({
+          sessionId: getString(argumentsObject, 'sessionId', true)!,
+          pluginId: getString(argumentsObject, 'pluginId', true)!,
+          offset: getNumber(argumentsObject, 'offset', false, 0),
+          length: getNumber(argumentsObject, 'length', false, 0),
+          optionsJson: getString(argumentsObject, 'optionsJson'),
+        })
+      },
+    },
+    {
       name: 'omega_edit_preview_patch',
       description:
         'Preview an insert, overwrite, delete, or replace operation before applying it.',

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -3,6 +3,8 @@ import {
   delay,
   type IServerControlResult,
   IOFlags,
+  TransformPluginOperation,
+  applyTransformPlugin as applyClientTransformPlugin,
   createSession,
   del,
   destroySession,
@@ -16,6 +18,7 @@ import {
   getUndoCount,
   getViewportCount,
   insert,
+  listTransformPlugins as listClientTransformPlugins,
   overwrite,
   redo,
   replace,
@@ -37,6 +40,8 @@ import {
 } from './constants'
 import { concatBytes, encodeData, parseInputData } from './codec'
 import {
+  ApplyTransformPluginRequest,
+  ApplyTransformPluginResult,
   PatchPreview,
   PatchRequest,
   PatchResult,
@@ -47,10 +52,17 @@ import {
   SearchResult,
   SessionStatus,
   ToolkitOptions,
+  TransformPluginInfoResult,
 } from './types'
 
 const changeKindNames = new Map<number, string>(
   Object.entries(ChangeKind)
+    .filter(([, value]) => typeof value === 'number')
+    .map(([name, value]) => [value as number, name])
+)
+
+const transformPluginOperationNames = new Map<number, string>(
+  Object.entries(TransformPluginOperation)
     .filter(([, value]) => typeof value === 'number')
     .map(([name, value]) => [value as number, name])
 )
@@ -264,9 +276,9 @@ export class OmegaEditToolkit {
   }
 
   async search(request: SearchRequest): Promise<SearchResult> {
-    const offset = request.offset || 0
-    const length = request.length || 0
-    const requestedLimit = request.limit || 100
+    const offset = request.offset ?? 0
+    const length = request.length ?? 0
+    const requestedLimit = request.limit ?? 100
 
     assertNonNegativeInteger('offset', offset)
     assertNonNegativeInteger('length', length)
@@ -311,9 +323,9 @@ export class OmegaEditToolkit {
   async replaceSession(
     request: ReplaceSessionRequest
   ): Promise<ReplaceSessionResult> {
-    const offset = request.offset || 0
-    const length = request.length || 0
-    const requestedLimit = request.limit || 0
+    const offset = request.offset ?? 0
+    const length = request.length ?? 0
+    const requestedLimit = request.limit ?? 0
     const frontToBack = request.frontToBack !== false
     const overwriteOnly = request.overwriteOnly || false
 
@@ -368,6 +380,63 @@ export class OmegaEditToolkit {
       replacedCount,
       frontToBack,
       overwriteOnly,
+    }
+  }
+
+  async listTransformPlugins(): Promise<TransformPluginInfoResult[]> {
+    await this.ensureServerRunning()
+
+    return (await listClientTransformPlugins()).map((plugin) => ({
+      id: plugin.id,
+      name: plugin.name,
+      description: plugin.description,
+      operation: plugin.operation,
+      operationName:
+        transformPluginOperationNames.get(plugin.operation) ||
+        `${plugin.operation}`,
+      flags: plugin.flags,
+      abiVersion: plugin.abiVersion,
+    }))
+  }
+
+  async applyTransformPlugin(
+    request: ApplyTransformPluginRequest
+  ): Promise<ApplyTransformPluginResult> {
+    const offset = request.offset ?? 0
+    const length = request.length ?? 0
+
+    assertNonNegativeInteger('offset', offset)
+    assertNonNegativeInteger('length', length)
+
+    if (!request.pluginId) {
+      throw new Error('pluginId is required')
+    }
+
+    await this.ensureServerRunning()
+
+    const response = await applyClientTransformPlugin(
+      request.sessionId,
+      request.pluginId,
+      offset,
+      length,
+      request.optionsJson
+    )
+
+    return {
+      sessionId: response.sessionId,
+      pluginId: response.pluginId,
+      offset: response.offset,
+      length: response.length,
+      operation: response.operation,
+      operationName:
+        transformPluginOperationNames.get(response.operation) ||
+        `${response.operation}`,
+      contentChanged: response.contentChanged,
+      computedFileSize: response.computedFileSize,
+      replacementLength: response.replacementLength,
+      resultLabel: response.resultLabel,
+      resultMimeType: response.resultMimeType,
+      result: encodeData(response.result),
     }
   }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -83,6 +83,39 @@ export interface ReplaceSessionResult {
   overwriteOnly: boolean
 }
 
+export interface TransformPluginInfoResult {
+  id: string
+  name: string
+  description: string
+  operation: number
+  operationName: string
+  flags: number
+  abiVersion: number
+}
+
+export interface ApplyTransformPluginRequest {
+  sessionId: string
+  pluginId: string
+  offset?: number
+  length?: number
+  optionsJson?: string
+}
+
+export interface ApplyTransformPluginResult {
+  sessionId: string
+  pluginId: string
+  offset: number
+  length: number
+  operation: number
+  operationName: string
+  contentChanged: boolean
+  computedFileSize: number
+  replacementLength: number
+  resultLabel?: string
+  resultMimeType?: string
+  result: EncodedData
+}
+
 export interface PatchRequest {
   sessionId: string
   kind: PatchKind

--- a/packages/ai/tests/specs/mcp.spec.ts
+++ b/packages/ai/tests/specs/mcp.spec.ts
@@ -127,6 +127,14 @@ describe('@omega-edit/ai mcp server', function () {
         tools.some((tool) => tool.name === 'omega_edit_replace_session'),
         'expected omega_edit_replace_session in tool list'
       )
+      assert.ok(
+        tools.some((tool) => tool.name === 'omega_edit_list_transform_plugins'),
+        'expected omega_edit_list_transform_plugins in tool list'
+      )
+      assert.ok(
+        tools.some((tool) => tool.name === 'omega_edit_apply_transform_plugin'),
+        'expected omega_edit_apply_transform_plugin in tool list'
+      )
 
       const createSessionResponse = await sendRequest('tools/call', {
         name: 'omega_edit_create_session',
@@ -139,6 +147,31 @@ describe('@omega-edit/ai mcp server', function () {
       ).structuredContent as Record<string, unknown>) || { sessionId: '' }
       createdSessionId = createStructured.sessionId as string
       assert.ok(createdSessionId.length > 0)
+
+      const listPluginsResponse = await sendRequest('tools/call', {
+        name: 'omega_edit_list_transform_plugins',
+        arguments: {},
+      })
+      const listPluginsStructured = ((
+        listPluginsResponse.result as Record<string, unknown>
+      ).structuredContent as Record<string, unknown>) || { plugins: [] }
+      assert.ok(Array.isArray(listPluginsStructured.plugins))
+
+      const missingPluginResponse = await sendRequest('tools/call', {
+        name: 'omega_edit_apply_transform_plugin',
+        arguments: {
+          sessionId: createdSessionId,
+          pluginId: 'omega.example.missing',
+        },
+      })
+      const missingPluginResult =
+        (missingPluginResponse.result as Record<string, unknown>) || {}
+      assert.equal(missingPluginResult.isError, true)
+      assert.match(
+        ((missingPluginResult.structuredContent as Record<string, unknown>)
+          .error as string) || '',
+        /omega\.example\.missing/
+      )
 
       const readRangeResponse = await sendRequest('tools/call', {
         name: 'omega_edit_read_range',

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -51,6 +51,28 @@ describe('@omega-edit/ai toolkit', function () {
       assert.equal(initialRange.actualLength, 6)
       assert.equal(initialRange.data.utf8, 'abcdef')
 
+      const plugins = await toolkit.listTransformPlugins()
+      assert.ok(Array.isArray(plugins))
+
+      await assert.rejects(
+        () =>
+          toolkit.applyTransformPlugin({
+            sessionId: createdSessionId,
+            pluginId: 'omega.example.missing',
+          }),
+        /omega\.example\.missing/
+      )
+
+      await assert.rejects(
+        () =>
+          toolkit.applyTransformPlugin({
+            sessionId: createdSessionId,
+            pluginId: 'omega.example.missing',
+            offset: Number.NaN,
+          }),
+        /offset must be a non-negative integer/
+      )
+
       const searchResult = await toolkit.search({
         sessionId: createdSessionId,
         pattern: parseInputData('cd', 'utf8'),

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -234,6 +234,19 @@ These are especially useful for front-ends such as VS Code extensions that want 
 - `replaceSession(...)` - search-and-replace across the session
 - `profileSession(...)` - byte-frequency profiling and line-ending detection
 
+### Transform Plugins
+
+- `listTransformPlugins()` - discover plugins registered with the native server
+- `applyTransformPlugin(sessionId, pluginId, offset?, length?, optionsJson?)` - apply a plugin to a bounded session range
+
+Start the server with `transformPluginDirectories` or `--transform-plugin-dir`
+before listing or applying plugins. See the
+[Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins)
+for ABI, SDK, directory layout, and exemplar plugin details, including base64
+encode/decode, zlib stored-block compress/decompress, and inspect-only hash examples.
+The zlib examples intentionally cover the stored-block subset so they remain
+self-contained fixtures.
+
 ### Logging
 
 ```typescript

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -35,6 +35,10 @@ import type { GetCharacterCountsResponse } from './omega_edit'
 import type { GetCharacterCountsRequest } from './omega_edit'
 import type { GetByteFrequencyProfileResponse } from './omega_edit'
 import type { GetByteFrequencyProfileRequest } from './omega_edit'
+import type { ApplyTransformPluginResponse } from './omega_edit'
+import type { ApplyTransformPluginRequest } from './omega_edit'
+import type { ListTransformPluginsResponse } from './omega_edit'
+import type { ListTransformPluginsRequest } from './omega_edit'
 import type { DestroyLastCheckpointResponse } from './omega_edit'
 import type { DestroyLastCheckpointRequest } from './omega_edit'
 import type { ReplaceSessionCheckpointedResponse } from './omega_edit'
@@ -1430,6 +1434,81 @@ export interface IEditorServiceClient {
     callback: (
       err: grpc.ServiceError | null,
       value?: DestroyLastCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  /**
+   * List transform plugins registered with the native server.
+   *
+   * @generated from protobuf rpc: ListTransformPlugins
+   */
+  listTransformPlugins(
+    input: ListTransformPluginsRequest,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: ListTransformPluginsResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  listTransformPlugins(
+    input: ListTransformPluginsRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: ListTransformPluginsResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  listTransformPlugins(
+    input: ListTransformPluginsRequest,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: ListTransformPluginsResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  listTransformPlugins(
+    input: ListTransformPluginsRequest,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: ListTransformPluginsResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  /**
+   * Apply a transform plugin to a session range. Plugins may replace content,
+   * inspect content and return derived bytes, or do both.
+   *
+   * @generated from protobuf rpc: ApplyTransformPlugin
+   */
+  applyTransformPlugin(
+    input: ApplyTransformPluginRequest,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: ApplyTransformPluginResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  applyTransformPlugin(
+    input: ApplyTransformPluginRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: ApplyTransformPluginResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  applyTransformPlugin(
+    input: ApplyTransformPluginRequest,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: ApplyTransformPluginResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  applyTransformPlugin(
+    input: ApplyTransformPluginRequest,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: ApplyTransformPluginResponse
     ) => void
   ): grpc.ClientUnaryCall
   /**
@@ -3084,6 +3163,89 @@ export class EditorServiceClient
     )
   }
   /**
+   * List transform plugins registered with the native server.
+   *
+   * @generated from protobuf rpc: ListTransformPlugins
+   */
+  listTransformPlugins(
+    input: ListTransformPluginsRequest,
+    metadata:
+      | grpc.Metadata
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: ListTransformPluginsResponse
+        ) => void),
+    options?:
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: ListTransformPluginsResponse
+        ) => void),
+    callback?: (
+      err: grpc.ServiceError | null,
+      value?: ListTransformPluginsResponse
+    ) => void
+  ): grpc.ClientUnaryCall {
+    const method = EditorService.methods[34]
+    return this.makeUnaryRequest<
+      ListTransformPluginsRequest,
+      ListTransformPluginsResponse
+    >(
+      `/${EditorService.typeName}/${method.name}`,
+      (value: ListTransformPluginsRequest): Buffer =>
+        Buffer.from(method.I.toBinary(value, this._binaryOptions)),
+      (value: Buffer): ListTransformPluginsResponse =>
+        method.O.fromBinary(value, this._binaryOptions),
+      input,
+      metadata as any,
+      options as any,
+      callback as any
+    )
+  }
+  /**
+   * Apply a transform plugin to a session range. Plugins may replace content,
+   * inspect content and return derived bytes, or do both.
+   *
+   * @generated from protobuf rpc: ApplyTransformPlugin
+   */
+  applyTransformPlugin(
+    input: ApplyTransformPluginRequest,
+    metadata:
+      | grpc.Metadata
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: ApplyTransformPluginResponse
+        ) => void),
+    options?:
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: ApplyTransformPluginResponse
+        ) => void),
+    callback?: (
+      err: grpc.ServiceError | null,
+      value?: ApplyTransformPluginResponse
+    ) => void
+  ): grpc.ClientUnaryCall {
+    const method = EditorService.methods[35]
+    return this.makeUnaryRequest<
+      ApplyTransformPluginRequest,
+      ApplyTransformPluginResponse
+    >(
+      `/${EditorService.typeName}/${method.name}`,
+      (value: ApplyTransformPluginRequest): Buffer =>
+        Buffer.from(method.I.toBinary(value, this._binaryOptions)),
+      (value: Buffer): ApplyTransformPluginResponse =>
+        method.O.fromBinary(value, this._binaryOptions),
+      input,
+      metadata as any,
+      options as any,
+      callback as any
+    )
+  }
+  /**
    * Compute a byte-frequency histogram (256 buckets, one per byte value) over
    * a range of session data.  Bucket 256 counts DOS-style CR+LF line endings.
    *
@@ -3109,7 +3271,7 @@ export class EditorServiceClient
       value?: GetByteFrequencyProfileResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[34]
+    const method = EditorService.methods[36]
     return this.makeUnaryRequest<
       GetByteFrequencyProfileRequest,
       GetByteFrequencyProfileResponse
@@ -3151,7 +3313,7 @@ export class EditorServiceClient
       value?: GetCharacterCountsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[35]
+    const method = EditorService.methods[37]
     return this.makeUnaryRequest<
       GetCharacterCountsRequest,
       GetCharacterCountsResponse
@@ -3196,7 +3358,7 @@ export class EditorServiceClient
       value?: ServerControlResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[36]
+    const method = EditorService.methods[38]
     return this.makeUnaryRequest<ServerControlRequest, ServerControlResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: ServerControlRequest): Buffer =>
@@ -3229,7 +3391,7 @@ export class EditorServiceClient
       value?: GetHeartbeatResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[37]
+    const method = EditorService.methods[39]
     return this.makeUnaryRequest<GetHeartbeatRequest, GetHeartbeatResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetHeartbeatRequest): Buffer =>
@@ -3258,7 +3420,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToSessionEventsResponse> {
-    const method = EditorService.methods[38]
+    const method = EditorService.methods[40]
     return this.makeServerStreamRequest<
       SubscribeToSessionEventsRequest,
       SubscribeToSessionEventsResponse
@@ -3284,7 +3446,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToViewportEventsResponse> {
-    const method = EditorService.methods[39]
+    const method = EditorService.methods[41]
     return this.makeServerStreamRequest<
       SubscribeToViewportEventsRequest,
       SubscribeToViewportEventsResponse
@@ -3324,7 +3486,7 @@ export class EditorServiceClient
       value?: UnsubscribeToSessionEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[40]
+    const method = EditorService.methods[42]
     return this.makeUnaryRequest<
       UnsubscribeToSessionEventsRequest,
       UnsubscribeToSessionEventsResponse
@@ -3365,7 +3527,7 @@ export class EditorServiceClient
       value?: UnsubscribeToViewportEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[41]
+    const method = EditorService.methods[43]
     return this.makeUnaryRequest<
       UnsubscribeToViewportEventsRequest,
       UnsubscribeToViewportEventsResponse

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -1487,6 +1487,132 @@ export interface DestroyLastCheckpointResponse {
   remainingCheckpoints: number // Remaining checkpoint count after revert.
 }
 /**
+ * Metadata advertised by a registered transform plugin.
+ *
+ * @generated from protobuf message omega_edit.v1.TransformPluginInfo
+ */
+export interface TransformPluginInfo {
+  /**
+   * @generated from protobuf field: string id = 1
+   */
+  id: string
+  /**
+   * @generated from protobuf field: string name = 2
+   */
+  name: string
+  /**
+   * @generated from protobuf field: string description = 3
+   */
+  description: string
+  /**
+   * @generated from protobuf field: omega_edit.v1.TransformPluginOperation operation = 4
+   */
+  operation: TransformPluginOperation
+  /**
+   * @generated from protobuf field: uint32 flags = 5
+   */
+  flags: number
+  /**
+   * @generated from protobuf field: uint32 abi_version = 6
+   */
+  abiVersion: number
+}
+/**
+ * Request registered transform plugin metadata.
+ *
+ * @generated from protobuf message omega_edit.v1.ListTransformPluginsRequest
+ */
+export interface ListTransformPluginsRequest {}
+/**
+ * Registered transform plugin metadata.
+ *
+ * @generated from protobuf message omega_edit.v1.ListTransformPluginsResponse
+ */
+export interface ListTransformPluginsResponse {
+  /**
+   * @generated from protobuf field: repeated omega_edit.v1.TransformPluginInfo plugins = 1
+   */
+  plugins: TransformPluginInfo[]
+}
+/**
+ * Request applying a transform plugin to a session range.
+ *
+ * @generated from protobuf message omega_edit.v1.ApplyTransformPluginRequest
+ */
+export interface ApplyTransformPluginRequest {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session to transform.
+  /**
+   * @generated from protobuf field: string plugin_id = 2
+   */
+  pluginId: string // Registered plugin identifier.
+  /**
+   * @generated from protobuf field: optional int64 offset = 3
+   */
+  offset?: number // Starting byte offset (default: 0).
+  /**
+   * @generated from protobuf field: optional int64 length = 4
+   */
+  length?: number // Number of bytes to transform (0/default = through EOF).
+  /**
+   * @generated from protobuf field: optional string options_json = 5
+   */
+  optionsJson?: string // Plugin-specific options.
+}
+/**
+ * Result of applying a transform plugin.
+ *
+ * @generated from protobuf message omega_edit.v1.ApplyTransformPluginResponse
+ */
+export interface ApplyTransformPluginResponse {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session that was transformed.
+  /**
+   * @generated from protobuf field: string plugin_id = 2
+   */
+  pluginId: string // Plugin that was applied.
+  /**
+   * @generated from protobuf field: int64 offset = 3
+   */
+  offset: number // Starting offset of the processed range.
+  /**
+   * @generated from protobuf field: int64 length = 4
+   */
+  length: number // Length of the processed range.
+  /**
+   * @generated from protobuf field: omega_edit.v1.TransformPluginOperation operation = 5
+   */
+  operation: TransformPluginOperation // Plugin operation mode.
+  /**
+   * @generated from protobuf field: bool content_changed = 6
+   */
+  contentChanged: boolean // True when the plugin replaced content.
+  /**
+   * @generated from protobuf field: int64 computed_file_size = 7
+   */
+  computedFileSize: number // Session size after the transform.
+  /**
+   * @generated from protobuf field: int64 replacement_length = 8
+   */
+  replacementLength: number // Replacement bytes produced by the plugin.
+  /**
+   * @generated from protobuf field: optional string result_label = 9
+   */
+  resultLabel?: string // Plugin-provided result label.
+  /**
+   * @generated from protobuf field: optional string result_mime_type = 10
+   */
+  resultMimeType?: string // Plugin-provided result MIME type.
+  /**
+   * @generated from protobuf field: bytes result = 11
+   */
+  result: Uint8Array // Plugin-provided inspection bytes.
+}
+/**
  * Request to compute a byte-frequency histogram.
  *
  * @generated from protobuf message omega_edit.v1.GetByteFrequencyProfileRequest
@@ -2066,6 +2192,29 @@ export enum ServerControlStatus {
    * @generated from protobuf enum value: SERVER_CONTROL_STATUS_DRAINING = 2;
    */
   DRAINING = 2,
+}
+/**
+ * Transform plugin operation mode.
+ *
+ * @generated from protobuf enum omega_edit.v1.TransformPluginOperation
+ */
+export enum TransformPluginOperation {
+  /**
+   * @generated from protobuf enum value: TRANSFORM_PLUGIN_OPERATION_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+  /**
+   * @generated from protobuf enum value: TRANSFORM_PLUGIN_OPERATION_REPLACE = 1;
+   */
+  REPLACE = 1,
+  /**
+   * @generated from protobuf enum value: TRANSFORM_PLUGIN_OPERATION_INSPECT = 2;
+   */
+  INSPECT = 2,
+  /**
+   * @generated from protobuf enum value: TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT = 3;
+   */
+  REPLACE_AND_INSPECT = 3,
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class GetServerInfoRequest$Type extends MessageType<GetServerInfoRequest> {
@@ -9251,6 +9400,606 @@ class DestroyLastCheckpointResponse$Type extends MessageType<DestroyLastCheckpoi
 export const DestroyLastCheckpointResponse =
   new DestroyLastCheckpointResponse$Type()
 // @generated message type with reflection information, may provide speed optimized methods
+class TransformPluginInfo$Type extends MessageType<TransformPluginInfo> {
+  constructor() {
+    super('omega_edit.v1.TransformPluginInfo', [
+      { no: 1, name: 'id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 2, name: 'name', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 3,
+        name: 'description',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 4,
+        name: 'operation',
+        kind: 'enum',
+        T: () => [
+          'omega_edit.v1.TransformPluginOperation',
+          TransformPluginOperation,
+          'TRANSFORM_PLUGIN_OPERATION_',
+        ],
+      },
+      { no: 5, name: 'flags', kind: 'scalar', T: 13 /*ScalarType.UINT32*/ },
+      {
+        no: 6,
+        name: 'abi_version',
+        kind: 'scalar',
+        T: 13 /*ScalarType.UINT32*/,
+      },
+    ])
+  }
+  create(value?: PartialMessage<TransformPluginInfo>): TransformPluginInfo {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.id = ''
+    message.name = ''
+    message.description = ''
+    message.operation = 0
+    message.flags = 0
+    message.abiVersion = 0
+    if (value !== undefined)
+      reflectionMergePartial<TransformPluginInfo>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: TransformPluginInfo
+  ): TransformPluginInfo {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string id */ 1:
+          message.id = reader.string()
+          break
+        case /* string name */ 2:
+          message.name = reader.string()
+          break
+        case /* string description */ 3:
+          message.description = reader.string()
+          break
+        case /* omega_edit.v1.TransformPluginOperation operation */ 4:
+          message.operation = reader.int32()
+          break
+        case /* uint32 flags */ 5:
+          message.flags = reader.uint32()
+          break
+        case /* uint32 abi_version */ 6:
+          message.abiVersion = reader.uint32()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: TransformPluginInfo,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string id = 1; */
+    if (message.id !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.id)
+    /* string name = 2; */
+    if (message.name !== '')
+      writer.tag(2, WireType.LengthDelimited).string(message.name)
+    /* string description = 3; */
+    if (message.description !== '')
+      writer.tag(3, WireType.LengthDelimited).string(message.description)
+    /* omega_edit.v1.TransformPluginOperation operation = 4; */
+    if (message.operation !== 0)
+      writer.tag(4, WireType.Varint).int32(message.operation)
+    /* uint32 flags = 5; */
+    if (message.flags !== 0)
+      writer.tag(5, WireType.Varint).uint32(message.flags)
+    /* uint32 abi_version = 6; */
+    if (message.abiVersion !== 0)
+      writer.tag(6, WireType.Varint).uint32(message.abiVersion)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.TransformPluginInfo
+ */
+export const TransformPluginInfo = new TransformPluginInfo$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class ListTransformPluginsRequest$Type extends MessageType<ListTransformPluginsRequest> {
+  constructor() {
+    super('omega_edit.v1.ListTransformPluginsRequest', [])
+  }
+  create(
+    value?: PartialMessage<ListTransformPluginsRequest>
+  ): ListTransformPluginsRequest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    if (value !== undefined)
+      reflectionMergePartial<ListTransformPluginsRequest>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: ListTransformPluginsRequest
+  ): ListTransformPluginsRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: ListTransformPluginsRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.ListTransformPluginsRequest
+ */
+export const ListTransformPluginsRequest =
+  new ListTransformPluginsRequest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class ListTransformPluginsResponse$Type extends MessageType<ListTransformPluginsResponse> {
+  constructor() {
+    super('omega_edit.v1.ListTransformPluginsResponse', [
+      {
+        no: 1,
+        name: 'plugins',
+        kind: 'message',
+        repeat: 2 /*RepeatType.UNPACKED*/,
+        T: () => TransformPluginInfo,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<ListTransformPluginsResponse>
+  ): ListTransformPluginsResponse {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.plugins = []
+    if (value !== undefined)
+      reflectionMergePartial<ListTransformPluginsResponse>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: ListTransformPluginsResponse
+  ): ListTransformPluginsResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* repeated omega_edit.v1.TransformPluginInfo plugins */ 1:
+          message.plugins.push(
+            TransformPluginInfo.internalBinaryRead(
+              reader,
+              reader.uint32(),
+              options
+            )
+          )
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: ListTransformPluginsResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* repeated omega_edit.v1.TransformPluginInfo plugins = 1; */
+    for (let i = 0; i < message.plugins.length; i++)
+      TransformPluginInfo.internalBinaryWrite(
+        message.plugins[i],
+        writer.tag(1, WireType.LengthDelimited).fork(),
+        options
+      ).join()
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.ListTransformPluginsResponse
+ */
+export const ListTransformPluginsResponse =
+  new ListTransformPluginsResponse$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class ApplyTransformPluginRequest$Type extends MessageType<ApplyTransformPluginRequest> {
+  constructor() {
+    super('omega_edit.v1.ApplyTransformPluginRequest', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 2, name: 'plugin_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 3,
+        name: 'offset',
+        kind: 'scalar',
+        opt: true,
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 4,
+        name: 'length',
+        kind: 'scalar',
+        opt: true,
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 5,
+        name: 'options_json',
+        kind: 'scalar',
+        opt: true,
+        T: 9 /*ScalarType.STRING*/,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<ApplyTransformPluginRequest>
+  ): ApplyTransformPluginRequest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.pluginId = ''
+    if (value !== undefined)
+      reflectionMergePartial<ApplyTransformPluginRequest>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: ApplyTransformPluginRequest
+  ): ApplyTransformPluginRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* string plugin_id */ 2:
+          message.pluginId = reader.string()
+          break
+        case /* optional int64 offset */ 3:
+          message.offset = reader.int64().toNumber()
+          break
+        case /* optional int64 length */ 4:
+          message.length = reader.int64().toNumber()
+          break
+        case /* optional string options_json */ 5:
+          message.optionsJson = reader.string()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: ApplyTransformPluginRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* string plugin_id = 2; */
+    if (message.pluginId !== '')
+      writer.tag(2, WireType.LengthDelimited).string(message.pluginId)
+    /* optional int64 offset = 3; */
+    if (message.offset !== undefined)
+      writer.tag(3, WireType.Varint).int64(message.offset)
+    /* optional int64 length = 4; */
+    if (message.length !== undefined)
+      writer.tag(4, WireType.Varint).int64(message.length)
+    /* optional string options_json = 5; */
+    if (message.optionsJson !== undefined)
+      writer.tag(5, WireType.LengthDelimited).string(message.optionsJson)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.ApplyTransformPluginRequest
+ */
+export const ApplyTransformPluginRequest =
+  new ApplyTransformPluginRequest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class ApplyTransformPluginResponse$Type extends MessageType<ApplyTransformPluginResponse> {
+  constructor() {
+    super('omega_edit.v1.ApplyTransformPluginResponse', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 2, name: 'plugin_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 3,
+        name: 'offset',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 4,
+        name: 'length',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 5,
+        name: 'operation',
+        kind: 'enum',
+        T: () => [
+          'omega_edit.v1.TransformPluginOperation',
+          TransformPluginOperation,
+          'TRANSFORM_PLUGIN_OPERATION_',
+        ],
+      },
+      {
+        no: 6,
+        name: 'content_changed',
+        kind: 'scalar',
+        T: 8 /*ScalarType.BOOL*/,
+      },
+      {
+        no: 7,
+        name: 'computed_file_size',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 8,
+        name: 'replacement_length',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 9,
+        name: 'result_label',
+        kind: 'scalar',
+        opt: true,
+        T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 10,
+        name: 'result_mime_type',
+        kind: 'scalar',
+        opt: true,
+        T: 9 /*ScalarType.STRING*/,
+      },
+      { no: 11, name: 'result', kind: 'scalar', T: 12 /*ScalarType.BYTES*/ },
+    ])
+  }
+  create(
+    value?: PartialMessage<ApplyTransformPluginResponse>
+  ): ApplyTransformPluginResponse {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.pluginId = ''
+    message.offset = 0
+    message.length = 0
+    message.operation = 0
+    message.contentChanged = false
+    message.computedFileSize = 0
+    message.replacementLength = 0
+    message.result = new Uint8Array(0)
+    if (value !== undefined)
+      reflectionMergePartial<ApplyTransformPluginResponse>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: ApplyTransformPluginResponse
+  ): ApplyTransformPluginResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* string plugin_id */ 2:
+          message.pluginId = reader.string()
+          break
+        case /* int64 offset */ 3:
+          message.offset = reader.int64().toNumber()
+          break
+        case /* int64 length */ 4:
+          message.length = reader.int64().toNumber()
+          break
+        case /* omega_edit.v1.TransformPluginOperation operation */ 5:
+          message.operation = reader.int32()
+          break
+        case /* bool content_changed */ 6:
+          message.contentChanged = reader.bool()
+          break
+        case /* int64 computed_file_size */ 7:
+          message.computedFileSize = reader.int64().toNumber()
+          break
+        case /* int64 replacement_length */ 8:
+          message.replacementLength = reader.int64().toNumber()
+          break
+        case /* optional string result_label */ 9:
+          message.resultLabel = reader.string()
+          break
+        case /* optional string result_mime_type */ 10:
+          message.resultMimeType = reader.string()
+          break
+        case /* bytes result */ 11:
+          message.result = reader.bytes()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: ApplyTransformPluginResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* string plugin_id = 2; */
+    if (message.pluginId !== '')
+      writer.tag(2, WireType.LengthDelimited).string(message.pluginId)
+    /* int64 offset = 3; */
+    if (message.offset !== 0)
+      writer.tag(3, WireType.Varint).int64(message.offset)
+    /* int64 length = 4; */
+    if (message.length !== 0)
+      writer.tag(4, WireType.Varint).int64(message.length)
+    /* omega_edit.v1.TransformPluginOperation operation = 5; */
+    if (message.operation !== 0)
+      writer.tag(5, WireType.Varint).int32(message.operation)
+    /* bool content_changed = 6; */
+    if (message.contentChanged !== false)
+      writer.tag(6, WireType.Varint).bool(message.contentChanged)
+    /* int64 computed_file_size = 7; */
+    if (message.computedFileSize !== 0)
+      writer.tag(7, WireType.Varint).int64(message.computedFileSize)
+    /* int64 replacement_length = 8; */
+    if (message.replacementLength !== 0)
+      writer.tag(8, WireType.Varint).int64(message.replacementLength)
+    /* optional string result_label = 9; */
+    if (message.resultLabel !== undefined)
+      writer.tag(9, WireType.LengthDelimited).string(message.resultLabel)
+    /* optional string result_mime_type = 10; */
+    if (message.resultMimeType !== undefined)
+      writer.tag(10, WireType.LengthDelimited).string(message.resultMimeType)
+    /* bytes result = 11; */
+    if (message.result.length)
+      writer.tag(11, WireType.LengthDelimited).bytes(message.result)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.ApplyTransformPluginResponse
+ */
+export const ApplyTransformPluginResponse =
+  new ApplyTransformPluginResponse$Type()
+// @generated message type with reflection information, may provide speed optimized methods
 class GetByteFrequencyProfileRequest$Type extends MessageType<GetByteFrequencyProfileRequest> {
   constructor() {
     super('omega_edit.v1.GetByteFrequencyProfileRequest', [
@@ -10782,6 +11531,18 @@ export const EditorService = new ServiceType('omega_edit.v1.EditorService', [
     options: {},
     I: DestroyLastCheckpointRequest,
     O: DestroyLastCheckpointResponse,
+  },
+  {
+    name: 'ListTransformPlugins',
+    options: {},
+    I: ListTransformPluginsRequest,
+    O: ListTransformPluginsResponse,
+  },
+  {
+    name: 'ApplyTransformPlugin',
+    options: {},
+    I: ApplyTransformPluginRequest,
+    O: ApplyTransformPluginResponse,
   },
   {
     name: 'GetByteFrequencyProfile',

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -19,6 +19,7 @@
 
 import {
   CountKind,
+  type ApplyTransformPluginResponse,
   type CreateSessionRequest,
   type CreateSessionResponse,
   type GetByteFrequencyProfileResponse,
@@ -30,6 +31,7 @@ import {
   type GetLanguageResponse,
   type GetSegmentResponse,
   type GetSessionCountResponse,
+  type ListTransformPluginsResponse,
   type NotifyChangedViewportsResponse,
   type DestroyLastCheckpointResponse,
   type ReplaceSessionRequest,
@@ -41,6 +43,7 @@ import {
   type SearchSessionRequest,
   type SearchSessionResponse,
   type SingleCount,
+  type TransformPluginInfo,
 } from './generated/omega_edit/v1/omega_edit'
 import { debugLog, getLogger } from '../logger'
 import { getClient } from '../client'
@@ -656,6 +659,97 @@ export async function notifyChangedViewports(
         return resolve(required.count)
       } catch (error) {
         return reject(makeWrappedError('notifyChangedViewports', error))
+      }
+    })
+  })
+}
+
+export async function listTransformPlugins(): Promise<TransformPluginInfo[]> {
+  const log = getLogger()
+  log.debug({ fn: 'protobufTs.listTransformPlugins' })
+  const client = await getClient()
+
+  return new Promise<TransformPluginInfo[]>((resolve, reject) => {
+    client.listTransformPlugins({}, (err, response) => {
+      if (err) {
+        log.error({
+          fn: 'protobufTs.listTransformPlugins',
+          err: {
+            msg: err.message,
+            details: err.details,
+            code: err.code,
+            stack: err.stack,
+          },
+        })
+        return reject(makeWrappedError('listTransformPlugins', err))
+      }
+
+      try {
+        const required = requireResponse(
+          response as ListTransformPluginsResponse | undefined,
+          'listTransformPlugins'
+        )
+        debugLog(log, () => ({
+          fn: 'protobufTs.listTransformPlugins',
+          resp: required,
+        }))
+        return resolve(required.plugins)
+      } catch (error) {
+        return reject(makeWrappedError('listTransformPlugins', error))
+      }
+    })
+  })
+}
+
+export async function applyTransformPlugin(
+  sessionId: string,
+  pluginId: string,
+  offset: number = 0,
+  length: number = 0,
+  optionsJson?: string
+): Promise<ApplyTransformPluginResponse> {
+  const log = getLogger()
+  const request = {
+    sessionId,
+    pluginId,
+    offset,
+    length,
+    optionsJson,
+  }
+  debugLog(log, () => ({
+    fn: 'protobufTs.applyTransformPlugin',
+    rqst: request,
+  }))
+  const client = await getClient()
+
+  return new Promise<ApplyTransformPluginResponse>((resolve, reject) => {
+    client.applyTransformPlugin(request, (err, response) => {
+      if (err) {
+        log.error({
+          fn: 'protobufTs.applyTransformPlugin',
+          rqst: request,
+          err: {
+            msg: err.message,
+            details: err.details,
+            code: err.code,
+            stack: err.stack,
+          },
+        })
+        return reject(makeWrappedError('applyTransformPlugin', err))
+      }
+
+      try {
+        const required = requireResponse(
+          response as ApplyTransformPluginResponse | undefined,
+          'applyTransformPlugin'
+        )
+        debugLog(log, () => ({
+          fn: 'protobufTs.applyTransformPlugin',
+          resp: required,
+        }))
+        return resolve(required)
+      } catch (error) {
+        return reject(makeWrappedError('applyTransformPlugin', error))
       }
     })
   })

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -18,11 +18,15 @@
  */
 
 import {
+  TransformPluginOperation as RawProtoTransformPluginOperation,
   IOFlags as ProtoIOFlags,
   SessionEventKind as RawProtoSessionEventKind,
   ViewportEventKind as RawProtoViewportEventKind,
+  type ApplyTransformPluginResponse as RawApplyTransformPluginResponse,
+  type TransformPluginInfo as RawTransformPluginInfo,
 } from './protobuf_ts/generated/omega_edit/v1/omega_edit'
 import {
+  applyTransformPlugin as rawApplyTransformPlugin,
   beginSessionTransaction as rawBeginSessionTransaction,
   countCharacters as rawCountCharacters,
   createSession as rawCreateSession,
@@ -35,6 +39,7 @@ import {
   getLanguage as rawGetLanguage,
   getSegment as rawGetSegment,
   getSessionCount as rawGetSessionCount,
+  listTransformPlugins as rawListTransformPlugins,
   notifyChangedViewports as rawNotifyChangedViewports,
   pauseSessionChanges as rawPauseSessionChanges,
   profileSession as rawProfileSession,
@@ -115,6 +120,18 @@ export const ViewportEventKind = {
 } as const
 export type ViewportEventKind =
   (typeof ViewportEventKind)[keyof typeof ViewportEventKind]
+
+export const TransformPluginOperation = {
+  UNSPECIFIED: RawProtoTransformPluginOperation.UNSPECIFIED,
+  REPLACE: RawProtoTransformPluginOperation.REPLACE,
+  INSPECT: RawProtoTransformPluginOperation.INSPECT,
+  REPLACE_AND_INSPECT: RawProtoTransformPluginOperation.REPLACE_AND_INSPECT,
+} as const
+export type TransformPluginOperation =
+  (typeof TransformPluginOperation)[keyof typeof TransformPluginOperation]
+
+export type TransformPluginInfo = RawTransformPluginInfo
+export type ApplyTransformPluginResponse = RawApplyTransformPluginResponse
 
 export const PROFILE_DOS_EOL = 256
 
@@ -298,6 +315,39 @@ export function notifyChangedViewports(session_id: string): Promise<number> {
   return rawNotifyChangedViewports(session_id).then((count) =>
     requireSafeIntegerOutput('changed viewport count', count)
   )
+}
+
+export function listTransformPlugins(): Promise<TransformPluginInfo[]> {
+  return rawListTransformPlugins()
+}
+
+export async function applyTransformPlugin(
+  session_id: string,
+  plugin_id: string,
+  offset: number = 0,
+  length: number = 0,
+  options_json?: string
+): Promise<ApplyTransformPluginResponse> {
+  return await enqueueSessionMutation(session_id, async () => {
+    const response = await rawApplyTransformPlugin(
+      session_id,
+      plugin_id,
+      requireSafeIntegerInput('applyTransformPlugin offset', offset),
+      requireSafeIntegerInput('applyTransformPlugin length', length),
+      options_json
+    )
+    requireSafeIntegerOutput('applyTransformPlugin offset', response.offset)
+    requireSafeIntegerOutput('applyTransformPlugin length', response.length)
+    requireSafeIntegerOutput(
+      'applyTransformPlugin computed file size',
+      response.computedFileSize
+    )
+    requireSafeIntegerOutput(
+      'applyTransformPlugin replacement length',
+      response.replacementLength
+    )
+    return response
+  })
 }
 
 export function profileSession(

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -19,6 +19,7 @@
 
 import { expect, expectOpaqueId, opaqueIdPattern, testPort } from './common.js'
 import {
+  applyTransformPlugin,
   del,
   countCharacters,
   createSession,
@@ -39,6 +40,7 @@ import {
   getViewportCount,
   insert,
   IOFlags,
+  listTransformPlugins,
   notifyChangedViewports,
   profileSession,
   saveSession,
@@ -1270,6 +1272,24 @@ describe('Sessions', () => {
           `viewport already exists: ${desiredViewportId}`
         )
       }
+    } finally {
+      await destroySession(sessionId)
+    }
+  })
+
+  it('Should expose transform plugin discovery and missing-plugin errors', async () => {
+    const plugins = await listTransformPlugins()
+    expect(plugins).to.be.an('array')
+
+    const session = await createSessionFromBytes(Buffer.from('abc'))
+    const sessionId = session.getSessionId()
+
+    try {
+      await applyTransformPlugin(sessionId, 'omega.example.missing')
+      expect.fail('applyTransformPlugin should reject unknown plugin IDs')
+    } catch (err) {
+      expect((err as Error).message).to.include('NOT_FOUND')
+      expect((err as Error).message).to.include('omega.example.missing')
     } finally {
       await destroySession(sessionId)
     }

--- a/packages/client/tests/specs/transformPlugin.spec.ts
+++ b/packages/client/tests/specs/transformPlugin.spec.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2021 Concurrent Technologies Corporation.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  TransformPluginOperation,
+  applyTransformPlugin,
+  createSessionFromBytes,
+  destroySession,
+  findFirstAvailablePort,
+  getClient,
+  getComputedFileSize,
+  getSegment,
+  listTransformPlugins,
+  resetClient,
+  stopProcessUsingPID,
+  stopServiceOnPort,
+} from '@omega-edit/client'
+import omegaEditServer from '@omega-edit/server'
+import * as fs from 'fs'
+import * as path from 'path'
+import waitPort from 'wait-port'
+import { expect, initChai, testHost } from './common.js'
+import { getModuleCompat } from './moduleCompat.js'
+
+const { __dirname } = getModuleCompat(import.meta.url)
+const repoRoot = path.resolve(__dirname, '../../../..')
+const { runServerWithArgs } =
+  omegaEditServer as typeof import('@omega-edit/server')
+
+function directoryHasTransformPlugin(directory: string): boolean {
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    return false
+  }
+
+  return fs.readdirSync(directory).some((file) => {
+    return (
+      file.startsWith('omega_transform_') &&
+      (file.endsWith('.dll') || file.endsWith('.so') || file.endsWith('.dylib'))
+    )
+  })
+}
+
+function findTransformPluginDirectory(): string | undefined {
+  const candidates = [
+    process.env.OMEGA_EDIT_TEST_PLUGIN_DIR || '',
+    path.join(
+      repoRoot,
+      '_build_core',
+      'packages',
+      'core',
+      'src',
+      'tests',
+      'plugins'
+    ),
+    path.join(repoRoot, 'build', 'core', 'src', 'tests', 'plugins'),
+    path.join(repoRoot, 'build-coverage', 'core', 'src', 'tests', 'plugins'),
+  ].filter(Boolean)
+
+  return candidates.find(directoryHasTransformPlugin)
+}
+
+describe('Transform plugin gRPC integration', () => {
+  before(async () => {
+    await initChai()
+  })
+
+  it('Should list and apply exemplar transform plugins through gRPC', async function () {
+    const pluginDirectory = findTransformPluginDirectory()
+    if (!pluginDirectory) {
+      this.skip()
+    }
+
+    const port = await findFirstAvailablePort(21000, 21999)
+    if (port === null) {
+      throw new Error('No available port found for transform plugin test')
+    }
+
+    const previousServerUri = process.env.OMEGA_EDIT_SERVER_URI
+    const previousServerSocket = process.env.OMEGA_EDIT_SERVER_SOCKET
+    let pid: number | undefined
+    let sessionId = ''
+
+    try {
+      delete process.env.OMEGA_EDIT_SERVER_URI
+      delete process.env.OMEGA_EDIT_SERVER_SOCKET
+
+      await stopServiceOnPort(port)
+      const serverProcess = await runServerWithArgs([
+        `--interface=${testHost}`,
+        `--port=${port}`,
+        `--transform-plugin-dir=${pluginDirectory}`,
+      ])
+      pid = serverProcess.pid
+      expect(pid).to.be.a('number').greaterThan(0)
+      await waitPort({
+        host: testHost,
+        port,
+        output: 'silent',
+        timeout: 20000,
+      })
+
+      resetClient()
+      expect(await getClient(port, testHost)).to.not.be.undefined
+
+      const plugins = await listTransformPlugins()
+      expect(plugins.map((plugin) => plugin.id)).to.include.members([
+        'omega.example.base64_decode',
+        'omega.example.base64_encode',
+        'omega.example.fnv1a64',
+        'omega.example.zlib_compress',
+        'omega.example.zlib_decompress',
+        'omega.example.xor_ff',
+        'omega.example.repeat',
+        'omega.example.checksum8',
+      ])
+
+      const session = await createSessionFromBytes(Buffer.from('abc', 'utf8'))
+      sessionId = session.getSessionId()
+
+      const encodeResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.base64_encode',
+        0,
+        3
+      )
+      expect(encodeResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(encodeResponse.contentChanged).to.equal(true)
+      expect(encodeResponse.replacementLength).to.equal(4)
+      expect(encodeResponse.computedFileSize).to.equal(4)
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 4)).toString('utf8')
+      ).to.equal('YWJj')
+
+      const decodeResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.base64_decode',
+        0,
+        4
+      )
+      expect(decodeResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(decodeResponse.contentChanged).to.equal(true)
+      expect(decodeResponse.replacementLength).to.equal(3)
+      expect(decodeResponse.computedFileSize).to.equal(3)
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
+      ).to.equal('abc')
+
+      const compressResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.zlib_compress',
+        0,
+        3
+      )
+      expect(compressResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(compressResponse.contentChanged).to.equal(true)
+      expect(compressResponse.replacementLength).to.equal(14)
+      expect(compressResponse.computedFileSize).to.equal(14)
+      expect(Array.from(await getSegment(sessionId, 0, 2))).to.deep.equal([
+        0x78, 0x01,
+      ])
+
+      const decompressResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.zlib_decompress',
+        0,
+        14
+      )
+      expect(decompressResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(decompressResponse.contentChanged).to.equal(true)
+      expect(decompressResponse.replacementLength).to.equal(3)
+      expect(decompressResponse.computedFileSize).to.equal(3)
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
+      ).to.equal('abc')
+
+      const repeatResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.repeat',
+        1,
+        2
+      )
+      expect(repeatResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(repeatResponse.contentChanged).to.equal(true)
+      expect(repeatResponse.replacementLength).to.equal(4)
+      expect(repeatResponse.computedFileSize).to.equal(5)
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 5)).toString('utf8')
+      ).to.equal('abcbc')
+
+      const checksumResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.checksum8',
+        0,
+        5
+      )
+      expect(checksumResponse.operation).to.equal(
+        TransformPluginOperation.INSPECT
+      )
+      expect(checksumResponse.contentChanged).to.equal(false)
+      expect(checksumResponse.resultLabel).to.equal('checksum8')
+      expect(checksumResponse.resultMimeType).to.equal('text/plain')
+      expect(Buffer.from(checksumResponse.result).toString('utf8')).to.equal(
+        '0xEB'
+      )
+      expect(await getComputedFileSize(sessionId)).to.equal(5)
+
+      const hashResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.fnv1a64',
+        0,
+        5
+      )
+      expect(hashResponse.operation).to.equal(TransformPluginOperation.INSPECT)
+      expect(hashResponse.contentChanged).to.equal(false)
+      expect(hashResponse.resultLabel).to.equal('fnv1a64')
+      expect(hashResponse.resultMimeType).to.equal('text/plain')
+      expect(Buffer.from(hashResponse.result).toString('utf8')).to.equal(
+        '0x6334A32D761281D8'
+      )
+      expect(await getComputedFileSize(sessionId)).to.equal(5)
+
+      const xorResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.xor_ff',
+        0,
+        1
+      )
+      expect(xorResponse.operation).to.equal(TransformPluginOperation.REPLACE)
+      expect(xorResponse.contentChanged).to.equal(true)
+      expect(xorResponse.replacementLength).to.equal(1)
+      expect(Array.from(await getSegment(sessionId, 0, 1))).to.deep.equal([
+        'a'.charCodeAt(0) ^ 0xff,
+      ])
+    } finally {
+      if (sessionId) {
+        await destroySession(sessionId).catch(() => undefined)
+      }
+      if (pid) {
+        await stopProcessUsingPID(pid).catch(() => false)
+      }
+      await stopServiceOnPort(port)
+      resetClient()
+
+      if (previousServerUri === undefined) {
+        delete process.env.OMEGA_EDIT_SERVER_URI
+      } else {
+        process.env.OMEGA_EDIT_SERVER_URI = previousServerUri
+      }
+
+      if (previousServerSocket === undefined) {
+        delete process.env.OMEGA_EDIT_SERVER_SOCKET
+      } else {
+        process.env.OMEGA_EDIT_SERVER_SOCKET = previousServerSocket
+      }
+    }
+  })
+})

--- a/packages/server/DEVELOPMENT.md
+++ b/packages/server/DEVELOPMENT.md
@@ -39,6 +39,17 @@ yarn package
 
 This refreshes the native server executable, builds the Node.js wrapper, and produces a tarball named `omega-edit-node-server-v${version}.tgz`.
 
+## Transform Plugin Development
+
+The native server can register transform plugins from one or more directories using
+`--transform-plugin-dir`, `OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS`, or the TypeScript
+`transformPluginDirectories` launcher option.
+
+Developer-facing ABI, SDK, layout, and exemplar plugin documentation lives in the
+[Transform Plugins wiki page](../../wiki/Transform-Plugins.md). Keep that page,
+`packages/server/README.md`, and the exemplar sources under `core/src/plugins/`
+in sync when changing plugin loading or adding release plugins.
+
 ## How the Binary is Bundled
 
 The server package locates its native binary through a search algorithm:

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -65,6 +65,7 @@ const proc = await runServer(9000, '127.0.0.1', '/tmp/server.pid', {
   maxViewportsPerSession: 64,
   logFile: '/tmp/omega-edit-server.log',
   logLevel: 'info',
+  transformPluginDirectories: ['./plugins'],
 })
 
 // Or pass raw CLI arguments
@@ -118,6 +119,7 @@ interface HeartbeatOptions {
   logFile?: string               // Append native server lifecycle logs to this file
   logLevel?: string              // Native log level: debug, info, warn, error
   logConfigFile?: string         // Compatibility shim for logback-style XML config
+  transformPluginDirectories?: string[] // Directories containing transform plugin shared libraries
 }
 ```
 
@@ -144,6 +146,15 @@ The native binary supports:
 | `--log-file` | Append native server logs to a file |
 | `--log-level` | Set native server log verbosity |
 | `--log-config` | Read log file/level from a logback-style XML config |
+| `--transform-plugin-dir` | Register transform plugins from a directory; repeat for multiple directories |
+
+Transform plugin directories can also be supplied with `OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS`.
+Use the platform path-list separator (`:` on Unix-like systems, `;` on Windows).
+See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the native ABI,
+SDK helpers, plugin directory layout, and exemplar plugins, including base64
+encode/decode, zlib stored-block compress/decompress, and inspect-only hash examples.
+The zlib examples intentionally cover the stored-block subset so they remain
+self-contained fixtures.
 
 ## Platform Support
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -53,6 +53,8 @@ export interface HeartbeatOptions {
   logLevel?: string
   /** Compatibility shim: read native log file/level from a logback-style XML config. */
   logConfigFile?: string
+  /** Register transform plugins from these directories. */
+  transformPluginDirectories?: string[]
 }
 
 /**
@@ -212,6 +214,9 @@ function heartbeatToArgs(opts?: HeartbeatOptions): string[] {
   }
   if (opts.logLevel !== undefined) {
     args.push(`--log-level=${opts.logLevel}`)
+  }
+  for (const directory of opts.transformPluginDirectories ?? []) {
+    args.push(`--transform-plugin-dir=${directory}`)
   }
   return args
 }

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -30,14 +30,14 @@ const serverBinaryName = isWin
 // Look for the C++ server binary in several possible locations
 function findServerBinary() {
   const searchPaths = [
+    // Environment variable override
+    process.env.CPP_SERVER_BINARY || '',
     path.resolve('../../server/cpp/build', serverBinaryName),
     path.resolve('../../server/cpp/build/Release', serverBinaryName),
     path.resolve('../../server/cpp/build/Debug', serverBinaryName),
     path.resolve('../../_build/server/cpp', serverBinaryName),
     path.resolve('../../build/server/cpp', serverBinaryName),
     path.resolve('../../build/server/cpp/Release', serverBinaryName),
-    // Environment variable override
-    process.env.CPP_SERVER_BINARY || '',
   ].filter(Boolean)
 
   for (const p of searchPaths) {

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -200,6 +200,13 @@ service EditorService {
   rpc DestroyLastCheckpoint(DestroyLastCheckpointRequest)
       returns (DestroyLastCheckpointResponse);
 
+  // List transform plugins registered with the native server.
+  rpc ListTransformPlugins(ListTransformPluginsRequest) returns (ListTransformPluginsResponse);
+
+  // Apply a transform plugin to a session range. Plugins may replace content,
+  // inspect content and return derived bytes, or do both.
+  rpc ApplyTransformPlugin(ApplyTransformPluginRequest) returns (ApplyTransformPluginResponse);
+
   // Compute a byte-frequency histogram (256 buckets, one per byte value) over
   // a range of session data.  Bucket 256 counts DOS-style CR+LF line endings.
   rpc GetByteFrequencyProfile(GetByteFrequencyProfileRequest) returns (GetByteFrequencyProfileResponse);
@@ -913,6 +920,56 @@ message DestroyLastCheckpointRequest {
 message DestroyLastCheckpointResponse {
   string session_id = 1;             // Session that was reverted.
   int64 remaining_checkpoints = 2;   // Remaining checkpoint count after revert.
+}
+
+// Transform plugin operation mode.
+enum TransformPluginOperation {
+  TRANSFORM_PLUGIN_OPERATION_UNSPECIFIED = 0;
+  TRANSFORM_PLUGIN_OPERATION_REPLACE = 1;
+  TRANSFORM_PLUGIN_OPERATION_INSPECT = 2;
+  TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT = 3;
+}
+
+// Metadata advertised by a registered transform plugin.
+message TransformPluginInfo {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  TransformPluginOperation operation = 4;
+  uint32 flags = 5;
+  uint32 abi_version = 6;
+}
+
+// Request registered transform plugin metadata.
+message ListTransformPluginsRequest {}
+
+// Registered transform plugin metadata.
+message ListTransformPluginsResponse {
+  repeated TransformPluginInfo plugins = 1;
+}
+
+// Request applying a transform plugin to a session range.
+message ApplyTransformPluginRequest {
+  string session_id = 1;             // Session to transform.
+  string plugin_id = 2;              // Registered plugin identifier.
+  optional int64 offset = 3;         // Starting byte offset (default: 0).
+  optional int64 length = 4;         // Number of bytes to transform (0/default = through EOF).
+  optional string options_json = 5;  // Plugin-specific options.
+}
+
+// Result of applying a transform plugin.
+message ApplyTransformPluginResponse {
+  string session_id = 1;                     // Session that was transformed.
+  string plugin_id = 2;                      // Plugin that was applied.
+  int64 offset = 3;                          // Starting offset of the processed range.
+  int64 length = 4;                          // Length of the processed range.
+  TransformPluginOperation operation = 5;    // Plugin operation mode.
+  bool content_changed = 6;                  // True when the plugin replaced content.
+  int64 computed_file_size = 7;              // Session size after the transform.
+  int64 replacement_length = 8;              // Replacement bytes produced by the plugin.
+  optional string result_label = 9;          // Plugin-provided result label.
+  optional string result_mime_type = 10;     // Plugin-provided result MIME type.
+  bytes result = 11;                         // Plugin-provided inspection bytes.
 }
 
 // Request to compute a byte-frequency histogram.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <limits>
 #include <optional>
 #include <sstream>
@@ -75,6 +76,15 @@ struct process_memory_metrics {
     std::optional<int64_t> resident_memory_bytes;
     std::optional<int64_t> virtual_memory_bytes;
     std::optional<int64_t> peak_resident_memory_bytes;
+};
+
+struct transform_plugin_response_guard {
+    omega_transform_plugin_response_t response{};
+
+    transform_plugin_response_guard() = default;
+    transform_plugin_response_guard(const transform_plugin_response_guard &) = delete;
+    auto operator=(const transform_plugin_response_guard &) -> transform_plugin_response_guard & = delete;
+    ~transform_plugin_response_guard() { omega_transform_plugin_response_clear(&response); }
 };
 
 static const std::string &get_runtime_kind() {
@@ -308,6 +318,33 @@ static grpc::Status validate_replace_payload_sizes(const std::string &pattern, c
     return grpc::Status::OK;
 }
 
+static ::omega_edit::v1::TransformPluginOperation to_proto_transform_plugin_operation(
+        omega_transform_plugin_operation_t operation) {
+    switch (operation) {
+        case OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE:
+            return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_REPLACE;
+        case OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT:
+            return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_INSPECT;
+        case OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT:
+            return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT;
+        default:
+            return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_UNSPECIFIED;
+    }
+}
+
+static void fill_transform_plugin_info(const omega_transform_plugin_info_t *info,
+                                       ::omega_edit::v1::TransformPluginInfo *response) {
+    if (!info || !response) {
+        return;
+    }
+    response->set_id(info->id ? info->id : "");
+    response->set_name(info->name ? info->name : "");
+    response->set_description(info->description ? info->description : "");
+    response->set_operation(to_proto_transform_plugin_operation(info->operation));
+    response->set_flags(info->flags);
+    response->set_abi_version(info->abi_version);
+}
+
 static grpc::Status validate_viewport_range(int64_t offset, int64_t capacity) {
     if (offset < 0 || capacity <= 0) {
         return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
@@ -322,12 +359,28 @@ static grpc::Status validate_viewport_range(int64_t offset, int64_t capacity) {
 }
 
 EditorServiceImpl::EditorServiceImpl(HeartbeatConfig heartbeat_config, ResourceLimits resource_limits,
-                                     std::function<void()> shutdown_callback)
-    : session_manager_(resource_limits), start_time_(std::chrono::steady_clock::now()),
-      heartbeat_config_(heartbeat_config), resource_limits_(resource_limits),
-      shutdown_callback_(std::move(shutdown_callback)),
+                                     std::function<void()> shutdown_callback,
+                                     std::vector<std::string> transform_plugin_directories)
+    : session_manager_(resource_limits),
       content_type_detector_(create_default_content_type_detector()),
-      language_detector_(create_default_language_detector()) {
+      language_detector_(create_default_language_detector()),
+      transform_plugin_registry_(omega_transform_plugin_registry_create()),
+      start_time_(std::chrono::steady_clock::now()),
+      heartbeat_config_(heartbeat_config), resource_limits_(resource_limits),
+      shutdown_callback_(std::move(shutdown_callback)) {
+    for (const auto &plugin_directory: transform_plugin_directories) {
+        if (plugin_directory.empty()) {
+            continue;
+        }
+        const auto loaded_count = omega_transform_plugin_registry_register_directory(
+                transform_plugin_registry_, plugin_directory.c_str());
+        if (loaded_count < 0) {
+            std::cerr << "Warning: could not register transform plugin directory: " << plugin_directory << "\n";
+        } else {
+            std::cerr << "Registered " << loaded_count << " transform plugin(s) from " << plugin_directory << "\n";
+        }
+    }
+
     if (heartbeat_config_.session_timeout.count() > 0 && heartbeat_config_.cleanup_interval.count() > 0) {
         reaper_thread_ = std::thread(&EditorServiceImpl::reaper_loop, this);
     }
@@ -343,6 +396,8 @@ EditorServiceImpl::~EditorServiceImpl() {
         reaper_thread_.join();
     }
     session_manager_.destroy_all();
+    omega_transform_plugin_registry_destroy(transform_plugin_registry_);
+    transform_plugin_registry_ = nullptr;
 }
 
 void EditorServiceImpl::reaper_loop() {
@@ -1477,6 +1532,101 @@ grpc::Status EditorServiceImpl::DestroyLastCheckpoint(
 
     response->set_session_id(request->session_id());
     response->set_remaining_checkpoints(omega_session_get_num_checkpoints(session));
+    return grpc::Status::OK;
+}
+
+grpc::Status EditorServiceImpl::ListTransformPlugins(
+        grpc::ServerContext * /*context*/,
+        const ::omega_edit::v1::ListTransformPluginsRequest * /*request*/,
+        ::omega_edit::v1::ListTransformPluginsResponse *response) {
+    std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
+    const auto count = omega_transform_plugin_registry_get_count(transform_plugin_registry_);
+    for (int64_t i = 0; i < count; ++i) {
+        fill_transform_plugin_info(omega_transform_plugin_registry_get_info(transform_plugin_registry_, i),
+                                   response->add_plugins());
+    }
+    return grpc::Status::OK;
+}
+
+grpc::Status EditorServiceImpl::ApplyTransformPlugin(
+        grpc::ServerContext * /*context*/,
+        const ::omega_edit::v1::ApplyTransformPluginRequest *request,
+        ::omega_edit::v1::ApplyTransformPluginResponse *response) {
+    if (request->plugin_id().empty()) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "plugin_id is required");
+    }
+
+    const int64_t offset = request->has_offset() ? request->offset() : 0;
+    const int64_t length = request->has_length() ? request->length() : 0;
+    if (offset < 0 || length < 0) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                            "transform offset and length must be non-negative");
+    }
+
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
+        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    }
+    auto *session = locked_session.session();
+
+    const auto file_size_before = omega_session_get_computed_file_size(session);
+    if (file_size_before < 0 || offset > file_size_before) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "transform range offset is outside the session");
+    }
+    const auto remaining = file_size_before - offset;
+    const auto effective_length = (length == 0 || length > remaining) ? remaining : length;
+
+    omega_transform_plugin_operation_t operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
+    transform_plugin_response_guard plugin_response;
+    {
+        // Serializes registry/plugin-library access while the session lock above serializes
+        // access to the non-thread-safe omega_session_t.
+        std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
+        const auto *plugin_info = omega_transform_plugin_registry_find_info(transform_plugin_registry_,
+                                                                           request->plugin_id().c_str());
+        if (!plugin_info) {
+            return grpc::Status(grpc::StatusCode::NOT_FOUND,
+                                "transform plugin not found: " + request->plugin_id());
+        }
+
+        operation = plugin_info->operation;
+        const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
+        if (0 != omega_transform_plugin_registry_apply_to_session(transform_plugin_registry_,
+                                                                  request->plugin_id().c_str(), session,
+                                                                  offset, length, options_json,
+                                                                  &plugin_response.response)) {
+            return grpc::Status(grpc::StatusCode::INTERNAL,
+                                "transform plugin failed: " + request->plugin_id());
+        }
+    }
+
+    if (plugin_response.response.result_length < 0 ||
+        (plugin_response.response.result_length > 0 && plugin_response.response.result_bytes == nullptr)) {
+        return grpc::Status(grpc::StatusCode::INTERNAL,
+                            "transform plugin returned an invalid inspection result");
+    }
+
+    const bool operation_replaces = operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE ||
+                                    operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT;
+    response->set_session_id(request->session_id());
+    response->set_plugin_id(request->plugin_id());
+    response->set_offset(offset);
+    response->set_length(effective_length);
+    response->set_operation(to_proto_transform_plugin_operation(operation));
+    response->set_content_changed(operation_replaces &&
+                                  (effective_length > 0 || plugin_response.response.replacement_length > 0));
+    response->set_computed_file_size(omega_session_get_computed_file_size(session));
+    response->set_replacement_length(plugin_response.response.replacement_length);
+    if (plugin_response.response.result_label) {
+        response->set_result_label(plugin_response.response.result_label);
+    }
+    if (plugin_response.response.result_mime_type) {
+        response->set_result_mime_type(plugin_response.response.result_mime_type);
+    }
+    if (plugin_response.response.result_length > 0) {
+        response->set_result(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
+                             static_cast<size_t>(plugin_response.response.result_length));
+    }
     return grpc::Status::OK;
 }
 

--- a/server/cpp/src/editor_service.h
+++ b/server/cpp/src/editor_service.h
@@ -21,6 +21,7 @@
 #include <grpcpp/grpcpp.h>
 #include <omega_edit/v1/omega_edit.grpc.pb.h>
 #include <omega_edit/fwd_defs.h>
+#include <omega_edit/transform.h>
 
 #include <atomic>
 #include <chrono>
@@ -28,7 +29,9 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace omega_edit {
 namespace grpc_server {
@@ -44,7 +47,8 @@ class EditorServiceImpl final : public ::omega_edit::v1::EditorService::Service 
 public:
     /// Construct with optional heartbeat config, resource limits, and shutdown callback
     explicit EditorServiceImpl(HeartbeatConfig heartbeat_config = {}, ResourceLimits resource_limits = {},
-                               std::function<void()> shutdown_callback = nullptr);
+                               std::function<void()> shutdown_callback = nullptr,
+                               std::vector<std::string> transform_plugin_directories = {});
     ~EditorServiceImpl() override;
 
     grpc::Status GetServerInfo(grpc::ServerContext *context, const ::omega_edit::v1::GetServerInfoRequest *request,
@@ -170,6 +174,14 @@ public:
         const ::omega_edit::v1::DestroyLastCheckpointRequest *request,
         ::omega_edit::v1::DestroyLastCheckpointResponse *response) override;
 
+    grpc::Status ListTransformPlugins(grpc::ServerContext *context,
+                                      const ::omega_edit::v1::ListTransformPluginsRequest *request,
+                                      ::omega_edit::v1::ListTransformPluginsResponse *response) override;
+
+    grpc::Status ApplyTransformPlugin(grpc::ServerContext *context,
+                                      const ::omega_edit::v1::ApplyTransformPluginRequest *request,
+                                      ::omega_edit::v1::ApplyTransformPluginResponse *response) override;
+
     grpc::Status GetByteFrequencyProfile(grpc::ServerContext *context,
                                          const ::omega_edit::v1::GetByteFrequencyProfileRequest *request,
                                          ::omega_edit::v1::GetByteFrequencyProfileResponse *response) override;
@@ -214,6 +226,8 @@ private:
     SessionManager session_manager_;
     std::unique_ptr<IContentTypeDetector> content_type_detector_;
     std::unique_ptr<ILanguageDetector> language_detector_;
+    omega_transform_plugin_registry_t *transform_plugin_registry_{nullptr};
+    std::mutex transform_plugin_mutex_;
     std::chrono::steady_clock::time_point start_time_;
     std::atomic<bool> graceful_shutdown_{false};
 

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -39,6 +39,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <vector>
 
 #ifdef _WIN32
 #include <process.h>
@@ -251,6 +252,22 @@ static bool parse_size_t(const std::string &str, const std::string &name, size_t
     }
 }
 
+static void append_transform_plugin_directories(const std::string &directories, std::vector<std::string> &out) {
+#ifdef _WIN32
+    constexpr char delimiter = ';';
+#else
+    constexpr char delimiter = ':';
+#endif
+
+    std::stringstream stream(directories);
+    std::string directory;
+    while (std::getline(stream, directory, delimiter)) {
+        if (!directory.empty()) {
+            out.push_back(directory);
+        }
+    }
+}
+
 static void print_usage(const char *progname) {
     std::cerr << "Ωedit gRPC server (C++ middleware)\n"
               << "Usage: " << progname << " [OPTIONS]\n"
@@ -276,6 +293,9 @@ static void print_usage(const char *progname) {
               << "      --max-change-bytes <bytes>   Limit insert/overwrite payload size (0 = unbounded)\n"
               << "      --max-viewports-per-session <count>\n"
               << "                                   Limit concurrently open viewports per session (0 = unbounded)\n"
+              << "\nTransform plugin options:\n"
+              << "      --transform-plugin-dir <dir>\n"
+              << "                                   Register transform plugins from a directory (repeatable)\n"
               << "\nGeneral:\n"
               << "  -h, --help                       Show this help\n"
               << "  -v, --version                    Show version\n";
@@ -300,6 +320,7 @@ int main(int argc, char **argv) {
     size_t viewport_event_queue_capacity = resource_limits.viewport_event_queue_capacity;
     int64_t max_change_bytes = resource_limits.max_change_bytes;
     size_t max_viewports_per_session = resource_limits.max_viewports_per_session;
+    std::vector<std::string> transform_plugin_directories;
     // Environment variable defaults
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_HOST")) {
         interface_addr = env;
@@ -358,6 +379,9 @@ int main(int argc, char **argv) {
     if (const char *env = std::getenv("OMEGA_EDIT_MAX_VIEWPORTS_PER_SESSION")) {
         if (!parse_size_t(env, "OMEGA_EDIT_MAX_VIEWPORTS_PER_SESSION", 0, std::numeric_limits<size_t>::max(),
                        max_viewports_per_session)) return 1;
+    }
+    if (const char *env = std::getenv("OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS")) {
+        append_transform_plugin_directories(env, transform_plugin_directories);
     }
 
     // Parse command line arguments
@@ -492,6 +516,12 @@ int main(int argc, char **argv) {
                 }
                 if (!parse_size_t(value, "--max-viewports-per-session", 0, std::numeric_limits<size_t>::max(),
                                max_viewports_per_session)) return 1;
+            } else if (key == "--transform-plugin-dir") {
+                if (value.empty()) {
+                    std::cerr << "Error: " << key << " requires a value\n";
+                    return 1;
+                }
+                transform_plugin_directories.push_back(value);
             }
             // Silently ignore unknown options.
         }
@@ -534,7 +564,8 @@ int main(int argc, char **argv) {
         // Set the shutdown flag so the monitor thread exits cleanly and shuts down the server
         g_shutdown_requested.store(true, std::memory_order_relaxed);
     };
-    omega_edit::grpc_server::EditorServiceImpl service(heartbeat_config, resource_limits, shutdown_callback);
+    omega_edit::grpc_server::EditorServiceImpl service(heartbeat_config, resource_limits, shutdown_callback,
+                                                       transform_plugin_directories);
 
     grpc::EnableDefaultHealthCheckService(true);
 #ifdef HAS_GRPC_REFLECTION

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -210,6 +210,10 @@ npx oe patch --session <session-id> --offset 8 --hex 0000000d
 
 This AI tooling is a distinguishing feature of Ωedit™: it exposes the editing engine as stable, machine-readable tools instead of forcing agents to rely on terminal scraping, ad hoc Python, or whole-file rewrites. The implementation lives in `packages/ai/`, and the end-to-end tests are in `packages/ai/tests/specs/toolkit.spec.ts` and `packages/ai/tests/specs/mcp.spec.ts`.
 
+## Transform Plugins
+
+OmegaEdit can load native `.so`, `.dylib`, and `.dll` transform plugins from registered plugin directories. Plugins can replace a selected byte range, expand or shrink content, or inspect a range and return results such as checksums and hashes. The shipped examples include one-for-one transforms, base64 encode/decode, zlib stored-block compress/decompress, expansion/shrink behavior, and inspect-only results. See [Transform Plugins](Transform-Plugins) for the ABI, SDK helpers, plugin directory layout, server registration options, and exemplar plugins.
+
 ## Comparison with Other Editing Engines
 
 Most text and binary editors use one of a small number of well-known buffer data structures. The table below compares the most common approaches with Ωedit™'s segment-based change-tracking model. `vi` / Vim is included as a familiar reference point, though it is primarily an end-user editor rather than an embeddable editing engine.

--- a/wiki/Transform-Plugins.md
+++ b/wiki/Transform-Plugins.md
@@ -1,0 +1,340 @@
+# Transform Plugins
+
+OmegaEdit transform plugins are native shared libraries that can be discovered by the
+gRPC server and applied to a byte range in a session. They are intended for reusable
+range operations that should live outside the core editor engine, such as encoding,
+decoding, compression, checksums, hashes, or binary-safe one-for-one byte transforms.
+
+Plugins are loaded from ordinary platform shared-library files:
+
+| Platform | Extension |
+| --- | --- |
+| Linux | `.so` |
+| macOS | `.dylib` |
+| Windows | `.dll` |
+
+The native ABI is declared in:
+
+- `core/src/include/omega_edit/transform.h`
+- `core/src/include/omega_edit/transform_plugin_sdk.h`
+
+## Operation Modes
+
+Each plugin advertises one operation mode:
+
+| Mode | Behavior |
+| --- | --- |
+| `OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE` | Produces replacement bytes for the selected range. Content changes if the selected range or replacement is non-empty. |
+| `OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT` | Leaves content unchanged and returns result bytes, such as a checksum or hash. |
+| `OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT` | Produces replacement bytes and an inspection result. |
+
+Plugins also advertise flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE` | Replacement length is expected to match input length. |
+| `OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND` | Replacement may be longer than input. |
+| `OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK` | Replacement may be shorter than input. |
+| `OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT` | Inspection result bytes should be treated as text. |
+| `OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE` | Plugin can operate on arbitrary bytes. |
+
+Flags are metadata for discovery and user interfaces. The server still validates the
+actual response it receives from the plugin before applying it.
+
+## ABI Contract
+
+A plugin must export two C ABI functions:
+
+```c
+OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr);
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(
+    const omega_transform_plugin_request_t *request_ptr,
+    omega_transform_plugin_response_t *response_ptr);
+```
+
+`omega_transform_plugin_get_info` fills out stable metadata:
+
+```c
+info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+info_ptr->id = "omega.example.my_plugin";
+info_ptr->name = "My Plugin";
+info_ptr->description = "What this plugin does.";
+info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+```
+
+The plugin ID must be unique across all registered plugins. A reverse-DNS style ID
+is recommended, for example `com.example.base64_encode`.
+
+`omega_transform_plugin_apply` receives:
+
+| Field | Description |
+| --- | --- |
+| `input_bytes` / `input_length` | Bytes selected from the current session range. |
+| `session_offset` | Range start offset in the session. |
+| `session_length` | Requested range length after clamping to the session end. |
+| `options_json` | Optional plugin-specific JSON string supplied by the caller. |
+| `alloc` / `allocator_user_data_ptr` | Allocator that must be used for response-owned memory. |
+
+The plugin returns replacement bytes and/or result bytes through
+`omega_transform_plugin_response_t`.
+
+Important rules:
+
+- Return `0` on success and non-zero on failure.
+- Validate null pointers and negative lengths.
+- Allocate all response memory through `request_ptr->alloc` or the SDK helpers.
+- Do not free response memory yourself after assigning it to the response.
+- Treat `options_json` as optional; it may be null.
+- Keep plugin entry points thread-safe. The server serializes access to the registry,
+  but plugin code should not rely on mutable global state unless it protects it.
+
+## SDK Helpers
+
+Include the SDK header for export macros and allocation helpers:
+
+```c
+#include <omega_edit/transform_plugin_sdk.h>
+```
+
+Useful helpers:
+
+| Helper | Purpose |
+| --- | --- |
+| `OMEGA_TRANSFORM_PLUGIN_EXPORT` | Exports plugin entry points on all supported platforms. |
+| `omega_transform_plugin_sdk_alloc` | Allocates response memory with the server-provided allocator. |
+| `omega_transform_plugin_sdk_copy_bytes` | Copies byte ranges into response-owned memory. |
+| `omega_transform_plugin_sdk_copy_cstring` | Copies C strings into response-owned memory. |
+| `omega_transform_plugin_sdk_set_replacement` | Fills replacement bytes and length. |
+| `omega_transform_plugin_sdk_set_text_result` | Fills text result bytes, label, and MIME type. |
+
+## Minimal Plugin
+
+This one-for-one example inverts every byte in the selected range:
+
+```c
+#include <omega_edit/transform_plugin_sdk.h>
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) return -1;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    info_ptr->id = "com.example.xor_ff";
+    info_ptr->name = "XOR 0xFF";
+    info_ptr->description = "Invert every byte in the selected range.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags =
+        OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE |
+        OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(
+    const omega_transform_plugin_request_t *request_ptr,
+    omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || request_ptr->input_length < 0) {
+        return -1;
+    }
+
+    omega_byte_t *bytes = omega_transform_plugin_sdk_copy_bytes(
+        request_ptr, request_ptr->input_bytes, request_ptr->input_length);
+    if (!bytes) return -1;
+
+    for (int64_t i = 0; i < request_ptr->input_length; ++i) {
+        bytes[i] = request_ptr->input_bytes[i] ^ 0xff;
+    }
+
+    response_ptr->replacement_bytes = bytes;
+    response_ptr->replacement_length = request_ptr->input_length;
+    return 0;
+}
+```
+
+## Building Plugins
+
+Plugins are CMake `MODULE` libraries in this repository. The exemplar plugins are
+built when either `BUILD_EXAMPLES=ON` or `BUILD_TESTS=ON`:
+
+```bash
+cmake -S . -B _build -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON
+cmake --build _build --config Release --target omega_edit_transform_plugins
+```
+
+The current in-repo output directory is:
+
+```text
+_build/packages/core/src/tests/plugins/
+```
+
+The filename does not determine the plugin ID. The plugin ID comes from
+`omega_transform_plugin_get_info`.
+
+## Plugin Directory Layout
+
+At runtime, put one or more plugin shared libraries in a directory:
+
+```text
+plugins/
+|- omega_transform_base64_decode.dll
+|- omega_transform_base64_encode.dll
+|- omega_transform_fnv1a64.dll
+|- omega_transform_zlib_compress.dll
+|- omega_transform_zlib_decompress.dll
+|- omega_transform_xor_ff.dll
+|- omega_transform_repeat.dll
+`- omega_transform_checksum8.dll
+```
+
+Use the platform extension for your target operating system. Non-plugin files in
+the directory are ignored if they cannot be loaded or do not expose the required
+symbols.
+
+## Registering Plugins
+
+Native API:
+
+```c
+omega_transform_plugin_registry_t *registry =
+    omega_transform_plugin_registry_create();
+
+omega_transform_plugin_registry_register_directory(registry, "./plugins");
+```
+
+Native gRPC server CLI:
+
+```bash
+omega-edit-grpc-server --port=9000 --transform-plugin-dir ./plugins
+```
+
+The flag can be repeated. The server also reads a platform-path-list environment
+variable:
+
+```bash
+OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS="./plugins:./more-plugins"
+```
+
+On Windows, use semicolons:
+
+```powershell
+$env:OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS = ".\plugins;.\more-plugins"
+```
+
+TypeScript server launcher:
+
+```typescript
+import { runServer } from '@omega-edit/server'
+
+await runServer(9000, '127.0.0.1', undefined, {
+  transformPluginDirectories: ['./plugins'],
+})
+```
+
+## Discovering and Applying Plugins
+
+TypeScript client:
+
+```typescript
+import {
+  applyTransformPlugin,
+  createSession,
+  listTransformPlugins,
+  startServer,
+} from '@omega-edit/client'
+
+await startServer(9000, '127.0.0.1', undefined, {
+  transformPluginDirectories: ['./plugins'],
+})
+
+const plugins = await listTransformPlugins()
+console.log(plugins.map((plugin) => plugin.id))
+
+const sessionId = (await createSession('input.bin')).getSessionId()
+const result = await applyTransformPlugin(
+  sessionId,
+  'omega.example.checksum8',
+  0,
+  1024
+)
+console.log(Buffer.from(result.result).toString('utf8'))
+```
+
+AI CLI:
+
+```bash
+oe list-transform-plugins
+oe apply-transform-plugin \
+  --session <session-id> \
+  --plugin omega.example.checksum8 \
+  --offset 0 \
+  --length 1024
+oe apply-transform-plugin \
+  --session <session-id> \
+  --plugin omega.example.base64_encode \
+  --offset 0 \
+  --length 1024
+oe apply-transform-plugin \
+  --session <session-id> \
+  --plugin omega.example.zlib_compress \
+  --offset 0 \
+  --length 1024
+```
+
+MCP tools:
+
+- `omega_edit_list_transform_plugins`
+- `omega_edit_apply_transform_plugin`
+
+## Exemplar Plugins
+
+The repository ships small examples in `core/src/plugins/`:
+
+| Plugin ID | Source | Operation | Demonstrates |
+| --- | --- | --- | --- |
+| `omega.example.base64_encode` | `base64_encode.c` | Replace | Expansion by encoding arbitrary bytes as base64 text. |
+| `omega.example.base64_decode` | `base64_decode.c` | Replace | Shrinking text content back to decoded bytes, with validation. ASCII whitespace is tolerated; other invalid bytes fail. |
+| `omega.example.fnv1a64` | `fnv1a64.c` | Inspect | 64-bit hash calculation without changing session content. |
+| `omega.example.zlib_compress` | `zlib_compress.c` | Replace | Valid zlib streams using stored DEFLATE blocks, without a required external dependency. |
+| `omega.example.zlib_decompress` | `zlib_decompress.c` | Replace | Shrinking stored-block zlib streams back to the original bytes, with header and checksum validation. |
+| `omega.example.xor_ff` | `xor_ff.c` | Replace | One-for-one binary-safe byte transform. |
+| `omega.example.repeat` | `repeat.c` | Replace | Expansion by replacing a range with two copies of itself. |
+| `omega.example.checksum8` | `checksum8.c` | Inspect | Text result without changing session content. |
+
+These examples are intentionally small so they can serve as test fixtures and copyable
+developer starting points.
+
+The zlib examples intentionally avoid a required external compression dependency:
+`omega.example.zlib_compress` emits valid zlib streams with stored DEFLATE blocks,
+and `omega.example.zlib_decompress` accepts that stored-block subset with zlib header
+and Adler-32 validation. Because stored blocks have no compression level, the exemplar
+compressor intentionally ignores `options_json`; a production compression plugin can use
+that field for settings such as compression level.
+
+## Release Notes for Plugin Authors
+
+The current ABI version is `1`.
+
+When changing the ABI:
+
+1. Bump `OMEGA_TRANSFORM_PLUGIN_ABI_VERSION`.
+2. Keep the server's load-time ABI validation strict.
+3. Update this page and the exemplar plugins.
+4. Mention the ABI version change in release notes.
+
+When adding release plugins:
+
+1. Put source under `core/src/plugins/`.
+2. Add the source file to the plugin target list in `core/CMakeLists.txt`.
+3. Add native registry/harness coverage.
+4. Add client or AI coverage if the plugin exercises new behavior.
+5. Document the plugin ID, operation, options JSON, and result format.
+
+## See Also
+
+- [Home](Home)
+- [Embedding OmegaEdit Core](Embedding-OmegaEdit-Core)
+- [`core/src/plugins/`](https://github.com/ctc-oss/omega-edit/tree/main/core/src/plugins)
+- [`core/src/tools/transform_plugin_harness.cpp`](https://github.com/ctc-oss/omega-edit/blob/main/core/src/tools/transform_plugin_harness.cpp)


### PR DESCRIPTION
## Summary

This is the first reviewable foundation for #1421. It adds the core transform/plugin plumbing, exemplar plugins, a native harness, and the gRPC server surface for plugin discovery/application.

## Completed in this draft

- Adds internal one-for-one transform support in core.
- Adds a dynamic transform plugin ABI and registry for `.so`, `.dylib`, and `.dll` discovery from plugin directories.
- Adds a plugin SDK helper header for plugin authors.
- Adds exemplar plugins: `xor_ff`, `repeat`, and `checksum8`.
- Adds `omega-transform-plugin-harness` for listing/running plugins in tests and developer workflows.
- Adds focused core tests for built-in transforms and plugin registry/application behavior.
- Adds `ListTransformPlugins` and `ApplyTransformPlugin` RPCs to the v1 proto.
- Wires the native C++ gRPC server to register transform plugin directories and serve the new RPCs.
- Regenerates protobuf-ts client stubs for the new RPC surface.

## Still planned before this issue is complete

- Public TypeScript client convenience APIs for listing/applying plugins and inspecting results.
- CLI/AI tooling commands that discover and run transform plugins.
- End-to-end gRPC tests that start the server with exemplar plugins and exercise list/apply over RPC.
- Developer/release docs for plugin ABI, SDK usage, plugin directory layout, and examples.
- Richer exemplar plugins such as base64, zlib, hash, and checksum variants.

## Validation

- `cmake --build build --target omegaEdit_tests omega-transform-plugin-harness --config Debug`
- `build\core\src\tests\Debug\omegaEdit_tests.exe --reporter compact`
- `build\core\Debug\omega-transform-plugin-harness.exe --plugin-dir build\core\src\tests\plugins --list`
- `yarn --cwd packages/client build:esm`
- `cmake --build build --target omega_edit --config Release`
- `cmake -S server/cpp -B server/cpp/build/build -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake -DOMEGA_EDIT_INCLUDE=D:/GitHub/omega-edit/core/src/include -DOMEGA_EDIT_LIB=D:/GitHub/omega-edit/build/core/Release/omega_edit.lib`
- `cmake --build server/cpp/build/build --target omega-edit-grpc-server --config Release`

Draft because the client/CLI/docs/e2e layers are intentionally still open.