### PR TITLE
Integrate byte range transforms in VS Code extension

### DIFF
--- a/core/src/include/omega_edit/transform.h
+++ b/core/src/include/omega_edit/transform.h
@@ -59,6 +59,14 @@ typedef struct {
     const char *description;
     omega_transform_plugin_operation_t operation;
     uint32_t flags;
+    /** Optional UI/help text for plugin-specific JSON arguments. */
+    const char *help;
+    /** Optional example JSON arguments. */
+    const char *example;
+    /** Optional default JSON arguments. */
+    const char *default_args;
+    /** Optional JSON Schema used to validate options_json before apply. */
+    const char *args_schema;
 } omega_transform_plugin_info_t;
 
 typedef void *(*omega_transform_plugin_alloc_t)(size_t size, void *user_data_ptr);
@@ -110,6 +118,8 @@ int omega_transform_plugin_registry_register_directory(omega_transform_plugin_re
                                                       const char *plugin_directory);
 
 int64_t omega_transform_plugin_registry_get_count(const omega_transform_plugin_registry_t *registry_ptr);
+
+int omega_transform_plugin_options_match_args_schema(const char *options_json, const char *args_schema);
 
 const omega_transform_plugin_info_t *omega_transform_plugin_registry_get_info(
         const omega_transform_plugin_registry_t *registry_ptr, int64_t index);

--- a/core/src/include/omega_edit/transform_plugin_sdk.h
+++ b/core/src/include/omega_edit/transform_plugin_sdk.h
@@ -30,6 +30,8 @@
 #define OMEGA_TRANSFORM_PLUGIN_EXPORT __attribute__((visibility("default")))
 #endif
 
+static const char OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA[] = "";
+
 static inline void *omega_transform_plugin_sdk_alloc(const omega_transform_plugin_request_t *request_ptr, size_t size) {
     if (!request_ptr || !request_ptr->alloc) { return NULL; }
     return request_ptr->alloc(size == 0 ? 1 : size, request_ptr->allocator_user_data_ptr);

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -18,11 +18,15 @@
 #include "../include/omega_edit/session.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <map>
 #include <memory>
+#include <regex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #ifdef _WIN32
@@ -99,6 +103,323 @@ namespace {
         omega_transform_plugin_apply_fn apply{};
         std::string path;
     };
+
+    struct json_value_t {
+        enum class kind_t { null_value, object, array, string, number, boolean };
+
+        kind_t kind{kind_t::null_value};
+        std::map<std::string, json_value_t> object_value;
+        std::vector<json_value_t> array_value;
+        std::string string_value;
+        double number_value{};
+        bool bool_value{};
+    };
+
+    class json_parser_t {
+    public:
+        explicit json_parser_t(const char *input) : input_(input ? input : "") {}
+
+        auto parse(json_value_t &value) -> bool {
+            skip_ws();
+            if (!parse_value(value)) { return false; }
+            skip_ws();
+            return input_[pos_] == '\0';
+        }
+
+    private:
+        const char *input_;
+        size_t pos_{};
+
+        void skip_ws() {
+            while (std::isspace(static_cast<unsigned char>(input_[pos_]))) { ++pos_; }
+        }
+
+        auto consume(char expected) -> bool {
+            skip_ws();
+            if (input_[pos_] != expected) { return false; }
+            ++pos_;
+            return true;
+        }
+
+        auto parse_value(json_value_t &value) -> bool {
+            skip_ws();
+            switch (input_[pos_]) {
+                case '{':
+                    return parse_object(value);
+                case '[':
+                    return parse_array(value);
+                case '"':
+                    value.kind = json_value_t::kind_t::string;
+                    return parse_string(value.string_value);
+                case 't':
+                    return parse_literal("true", json_value_t::kind_t::boolean, value, true);
+                case 'f':
+                    return parse_literal("false", json_value_t::kind_t::boolean, value, false);
+                case 'n':
+                    return parse_literal("null", json_value_t::kind_t::null_value, value, false);
+                default:
+                    return parse_number(value);
+            }
+        }
+
+        auto parse_literal(const char *literal, json_value_t::kind_t kind, json_value_t &value, bool bool_value)
+                -> bool {
+            const auto length = std::strlen(literal);
+            if (std::strncmp(input_ + pos_, literal, length) != 0) { return false; }
+            pos_ += length;
+            value.kind = kind;
+            value.bool_value = bool_value;
+            return true;
+        }
+
+        auto parse_string(std::string &value) -> bool {
+            if (input_[pos_] != '"') { return false; }
+            ++pos_;
+            value.clear();
+            while (input_[pos_] != '\0') {
+                const char ch = input_[pos_++];
+                if (ch == '"') { return true; }
+                if (static_cast<unsigned char>(ch) < 0x20) { return false; }
+                if (ch != '\\') {
+                    value.push_back(ch);
+                    continue;
+                }
+                const char escaped = input_[pos_++];
+                switch (escaped) {
+                    case '"':
+                    case '\\':
+                    case '/':
+                        value.push_back(escaped);
+                        break;
+                    case 'b':
+                        value.push_back('\b');
+                        break;
+                    case 'f':
+                        value.push_back('\f');
+                        break;
+                    case 'n':
+                        value.push_back('\n');
+                        break;
+                    case 'r':
+                        value.push_back('\r');
+                        break;
+                    case 't':
+                        value.push_back('\t');
+                        break;
+                    default:
+                        return false;
+                }
+            }
+            return false;
+        }
+
+        auto parse_object(json_value_t &value) -> bool {
+            if (!consume('{')) { return false; }
+            value = {};
+            value.kind = json_value_t::kind_t::object;
+            skip_ws();
+            if (consume('}')) { return true; }
+            while (input_[pos_] != '\0') {
+                std::string key;
+                skip_ws();
+                if (!parse_string(key) || !consume(':')) { return false; }
+                json_value_t member;
+                if (!parse_value(member)) { return false; }
+                value.object_value[key] = std::move(member);
+                skip_ws();
+                if (consume('}')) { return true; }
+                if (!consume(',')) { return false; }
+            }
+            return false;
+        }
+
+        auto parse_array(json_value_t &value) -> bool {
+            if (!consume('[')) { return false; }
+            value = {};
+            value.kind = json_value_t::kind_t::array;
+            skip_ws();
+            if (consume(']')) { return true; }
+            while (input_[pos_] != '\0') {
+                json_value_t item;
+                if (!parse_value(item)) { return false; }
+                value.array_value.push_back(std::move(item));
+                skip_ws();
+                if (consume(']')) { return true; }
+                if (!consume(',')) { return false; }
+            }
+            return false;
+        }
+
+        auto parse_number(json_value_t &value) -> bool {
+            skip_ws();
+            const auto start = pos_;
+            if (input_[pos_] == '-') { ++pos_; }
+            if (!std::isdigit(static_cast<unsigned char>(input_[pos_]))) { return false; }
+            if (input_[pos_] == '0') {
+                ++pos_;
+            } else {
+                while (std::isdigit(static_cast<unsigned char>(input_[pos_]))) { ++pos_; }
+            }
+            if (input_[pos_] == '.') {
+                ++pos_;
+                if (!std::isdigit(static_cast<unsigned char>(input_[pos_]))) { return false; }
+                while (std::isdigit(static_cast<unsigned char>(input_[pos_]))) { ++pos_; }
+            }
+            if (input_[pos_] == 'e' || input_[pos_] == 'E') {
+                ++pos_;
+                if (input_[pos_] == '+' || input_[pos_] == '-') { ++pos_; }
+                if (!std::isdigit(static_cast<unsigned char>(input_[pos_]))) { return false; }
+                while (std::isdigit(static_cast<unsigned char>(input_[pos_]))) { ++pos_; }
+            }
+            char *end_ptr = nullptr;
+            const std::string token(input_ + start, pos_ - start);
+            value.kind = json_value_t::kind_t::number;
+            value.number_value = std::strtod(token.c_str(), &end_ptr);
+            return end_ptr && *end_ptr == '\0';
+        }
+    };
+
+    auto json_object_member_(const json_value_t &value, const char *key) -> const json_value_t * {
+        if (value.kind != json_value_t::kind_t::object) { return nullptr; }
+        const auto iter = value.object_value.find(key);
+        return iter == value.object_value.end() ? nullptr : &iter->second;
+    }
+
+    auto json_string_value_(const json_value_t &value, std::string &out) -> bool {
+        if (value.kind != json_value_t::kind_t::string) { return false; }
+        out = value.string_value;
+        return true;
+    }
+
+    auto json_boolean_value_(const json_value_t &value, bool &out) -> bool {
+        if (value.kind != json_value_t::kind_t::boolean) { return false; }
+        out = value.bool_value;
+        return true;
+    }
+
+    auto schema_number_(const json_value_t &schema, const char *key, double &out) -> bool {
+        const auto *member = json_object_member_(schema, key);
+        if (!member) { return false; }
+        if (member->kind != json_value_t::kind_t::number) { return false; }
+        out = member->number_value;
+        return true;
+    }
+
+    auto schema_integer_(const json_value_t &schema, const char *key, int64_t &out) -> bool {
+        double number = 0;
+        if (!schema_number_(schema, key, number)) { return false; }
+        out = static_cast<int64_t>(number);
+        return number == static_cast<double>(out);
+    }
+
+    auto validate_schema_value_(const json_value_t &value, const json_value_t &schema) -> bool {
+        if (schema.kind != json_value_t::kind_t::object) { return false; }
+
+        const auto *one_of = json_object_member_(schema, "oneOf");
+        if (one_of) {
+            if (one_of->kind != json_value_t::kind_t::array) { return false; }
+            auto matches = 0;
+            for (const auto &candidate: one_of->array_value) {
+                if (validate_schema_value_(value, candidate)) { ++matches; }
+            }
+            if (matches != 1) { return false; }
+        }
+
+        const auto *not_schema = json_object_member_(schema, "not");
+        if (not_schema && validate_schema_value_(value, *not_schema)) { return false; }
+
+        std::string type;
+        if (const auto *type_value = json_object_member_(schema, "type")) {
+            if (!json_string_value_(*type_value, type)) { return false; }
+            if (type == "object" && value.kind != json_value_t::kind_t::object) { return false; }
+            if (type == "array" && value.kind != json_value_t::kind_t::array) { return false; }
+            if (type == "string" && value.kind != json_value_t::kind_t::string) { return false; }
+            if (type == "integer") {
+                if (value.kind != json_value_t::kind_t::number) { return false; }
+                const auto integer_value = static_cast<int64_t>(value.number_value);
+                if (value.number_value != static_cast<double>(integer_value)) { return false; }
+            }
+            if (type != "object" && type != "array" && type != "string" && type != "integer") { return false; }
+        }
+
+        if (const auto *required = json_object_member_(schema, "required")) {
+            if (required->kind != json_value_t::kind_t::array) { return false; }
+            if (value.kind != json_value_t::kind_t::object) { return false; }
+            for (const auto &required_key: required->array_value) {
+                std::string key;
+                if (!json_string_value_(required_key, key) || value.object_value.find(key) == value.object_value.end()) {
+                    return false;
+                }
+            }
+        }
+
+        if (value.kind == json_value_t::kind_t::object) {
+            const auto *properties = json_object_member_(schema, "properties");
+            if (properties && properties->kind != json_value_t::kind_t::object) { return false; }
+
+            bool additional_properties = true;
+            if (const auto *additional = json_object_member_(schema, "additionalProperties")) {
+                if (!json_boolean_value_(*additional, additional_properties)) { return false; }
+            }
+
+            if (properties) {
+                for (const auto &[key, member]: value.object_value) {
+                    const auto property_iter = properties->object_value.find(key);
+                    if (property_iter == properties->object_value.end()) {
+                        if (!additional_properties) { return false; }
+                        continue;
+                    }
+                    if (!validate_schema_value_(member, property_iter->second)) { return false; }
+                }
+            } else if (!additional_properties && !value.object_value.empty()) {
+                return false;
+            }
+        }
+
+        if (value.kind == json_value_t::kind_t::array) {
+            int64_t min_items = 0;
+            if (schema_integer_(schema, "minItems", min_items) &&
+                static_cast<int64_t>(value.array_value.size()) < min_items) {
+                return false;
+            }
+            if (const auto *items = json_object_member_(schema, "items")) {
+                for (const auto &item: value.array_value) {
+                    if (!validate_schema_value_(item, *items)) { return false; }
+                }
+            }
+        }
+
+        if (value.kind == json_value_t::kind_t::string) {
+            if (const auto *pattern = json_object_member_(schema, "pattern")) {
+                std::string pattern_text;
+                if (!json_string_value_(*pattern, pattern_text)) { return false; }
+                try {
+                    if (!std::regex_match(value.string_value, std::regex(pattern_text))) { return false; }
+                } catch (const std::regex_error &) {
+                    return false;
+                }
+            }
+        }
+
+        if (type == "integer") {
+            double minimum = 0;
+            if (schema_number_(schema, "minimum", minimum) && value.number_value < minimum) { return false; }
+            double maximum = 0;
+            if (schema_number_(schema, "maximum", maximum) && value.number_value > maximum) { return false; }
+        }
+
+        return true;
+    }
+
+    auto options_match_args_schema_(const char *options_json, const char *args_schema) -> bool {
+        if (!options_json || !*options_json) { return true; }
+        if (!args_schema || !*args_schema) { return false; }
+        json_value_t options;
+        json_value_t schema;
+        if (!json_parser_t(options_json).parse(options)) { return false; }
+        if (!json_parser_t(args_schema).parse(schema)) { return false; }
+        return validate_schema_value_(options, schema);
+    }
 
     auto plugin_operation_is_valid_(omega_transform_plugin_operation_t operation) -> bool {
         return operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE ||
@@ -224,6 +545,10 @@ int64_t omega_transform_plugin_registry_get_count(const omega_transform_plugin_r
     return static_cast<int64_t>(registry_ptr->plugins.size());
 }
 
+int omega_transform_plugin_options_match_args_schema(const char *options_json, const char *args_schema) {
+    return options_match_args_schema_(options_json, args_schema) ? 0 : -1;
+}
+
 const omega_transform_plugin_info_t *omega_transform_plugin_registry_get_info(
         const omega_transform_plugin_registry_t *registry_ptr, int64_t index) {
     if (!registry_ptr || index < 0 || index >= static_cast<int64_t>(registry_ptr->plugins.size())) { return nullptr; }
@@ -250,6 +575,7 @@ int omega_transform_plugin_registry_apply_to_session(omega_transform_plugin_regi
     auto iter = std::find_if(registry_ptr->plugins.begin(), registry_ptr->plugins.end(),
                              [plugin_id](const auto &plugin) { return plugin->info.id == std::string(plugin_id); });
     if (iter == registry_ptr->plugins.end()) { return -1; }
+    if (0 != omega_transform_plugin_options_match_args_schema(options_json, (*iter)->info.args_schema)) { return -1; }
 
     std::vector<omega_byte_t> input_bytes;
     if (0 != read_session_range_(session_ptr, offset, length, input_bytes)) { return -1; }

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -206,6 +206,9 @@ namespace {
                     case 't':
                         value.push_back('\t');
                         break;
+                    case 'u':
+                        if (!parse_unicode_escape(value)) { return false; }
+                        break;
                     default:
                         return false;
                 }
@@ -276,6 +279,64 @@ namespace {
             value.kind = json_value_t::kind_t::number;
             value.number_value = std::strtod(token.c_str(), &end_ptr);
             return end_ptr && *end_ptr == '\0';
+        }
+
+        static auto hex_digit_value(char ch) -> int {
+            if (ch >= '0' && ch <= '9') { return ch - '0'; }
+            if (ch >= 'a' && ch <= 'f') { return 10 + ch - 'a'; }
+            if (ch >= 'A' && ch <= 'F') { return 10 + ch - 'A'; }
+            return -1;
+        }
+
+        auto parse_hex4(unsigned int &code_unit) -> bool {
+            code_unit = 0;
+            for (auto index = 0; index < 4; ++index) {
+                if (input_[pos_] == '\0') { return false; }
+                const auto digit = hex_digit_value(input_[pos_]);
+                if (digit < 0) { return false; }
+                ++pos_;
+                code_unit = (code_unit << 4U) | static_cast<unsigned int>(digit);
+            }
+            return true;
+        }
+
+        static void append_utf8(std::string &value, unsigned int code_point) {
+            if (code_point <= 0x7F) {
+                value.push_back(static_cast<char>(code_point));
+            } else if (code_point <= 0x7FF) {
+                value.push_back(static_cast<char>(0xC0U | (code_point >> 6U)));
+                value.push_back(static_cast<char>(0x80U | (code_point & 0x3FU)));
+            } else if (code_point <= 0xFFFF) {
+                value.push_back(static_cast<char>(0xE0U | (code_point >> 12U)));
+                value.push_back(static_cast<char>(0x80U | ((code_point >> 6U) & 0x3FU)));
+                value.push_back(static_cast<char>(0x80U | (code_point & 0x3FU)));
+            } else {
+                value.push_back(static_cast<char>(0xF0U | (code_point >> 18U)));
+                value.push_back(static_cast<char>(0x80U | ((code_point >> 12U) & 0x3FU)));
+                value.push_back(static_cast<char>(0x80U | ((code_point >> 6U) & 0x3FU)));
+                value.push_back(static_cast<char>(0x80U | (code_point & 0x3FU)));
+            }
+        }
+
+        auto parse_unicode_escape(std::string &value) -> bool {
+            unsigned int code_unit = 0;
+            if (!parse_hex4(code_unit)) { return false; }
+
+            if (code_unit >= 0xD800 && code_unit <= 0xDBFF) {
+                if (input_[pos_] != '\\') { return false; }
+                ++pos_;
+                if (input_[pos_] != 'u') { return false; }
+                ++pos_;
+                unsigned int low_surrogate = 0;
+                if (!parse_hex4(low_surrogate) || low_surrogate < 0xDC00 || low_surrogate > 0xDFFF) { return false; }
+                const auto code_point = 0x10000U + (((code_unit - 0xD800U) << 10U) | (low_surrogate - 0xDC00U));
+                append_utf8(value, code_point);
+                return true;
+            }
+
+            if (code_unit >= 0xDC00 && code_unit <= 0xDFFF) { return false; }
+            append_utf8(value, code_unit);
+            return true;
         }
     };
 

--- a/examples/vscode-extension/README.md
+++ b/examples/vscode-extension/README.md
@@ -16,10 +16,10 @@ A standalone reference VS Code extension that demonstrates how to use [Ωedit™
 | Viewport to webview data flow                             | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
 | Insert / delete / overwrite / replace from UI             | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
 | Search and replace with text/hex and direction controls   | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
-| Undo / redo with stack counts                             | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
+| Discover and apply byte range transform plugins           | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
+| VS Code undo / redo with Structure-pane stack counts      | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
 | VS Code dirty-document tracking (`onDidChangeCustomDocument`) | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
 | VS Code-initiated save / save-as / revert / backup            | [hexEditorProvider.ts](src/hexEditorProvider.ts)                                    |
-| Save / Save As / dirty tracking                               | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [webview.ts](src/webview.ts)     |
 | Export / replay JSON change scripts                       | [hexEditorProvider.ts](src/hexEditorProvider.ts) + [extension.ts](src/extension.ts) |
 | Bytes-per-row and offset-radix controls                   | [webview.ts](src/webview.ts)                                                        |
 | Status bar, binary inspector, and server health indicator | [webview.ts](src/webview.ts)                                                        |
@@ -36,6 +36,7 @@ The example now leans on higher-level editor-facing helpers from `@omega-edit/cl
 | `EditorSessionModel`        | Tracks computed file size, change count, viewport identity, and sync waiters        |
 | `EditorHistoryController`   | Tracks local vs checkpoint-backed undo/redo and save-state semantics                |
 | `EditorSearchController`    | Owns bounded vs large search mode and routes replace-all to bounded or checkpointed flows |
+| `listTransformPlugins()` / `applyTransformPlugin()` | Discovers native transform plugins, including option help/schema metadata, and applies them to the active byte selection |
 
 ## Quick Start
 
@@ -77,7 +78,7 @@ Current implementation note:
 1. `activate()` reads the `omegaEdit.serverPort` setting and starts the bundled native server through `@omega-edit/client`.
 2. Opening a file creates an Ωedit™ session and viewport, then uses the client-managed heartbeat and subscription helpers for the steady-state connection wiring.
 3. The native server now uses server-managed checkpoint directories under the host temp directory for auto-managed sessions, which keeps checkpoint artifacts out of the source file's folder and makes cleanup predictable.
-4. The webview drives edits, navigation, search, replace, save, and replay through the provider, and the provider pushes back reactive state updates for the viewport, undo/redo counts, dirty state, replace counts, and server health.
+4. The webview drives edits, navigation, search, replace, and transforms through the provider, while native VS Code actions handle undo, redo, save, and save-as. The provider pushes back reactive state updates for the viewport, Structure-pane undo/redo counts, dirty state, replace counts, transform results, and server health. Transform option help, examples, defaults, and JSON Schema validation come from the plugin metadata rather than hardcoded webview logic.
 5. The analysis side pane profiles the current visible range or active multi-byte selection. The provider asks Ωedit™ for byte frequency, server-detected content type, language, and character-count data, while the webview renders a 256-bin frequency chart with linear/log scaling and derives local byte classes, mode, frequency-spread, top-byte summaries, entropy, and longest-run structure hints from the buffered data. Content type is sampled from the beginning of the session so file signatures and extension-aware server fallbacks remain useful even while inspecting a later range. Large selections are capped for profiling so exploratory range analysis does not monopolize the extension host.
 6. `deactivate()` calls `stopServerGraceful()` so the server can shut down cleanly.
 
@@ -97,15 +98,16 @@ This mode decision is made only when the user runs an explicit search. If a repl
 | `omegaEdit.serverPort`  | `9000`  | gRPC server port                                                           |
 | `omegaEdit.logLevel`    | `info`  | Client log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`) |
 | `omegaEdit.bytesPerRow` | `16`    | Bytes displayed per row (8 / 16 / 32)                                      |
+| `omegaEdit.transformPluginDirectories` | `[]` | Native transform plugin directories; local build plugin folders are auto-detected when this is empty |
 
 ## Keyboard Shortcuts
 
 | Key                      | Action                                                     |
 | ------------------------ | ---------------------------------------------------------- |
-| `Ctrl+Z`                 | Undo                                                       |
-| `Ctrl+Y`                 | Redo                                                       |
-| `Ctrl+S`                 | Save                                                       |
-| `Ctrl+Shift+S`           | Save As                                                    |
+| `Ctrl+Z`                 | Native VS Code undo                                       |
+| `Ctrl+Y`                 | Native VS Code redo                                       |
+| `Ctrl+S`                 | Native VS Code save                                       |
+| `Ctrl+Shift+S`           | Native VS Code save as                                    |
 | `Ctrl+F`                 | Focus search                                               |
 | Arrow keys               | Move selection, or scroll by line when nothing is selected |
 | `Page Up` / `Page Down`  | Scroll by 32 rows                                          |

--- a/examples/vscode-extension/package.json
+++ b/examples/vscode-extension/package.json
@@ -23,6 +23,8 @@
     "onCustomEditor:omegaEdit.hexEditor",
     "onCommand:omegaEdit.openInHexEditor",
     "onCommand:omegaEdit.goToOffset",
+    "onCommand:omegaEdit.undo",
+    "onCommand:omegaEdit.redo",
     "onCommand:omegaEdit.exportChangeScript",
     "onCommand:omegaEdit.replayChangeScript"
   ],
@@ -70,6 +72,14 @@
             32
           ],
           "description": "Number of bytes displayed per row in the hex view"
+        },
+        "omegaEdit.transformPluginDirectories": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "Directories containing OmegaEdit transform plugin shared libraries"
         }
       }
     },
@@ -81,6 +91,16 @@
       {
         "command": "omegaEdit.goToOffset",
         "title": "Ωedit™: Go to Offset"
+      },
+      {
+        "command": "omegaEdit.undo",
+        "title": "OmegaEdit: Undo",
+        "enablement": "omegaEdit.hexEditorActive && omegaEdit.canUndo"
+      },
+      {
+        "command": "omegaEdit.redo",
+        "title": "OmegaEdit: Redo",
+        "enablement": "omegaEdit.hexEditorActive && omegaEdit.canRedo"
       },
       {
         "command": "omegaEdit.exportChangeScript",
@@ -109,6 +129,14 @@
       "commandPalette": [
         {
           "command": "omegaEdit.openInHexEditor"
+        },
+        {
+          "command": "omegaEdit.undo",
+          "when": "omegaEdit.hexEditorActive"
+        },
+        {
+          "command": "omegaEdit.redo",
+          "when": "omegaEdit.hexEditorActive"
         }
       ]
     }

--- a/examples/vscode-extension/src/constants.ts
+++ b/examples/vscode-extension/src/constants.ts
@@ -1,6 +1,8 @@
 export const OMEGA_EDIT_VIEW_TYPE = 'omegaEdit.hexEditor'
 export const OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND = 'omegaEdit.openInHexEditor'
 export const OMEGA_EDIT_GO_TO_OFFSET_COMMAND = 'omegaEdit.goToOffset'
+export const OMEGA_EDIT_UNDO_COMMAND = 'omegaEdit.undo'
+export const OMEGA_EDIT_REDO_COMMAND = 'omegaEdit.redo'
 export const OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND =
   'omegaEdit.exportChangeScript'
 export const OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND =

--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -13,12 +13,17 @@
 // limitations under the License.
 
 import { getClient, startServer, stopServerGraceful } from '@omega-edit/client'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import * as vscode from 'vscode'
 import {
   OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND,
   OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
   OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+  OMEGA_EDIT_REDO_COMMAND,
   OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND,
+  OMEGA_EDIT_UNDO_COMMAND,
   OMEGA_EDIT_VIEW_TYPE,
 } from './constants'
 import { HexEditorProvider } from './hexEditorProvider'
@@ -28,6 +33,62 @@ let activeProvider: HexEditorProvider | undefined
 
 const DEFAULT_SERVER_PORT = 9000
 const SERVER_PORT_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_PORT'
+
+function transformPluginFileExtension(): string {
+  switch (os.platform()) {
+    case 'win32':
+      return '.dll'
+    case 'darwin':
+      return '.dylib'
+    default:
+      return '.so'
+  }
+}
+
+function directoryHasTransformPlugin(directory: string): boolean {
+  try {
+    const extension = transformPluginFileExtension()
+    return fs
+      .readdirSync(directory, { withFileTypes: true })
+      .some(
+        (entry) =>
+          entry.isFile() &&
+          entry.name.startsWith('omega_transform_') &&
+          entry.name.endsWith(extension)
+      )
+  } catch {
+    return false
+  }
+}
+
+function getDefaultTransformPluginDirectories(
+  context: vscode.ExtensionContext
+): string[] {
+  const repoRoot = path.resolve(context.extensionPath, '..', '..')
+  const candidates = [
+    process.env.OMEGA_EDIT_TEST_PLUGIN_DIR ?? '',
+    path.join(repoRoot, '_build_core', 'plugins', 'plugins'),
+    path.join(repoRoot, '_build_core', 'core', 'src', 'tests', 'plugins'),
+    path.join(repoRoot, '_build', 'plugins', 'plugins'),
+    path.join(repoRoot, 'build', 'core', 'src', 'tests', 'plugins'),
+    path.join(repoRoot, 'build-coverage', 'core', 'src', 'tests', 'plugins'),
+  ].filter(Boolean)
+
+  return candidates.filter(directoryHasTransformPlugin)
+}
+
+function resolveTransformPluginDirectories(
+  context: vscode.ExtensionContext,
+  config: vscode.WorkspaceConfiguration
+): string[] {
+  const configured = config
+    .get<string[]>('transformPluginDirectories', [])
+    .filter((directory) => directory.trim().length > 0)
+
+  return configured.length > 0
+    ? configured
+    : getDefaultTransformPluginDirectories(context)
+}
 
 function isTestRuntime(): boolean {
   return process.env.NODE_ENV === 'test'
@@ -62,9 +123,15 @@ export async function activate(
 
   const logLevel = config.get<string>('logLevel', 'info')
   process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL = logLevel
+  const transformPluginDirectories = resolveTransformPluginDirectories(
+    context,
+    config
+  )
 
   try {
-    serverPid = await startServer(port)
+    serverPid = await startServer(port, undefined, undefined, {
+      transformPluginDirectories,
+    })
     if (serverPid && !isTestRuntime()) {
       void vscode.window.showInformationMessage(
         `Ωedit™ server started on port ${port} (pid ${serverPid})`
@@ -154,6 +221,18 @@ export async function activate(
         }
       }
     )
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(OMEGA_EDIT_UNDO_COMMAND, async () => {
+      await provider.undoActive()
+    })
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(OMEGA_EDIT_REDO_COMMAND, async () => {
+      await provider.redoActive()
+    })
   )
 
   context.subscriptions.push(

--- a/examples/vscode-extension/src/hexEditorProvider.ts
+++ b/examples/vscode-extension/src/hexEditorProvider.ts
@@ -738,8 +738,8 @@ export class HexEditorProvider
     const response = await applyTransformPlugin(
       session.sessionId,
       pluginId,
-      offset,
-      length,
+      clampedOffset,
+      originalLength,
       optionsJson
     )
 

--- a/examples/vscode-extension/src/hexEditorProvider.ts
+++ b/examples/vscode-extension/src/hexEditorProvider.ts
@@ -29,6 +29,7 @@
 
 import {
   ALL_EVENTS,
+  applyTransformPlugin,
   countCharacters,
   del,
   destroyLastCheckpoint,
@@ -48,6 +49,7 @@ import {
   IOFlags,
   type IServerInfo,
   insert,
+  listTransformPlugins,
   modifyViewport,
   numAscii,
   overwrite,
@@ -56,6 +58,7 @@ import {
   redo,
   saveSession,
   startServerHeartbeatLoop,
+  type TransformPluginInfo,
   type ServerHeartbeatLoop,
   undo,
   ViewportEventKind,
@@ -108,6 +111,10 @@ const SESSION_SYNC_TIMEOUT_MS = 2000
 const VIEWPORT_BUFFER_BYTES = 8 * 1024
 const SERVER_HEALTH_WARN_LATENCY_MS = 75
 const SERVER_HEALTH_ERROR_LATENCY_MS = 250
+const MAX_TRANSFORM_RESULT_TEXT_LENGTH = 240
+const CONTEXT_HEX_EDITOR_ACTIVE = 'omegaEdit.hexEditorActive'
+const CONTEXT_CAN_UNDO = 'omegaEdit.canUndo'
+const CONTEXT_CAN_REDO = 'omegaEdit.canRedo'
 
 function classifyServerHealthLatency(
   latencyMs: number
@@ -135,6 +142,54 @@ function getOptionalNumberProperty(
 ): number | undefined {
   const value = (source as Record<string, unknown>)[key]
   return typeof value === 'number' ? value : undefined
+}
+
+function truncateTransformResult(value: string): string {
+  if (value.length <= MAX_TRANSFORM_RESULT_TEXT_LENGTH) {
+    return value
+  }
+  return `${value.slice(0, MAX_TRANSFORM_RESULT_TEXT_LENGTH - 1)}...`
+}
+
+function transformResultToText(bytes: Uint8Array): string {
+  if (bytes.byteLength === 0) {
+    return ''
+  }
+
+  return truncateTransformResult(Buffer.from(bytes).toString('utf8'))
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return (
+    left.byteLength === right.byteLength &&
+    Buffer.from(left).equals(Buffer.from(right))
+  )
+}
+
+function serializeTransformPlugin(plugin: TransformPluginInfo): {
+  id: string
+  name: string
+  description: string
+  operation: number
+  flags: number
+  abiVersion: number
+  help: string
+  example: string
+  defaultArgs: string
+  argsSchema: string
+} {
+  return {
+    id: plugin.id,
+    name: plugin.name,
+    description: plugin.description,
+    operation: plugin.operation,
+    flags: plugin.flags,
+    abiVersion: plugin.abiVersion,
+    help: plugin.help,
+    example: plugin.example,
+    defaultArgs: plugin.defaultArgs,
+    argsSchema: plugin.argsSchema,
+  }
 }
 
 /**
@@ -231,6 +286,20 @@ export class HexEditorProvider
     await this.handleWebviewMessage(session, msg)
   }
 
+  public async undoActive(): Promise<void> {
+    if (!this.activeSession) {
+      return
+    }
+    await vscode.commands.executeCommand('undo')
+  }
+
+  public async redoActive(): Promise<void> {
+    if (!this.activeSession) {
+      return
+    }
+    await vscode.commands.executeCommand('redo')
+  }
+
   // â”€â”€ VS Code Custom Editor API â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   async openCustomDocument(
@@ -302,6 +371,7 @@ export class HexEditorProvider
     }
     this.sessions.set(uri.toString(), session)
     this.activeSession = session
+    this.updateEditCommandContexts(session)
 
     // --- Configure the webview ---
     webviewPanel.webview.options = { enableScripts: true }
@@ -325,6 +395,10 @@ export class HexEditorProvider
     webviewPanel.onDidChangeViewState(() => {
       if (webviewPanel.active) {
         this.activeSession = session
+        this.updateEditCommandContexts(session)
+      } else if (this.activeSession === session) {
+        this.activeSession = undefined
+        this.updateEditCommandContexts(undefined)
       }
     })
 
@@ -334,6 +408,7 @@ export class HexEditorProvider
       this.documents.delete(uri.toString())
       if (this.activeSession === session) {
         this.activeSession = undefined
+        this.updateEditCommandContexts(undefined)
       }
       if (this.sessions.size === 0) {
         this.stopHealthPolling()
@@ -356,7 +431,6 @@ export class HexEditorProvider
     session.restoredFromBackup = false
     session.history.markSaved()
     this.postEditState(session)
-    vscode.window.showInformationMessage('File saved')
   }
 
   async saveCustomDocumentAs(
@@ -370,7 +444,6 @@ export class HexEditorProvider
     }
     await saveSession(session.sessionId, destination.fsPath, IOFlags.OVERWRITE)
     session.restoredFromBackup = false
-    vscode.window.showInformationMessage(`File saved as ${destination.fsPath}`)
   }
 
   async revertCustomDocument(
@@ -406,6 +479,7 @@ export class HexEditorProvider
     await this.startSessionSubscriptions(session)
     await this.sendViewportData(session)
     this.postEditState(session)
+    await this.sendTransformPlugins(session)
   }
 
   async backupCustomDocument(
@@ -599,10 +673,124 @@ export class HexEditorProvider
 
   private postEditState(session: EditorSession): void {
     const editState = session.history.getEditState()
+    if (this.activeSession === session) {
+      this.updateEditCommandContexts(session)
+    }
     session.panel.webview.postMessage({
       type: 'editState',
       ...editState,
       isDirty: editState.isDirty || !!session.restoredFromBackup,
+    })
+  }
+
+  private updateEditCommandContexts(session: EditorSession | undefined): void {
+    const editState = session?.history.getEditState()
+    void vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_HEX_EDITOR_ACTIVE,
+      !!session
+    )
+    void vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_CAN_UNDO,
+      !!editState?.canUndo
+    )
+    void vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_CAN_REDO,
+      !!editState?.canRedo
+    )
+  }
+
+  private async sendTransformPlugins(session: EditorSession): Promise<void> {
+    try {
+      const plugins = await listTransformPlugins()
+      session.panel.webview.postMessage({
+        type: 'transformPlugins',
+        plugins: plugins.map(serializeTransformPlugin),
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      session.panel.webview.postMessage({
+        type: 'transformPlugins',
+        plugins: [],
+        error: message,
+      })
+    }
+  }
+
+  private async applyTransformToRange(
+    session: EditorSession,
+    pluginId: string,
+    offset: number,
+    length: number,
+    optionsJson?: string
+  ): Promise<void> {
+    const clampedOffset = Math.max(0, Math.min(offset, session.fileSize))
+    const remainingLength = Math.max(0, session.fileSize - clampedOffset)
+    const originalLength =
+      length === 0 ? remainingLength : Math.min(length, remainingLength)
+    const originalBytes =
+      originalLength > 0
+        ? await getSegment(session.sessionId, clampedOffset, originalLength)
+        : new Uint8Array()
+    const sessionSyncVersion = session.sessionSyncVersion
+    const response = await applyTransformPlugin(
+      session.sessionId,
+      pluginId,
+      offset,
+      length,
+      optionsJson
+    )
+
+    let contentChanged = response.contentChanged
+    if (response.contentChanged) {
+      const replacement =
+        response.replacementLength > 0
+          ? await getSegment(
+              session.sessionId,
+              response.offset,
+              response.replacementLength
+            )
+          : new Uint8Array()
+      const isNoOpReplace =
+        response.offset === clampedOffset &&
+        response.length === originalLength &&
+        bytesEqual(originalBytes, replacement)
+
+      if (isNoOpReplace) {
+        await this.waitForSessionSync(session, sessionSyncVersion)
+        const undoSyncVersion = session.sessionSyncVersion
+        await undo(session.sessionId)
+        await this.waitForSessionSync(session, undoSyncVersion)
+        contentChanged = false
+      } else {
+        session.history.recordLocalChange({
+          serial: session.history.getChangeLog().length + 1,
+          kind: 'REPLACE',
+          offset: response.offset,
+          length: response.length,
+          data: Buffer.from(replacement).toString('hex'),
+        })
+        this.postEditState(session)
+        this.notifyDocumentChanged(session)
+        await this.waitForSessionSync(session, sessionSyncVersion)
+        this.clearSearchState(session)
+      }
+    }
+
+    session.panel.webview.postMessage({
+      type: 'transformComplete',
+      pluginId: response.pluginId,
+      offset: response.offset,
+      length: response.length,
+      operation: response.operation,
+      contentChanged,
+      replacementLength: response.replacementLength,
+      computedFileSize: response.computedFileSize,
+      resultLabel: response.resultLabel ?? '',
+      resultMimeType: response.resultMimeType ?? '',
+      resultText: transformResultToText(response.result),
     })
   }
 
@@ -1238,6 +1426,11 @@ export class HexEditorProvider
           break
         }
 
+        case 'requestTransformPlugins': {
+          await this.sendTransformPlugins(session)
+          break
+        }
+
         // --- Editing ---
         case 'insert': {
           const sessionSyncVersion = session.sessionSyncVersion
@@ -1360,6 +1553,19 @@ export class HexEditorProvider
           break
         }
 
+        case 'applyTransform': {
+          await session.search.preserveState(async () => {
+            await this.applyTransformToRange(
+              session,
+              msg.pluginId,
+              msg.offset,
+              msg.length,
+              msg.optionsJson?.trim() || undefined
+            )
+          })
+          break
+        }
+
         // --- Undo / Redo ---
         case 'undo': {
           // Route through VS Code so it pops from its CustomDocumentEditEvent
@@ -1460,10 +1666,18 @@ type WebviewMessage =
       requestedLength: number
       isCapped: boolean
     }
+  | { type: 'requestTransformPlugins' }
   | { type: 'insert'; offset: number; data: string }
   | { type: 'delete'; offset: number; length: number }
   | { type: 'overwrite'; offset: number; data: string }
   | { type: 'replace'; offset: number; length: number; data: string }
+  | {
+      type: 'applyTransform'
+      pluginId: string
+      offset: number
+      length: number
+      optionsJson?: string
+    }
   | {
       type: 'replaceAllMatches'
       offsets?: number[]

--- a/examples/vscode-extension/src/webview.ts
+++ b/examples/vscode-extension/src/webview.ts
@@ -20,7 +20,7 @@
  *
  * Layout:
  *   ┌─────────────────────────────────────────────────────────┐
- *   │  Toolbar: [Search] [Insert/Delete/Overwrite] [Undo/Redo/Save]  │
+ *   │  Toolbar: [Search] [Insert/Delete/Overwrite] [Transforms]      │
  *   ├────────────┬─────────────────────────┬──────────────────┤
  *   │  Offset    │  Hex                    │  ASCII           │
  *   │  00000000  │  48 65 6C 6C 6F ...     │  Hello...        │
@@ -122,6 +122,7 @@ export function getWebviewContent(bytesPerRow: number): string {
   .toolbar input:focus, .toolbar select:focus { outline: 1px solid var(--button-bg); }
   .toolbar input[type="text"] { width: 160px; }
   .toolbar input.narrow { width: 80px; }
+  .toolbar select.transform-select { width: 180px; }
   button {
     background: var(--button-bg);
     color: var(--button-fg);
@@ -622,6 +623,31 @@ export function getWebviewContent(bytesPerRow: number): string {
   .status-action {
     color: var(--vscode-terminal-ansiYellow, #dcdcaa);
   }
+  .status-action.flash {
+    animation: status-action-flash 1200ms ease-out;
+  }
+  @keyframes status-action-flash {
+    0% {
+      color: var(--vscode-editorWarning-foreground, #ffcc66);
+      background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #ffcc66) 26%, transparent);
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--vscode-editorWarning-foreground, #ffcc66) 48%, transparent);
+    }
+    35% {
+      color: var(--vscode-editorWarning-foreground, #ffcc66);
+      background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #ffcc66) 18%, transparent);
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--vscode-editorWarning-foreground, #ffcc66) 0%, transparent);
+    }
+    100% {
+      color: var(--vscode-terminal-ansiYellow, #dcdcaa);
+      background: transparent;
+      box-shadow: none;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .status-action.flash {
+      animation-duration: 1ms;
+    }
+  }
   .server-health {
     display: inline-flex;
     align-items: center;
@@ -759,6 +785,43 @@ export function getWebviewContent(bytesPerRow: number): string {
   .edit-dialog .field label { display: block; margin-bottom: 2px; font-size: 11px; }
   .edit-dialog .field input { width: 100%; }
   .edit-dialog .actions { display: flex; gap: 6px; justify-content: flex-end; margin-top: 12px; }
+  .edit-dialog .help-body {
+    color: var(--fg);
+    font-size: 12px;
+    line-height: 1.45;
+    max-width: 460px;
+  }
+  .edit-dialog .help-muted {
+    color: var(--offset-fg);
+    margin-bottom: 10px;
+  }
+  .edit-dialog .help-section-title {
+    color: var(--offset-fg);
+    font-size: 11px;
+    margin: 10px 0 4px;
+    text-transform: uppercase;
+  }
+  .edit-dialog .help-example {
+    display: block;
+    width: 100%;
+    background: var(--input-bg);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 6px 8px;
+    margin-top: 4px;
+    font-family: var(--mono);
+    font-size: 12px;
+    text-align: left;
+    white-space: pre-wrap;
+    cursor: pointer;
+    user-select: text;
+  }
+  .edit-dialog .help-example:hover,
+  .edit-dialog .help-example:focus {
+    background: color-mix(in srgb, var(--button-bg) 22%, var(--input-bg));
+    outline: 1px solid var(--button-bg);
+  }
   .overlay {
     display: none;
     position: fixed;
@@ -820,10 +883,10 @@ export function getWebviewContent(bytesPerRow: number): string {
     <button class="secondary" id="deleteBtn" title="Delete bytes at selected offset">Del</button>
   </div>
   <div class="toolbar-group">
-    <button class="secondary" id="undoBtn" title="Undo (Ctrl+Z)">Undo</button>
-    <button class="secondary" id="redoBtn" title="Redo (Ctrl+Y)">Redo</button>
-    <button class="secondary" id="saveBtn" title="Save (Ctrl+S)">Save</button>
-    <button class="secondary" id="saveAsBtn" title="Save As (Ctrl+Shift+S)">Save As</button>
+    <label for="transformSelect">Transform:</label>
+    <select class="transform-select" id="transformSelect" title="Byte range transform">
+      <option value="">Loading transforms...</option>
+    </select>
   </div>
 </div>
 
@@ -878,6 +941,10 @@ export function getWebviewContent(bytesPerRow: number): string {
         <div class="analysis-section">
           <div class="analysis-section-title" id="structureScopeTitle">Visible Bytes</div>
           <div class="analysis-metrics" id="structureMetrics"></div>
+        </div>
+        <div class="analysis-section">
+          <div class="analysis-section-title">History</div>
+          <div class="analysis-metrics" id="structureHistoryMetrics"></div>
         </div>
         <div class="analysis-section">
           <div class="analysis-section-title">Timing</div>
@@ -938,6 +1005,19 @@ export function getWebviewContent(bytesPerRow: number): string {
   </div>
 </div>
 
+<div class="edit-dialog" id="transformOptionsDialog">
+  <h3 id="transformOptionsTitle">Transform Options</h3>
+  <div class="help-body" id="transformOptionsBody"></div>
+  <div class="field" id="transformOptionsField">
+    <label for="transformOptions">Options JSON:</label>
+    <input type="text" id="transformOptions" placeholder="options JSON" />
+  </div>
+  <div class="actions">
+    <button class="secondary" id="transformOptionsCancel">Cancel</button>
+    <button id="transformOptionsApply">Apply</button>
+  </div>
+</div>
+
 <script>
 (function () {
   // VS Code webview API
@@ -990,6 +1070,13 @@ export function getWebviewContent(bytesPerRow: number): string {
   let pendingAnalysisProfileKey = ''
   let analysisProfileRequestTimer = null
   let frequencyScale = 'linear'
+  let historyCanUndo = false
+  let historyCanRedo = false
+  let historyUndoCount = 0
+  let historyRedoCount = 0
+  let transformPlugins = []
+  let transformPluginsRequested = false
+  const transformOptionsByPluginId = new Map()
   const renderSamples = []
 
   // ── DOM Refs ────────────────────────────────────────
@@ -1027,10 +1114,8 @@ export function getWebviewContent(bytesPerRow: number): string {
   const nextMatchBtn = document.getElementById('nextMatch')
   const topBtn = document.getElementById('topBtn')
   const bottomBtn = document.getElementById('bottomBtn')
-  const undoBtn = document.getElementById('undoBtn')
-  const redoBtn = document.getElementById('redoBtn')
-  const saveBtn = document.getElementById('saveBtn')
-  const saveAsBtn = document.getElementById('saveAsBtn')
+  const transformSelect = document.getElementById('transformSelect')
+  const transformOptions = document.getElementById('transformOptions')
   const editDialog = document.getElementById('editDialog')
   const overlay = document.getElementById('overlay')
   const editTitle = document.getElementById('editTitle')
@@ -1039,6 +1124,12 @@ export function getWebviewContent(bytesPerRow: number): string {
   const editData = document.getElementById('editData')
   const editLengthField = document.getElementById('editLengthField')
   const editDataField = document.getElementById('editDataField')
+  const transformOptionsDialog = document.getElementById('transformOptionsDialog')
+  const transformOptionsTitle = document.getElementById('transformOptionsTitle')
+  const transformOptionsBody = document.getElementById('transformOptionsBody')
+  const transformOptionsField = document.getElementById('transformOptionsField')
+  const transformOptionsApply = document.getElementById('transformOptionsApply')
+  const transformOptionsCancel = document.getElementById('transformOptionsCancel')
   const profileTab = document.getElementById('profileTab')
   const structureTab = document.getElementById('structureTab')
   const profilePanel = document.getElementById('profilePanel')
@@ -1053,6 +1144,7 @@ export function getWebviewContent(bytesPerRow: number): string {
   const profileByteBars = document.getElementById('profileByteBars')
   const structureScopeTitle = document.getElementById('structureScopeTitle')
   const structureMetrics = document.getElementById('structureMetrics')
+  const structureHistoryMetrics = document.getElementById('structureHistoryMetrics')
 
   function clamp(min, value, max) {
     return Math.max(min, Math.min(value, max))
@@ -1790,7 +1882,17 @@ export function getWebviewContent(bytesPerRow: number): string {
       },
     ])
 
+    renderHistoryMetrics()
     renderTimingMetrics()
+  }
+
+  function renderHistoryMetrics() {
+    renderMetricRows(structureHistoryMetrics, [
+      { label: 'Undo', value: historyUndoCount.toLocaleString() },
+      { label: 'Redo', value: historyRedoCount.toLocaleString() },
+      { label: 'Can Undo', value: historyCanUndo ? 'Yes' : 'No' },
+      { label: 'Can Redo', value: historyCanRedo ? 'Yes' : 'No' },
+    ])
   }
 
   function updateAnalysisPanels() {
@@ -1881,7 +1983,6 @@ export function getWebviewContent(bytesPerRow: number): string {
 
   function updateDirtyStatus(isDirty) {
     statusDirty.textContent = isDirty ? 'Dirty' : 'Saved'
-    saveBtn.disabled = !isDirty
   }
 
   function updateActionStatus(message = '', source = 'generic') {
@@ -1889,10 +1990,354 @@ export function getWebviewContent(bytesPerRow: number): string {
     replaceSummaryActive = source === 'replace-summary' && message.length > 0
   }
 
+  function flashActionStatus() {
+    statusAction.classList.remove('flash')
+    void statusAction.offsetWidth
+    statusAction.classList.add('flash')
+  }
+
   function clearReplaceSummaryActionStatus() {
     if (replaceSummaryActive) {
       updateActionStatus('')
     }
+  }
+
+  function transformOperationLabel(operation) {
+    switch (operation) {
+      case 1:
+        return 'replace'
+      case 2:
+        return 'inspect'
+      case 3:
+        return 'replace + inspect'
+      default:
+        return 'transform'
+    }
+  }
+
+  function selectedTransformPlugin() {
+    return transformPlugins.find((plugin) => plugin.id === transformSelect.value) ?? null
+  }
+
+  function advertisedTransformExamples(plugin) {
+    const examples = []
+    const addExample = (value) => {
+      const text = typeof value === 'string' ? value : JSON.stringify(value)
+      if (text && !examples.includes(text)) {
+        examples.push(text)
+      }
+    }
+    if (plugin?.example) {
+      try {
+        const parsed = JSON.parse(plugin.example)
+        if (Array.isArray(parsed)) {
+          for (const example of parsed) {
+            addExample(example)
+          }
+        } else {
+          addExample(plugin.example)
+        }
+      } catch {
+        addExample(plugin.example)
+      }
+    }
+    if (plugin?.defaultArgs) {
+      addExample(plugin.defaultArgs)
+    }
+    return examples
+  }
+
+  function getTransformOptionHelp(plugin) {
+    const description = plugin?.description || plugin?.name || plugin?.id || ''
+    const examples = advertisedTransformExamples(plugin)
+    return {
+      description: description || 'This transform did not advertise a description.',
+      help: plugin?.help || '',
+      examples,
+      defaultArgs: plugin?.defaultArgs || '',
+      argsSchema: plugin?.argsSchema || '',
+    }
+  }
+
+  function validateJsonSchemaValue(value, schema, path) {
+    if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+      return null
+    }
+    if (Array.isArray(schema.oneOf)) {
+      const matches = schema.oneOf.filter((candidate) => validateJsonSchemaValue(value, candidate, path) === null)
+      return matches.length === 1 ? null : path + ' must match exactly one allowed shape'
+    }
+    if (schema.not && validateJsonSchemaValue(value, schema.not, path) === null) {
+      return path + ' uses a disallowed option combination'
+    }
+    if (schema.type === 'object') {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return path + ' must be an object'
+      }
+      const keys = Object.keys(value)
+      if (Array.isArray(schema.required)) {
+        const missing = schema.required.find((key) => !Object.prototype.hasOwnProperty.call(value, key))
+        if (missing) {
+          return path + ' is missing "' + missing + '"'
+        }
+      }
+      if (Number.isInteger(schema.maxProperties) && keys.length > schema.maxProperties) {
+        return path + ' has too many properties'
+      }
+      const properties = schema.properties && typeof schema.properties === 'object' ? schema.properties : {}
+      if (schema.additionalProperties === false) {
+        const unknown = keys.find((key) => !Object.prototype.hasOwnProperty.call(properties, key))
+        if (unknown) {
+          return path + ' has unknown option "' + unknown + '"'
+        }
+      }
+      for (const key of keys) {
+        if (properties[key]) {
+          const error = validateJsonSchemaValue(value[key], properties[key], path + '.' + key)
+          if (error) {
+            return error
+          }
+        }
+      }
+    }
+    if (schema.type === 'array') {
+      if (!Array.isArray(value)) {
+        return path + ' must be an array'
+      }
+      if (Number.isInteger(schema.minItems) && value.length < schema.minItems) {
+        return path + ' must contain at least ' + schema.minItems + ' item'
+      }
+      if (schema.items) {
+        for (let i = 0; i < value.length; i += 1) {
+          const error = validateJsonSchemaValue(value[i], schema.items, path + '[' + i + ']')
+          if (error) {
+            return error
+          }
+        }
+      }
+    }
+    if (schema.type === 'string') {
+      if (typeof value !== 'string') {
+        return path + ' must be a string'
+      }
+      if (schema.pattern && !(new RegExp(schema.pattern).test(value))) {
+        return path + ' does not match the expected format'
+      }
+    }
+    if (schema.type === 'integer') {
+      if (!Number.isInteger(value)) {
+        return path + ' must be an integer'
+      }
+      if (typeof schema.minimum === 'number' && value < schema.minimum) {
+        return path + ' must be at least ' + schema.minimum
+      }
+      if (typeof schema.maximum === 'number' && value > schema.maximum) {
+        return path + ' must be at most ' + schema.maximum
+      }
+    }
+    return null
+  }
+
+  function validateTransformOptions(plugin, optionsJson) {
+    if (optionsJson.length === 0) {
+      return null
+    }
+
+    let parsedOptions
+    try {
+      parsedOptions = JSON.parse(optionsJson)
+    } catch {
+      return 'Invalid transform options JSON'
+    }
+
+    if (!plugin?.argsSchema) {
+      return 'Selected transform did not advertise an options schema'
+    }
+
+    let schema
+    try {
+      schema = JSON.parse(plugin.argsSchema)
+    } catch {
+      return 'Selected transform advertised an invalid options schema'
+    }
+    return validateJsonSchemaValue(parsedOptions, schema, 'options')
+  }
+
+  function updateTransformControls() {
+    const hasRange = hasSelection() && getSelectionLength() > 0
+    transformSelect.disabled = !hasRange
+    transformSelect.title = !hasRange
+      ? 'Select one or more bytes to transform'
+      : transformPlugins.length === 0
+        ? 'No transform plugin is available'
+        : 'Choose a transform to apply to the selected bytes'
+  }
+
+  function requestTransformPlugins() {
+    if (transformPluginsRequested) {
+      return
+    }
+    transformPluginsRequested = true
+    vscode.postMessage({ type: 'requestTransformPlugins' })
+  }
+
+  function renderTransformOptionsDialog() {
+    const plugin = selectedTransformPlugin()
+    if (!plugin) {
+      updateActionStatus('No transform selected')
+      return
+    }
+
+    const help = getTransformOptionHelp(plugin)
+    const savedOptions = transformOptionsByPluginId.get(plugin.id)
+    const hasOptionsSchema = !!help.argsSchema
+    const selectionStart = getSelectionStart()
+    const selectionEnd = getSelectionEnd()
+    const selectionLength = getSelectionLength()
+    transformOptions.value = hasOptionsSchema ? (savedOptions ?? plugin.defaultArgs ?? '') : ''
+    transformOptions.placeholder = help.examples[0]
+      ? 'e.g. ' + help.examples[0]
+      : 'options JSON'
+    transformOptionsField.style.display = hasOptionsSchema ? 'block' : 'none'
+    transformOptionsTitle.textContent = plugin.name || plugin.id
+    const examplesHtml = help.examples.length > 0
+      ? '<div class="help-section-title">Examples</div>' +
+        help.examples
+          .map((example, index) =>
+            '<button type="button" class="help-example" data-example-index="' +
+            index +
+            '" title="Use this example">' +
+            escapeHtml(example) +
+            '</button>'
+          )
+          .join('')
+      : ''
+    transformOptionsBody.innerHTML =
+      '<div class="help-muted">' +
+      escapeHtml(plugin.id) +
+      ' | ' +
+      escapeHtml(transformOperationLabel(plugin.operation)) +
+      '</div>' +
+      '<div>' +
+      escapeHtml(help.description) +
+      '</div>' +
+      '<div class="help-section-title">Selected Range</div>' +
+      '<div class="analysis-metrics">' +
+      '<span class="analysis-label">Start</span>' +
+      '<span class="analysis-value">' +
+      escapeHtml(formatOffsetDisplay(selectionStart)) +
+      '</span>' +
+      '<span class="analysis-label">End</span>' +
+      '<span class="analysis-value">' +
+      escapeHtml(formatOffsetDisplay(selectionEnd)) +
+      '</span>' +
+      '<span class="analysis-label">Length</span>' +
+      '<span class="analysis-value">' +
+      selectionLength.toLocaleString() +
+      ' byte(s)</span>' +
+      '</div>' +
+      (help.help
+        ? '<div class="help-section-title">' +
+          (hasOptionsSchema ? 'Options JSON' : 'Help') +
+          '</div>' +
+          '<div>' +
+          escapeHtml(help.help) +
+          '</div>'
+        : '') +
+      examplesHtml
+    overlay.classList.add('active')
+    transformOptionsDialog.classList.add('active')
+    if (hasOptionsSchema) {
+      transformOptions.focus()
+    } else {
+      transformOptionsApply.focus()
+    }
+  }
+
+  function closeTransformOptionsDialog() {
+    if (transformOptionsDialog.contains(document.activeElement)) {
+      document.activeElement.blur()
+    }
+    transformOptionsDialog.classList.remove('active')
+    overlay.classList.remove('active')
+    transformSelect.value = ''
+    updateTransformControls()
+  }
+
+  function useTransformOptionExample(index) {
+    const help = getTransformOptionHelp(selectedTransformPlugin())
+    if (index < 0 || index >= help.examples.length) {
+      return
+    }
+    transformOptions.value = help.examples[index]
+    transformOptions.focus()
+  }
+
+  function setTransformPlugins(plugins) {
+    const previousPluginId = transformSelect.value
+    transformPlugins = Array.isArray(plugins) ? plugins : []
+    transformPluginsRequested = false
+
+    if (transformPlugins.length === 0) {
+      transformSelect.innerHTML = '<option value="">No transforms found</option>'
+      updateTransformControls()
+      return
+    }
+
+    transformSelect.innerHTML =
+      '<option value="">Select transform...</option>' +
+      transformPlugins
+      .map((plugin) => {
+        const label = escapeHtml(plugin.name || plugin.id)
+        const title = escapeHtml(
+          (plugin.description || plugin.id) +
+          ' (' + transformOperationLabel(plugin.operation) + ')'
+        )
+        return '<option value="' + escapeHtml(plugin.id) + '" title="' + title + '">' + label + '</option>'
+      })
+      .join('')
+
+    if (transformPlugins.some((plugin) => plugin.id === previousPluginId)) {
+      transformSelect.value = previousPluginId
+    }
+    updateTransformControls()
+  }
+
+  function applySelectedTransform() {
+    const plugin = selectedTransformPlugin()
+    if (!plugin) {
+      updateActionStatus('No transform selected')
+      return
+    }
+    if (!hasSelection()) {
+      updateActionStatus('Select one or more bytes to transform')
+      return
+    }
+
+    const optionsJson = transformOptions.value.trim()
+    const validationError = validateTransformOptions(plugin, optionsJson)
+    if (validationError) {
+      updateActionStatus(validationError)
+      return
+    }
+
+    const offset = getSelectionStart()
+    const length = getSelectionLength()
+    if (optionsJson) {
+      transformOptionsByPluginId.set(plugin.id, optionsJson)
+    } else {
+      transformOptionsByPluginId.delete(plugin.id)
+    }
+    closeTransformOptionsDialog()
+    clearReplaceSummaryActionStatus()
+    updateActionStatus('Applying ' + (plugin.name || plugin.id) + '...')
+    vscode.postMessage({
+      type: 'applyTransform',
+      pluginId: plugin.id,
+      offset,
+      length,
+      optionsJson: optionsJson || undefined,
+    })
   }
 
   function formatServerHealthSeverity(severity) {
@@ -2016,13 +2461,12 @@ export function getWebviewContent(bytesPerRow: number): string {
     replaceAllBtn.disabled = !hasMatches
   }
 
-  function updateEditButtons(canUndo, canRedo, undoCount = 0, redoCount = 0) {
-    undoBtn.disabled = !canUndo
-    redoBtn.disabled = !canRedo
-    undoBtn.textContent = 'Undo (' + undoCount + ')'
-    redoBtn.textContent = 'Redo (' + redoCount + ')'
-    undoBtn.title = 'Undo ' + undoCount + ' change(s) (Ctrl+Z)'
-    redoBtn.title = 'Redo ' + redoCount + ' change(s) (Ctrl+Y)'
+  function updateHistoryState(canUndo, canRedo, undoCount = 0, redoCount = 0) {
+    historyCanUndo = !!canUndo
+    historyCanRedo = !!canRedo
+    historyUndoCount = undoCount
+    historyRedoCount = redoCount
+    renderHistoryMetrics()
   }
 
   function totalRows() {
@@ -2200,6 +2644,7 @@ export function getWebviewContent(bytesPerRow: number): string {
       updateSelectedStatus()
       updateRenderedSelection()
       updateAnalysisPanels()
+      updateTransformControls()
       requestAnalysisProfile()
       return
     }
@@ -2218,6 +2663,29 @@ export function getWebviewContent(bytesPerRow: number): string {
     updateSelectedStatus()
     updateRenderedSelection()
     updateAnalysisPanels()
+    updateTransformControls()
+    requestAnalysisProfile()
+  }
+
+  function selectRange(offset, length) {
+    if (offset < 0 || fileSize <= 0) {
+      selectOffset(-1)
+      return
+    }
+
+    if (length <= 1) {
+      selectOffset(offset)
+      return
+    }
+
+    const selectionStart = clampOffset(offset)
+    const selectionEnd = clampOffset(offset + length - 1)
+    selectionAnchor = selectionStart
+    selectedOffset = Math.max(selectionStart, selectionEnd)
+    updateSelectedStatus()
+    updateRenderedSelection()
+    updateAnalysisPanels()
+    updateTransformControls()
     requestAnalysisProfile()
   }
 
@@ -2695,7 +3163,7 @@ export function getWebviewContent(bytesPerRow: number): string {
         break
 
       case 'editState':
-        updateEditButtons(
+        updateHistoryState(
           msg.canUndo,
           msg.canRedo,
           msg.undoCount ?? 0,
@@ -2765,6 +3233,41 @@ export function getWebviewContent(bytesPerRow: number): string {
 
       case 'searchStateCleared':
         clearSearchResults()
+        break
+
+      case 'transformPlugins':
+        setTransformPlugins(msg.plugins ?? [])
+        if (msg.error) {
+          updateActionStatus('Transform plugins unavailable: ' + msg.error)
+        }
+        break
+
+      case 'transformComplete':
+        if (msg.contentChanged) {
+          clearSearchResults()
+        }
+        if (typeof msg.offset === 'number' && msg.offset >= 0) {
+          const transformedLength = msg.contentChanged
+            ? (msg.replacementLength ?? msg.length ?? 1)
+            : (msg.length ?? 1)
+          selectRange(msg.offset, transformedLength)
+        }
+        if (msg.resultText) {
+          updateActionStatus(
+            (msg.resultLabel || 'Result') + ': ' + msg.resultText
+          )
+          flashActionStatus()
+        } else if (msg.contentChanged) {
+          updateActionStatus(
+            'Transformed ' +
+            (msg.length ?? 0).toLocaleString() +
+            ' byte(s) into ' +
+            (msg.replacementLength ?? 0).toLocaleString() +
+            ' byte(s)'
+          )
+        } else {
+          updateActionStatus('Transform completed')
+        }
         break
 
       case 'serverHealth':
@@ -2925,24 +3428,7 @@ export function getWebviewContent(bytesPerRow: number): string {
       return
     }
 
-    if (e.ctrlKey && e.key === 'z') {
-      e.preventDefault()
-      if (!undoBtn.disabled) {
-        vscode.postMessage({ type: 'undo' })
-      }
-    } else if (e.ctrlKey && e.key === 'y') {
-      e.preventDefault()
-      if (!redoBtn.disabled) {
-        vscode.postMessage({ type: 'redo' })
-      }
-    } else if (e.ctrlKey && e.key === 's') {
-      e.preventDefault()
-      if (e.shiftKey) {
-        vscode.postMessage({ type: 'saveAs' })
-      } else if (!saveBtn.disabled) {
-        vscode.postMessage({ type: 'save' })
-      }
-    } else if (e.ctrlKey && e.key === 'f') {
+    if (e.ctrlKey && e.key === 'f') {
       e.preventDefault()
       searchInput.focus()
     } else if (e.ctrlKey && e.key === 'g') {
@@ -3150,6 +3636,27 @@ export function getWebviewContent(bytesPerRow: number): string {
     updateInspectorEndianLabel()
     updateInspectorStatus()
   })
+  transformSelect.addEventListener('pointerdown', () => {
+    if (!transformSelect.disabled) {
+      requestTransformPlugins()
+    }
+  })
+  transformSelect.addEventListener('focus', () => {
+    if (!transformSelect.disabled && !transformPluginsRequested) {
+      requestTransformPlugins()
+    }
+  })
+  transformSelect.addEventListener('change', () => {
+    updateTransformControls()
+    if (selectedTransformPlugin()) {
+      renderTransformOptionsDialog()
+    }
+  })
+  transformOptions.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !transformOptionsApply.disabled) {
+      applySelectedTransform()
+    }
+  })
 
   nextMatchBtn.addEventListener('click', () => {
     if (!hasSearchResults()) return
@@ -3205,6 +3712,11 @@ export function getWebviewContent(bytesPerRow: number): string {
     overlay.classList.remove('active')
   }
 
+  function closeDialogs() {
+    closeEditDialog()
+    closeTransformOptionsDialog()
+  }
+
   function submitEdit() {
     const offset = parseInt(editOffset.value, 16)
     if (isNaN(offset) || offset < 0) return
@@ -3238,43 +3750,33 @@ export function getWebviewContent(bytesPerRow: number): string {
   })
   document.getElementById('editCancel').addEventListener('click', closeEditDialog)
   document.getElementById('editOk').addEventListener('click', submitEdit)
-  overlay.addEventListener('click', closeEditDialog)
+  overlay.addEventListener('click', closeDialogs)
+  transformOptionsCancel.addEventListener('click', closeTransformOptionsDialog)
+  transformOptionsApply.addEventListener('click', applySelectedTransform)
+  transformOptionsBody.addEventListener('click', (e) => {
+    const exampleButton = e.target.closest('.help-example[data-example-index]')
+    if (!exampleButton) {
+      return
+    }
+    const index = parseInt(exampleButton.dataset.exampleIndex, 10)
+    if (!Number.isNaN(index)) {
+      useTransformOptionExample(index)
+    }
+  })
 
   // Submit on Enter inside the edit dialog
   editData.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitEdit() })
   editLength.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitEdit() })
   editOffset.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitEdit() })
 
-  // ── Undo / Redo / Save Buttons ──────────────────────
-
-  undoBtn.addEventListener('click', () => {
-    if (!undoBtn.disabled) {
-      clearReplaceSummaryActionStatus()
-      vscode.postMessage({ type: 'undo' })
-    }
-  })
-  redoBtn.addEventListener('click', () => {
-    if (!redoBtn.disabled) {
-      clearReplaceSummaryActionStatus()
-      vscode.postMessage({ type: 'redo' })
-    }
-  })
-  saveBtn.addEventListener('click', () => {
-    if (!saveBtn.disabled) {
-      vscode.postMessage({ type: 'save' })
-    }
-  })
-  saveAsBtn.addEventListener('click', () => {
-    vscode.postMessage({ type: 'saveAs' })
-  })
-
   updateSearchButtons()
-  updateEditButtons(false, false)
+  updateHistoryState(false, false)
   syncSearchMode()
   updateDirtyStatus(false)
   updateActionStatus('')
   updateInspectorEndianLabel()
   updateInspectorStatus()
+  updateTransformControls()
   updateServerHealthStatus(null)
   updateOffsetStatus()
   updateSelectedStatus()
@@ -3283,6 +3785,7 @@ export function getWebviewContent(bytesPerRow: number): string {
   updateAnalysisPanels()
   renderColumnHeader()
   reportViewportMetrics()
+  requestTransformPlugins()
 })()
 </script>
 </body>

--- a/examples/vscode-extension/tests/extension.test.js
+++ b/examples/vscode-extension/tests/extension.test.js
@@ -8,7 +8,9 @@ const {
   OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND,
   OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
   OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+  OMEGA_EDIT_REDO_COMMAND,
   OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND,
+  OMEGA_EDIT_UNDO_COMMAND,
   OMEGA_EDIT_VIEW_TYPE,
 } = require('../out/constants.js')
 const { getWebviewContent } = require('../out/webview.js')
@@ -19,6 +21,8 @@ test('package.json matches shared extension constants', () => {
     `onCustomEditor:${OMEGA_EDIT_VIEW_TYPE}`,
     `onCommand:${OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND}`,
     `onCommand:${OMEGA_EDIT_GO_TO_OFFSET_COMMAND}`,
+    `onCommand:${OMEGA_EDIT_UNDO_COMMAND}`,
+    `onCommand:${OMEGA_EDIT_REDO_COMMAND}`,
     `onCommand:${OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND}`,
     `onCommand:${OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND}`,
   ])
@@ -36,11 +40,33 @@ test('package.json matches shared extension constants', () => {
   )
   assert.equal(
     packageJson.contributes.commands[2].command,
-    OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND
+    OMEGA_EDIT_UNDO_COMMAND
+  )
+  assert.equal(
+    packageJson.contributes.commands[2].enablement,
+    'omegaEdit.hexEditorActive && omegaEdit.canUndo'
   )
   assert.equal(
     packageJson.contributes.commands[3].command,
+    OMEGA_EDIT_REDO_COMMAND
+  )
+  assert.equal(
+    packageJson.contributes.commands[3].enablement,
+    'omegaEdit.hexEditorActive && omegaEdit.canRedo'
+  )
+  assert.equal(
+    packageJson.contributes.commands[4].command,
+    OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND
+  )
+  assert.equal(
+    packageJson.contributes.commands[5].command,
     OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND
+  )
+  assert.deepEqual(
+    packageJson.contributes.configuration.properties[
+      'omegaEdit.transformPluginDirectories'
+    ].default,
+    []
   )
 })
 
@@ -69,6 +95,19 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerJs, /getServerInfo/)
   assert.match(providerJs, /profileSession/)
   assert.match(providerJs, /countCharacters/)
+  assert.match(providerJs, /listTransformPlugins/)
+  assert.match(providerJs, /applyTransformPlugin/)
+  assert.match(providerJs, /omegaEdit\.hexEditorActive/)
+  assert.match(providerJs, /omegaEdit\.canUndo/)
+  assert.match(providerJs, /omegaEdit\.canRedo/)
+  assert.match(providerJs, /setContext/)
+  assert.match(providerJs, /type:\s*['"]transformPlugins['"]/)
+  assert.match(providerJs, /help:\s*plugin\.help/)
+  assert.match(providerJs, /example:\s*plugin\.example/)
+  assert.match(providerJs, /defaultArgs:\s*plugin\.defaultArgs/)
+  assert.match(providerJs, /argsSchema:\s*plugin\.argsSchema/)
+  assert.match(providerJs, /case\s+['"]applyTransform['"]/)
+  assert.match(providerJs, /kind:\s*['"]REPLACE['"]/)
   assert.match(providerJs, /getContentType/)
   assert.match(providerJs, /getLanguage/)
   assert.match(providerJs, /enqueueAnalysisProfile/)
@@ -78,6 +117,23 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(
     providerJs,
     /getContentType\)\(session\.sessionId,\s*0,\s*contentTypeSampleLength\)/
+  )
+
+  const extensionJs = fs.readFileSync(
+    path.resolve(__dirname, '../out/extension.js'),
+    'utf8'
+  )
+  assert.match(extensionJs, /transformPluginDirectories/)
+  assert.match(extensionJs, /OMEGA_EDIT_UNDO_COMMAND/)
+  assert.match(extensionJs, /OMEGA_EDIT_REDO_COMMAND/)
+  assert.match(extensionJs, /undoActive/)
+  assert.match(extensionJs, /redoActive/)
+  assert.match(extensionJs, /getDefaultTransformPluginDirectories/)
+  assert.match(extensionJs, /_build_core['"],\s*['"]plugins['"],\s*['"]plugins/)
+  assert.match(extensionJs, /directoryHasTransformPlugin/)
+  assert.match(
+    extensionJs,
+    /startServer\)\(port,\s*undefined,\s*undefined,\s*\{\s*transformPluginDirectories/
   )
 })
 
@@ -99,8 +155,16 @@ test('webview HTML includes core controls and configured row width', () => {
   assert.match(html, /id="bottomBtn"/)
   assert.match(html, /id="scrollbarTrack"/)
   assert.match(html, /id="scrollbarThumb"/)
-  assert.match(html, /class="secondary" id="saveBtn"/)
-  assert.match(html, /id="saveAsBtn"/)
+  assert.doesNotMatch(html, /id="saveBtn"/)
+  assert.doesNotMatch(html, /id="saveAsBtn"/)
+  assert.match(html, /id="transformSelect"/)
+  assert.match(html, /id="transformOptions"/)
+  assert.match(html, /id="transformOptionsDialog"/)
+  assert.match(html, /id="transformOptionsApply"/)
+  assert.match(html, /id="transformOptionsCancel"/)
+  assert.match(html, /data-example-index/)
+  assert.doesNotMatch(html, /id="transformApplyBtn"/)
+  assert.doesNotMatch(html, /id="transformRefreshBtn"/)
   assert.match(html, /id="editDialog"/)
   assert.match(html, /id="searchCaseLabel"/)
   assert.match(html, /id="statusDirty"/)
@@ -136,11 +200,12 @@ test('webview HTML includes core controls and configured row width', () => {
   )
   assert.match(html, /\.ascii-char\.non-printable\.high-bit/)
   assert.match(html, /id="structureMetrics"/)
+  assert.match(html, /id="structureHistoryMetrics"/)
   assert.doesNotMatch(html, /id="structureTopBytes"/)
   assert.match(html, /id="statusProgress"/)
   assert.match(html, /\.analysis-bar-fill \{[\s\S]*display: block;/)
-  assert.match(html, /title="Undo \(Ctrl\+Z\)">Undo<\/button>/)
-  assert.match(html, /title="Redo \(Ctrl\+Y\)">Redo<\/button>/)
+  assert.doesNotMatch(html, /id="undoBtn"/)
+  assert.doesNotMatch(html, /id="redoBtn"/)
   assert.match(html, /grid-template-columns: repeat\(32, 1ch\);/)
   assert.match(html, /min-width: calc\(32ch \+ 12px\);/)
   assert.match(
@@ -167,6 +232,7 @@ test('webview HTML includes core controls and configured row width', () => {
   assert.match(html, /function getSelectionStart\(\)/)
   assert.match(html, /function getSelectionEnd\(\)/)
   assert.match(html, /function getSelectionLength\(\)/)
+  assert.match(html, /function selectRange\(offset, length\)/)
   assert.match(html, /function offsetIsSelected\(offset\)/)
   assert.match(
     html,
@@ -204,16 +270,53 @@ test('webview HTML includes core controls and configured row width', () => {
   assert.match(html, /type: 'search'/)
   assert.match(html, /type: 'replace'/)
   assert.match(html, /type: 'replaceAllMatches'/)
+  assert.match(html, /type: 'requestTransformPlugins'/)
+  assert.match(html, /type: 'applyTransform'/)
+  assert.match(html, /case 'transformPlugins'/)
+  assert.match(html, /case 'transformComplete'/)
+  assert.match(html, /const transformedLength = msg\.contentChanged/)
+  assert.match(html, /selectRange\(msg\.offset, transformedLength\)/)
+  assert.match(html, /function applySelectedTransform\(\)/)
+  assert.match(html, /function getTransformOptionHelp\(plugin\)/)
+  assert.match(html, /function validateTransformOptions\(plugin, optionsJson\)/)
+  assert.match(html, /function validateJsonSchemaValue\(value, schema, path\)/)
+  assert.match(html, /function renderTransformOptionsDialog\(\)/)
+  assert.match(html, /transformSelect\.addEventListener\('pointerdown'/)
+  assert.match(html, /transformSelect\.addEventListener\('change'/)
+  assert.match(html, /function useTransformOptionExample\(index\)/)
+  assert.match(html, /function advertisedTransformExamples\(plugin\)/)
+  assert.match(
+    html,
+    /transformOptionsDialog\.contains\(document\.activeElement\)/
+  )
+  assert.match(html, /Selected Range/)
+  assert.match(html, /formatOffsetDisplay\(selectionStart\)/)
+  assert.match(html, /formatOffsetDisplay\(selectionEnd\)/)
+  assert.doesNotMatch(
+    html,
+    /These options are advertised by the selected transform/
+  )
+  assert.doesNotMatch(html, /does not advertise JSON options/)
+  assert.match(html, /argsSchema/)
+  assert.doesNotMatch(html, /class="help-schema"/)
+  assert.match(html, /did not advertise an options schema/)
+  assert.match(html, /Selected transform advertised an invalid options schema/)
+  assert.doesNotMatch(html, /omega\.example\.xor/)
+  assert.doesNotMatch(html, /bytes\/mask/)
+  assert.match(html, /function flashActionStatus\(\)/)
+  assert.match(html, /\.status-action\.flash/)
+  assert.match(html, /@keyframes status-action-flash/)
+  assert.match(html, /prefers-reduced-motion: reduce/)
+  assert.match(html, /flashActionStatus\(\)/)
+  assert.match(html, /JSON\.parse\(optionsJson\)/)
+  assert.match(html, /function updateTransformControls\(\)/)
+  assert.match(html, /No transforms found/)
   assert.match(
     html,
     /searchBtn\.disabled = searchInput\.value\.trim\(\)\.length === 0/
   )
-  assert.match(html, /saveBtn\.disabled = !isDirty/)
-  assert.match(
-    html,
-    /if \(e\.shiftKey\) {\s*vscode\.postMessage\({ type: 'saveAs' }\)\s*} else if \(!saveBtn\.disabled\) {\s*vscode\.postMessage\({ type: 'save' }\)/
-  )
-  assert.match(html, /type: 'saveAs'/)
+  assert.doesNotMatch(html, /saveBtn\.disabled = !isDirty/)
+  assert.doesNotMatch(html, /type: 'saveAs'/)
   assert.match(html, /function replaceCurrentMatch\(\)/)
   assert.match(html, /function replaceAllMatches\(\)/)
   assert.match(
@@ -268,16 +371,12 @@ test('webview HTML includes core controls and configured row width', () => {
     html,
     /offset: hasSelection\(\) \? getSelectionStart\(\) : Math\.max\(0, visibleOffset\),/
   )
-  assert.match(html, /undoBtn\.textContent = 'Undo \(' \+ undoCount \+ '\)'/)
-  assert.match(html, /redoBtn\.textContent = 'Redo \(' \+ redoCount \+ '\)'/)
-  assert.match(
-    html,
-    /undoBtn\.title = 'Undo ' \+ undoCount \+ ' change\(s\) \(Ctrl\+Z\)'/
-  )
-  assert.match(
-    html,
-    /redoBtn\.title = 'Redo ' \+ redoCount \+ ' change\(s\) \(Ctrl\+Y\)'/
-  )
+  assert.match(html, /function updateHistoryState\(canUndo, canRedo/)
+  assert.match(html, /historyUndoCount = undoCount/)
+  assert.match(html, /historyRedoCount = redoCount/)
+  assert.match(html, /function renderHistoryMetrics\(\)/)
+  assert.match(html, /label: 'Undo', value: historyUndoCount/)
+  assert.match(html, /label: 'Redo', value: historyRedoCount/)
   assert.match(html, /function updateDirtyStatus\(isDirty\)/)
   assert.match(html, /function updateInspectorEndianLabel\(\)/)
   assert.match(html, /function updateInspectorStatus\(\)/)
@@ -352,8 +451,5 @@ test('webview HTML includes core controls and configured row width', () => {
     html,
     /case 'replaceComplete'[\s\S]*'replace-summary'[\s\S]*let nextMatchOffset = null[\s\S]*applySingleReplaceToSearchMatches\([\s\S]*nextMatchOffset === null[\s\S]*msg\.selectionOffset/
   )
-  assert.match(
-    html,
-    /undoBtn\.addEventListener\('click', \(\) => \{[\s\S]*clearReplaceSummaryActionStatus\(\)[\s\S]*type: 'undo'/
-  )
+  assert.doesNotMatch(html, /undoBtn\.addEventListener/)
 })

--- a/examples/vscode-extension/tests/suite/extension.integration.test.js
+++ b/examples/vscode-extension/tests/suite/extension.integration.test.js
@@ -308,6 +308,220 @@ suite('OmegaEdit VS Code extension', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
+  test('tracks transform edits through undo and redo', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-transform-undo-')
+    )
+    const samplePath = path.join(tmpDir, 'transform.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a live session for the transform undo test')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.base64_encode',
+      offset: 0,
+      length: 3,
+    })
+
+    await assertSessionText(session.sessionId, 'YWJj')
+    let editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'undo',
+    })
+    await assertSessionText(session.sessionId, 'abc')
+    editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: false,
+      canRedo: true,
+      undoCount: 0,
+      redoCount: 1,
+      isDirty: false,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'redo',
+    })
+    await assertSessionText(session.sessionId, 'YWJj')
+    editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('does not record identity transform edits in undo history', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-transform-identity-')
+    )
+    const samplePath = path.join(tmpDir, 'transform-identity.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(
+      session,
+      'Expected a live session for the identity transform test'
+    )
+    const cleanEditState = lastMessageOfType(panel.messages, 'editState')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.and',
+      offset: 0,
+      length: 3,
+      optionsJson: JSON.stringify({ byte: '0xFF' }),
+    })
+
+    await assertSessionText(session.sessionId, 'abc')
+    let transformComplete = lastMessageOfType(
+      panel.messages,
+      'transformComplete'
+    )
+    assert.equal(transformComplete.contentChanged, false)
+    assert.deepEqual(
+      lastMessageOfType(panel.messages, 'editState'),
+      cleanEditState
+    )
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.base64_encode',
+      offset: 0,
+      length: 3,
+    })
+
+    await assertSessionText(session.sessionId, 'YWJj')
+    const transformedEditState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(transformedEditState, {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.and',
+      offset: 0,
+      length: 4,
+      optionsJson: JSON.stringify({ byte: '0xFF' }),
+    })
+
+    await assertSessionText(session.sessionId, 'YWJj')
+    transformComplete = lastMessageOfType(panel.messages, 'transformComplete')
+    assert.equal(transformComplete.contentChanged, false)
+    assert.deepEqual(
+      lastMessageOfType(panel.messages, 'editState'),
+      transformedEditState
+    )
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'undo',
+    })
+    await assertSessionText(session.sessionId, 'abc')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'redo',
+    })
+    await assertSessionText(session.sessionId, 'YWJj')
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('routes VS Code undo and redo commands for transform edits', async () => {
+    const provider = getHexEditorProviderForTesting()
+    assert.ok(
+      provider,
+      'Expected the activated extension to expose its provider'
+    )
+
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-command-undo-')
+    )
+    const samplePath = path.join(tmpDir, 'transform-command.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+    const uri = vscode.Uri.file(samplePath)
+
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      uri,
+      OMEGA_EDIT_VIEW_TYPE
+    )
+    const session = await waitForSession(provider, uri)
+    assert.ok(session, 'Expected a live session for the command undo test')
+
+    await provider.dispatchWebviewMessageForTesting(uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.base64_encode',
+      offset: 0,
+      length: 3,
+    })
+
+    await assertSessionText(session.sessionId, 'YWJj')
+
+    await vscode.commands.executeCommand('undo')
+    await assertSessionText(session.sessionId, 'abc')
+
+    await vscode.commands.executeCommand('redo')
+    await assertSessionText(session.sessionId, 'YWJj')
+
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
   test('tracks optimized replace counts and clears dirty state on save', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-replace-')

--- a/examples/vscode-extension/tests/suite/extension.integration.test.js
+++ b/examples/vscode-extension/tests/suite/extension.integration.test.js
@@ -385,6 +385,47 @@ suite('OmegaEdit VS Code extension', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
+  test('clamps stale transform ranges before applying', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-transform-clamp-')
+    )
+    const samplePath = path.join(tmpDir, 'transform-clamp.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a live session for the transform clamp test')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.base64_encode',
+      offset: 1,
+      length: 999,
+    })
+
+    await assertSessionText(session.sessionId, 'aYmM=')
+    assert.equal(
+      lastMessageOfType(panel.messages, 'transformComplete')?.contentChanged,
+      true
+    )
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
   test('does not record identity transform edits in undo history', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-transform-identity-')

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -54,7 +54,7 @@ oe patch --session <session-id> --offset 8 --hex 0000000d
 oe list-transform-plugins
 oe apply-transform-plugin --session <session-id> --plugin omega.example.checksum8 --offset 0 --length 128
 oe apply-transform-plugin --session <session-id> --plugin omega.example.base64_encode --offset 0 --length 128
-oe apply-transform-plugin --session <session-id> --plugin omega.example.zlib_compress --offset 0 --length 128
+oe apply-transform-plugin --session <session-id> --plugin omega.example.zlib_compress --offset 0 --length 128 --options-json '{"level":9}'
 
 # Save or export a slice
 oe save-session --session <session-id> --output ./patched.bin --overwrite

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -1516,6 +1516,22 @@ export interface TransformPluginInfo {
    * @generated from protobuf field: uint32 abi_version = 6
    */
   abiVersion: number
+  /**
+   * @generated from protobuf field: string help = 7
+   */
+  help: string // Human-readable help for plugin-specific JSON arguments.
+  /**
+   * @generated from protobuf field: string example = 8
+   */
+  example: string // Example JSON arguments.
+  /**
+   * @generated from protobuf field: string default_args = 9
+   */
+  defaultArgs: string // Default JSON arguments.
+  /**
+   * @generated from protobuf field: string args_schema = 10
+   */
+  argsSchema: string // JSON Schema for validating options_json before apply.
 }
 /**
  * Request registered transform plugin metadata.
@@ -9428,6 +9444,20 @@ class TransformPluginInfo$Type extends MessageType<TransformPluginInfo> {
         kind: 'scalar',
         T: 13 /*ScalarType.UINT32*/,
       },
+      { no: 7, name: 'help', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 8, name: 'example', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 9,
+        name: 'default_args',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 10,
+        name: 'args_schema',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
     ])
   }
   create(value?: PartialMessage<TransformPluginInfo>): TransformPluginInfo {
@@ -9438,6 +9468,10 @@ class TransformPluginInfo$Type extends MessageType<TransformPluginInfo> {
     message.operation = 0
     message.flags = 0
     message.abiVersion = 0
+    message.help = ''
+    message.example = ''
+    message.defaultArgs = ''
+    message.argsSchema = ''
     if (value !== undefined)
       reflectionMergePartial<TransformPluginInfo>(this, message, value)
     return message
@@ -9470,6 +9504,18 @@ class TransformPluginInfo$Type extends MessageType<TransformPluginInfo> {
           break
         case /* uint32 abi_version */ 6:
           message.abiVersion = reader.uint32()
+          break
+        case /* string help */ 7:
+          message.help = reader.string()
+          break
+        case /* string example */ 8:
+          message.example = reader.string()
+          break
+        case /* string default_args */ 9:
+          message.defaultArgs = reader.string()
+          break
+        case /* string args_schema */ 10:
+          message.argsSchema = reader.string()
           break
         default:
           let u = options.readUnknownField
@@ -9513,6 +9559,18 @@ class TransformPluginInfo$Type extends MessageType<TransformPluginInfo> {
     /* uint32 abi_version = 6; */
     if (message.abiVersion !== 0)
       writer.tag(6, WireType.Varint).uint32(message.abiVersion)
+    /* string help = 7; */
+    if (message.help !== '')
+      writer.tag(7, WireType.LengthDelimited).string(message.help)
+    /* string example = 8; */
+    if (message.example !== '')
+      writer.tag(8, WireType.LengthDelimited).string(message.example)
+    /* string default_args = 9; */
+    if (message.defaultArgs !== '')
+      writer.tag(9, WireType.LengthDelimited).string(message.defaultArgs)
+    /* string args_schema = 10; */
+    if (message.argsSchema !== '')
+      writer.tag(10, WireType.LengthDelimited).string(message.argsSchema)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/tests/specs/transformPlugin.spec.ts
+++ b/packages/client/tests/specs/transformPlugin.spec.ts
@@ -125,9 +125,42 @@ describe('Transform plugin gRPC integration', () => {
         'omega.example.repeat',
         'omega.example.checksum8',
       ])
+      const xorPlugin = plugins.find(
+        (plugin) => plugin.id === 'omega.example.xor'
+      )
+      expect(xorPlugin?.help).to.include('Options JSON accepts')
+      expect(xorPlugin?.example).to.equal('{"mask":["0x42","0x24"]}')
+      expect(xorPlugin?.defaultArgs).to.equal('{"byte":"0xFF"}')
+      expect(xorPlugin?.argsSchema).to.include('additionalProperties')
+      const base64EncodePlugin = plugins.find(
+        (plugin) => plugin.id === 'omega.example.base64_encode'
+      )
+      expect(base64EncodePlugin?.argsSchema).to.equal('')
+      const zlibCompressPlugin = plugins.find(
+        (plugin) => plugin.id === 'omega.example.zlib_compress'
+      )
+      expect(zlibCompressPlugin?.help).to.include('level')
+      expect(zlibCompressPlugin?.example).to.equal('{"level":9}')
+      expect(zlibCompressPlugin?.defaultArgs).to.equal('{"level":-1}')
+      expect(zlibCompressPlugin?.argsSchema).to.include('"maximum":9')
 
       const session = await createSessionFromBytes(Buffer.from('abc', 'utf8'))
       sessionId = session.getSessionId()
+
+      try {
+        await applyTransformPlugin(
+          sessionId,
+          'omega.example.base64_encode',
+          0,
+          3,
+          JSON.stringify({ level: 9 })
+        )
+        expect.fail(
+          'options should be rejected when no transform schema is advertised'
+        )
+      } catch (err) {
+        expect((err as Error).message).to.include('INVALID_ARGUMENT')
+      }
 
       const encodeResponse = await applyTransformPlugin(
         sessionId,
@@ -161,11 +194,27 @@ describe('Transform plugin gRPC integration', () => {
         Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
       ).to.equal('abc')
 
+      try {
+        await applyTransformPlugin(
+          sessionId,
+          'omega.example.zlib_compress',
+          0,
+          3,
+          JSON.stringify({ level: 10 })
+        )
+        expect.fail(
+          'level 10 should be rejected by the advertised transform schema'
+        )
+      } catch (err) {
+        expect((err as Error).message).to.include('INVALID_ARGUMENT')
+      }
+
       const compressResponse = await applyTransformPlugin(
         sessionId,
         'omega.example.zlib_compress',
         0,
-        3
+        3,
+        JSON.stringify({ level: 9 })
       )
       expect(compressResponse.operation).to.equal(
         TransformPluginOperation.REPLACE
@@ -271,18 +320,33 @@ describe('Transform plugin gRPC integration', () => {
         'b'.charCodeAt(0) ^ 0x42,
       ])
 
-      const xorBytesResponse = await applyTransformPlugin(
+      try {
+        await applyTransformPlugin(
+          sessionId,
+          'omega.example.xor',
+          2,
+          2,
+          JSON.stringify({ bytes: ['0x01', '0x02'] })
+        )
+        expect.fail(
+          'bytes should be rejected by the advertised transform schema'
+        )
+      } catch (err) {
+        expect((err as Error).message).to.include('INVALID_ARGUMENT')
+      }
+
+      const xorMaskResponse = await applyTransformPlugin(
         sessionId,
         'omega.example.xor',
         2,
         2,
-        JSON.stringify({ bytes: ['0x01', '0x02'] })
+        JSON.stringify({ mask: ['0x01', '0x02'] })
       )
-      expect(xorBytesResponse.operation).to.equal(
+      expect(xorMaskResponse.operation).to.equal(
         TransformPluginOperation.REPLACE
       )
-      expect(xorBytesResponse.contentChanged).to.equal(true)
-      expect(xorBytesResponse.replacementLength).to.equal(2)
+      expect(xorMaskResponse.contentChanged).to.equal(true)
+      expect(xorMaskResponse.replacementLength).to.equal(2)
       expect(Array.from(await getSegment(sessionId, 2, 2))).to.deep.equal([
         'c'.charCodeAt(0) ^ 0x01,
         'b'.charCodeAt(0) ^ 0x02,
@@ -308,7 +372,7 @@ describe('Transform plugin gRPC integration', () => {
         'omega.example.or',
         3,
         2,
-        JSON.stringify({ bytes: ['0x01', '0x04'] })
+        JSON.stringify({ mask: ['0x01', '0x04'] })
       )
       expect(orResponse.operation).to.equal(TransformPluginOperation.REPLACE)
       expect(orResponse.contentChanged).to.equal(true)

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,9 +6,12 @@ The plugins consume the Omega Edit transform plugin ABI and SDK from the core
 package. Third-party transform dependencies, such as zlib, are owned here rather
 than by the core library.
 
-The bitwise exemplars accept options JSON with a single byte or a repeating
-byte sequence, for example `{"byte":"0x42"}` or
-`{"bytes":["0x0F","0xF0"]}`. The same sequence form is accepted as `mask`.
+Transform plugin metadata includes a description, help text, example arguments,
+default arguments, and an optional JSON Schema for validating options on both
+the client and native apply path. The bitwise exemplars accept options JSON with
+a single repeated byte or a repeating mask sequence, for example
+`{"byte":"0x42"}` or `{"mask":["0x0F","0xF0"]}`. The zlib compression
+exemplar accepts `{"level":9}`, with valid levels from `-1` through `9`.
 
 ## Build
 

--- a/plugins/src/and.c
+++ b/plugins/src/and.c
@@ -16,15 +16,17 @@
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.and";
     info_ptr->name = "AND";
-    info_ptr->description =
-            "AND every byte in the selected range. Options JSON may supply {\"byte\":\"0x42\"} or "
-            "{\"bytes\":[\"0x0F\",\"0xF0\"]}; the sequence may also be supplied as mask. "
-            "Default byte is 0xFF.";
+    info_ptr->description = "AND every byte in the selected range.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "Options JSON accepts {\"byte\":\"0x42\"} for one repeated byte or "
+                     "{\"mask\":[\"0x0F\",\"0xF0\"]} for a repeating mask sequence.";
+    info_ptr->example = "{\"mask\":[\"0x0F\",\"0xF0\"]}";
+    info_ptr->default_args = "{\"byte\":\"0xFF\"}";
+    info_ptr->args_schema = OMEGA_BITMASK_OPTIONS_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/src/base64_decode.c
+++ b/plugins/src/base64_decode.c
@@ -66,12 +66,16 @@ static int validate_base64_(const omega_transform_plugin_request_t *request_ptr,
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.base64_decode";
     info_ptr->name = "Base64 Decode";
     info_ptr->description = "Decode RFC 4648 base64 text from the selected range.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "No JSON options are used.";
+    info_ptr->example = "";
+    info_ptr->default_args = "";
+    info_ptr->args_schema = OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/src/base64_encode.c
+++ b/plugins/src/base64_encode.c
@@ -18,12 +18,16 @@ static const char BASE64_ALPHABET[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmno
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.base64_encode";
     info_ptr->name = "Base64 Encode";
     info_ptr->description = "Encode the selected range as RFC 4648 base64 text.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "No JSON options are used.";
+    info_ptr->example = "";
+    info_ptr->default_args = "";
+    info_ptr->args_schema = OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/src/bitmask_options.h
+++ b/plugins/src/bitmask_options.h
@@ -28,6 +28,13 @@ typedef struct omega_bitmask_options_t {
     size_t length;
 } omega_bitmask_options_t;
 
+static const char OMEGA_BITMASK_OPTIONS_ARGS_SCHEMA[] =
+        "{\"type\":\"object\",\"properties\":{\"byte\":{\"oneOf\":["
+        "{\"type\":\"string\",\"pattern\":\"^0x[0-9A-Fa-f]{1,2}$\"},{\"type\":\"integer\",\"minimum\":0,"
+        "\"maximum\":255}]},\"mask\":{\"type\":\"array\",\"minItems\":1,\"items\":{\"oneOf\":[{\"type\":"
+        "\"string\",\"pattern\":\"^0x[0-9A-Fa-f]{1,2}$\"},{\"type\":\"integer\",\"minimum\":0,\"maximum\":"
+        "255}]}}},\"additionalProperties\":false,\"not\":{\"type\":\"object\",\"required\":[\"byte\",\"mask\"]}}";
+
 typedef enum omega_bitmask_operation_t {
     OMEGA_BITMASK_AND,
     OMEGA_BITMASK_OR,
@@ -207,7 +214,7 @@ static int omega_bitmask_parse_options(const char *options_json, omega_byte_t de
         ++cursor;
         omega_bitmask_skip_ws(&cursor);
 
-        if (strcmp(key, "byte") == 0 || strcmp(key, "bytes") == 0 || strcmp(key, "mask") == 0) {
+        if (strcmp(key, "byte") == 0 || strcmp(key, "mask") == 0) {
             if (omega_bitmask_parse_mask_value(&cursor, mask_out) != 0) { return -1; }
         } else {
             if (omega_bitmask_skip_json_value(&cursor) != 0) { return -1; }

--- a/plugins/src/checksum8.c
+++ b/plugins/src/checksum8.c
@@ -17,12 +17,16 @@
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.checksum8";
     info_ptr->name = "Checksum-8";
     info_ptr->description = "Calculate an 8-bit additive checksum over the selected range.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "No JSON options are used.";
+    info_ptr->example = "";
+    info_ptr->default_args = "";
+    info_ptr->args_schema = OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/src/fnv1a64.c
+++ b/plugins/src/fnv1a64.c
@@ -18,12 +18,16 @@
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.fnv1a64";
     info_ptr->name = "FNV-1a 64-bit Hash";
     info_ptr->description = "Calculate an FNV-1a 64-bit hash over the selected range.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "No JSON options are used.";
+    info_ptr->example = "";
+    info_ptr->default_args = "";
+    info_ptr->args_schema = OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/src/or.c
+++ b/plugins/src/or.c
@@ -16,15 +16,17 @@
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.or";
     info_ptr->name = "OR";
-    info_ptr->description =
-            "OR every byte in the selected range. Options JSON may supply {\"byte\":\"0x42\"} or "
-            "{\"bytes\":[\"0x01\",\"0x02\"]}; the sequence may also be supplied as mask. "
-            "Default byte is 0x00.";
+    info_ptr->description = "OR every byte in the selected range.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "Options JSON accepts {\"byte\":\"0x42\"} for one repeated byte or "
+                     "{\"mask\":[\"0x01\",\"0x02\"]} for a repeating mask sequence.";
+    info_ptr->example = "{\"mask\":[\"0x01\",\"0x02\"]}";
+    info_ptr->default_args = "{\"byte\":\"0x00\"}";
+    info_ptr->args_schema = OMEGA_BITMASK_OPTIONS_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/src/repeat.c
+++ b/plugins/src/repeat.c
@@ -17,12 +17,16 @@
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.repeat";
     info_ptr->name = "Repeat Range";
     info_ptr->description = "Replace the selected range with two copies of itself.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "No JSON options are used.";
+    info_ptr->example = "";
+    info_ptr->default_args = "";
+    info_ptr->args_schema = OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/src/xor.c
+++ b/plugins/src/xor.c
@@ -16,15 +16,17 @@
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.xor";
     info_ptr->name = "XOR";
-    info_ptr->description =
-            "XOR every byte in the selected range. Options JSON may supply {\"byte\":\"0x42\"} or "
-            "{\"bytes\":[\"0x42\",\"0x24\"]}; the sequence may also be supplied as mask. "
-            "Default byte is 0xFF.";
+    info_ptr->description = "XOR every byte in the selected range.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "Options JSON accepts {\"byte\":\"0x42\"} for one repeated byte or "
+                     "{\"mask\":[\"0x42\",\"0x24\"]} for a repeating mask sequence.";
+    info_ptr->example = "{\"mask\":[\"0x42\",\"0x24\"]}";
+    info_ptr->default_args = "{\"byte\":\"0xFF\"}";
+    info_ptr->args_schema = OMEGA_BITMASK_OPTIONS_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/src/zlib_compress.c
+++ b/plugins/src/zlib_compress.c
@@ -13,8 +13,10 @@
  **********************************************************************************************************************/
 
 #include <omega_edit/transform_plugin_sdk.h>
+#include <ctype.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 #include <zlib.h>
 
 static int input_length_to_ulong(int64_t input_length, uLong *input_length_out) {
@@ -23,15 +25,66 @@ static int input_length_to_ulong(int64_t input_length, uLong *input_length_out) 
     return 0;
 }
 
+static void skip_ws(const char **cursor) {
+    while (cursor && *cursor && isspace((unsigned char) **cursor)) { ++(*cursor); }
+}
+
+static int consume_char(const char **cursor, char ch) {
+    skip_ws(cursor);
+    if (!cursor || !*cursor || **cursor != ch) { return -1; }
+    ++(*cursor);
+    return 0;
+}
+
+static int parse_level_options(const char *options_json, int *level_out) {
+    if (!level_out) { return -1; }
+    *level_out = Z_DEFAULT_COMPRESSION;
+    if (!options_json || !*options_json) { return 0; }
+
+    const char *cursor = options_json;
+    if (consume_char(&cursor, '{') != 0) { return -1; }
+    skip_ws(&cursor);
+    if (*cursor == '}') {
+        ++cursor;
+        skip_ws(&cursor);
+        return *cursor == '\0' ? 0 : -1;
+    }
+
+    if (*cursor != '"') { return -1; }
+    ++cursor;
+    if (strncmp(cursor, "level", 5) != 0 || cursor[5] != '"') { return -1; }
+    cursor += 6;
+    if (consume_char(&cursor, ':') != 0) { return -1; }
+
+    char *end_ptr = NULL;
+    const long level = strtol(cursor, &end_ptr, 10);
+    if (end_ptr == cursor || level < Z_DEFAULT_COMPRESSION || level > Z_BEST_COMPRESSION) { return -1; }
+    cursor = end_ptr;
+    skip_ws(&cursor);
+    if (*cursor != '}') { return -1; }
+    ++cursor;
+    skip_ws(&cursor);
+    if (*cursor != '\0') { return -1; }
+
+    *level_out = (int) level;
+    return 0;
+}
+
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.zlib_compress";
     info_ptr->name = "Zlib Compress";
     info_ptr->description = "Compress the selected range with zlib.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK |
                       OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "Options JSON accepts {\"level\":9}. Use -1 for the zlib default, 0 for no compression, "
+                     "1 for fastest compression, or 9 for best compression.";
+    info_ptr->example = "{\"level\":9}";
+    info_ptr->default_args = "{\"level\":-1}";
+    info_ptr->args_schema = "{\"type\":\"object\",\"properties\":{\"level\":{\"type\":\"integer\",\"minimum\":-1,"
+                            "\"maximum\":9}},\"additionalProperties\":false}";
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 
@@ -44,6 +97,8 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_trans
 
     uLong input_length = 0;
     if (input_length_to_ulong(request_ptr->input_length, &input_length) != 0) { return -1; }
+    int level = Z_DEFAULT_COMPRESSION;
+    if (parse_level_options(request_ptr->options_json, &level) != 0) { return -1; }
 
     uLongf output_length = compressBound(input_length);
     if ((uint64_t) output_length > INT64_MAX) { return -1; }
@@ -55,8 +110,7 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_trans
 
     static const omega_byte_t empty_input = 0;
     const Bytef *input = request_ptr->input_length == 0 ? &empty_input : request_ptr->input_bytes;
-    const int rc = compress2((Bytef *) response_ptr->replacement_bytes, &output_length, input, input_length,
-                             Z_DEFAULT_COMPRESSION);
+    const int rc = compress2((Bytef *) response_ptr->replacement_bytes, &output_length, input, input_length, level);
     if (rc != Z_OK || (uint64_t) output_length > INT64_MAX) { return -1; }
 
     response_ptr->replacement_length = (int64_t) output_length;

--- a/plugins/src/zlib_decompress.c
+++ b/plugins/src/zlib_decompress.c
@@ -32,13 +32,17 @@ static int grow_buffer(omega_byte_t **buffer_ptr, size_t *capacity_ptr) {
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
-    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     info_ptr->id = "omega.example.zlib_decompress";
     info_ptr->name = "Zlib Decompress";
     info_ptr->description = "Decompress zlib-compressed data.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK |
                       OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "No JSON options are used.";
+    info_ptr->example = "";
+    info_ptr->default_args = "";
+    info_ptr->args_schema = OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }
 

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -39,6 +39,26 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.xor"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.repeat"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.checksum8"));
+    const auto base64_encode_info =
+            omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.base64_encode");
+    REQUIRE("" == std::string(base64_encode_info->args_schema));
+    const auto xor_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.xor");
+    REQUIRE("XOR" == std::string(xor_info->name));
+    REQUIRE(std::string(xor_info->help).find("Options JSON accepts") != std::string::npos);
+    REQUIRE("{\"mask\":[\"0x42\",\"0x24\"]}" == std::string(xor_info->example));
+    REQUIRE("{\"byte\":\"0xFF\"}" == std::string(xor_info->default_args));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"mask\":[\"0x01\",\"0x02\"]}",
+                                                                  xor_info->args_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"bytes\":[\"0x01\",\"0x02\"]}",
+                                                                   xor_info->args_schema));
+    const auto zlib_compress_info =
+            omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib_compress");
+    REQUIRE("Zlib Compress" == std::string(zlib_compress_info->name));
+    REQUIRE(std::string(zlib_compress_info->help).find("level") != std::string::npos);
+    REQUIRE("{\"level\":9}" == std::string(zlib_compress_info->example));
+    REQUIRE("{\"level\":-1}" == std::string(zlib_compress_info->default_args));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"level\":9}", zlib_compress_info->args_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"level\":10}", zlib_compress_info->args_schema));
 
     const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(session_ptr);
@@ -76,8 +96,12 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.xor", session_ptr,
                                                                    1, 1, "{\"byte\":256}", &response));
 
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(
+                          registry_ptr, "omega.example.xor", session_ptr, 2, 2, "{\"bytes\":[\"0x01\",\"0x02\"]}",
+                          &response));
+
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.xor", session_ptr, 2, 2, "{\"bytes\":[\"0x01\",\"0x02\"]}",
+                         registry_ptr, "omega.example.xor", session_ptr, 2, 2, "{\"mask\":[\"0x01\",\"0x02\"]}",
                          &response));
     REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42),
                          static_cast<char>('C' ^ 0x01), static_cast<char>('B' ^ 0x02), 'C', 'D'}) ==
@@ -94,7 +118,7 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     omega_transform_plugin_response_clear(&response);
 
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.or", session_ptr, 4, 2, "{\"bytes\":[\"0x01\",\"0x02\"]}",
+                         registry_ptr, "omega.example.or", session_ptr, 4, 2, "{\"mask\":[\"0x01\",\"0x02\"]}",
                          &response));
     REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42),
                          static_cast<char>(('C' ^ 0x01) & 0x0F),
@@ -114,6 +138,10 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(8 == response.replacement_length);
     omega_transform_plugin_response_clear(&response);
 
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64_encode",
+                                                                   codec_session_ptr, 0, 5, "{\"level\":9}",
+                                                                   &response));
+
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64_decode",
                                                                   codec_session_ptr, 0, 0, nullptr, &response));
     REQUIRE("hello" == omega_session_get_segment_string(codec_session_ptr, 0,
@@ -129,8 +157,13 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE("fnv1a64" == std::string(response.result_label));
     omega_transform_plugin_response_clear(&response);
 
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib_compress",
+                                                                   codec_session_ptr, 0, 5, "{\"level\":10}",
+                                                                   &response));
+
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib_compress",
-                                                                  codec_session_ptr, 0, 5, nullptr, &response));
+                                                                  codec_session_ptr, 0, 5, "{\"level\":9}",
+                                                                  &response));
     REQUIRE(0 < response.replacement_length);
     {
         const auto compressed = omega_session_get_segment_string(codec_session_ptr, 0,

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -49,8 +49,16 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE("{\"byte\":\"0xFF\"}" == std::string(xor_info->default_args));
     REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"mask\":[\"0x01\",\"0x02\"]}",
                                                                   xor_info->args_schema));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"\\u0062yte\":\"0x01\"}", xor_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"bytes\":[\"0x01\",\"0x02\"]}",
                                                                    xor_info->args_schema));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(
+                         "{\"name\":\"caf\\u00E9\",\"emoji\":\"\\uD83D\\uDE00\"}",
+                         "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\",\"pattern\":\"^caf\\u00E9$"
+                         "\"},\"emoji\":{\"type\":\"string\"}},\"additionalProperties\":false}"));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(
+                          "{\"emoji\":\"\\uD83D\"}", "{\"type\":\"object\",\"properties\":{\"emoji\":{\"type\":"
+                                                     "\"string\"}},\"additionalProperties\":false}"));
     const auto zlib_compress_info =
             omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib_compress");
     REQUIRE("Zlib Compress" == std::string(zlib_compress_info->name));

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -938,6 +938,10 @@ message TransformPluginInfo {
   TransformPluginOperation operation = 4;
   uint32 flags = 5;
   uint32 abi_version = 6;
+  string help = 7;          // Human-readable help for plugin-specific JSON arguments.
+  string example = 8;       // Example JSON arguments.
+  string default_args = 9;  // Default JSON arguments.
+  string args_schema = 10;  // JSON Schema for validating options_json before apply.
 }
 
 // Request registered transform plugin metadata.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -343,6 +343,10 @@ static void fill_transform_plugin_info(const omega_transform_plugin_info_t *info
     response->set_operation(to_proto_transform_plugin_operation(info->operation));
     response->set_flags(info->flags);
     response->set_abi_version(info->abi_version);
+    response->set_help(info->help ? info->help : "");
+    response->set_example(info->example ? info->example : "");
+    response->set_default_args(info->default_args ? info->default_args : "");
+    response->set_args_schema(info->args_schema ? info->args_schema : "");
 }
 
 static grpc::Status validate_viewport_range(int64_t offset, int64_t capacity) {
@@ -1591,6 +1595,10 @@ grpc::Status EditorServiceImpl::ApplyTransformPlugin(
 
         operation = plugin_info->operation;
         const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
+        if (0 != omega_transform_plugin_options_match_args_schema(options_json, plugin_info->args_schema)) {
+            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                "transform options do not match schema: " + request->plugin_id());
+        }
         if (0 != omega_transform_plugin_registry_apply_to_session(transform_plugin_registry_,
                                                                   request->plugin_id().c_str(), session,
                                                                   offset, length, options_json,

--- a/wiki/Transform-Plugins.md
+++ b/wiki/Transform-Plugins.md
@@ -62,12 +62,24 @@ info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
 info_ptr->id = "omega.example.my_plugin";
 info_ptr->name = "My Plugin";
 info_ptr->description = "What this plugin does.";
+info_ptr->help = "Options JSON accepts {\"byte\":\"0x42\"}.";
+info_ptr->example = "{\"byte\":\"0x42\"}";
+info_ptr->default_args = "{\"byte\":\"0xFF\"}";
+info_ptr->args_schema = "{\"type\":\"object\",\"properties\":{...}}";
 info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
 info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
 ```
 
 The plugin ID must be unique across all registered plugins. A reverse-DNS style ID
 is recommended, for example `com.example.base64_encode`.
+
+`description`, `help`, `example`, `default_args`, and `args_schema` are discovery
+metadata for clients. When `args_schema` is set, callers should validate
+`options_json` with the advertised JSON Schema before applying the transform; the
+native transform registry also validates the same schema before invoking the plugin.
+Transforms that do not accept JSON options should leave `args_schema`, `example`,
+and `default_args` empty. Supplying options to a transform without an advertised
+schema is rejected by the native apply path.
 
 `omega_transform_plugin_apply` receives:
 
@@ -125,6 +137,12 @@ omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     info_ptr->id = "com.example.xor";
     info_ptr->name = "XOR";
     info_ptr->description = "XOR every byte in the selected range.";
+    info_ptr->help = "Options JSON accepts {\"byte\":\"0x42\"}.";
+    info_ptr->example = "{\"byte\":\"0x42\"}";
+    info_ptr->default_args = "{\"byte\":\"0xFF\"}";
+    info_ptr->args_schema =
+        "{\"type\":\"object\",\"properties\":{\"byte\":{\"type\":\"string\"}},"
+        "\"additionalProperties\":false}";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags =
         OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE |
@@ -287,7 +305,8 @@ oe apply-transform-plugin \
   --session <session-id> \
   --plugin omega.example.zlib_compress \
   --offset 0 \
-  --length 1024
+  --length 1024 \
+  --options-json '{"level":9}'
 ```
 
 MCP tools:
@@ -301,14 +320,14 @@ The repository ships small examples in `plugins/src/`:
 
 | Plugin ID | Source | Operation | Demonstrates |
 | --- | --- | --- | --- |
-| `omega.example.and` | `and.c` | Replace | One-for-one binary-safe AND transform. Accepts options JSON like `{"byte":"0x42"}` or a repeating byte sequence using `bytes` or `mask`; defaults to `0xFF`. |
+| `omega.example.and` | `and.c` | Replace | One-for-one binary-safe AND transform. Accepts options JSON like `{"byte":"0x42"}` or a repeating byte sequence using `mask`; defaults to `0xFF`. |
 | `omega.example.base64_encode` | `base64_encode.c` | Replace | Expansion by encoding arbitrary bytes as base64 text. |
 | `omega.example.base64_decode` | `base64_decode.c` | Replace | Shrinking text content back to decoded bytes, with validation. ASCII whitespace is tolerated; other invalid bytes fail. |
 | `omega.example.fnv1a64` | `fnv1a64.c` | Inspect | 64-bit hash calculation without changing session content. |
 | `omega.example.or` | `or.c` | Replace | One-for-one binary-safe OR transform. Accepts options JSON like `{"byte":"0x42"}` or a repeating byte sequence like `{"mask":["0x01","0x02"]}`; defaults to `0x00`. |
-| `omega.example.zlib_compress` | `zlib_compress.c` | Replace | Compression with zlib, supplied by the plugin package toolchain. |
+| `omega.example.zlib_compress` | `zlib_compress.c` | Replace | Compression with zlib, supplied by the plugin package toolchain. Accepts `{"level":9}` with valid levels from `-1` through `9`; defaults to zlib's default compression. |
 | `omega.example.zlib_decompress` | `zlib_decompress.c` | Replace | Decompression with zlib, supplied by the plugin package toolchain. |
-| `omega.example.xor` | `xor.c` | Replace | One-for-one binary-safe XOR transform. Accepts options JSON like `{"byte":"0x42"}` or a repeating byte sequence using `bytes` or `mask`; defaults to `0xFF`. |
+| `omega.example.xor` | `xor.c` | Replace | One-for-one binary-safe XOR transform. Accepts options JSON like `{"byte":"0x42"}` or a repeating byte sequence using `mask`; defaults to `0xFF`. |
 | `omega.example.repeat` | `repeat.c` | Replace | Expansion by replacing a range with two copies of itself. |
 | `omega.example.checksum8` | `checksum8.c` | Inspect | Text result without changing session content. |
 


### PR DESCRIPTION
## Summary

- Add transform plugin discovery and apply controls to the VS Code extension webview.
- Wire `listTransformPlugins()` and `applyTransformPlugin()` through the custom editor provider for selected byte ranges.
- Add `omegaEdit.transformPluginDirectories` startup configuration and update docs/tests for the new workflow.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run test:unit`
- `npm run test:integration`

Opened as draft for review.