### PR TITLE
fix: simplify hex inspector pane to Shift+Space-only with drag support

### DIFF
--- a/examples/vscode-extension/package.json
+++ b/examples/vscode-extension/package.json
@@ -107,7 +107,8 @@
       },
       {
         "command": "omegaEdit.exportChangeScript",
-        "title": "OmegaEdit: Export Change Script"
+        "title": "OmegaEdit: Export Change Script",
+        "enablement": "omegaEdit.hexEditorActive && omegaEdit.hasPendingChanges"
       },
       {
         "command": "omegaEdit.replayChangeScript",

--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -31,11 +31,48 @@ import {
 } from './constants'
 import { HexEditorProvider } from './hexEditorProvider'
 
-let serverPid: number | undefined
 let activeProvider: HexEditorProvider | undefined
 
 const DEFAULT_SERVER_PORT = 9000
 const SERVER_PORT_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_PORT'
+const VALID_LOG_LEVELS = new Set([
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal',
+])
+
+function parseServerPort(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value > 0 && value <= 65535
+      ? value
+      : undefined
+  }
+
+  if (typeof value !== 'string' || !/^\d+$/.test(value.trim())) {
+    return undefined
+  }
+
+  const port = Number.parseInt(value.trim(), 10)
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : undefined
+}
+
+function isFileUri(uri: vscode.Uri | undefined): uri is vscode.Uri {
+  return !!uri && uri.scheme === 'file'
+}
+
+function parseOffsetInput(value: string): number | undefined {
+  const text = value.trim()
+  if (!/^(?:0x[0-9a-f]+|[0-9]+)$/i.test(text)) {
+    return undefined
+  }
+  const offset = text.toLowerCase().startsWith('0x')
+    ? Number.parseInt(text.slice(2), 16)
+    : Number.parseInt(text, 10)
+  return Number.isSafeInteger(offset) && offset >= 0 ? offset : undefined
+}
 
 function transformPluginFileExtension(): string {
   switch (os.platform()) {
@@ -84,9 +121,15 @@ function resolveTransformPluginDirectories(
   context: vscode.ExtensionContext,
   config: vscode.WorkspaceConfiguration
 ): string[] {
-  const configured = config
-    .get<string[]>('transformPluginDirectories', [])
-    .filter((directory) => directory.trim().length > 0)
+  const configuredValue = config.get<unknown>('transformPluginDirectories', [])
+  const configured = Array.isArray(configuredValue)
+    ? configuredValue
+        .filter(
+          (directory): directory is string =>
+            typeof directory === 'string' && directory.trim().length > 0
+        )
+        .map((directory) => directory.trim())
+    : []
 
   return configured.length > 0
     ? configured
@@ -98,15 +141,21 @@ function isTestRuntime(): boolean {
 }
 
 function resolveServerPort(config: vscode.WorkspaceConfiguration): number {
-  const envPort = Number.parseInt(
-    process.env[SERVER_PORT_OVERRIDE_ENV] ?? '',
-    10
-  )
-  if (Number.isInteger(envPort) && envPort > 0 && envPort <= 65535) {
+  const envPort = parseServerPort(process.env[SERVER_PORT_OVERRIDE_ENV])
+  if (envPort !== undefined) {
     return envPort
   }
 
-  return config.get<number>('serverPort', DEFAULT_SERVER_PORT)
+  return (
+    parseServerPort(config.get<unknown>('serverPort')) ?? DEFAULT_SERVER_PORT
+  )
+}
+
+function resolveLogLevel(config: vscode.WorkspaceConfiguration): string {
+  const value = config.get<unknown>('logLevel', 'info')
+  return typeof value === 'string' && VALID_LOG_LEVELS.has(value)
+    ? value
+    : 'info'
 }
 
 function reportActivationError(message: string): void {
@@ -124,13 +173,14 @@ export async function activate(
   const config = vscode.workspace.getConfiguration('omegaEdit')
   const port = resolveServerPort(config)
 
-  const logLevel = config.get<string>('logLevel', 'info')
+  const logLevel = resolveLogLevel(config)
   process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL = logLevel
   const transformPluginDirectories = resolveTransformPluginDirectories(
     context,
     config
   )
 
+  let serverPid: number | undefined
   try {
     serverPid = await startServer(port, undefined, undefined, {
       transformPluginDirectories,
@@ -150,11 +200,16 @@ export async function activate(
   try {
     await getClient(port)
   } catch {
+    try {
+      await stopServerGraceful()
+    } catch {
+      // Best effort cleanup; activation will report the connection failure.
+    }
     reportActivationError('Ωedit™ server started but is not reachable')
     return
   }
 
-  const provider = new HexEditorProvider(context, port)
+  const provider = new HexEditorProvider()
   activeProvider = provider
 
   context.subscriptions.push(
@@ -190,6 +245,13 @@ export async function activate(
           return
         }
 
+        if (!isFileUri(target)) {
+          void vscode.window.showWarningMessage(
+            'OmegaEdit Hex Editor can only open local files'
+          )
+          return
+        }
+
         await vscode.commands.executeCommand(
           'vscode.openWith',
           target,
@@ -207,20 +269,18 @@ export async function activate(
           prompt: 'Enter byte offset (decimal or 0x hex)',
           placeHolder: '0x0000',
           validateInput: (value) => {
-            const offset = value.startsWith('0x')
-              ? parseInt(value, 16)
-              : parseInt(value, 10)
-            return Number.isNaN(offset) || offset < 0
+            const offset = parseOffsetInput(value)
+            return offset === undefined
               ? 'Enter a valid non-negative integer'
               : null
           },
         })
 
         if (input !== undefined) {
-          const offset = input.startsWith('0x')
-            ? parseInt(input, 16)
-            : parseInt(input, 10)
-          provider.goToOffset(offset)
+          const offset = parseOffsetInput(input)
+          if (offset !== undefined) {
+            provider.goToOffset(offset)
+          }
         }
       }
     )

--- a/examples/vscode-extension/src/hexEditorProvider.ts
+++ b/examples/vscode-extension/src/hexEditorProvider.ts
@@ -80,6 +80,7 @@ interface EditorSession {
   offset: number
   visibleRows: number
   capacity: number
+  bytesPerRow: BytesPerRow
   filePath: string
   panel: vscode.WebviewPanel
   document: HexDocument
@@ -87,6 +88,7 @@ interface EditorSession {
   history: EditorHistoryController
   search: EditorSearchController
   restoredFromBackup?: boolean
+  disposed?: boolean
   pendingScrollOffset?: number
   scrollTask?: Promise<void>
   pendingAnalysisProfile?: AnalysisProfileRequest
@@ -116,9 +118,128 @@ const VIEWPORT_BUFFER_BYTES = 8 * 1024
 const SERVER_HEALTH_WARN_LATENCY_MS = 75
 const SERVER_HEALTH_ERROR_LATENCY_MS = 250
 const MAX_TRANSFORM_RESULT_TEXT_LENGTH = 240
+const MAX_TRANSFORM_RESULT_PREVIEW_BYTES = 4 * 1024
+const MAX_WEBVIEW_HEX_BYTES = 16 * 1024 * 1024
+const MAX_SEARCH_QUERY_LENGTH = 1024 * 1024
+const MAX_TRANSFORM_OPTIONS_LENGTH = 256 * 1024
+const MAX_ANALYSIS_PROFILE_BYTES = 64 * 1024
+const MAX_CHANGE_SCRIPT_BYTES = 32 * 1024 * 1024
+const MAX_CHANGE_SCRIPT_ENTRIES = 100_000
+const MAX_LABEL_LENGTH = 128
+const VALID_BYTES_PER_ROW = [8, 16, 32] as const
+const DEFAULT_BYTES_PER_ROW = 16
 const CONTEXT_HEX_EDITOR_ACTIVE = 'omegaEdit.hexEditorActive'
 const CONTEXT_CAN_UNDO = 'omegaEdit.canUndo'
 const CONTEXT_CAN_REDO = 'omegaEdit.canRedo'
+const CONTEXT_HAS_PENDING_CHANGES = 'omegaEdit.hasPendingChanges'
+
+type BytesPerRow = (typeof VALID_BYTES_PER_ROW)[number]
+
+function normalizeBytesPerRow(value: unknown): BytesPerRow {
+  return VALID_BYTES_PER_ROW.includes(value as BytesPerRow)
+    ? (value as BytesPerRow)
+    : DEFAULT_BYTES_PER_ROW
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function safeNonNegativeInteger(
+  value: unknown,
+  max = Number.MAX_SAFE_INTEGER
+): number | undefined {
+  return typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= max
+    ? value
+    : undefined
+}
+
+function safeBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function safeString(
+  value: unknown,
+  maxLength: number,
+  allowEmpty = false
+): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const text = value.trim()
+  if ((!allowEmpty && text.length === 0) || text.length > maxLength) {
+    return undefined
+  }
+  return text
+}
+
+function safeHexString(
+  value: unknown,
+  maxBytes: number,
+  allowEmpty = false
+): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const text = value.replace(/\s/g, '')
+  if ((!allowEmpty && text.length === 0) || text.length > maxBytes * 2) {
+    return undefined
+  }
+  if (text.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(text)) {
+    return undefined
+  }
+  return text
+}
+
+function safeJsonString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const text = value.trim()
+  if (text.length === 0) {
+    return undefined
+  }
+  if (text.length > maxLength) {
+    return undefined
+  }
+  try {
+    JSON.parse(text)
+  } catch {
+    return undefined
+  }
+  return text
+}
+
+function safeFileLengthRange(
+  session: EditorSession,
+  offsetValue: unknown,
+  lengthValue: unknown,
+  allowZeroLength = false,
+  maxLength = Number.MAX_SAFE_INTEGER
+): { offset: number; length: number } | undefined {
+  const offset = safeNonNegativeInteger(offsetValue)
+  const length = safeNonNegativeInteger(lengthValue, maxLength)
+  if (offset === undefined || length === undefined) {
+    return undefined
+  }
+  if ((!allowZeroLength && length === 0) || offset > session.fileSize) {
+    return undefined
+  }
+  if (length > Math.max(0, session.fileSize - offset)) {
+    return undefined
+  }
+  return { offset, length }
+}
+
+function safeSearchQuery(message: Record<string, unknown>): string | undefined {
+  const isHex = message.isHex === true
+  return isHex
+    ? safeHexString(message.query, MAX_SEARCH_QUERY_LENGTH, false)
+    : safeString(message.query, MAX_SEARCH_QUERY_LENGTH)
+}
 
 function classifyServerHealthLatency(
   latencyMs: number
@@ -160,7 +281,12 @@ function transformResultToText(bytes: Uint8Array): string {
     return ''
   }
 
-  return truncateTransformResult(Buffer.from(bytes).toString('utf8'))
+  const preview =
+    bytes.byteLength > MAX_TRANSFORM_RESULT_PREVIEW_BYTES
+      ? bytes.subarray(0, MAX_TRANSFORM_RESULT_PREVIEW_BYTES)
+      : bytes
+  const suffix = preview.byteLength < bytes.byteLength ? '...' : ''
+  return truncateTransformResult(Buffer.from(preview).toString('utf8') + suffix)
 }
 
 function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
@@ -196,6 +322,307 @@ function serializeTransformPlugin(plugin: TransformPluginInfo): {
   }
 }
 
+function safeChangeRecord(value: unknown): ChangeRecord | undefined {
+  if (!isRecord(value)) {
+    return undefined
+  }
+
+  const offset = safeNonNegativeInteger(value.offset)
+  if (offset === undefined) {
+    return undefined
+  }
+  const serial = safeNonNegativeInteger(value.serial) ?? 0
+
+  switch (value.kind) {
+    case 'INSERT': {
+      const data = safeHexString(value.data, MAX_WEBVIEW_HEX_BYTES)
+      return data
+        ? { serial, kind: 'INSERT', offset, length: 0, data }
+        : undefined
+    }
+    case 'DELETE': {
+      const length = safeNonNegativeInteger(value.length)
+      return length && length > 0
+        ? { serial, kind: 'DELETE', offset, length, data: '' }
+        : undefined
+    }
+    case 'OVERWRITE': {
+      const data = safeHexString(value.data, MAX_WEBVIEW_HEX_BYTES)
+      return data
+        ? {
+            serial,
+            kind: 'OVERWRITE',
+            offset,
+            length: data.length / 2,
+            data,
+          }
+        : undefined
+    }
+    case 'REPLACE': {
+      const length = safeNonNegativeInteger(value.length)
+      const data = safeHexString(value.data, MAX_WEBVIEW_HEX_BYTES, true)
+      const groupId = safeString(value.groupId, MAX_LABEL_LENGTH)
+      if (length === undefined || data === undefined) {
+        return undefined
+      }
+      return groupId
+        ? { serial, kind: 'REPLACE', offset, length, data, groupId }
+        : { serial, kind: 'REPLACE', offset, length, data }
+    }
+    default:
+      return undefined
+  }
+}
+
+function parseChangeScript(content: Uint8Array): ChangeRecord[] {
+  if (content.byteLength > MAX_CHANGE_SCRIPT_BYTES) {
+    throw new Error(
+      `Change script is too large (${content.byteLength.toLocaleString()} bytes)`
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(content))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid change script JSON: ${message}`)
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('Change script must be a JSON array')
+  }
+  if (parsed.length > MAX_CHANGE_SCRIPT_ENTRIES) {
+    throw new Error(
+      `Change script has too many entries (${parsed.length.toLocaleString()})`
+    )
+  }
+
+  return parsed.map((entry, index) => {
+    const change = safeChangeRecord(entry)
+    if (!change) {
+      throw new Error(`Invalid change record at index ${index}`)
+    }
+    return change
+  })
+}
+
+function normalizeWebviewMessage(
+  session: EditorSession,
+  raw: unknown
+): WebviewMessage | undefined {
+  if (!isRecord(raw) || typeof raw.type !== 'string') {
+    return undefined
+  }
+
+  switch (raw.type) {
+    case 'scroll':
+      return raw.direction === 'up' || raw.direction === 'down'
+        ? { type: 'scroll', direction: raw.direction }
+        : undefined
+
+    case 'scrollTo': {
+      const offset = safeNonNegativeInteger(raw.offset)
+      return offset === undefined ? undefined : { type: 'scrollTo', offset }
+    }
+
+    case 'setViewportMetrics': {
+      const visibleRows = safeNonNegativeInteger(raw.visibleRows, 100_000)
+      return visibleRows === undefined
+        ? undefined
+        : { type: 'setViewportMetrics', visibleRows }
+    }
+
+    case 'setBytesPerRow': {
+      const bytesPerRow = normalizeBytesPerRow(raw.bytesPerRow)
+      return raw.bytesPerRow === bytesPerRow
+        ? { type: 'setBytesPerRow', bytesPerRow }
+        : undefined
+    }
+
+    case 'requestAnalysisProfile': {
+      const offset = safeNonNegativeInteger(raw.offset)
+      const length = safeNonNegativeInteger(raw.length)
+      const requestedLength = safeNonNegativeInteger(raw.requestedLength)
+      const requestKey = safeString(raw.requestKey, MAX_LABEL_LENGTH)
+      const scopeLabel = safeString(raw.scopeLabel, MAX_LABEL_LENGTH)
+      if (
+        offset === undefined ||
+        length === undefined ||
+        requestedLength === undefined ||
+        !requestKey ||
+        !scopeLabel
+      ) {
+        return undefined
+      }
+      return {
+        type: 'requestAnalysisProfile',
+        offset,
+        length: Math.min(length, MAX_ANALYSIS_PROFILE_BYTES),
+        requestKey,
+        scopeLabel,
+        requestedLength,
+        isCapped: safeBoolean(raw.isCapped),
+      }
+    }
+
+    case 'requestTransformPlugins':
+    case 'undo':
+    case 'redo':
+    case 'save':
+    case 'saveAs':
+    case 'revert':
+      return { type: raw.type }
+
+    case 'copySelection':
+    case 'cutSelection': {
+      const range = safeFileLengthRange(
+        session,
+        raw.offset,
+        raw.length,
+        false,
+        MAX_WEBVIEW_HEX_BYTES
+      )
+      if (!range || (raw.format !== 'hex' && raw.format !== 'utf8')) {
+        return undefined
+      }
+      return {
+        type: raw.type,
+        ...range,
+        format: raw.format,
+      }
+    }
+
+    case 'insert': {
+      const offset = safeNonNegativeInteger(raw.offset)
+      const data = safeHexString(raw.data, MAX_WEBVIEW_HEX_BYTES)
+      if (offset === undefined || offset > session.fileSize || !data) {
+        return undefined
+      }
+      return { type: 'insert', offset, data }
+    }
+
+    case 'delete': {
+      const range = safeFileLengthRange(session, raw.offset, raw.length)
+      return range ? { type: 'delete', ...range } : undefined
+    }
+
+    case 'overwrite': {
+      const offset = safeNonNegativeInteger(raw.offset)
+      const data = safeHexString(raw.data, MAX_WEBVIEW_HEX_BYTES)
+      if (
+        offset === undefined ||
+        !data ||
+        offset >= session.fileSize ||
+        data.length / 2 > Math.max(0, session.fileSize - offset)
+      ) {
+        return undefined
+      }
+      return { type: 'overwrite', offset, data }
+    }
+
+    case 'replace': {
+      const range = safeFileLengthRange(session, raw.offset, raw.length, true)
+      const data = safeHexString(raw.data, MAX_WEBVIEW_HEX_BYTES, true)
+      return range && data !== undefined
+        ? { type: 'replace', ...range, data }
+        : undefined
+    }
+
+    case 'replaceAllMatches': {
+      const query = safeSearchQuery(raw)
+      const data = safeHexString(raw.data, MAX_WEBVIEW_HEX_BYTES, true)
+      const length = safeNonNegativeInteger(raw.length)
+      if (!query || data === undefined || !length) {
+        return undefined
+      }
+      return {
+        type: 'replaceAllMatches',
+        query,
+        isHex: raw.isHex === true,
+        caseInsensitive: safeBoolean(raw.caseInsensitive),
+        isReverse: safeBoolean(raw.isReverse),
+        length,
+        data,
+      }
+    }
+
+    case 'applyTransform': {
+      const pluginId = safeString(raw.pluginId, MAX_LABEL_LENGTH)
+      const offset = safeNonNegativeInteger(raw.offset)
+      const length = safeNonNegativeInteger(raw.length)
+      const optionsJson =
+        raw.optionsJson === undefined
+          ? undefined
+          : safeJsonString(raw.optionsJson, MAX_TRANSFORM_OPTIONS_LENGTH)
+      if (
+        !pluginId ||
+        offset === undefined ||
+        length === undefined ||
+        (raw.optionsJson !== undefined && optionsJson === undefined)
+      ) {
+        return undefined
+      }
+      return { type: 'applyTransform', pluginId, offset, length, optionsJson }
+    }
+
+    case 'search': {
+      const query = safeSearchQuery(raw)
+      if (!query) {
+        return undefined
+      }
+      return {
+        type: 'search',
+        query,
+        isHex: raw.isHex === true,
+        caseInsensitive: safeBoolean(raw.caseInsensitive),
+        isReverse: safeBoolean(raw.isReverse),
+      }
+    }
+
+    case 'goToMatch': {
+      const offset = safeNonNegativeInteger(raw.offset)
+      return offset === undefined ? undefined : { type: 'goToMatch', offset }
+    }
+
+    case 'findAdjacentMatch': {
+      const query = safeSearchQuery(raw)
+      const offset = safeNonNegativeInteger(raw.offset)
+      if (
+        !query ||
+        offset === undefined ||
+        (raw.direction !== 'forward' && raw.direction !== 'backward')
+      ) {
+        return undefined
+      }
+      return {
+        type: 'findAdjacentMatch',
+        query,
+        isHex: raw.isHex === true,
+        caseInsensitive: safeBoolean(raw.caseInsensitive),
+        direction: raw.direction,
+        offset,
+      }
+    }
+
+    default:
+      return undefined
+  }
+}
+
+function backupIdToFilePath(backupId: string | undefined): string | undefined {
+  if (!backupId) {
+    return undefined
+  }
+
+  try {
+    const backupUri = vscode.Uri.parse(backupId)
+    return backupUri.scheme === 'file' ? backupUri.fsPath : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * Represents a single file opened by the Hex Editor. VS Code tracks dirty
  * state and initiates saves through this object.
@@ -209,7 +636,10 @@ export class HexDocument implements vscode.CustomDocument {
     this.backupId = backupId
   }
 
-  dispose(): void {}
+  dispose(): void {
+    // VS Code calls this when all editors for the document are closed.
+    // Session and webview cleanup happens in webviewPanel.onDidDispose.
+  }
 }
 
 export class HexEditorProvider
@@ -222,9 +652,6 @@ export class HexEditorProvider
   >()
   readonly onDidChangeCustomDocument = this._onDidChangeCustomDocument.event
 
-  /** Open documents keyed by document URI string */
-  private documents = new Map<string, HexDocument>()
-
   /** Active editor sessions keyed by document URI string */
   private sessions = new Map<string, EditorSession>()
 
@@ -234,11 +661,6 @@ export class HexEditorProvider
   private heartbeatLoop: ServerHeartbeatLoop | undefined
 
   private serverInfo: IServerInfo | undefined
-
-  constructor(
-    private readonly context: vscode.ExtensionContext,
-    _port: number
-  ) {}
 
   private getViewportCapacity(bytesPerRow: number): number {
     const bufferedRows = Math.max(
@@ -279,18 +701,24 @@ export class HexEditorProvider
         await this.performRedoOnSession(session)
         return
       case 'save':
-      case 'saveAs':
-        await this.saveCustomDocument(
-          session.document,
-          new vscode.CancellationTokenSource().token
-        )
+      case 'saveAs': {
+        const cts = new vscode.CancellationTokenSource()
+        try {
+          await this.saveCustomDocument(session.document, cts.token)
+        } finally {
+          cts.dispose()
+        }
         return
-      case 'revert':
-        await this.revertCustomDocument(
-          session.document,
-          new vscode.CancellationTokenSource().token
-        )
+      }
+      case 'revert': {
+        const cts = new vscode.CancellationTokenSource()
+        try {
+          await this.revertCustomDocument(session.document, cts.token)
+        } finally {
+          cts.dispose()
+        }
         return
+      }
     }
 
     await this.handleWebviewMessage(session, msg)
@@ -318,7 +746,6 @@ export class HexEditorProvider
     _token: vscode.CancellationToken
   ): Promise<HexDocument> {
     const doc = new HexDocument(uri, openContext.backupId)
-    this.documents.set(uri.toString(), doc)
     return doc
   }
 
@@ -328,11 +755,14 @@ export class HexEditorProvider
     _token: vscode.CancellationToken
   ): Promise<void> {
     const uri = document.uri
+    if (uri.scheme !== 'file') {
+      throw new Error('OmegaEdit Hex Editor can only open local files')
+    }
     const filePath = uri.fsPath
 
     // --- Create Î©editâ„¢ session for this file ---
     const config = vscode.workspace.getConfiguration('omegaEdit')
-    const bytesPerRow = config.get<number>('bytesPerRow', 16)
+    const bytesPerRow = normalizeBytesPerRow(config.get('bytesPerRow'))
 
     // Keep a fixed buffered viewport so resizing the editor does not need to
     // resize the server-side viewport. Only the visible row count changes.
@@ -341,10 +771,9 @@ export class HexEditorProvider
     // --- Create a viewport starting at offset 0 ---
     // If VS Code supplies a backup id (crash-recovery), open from the backup so
     // unsaved edits are restored; save still targets the original filePath.
-    const wasRestoredFromBackup = !!document.backupId
-    const restoreFromPath = document.backupId
-      ? vscode.Uri.parse(document.backupId).fsPath
-      : filePath
+    const backupFilePath = backupIdToFilePath(document.backupId)
+    const wasRestoredFromBackup = !!backupFilePath
+    const restoreFromPath = backupFilePath ?? filePath
     document.backupId = undefined // consume – do not re-use on subsequent resolves
 
     const scope = await ScopedEditorSessionHandle.openFile(restoreFromPath, {
@@ -371,6 +800,7 @@ export class HexEditorProvider
       offset: 0,
       visibleRows: 32,
       capacity,
+      bytesPerRow,
       filePath,
       panel: webviewPanel,
       document,
@@ -384,8 +814,14 @@ export class HexEditorProvider
     this.updateEditCommandContexts(session)
 
     // --- Configure the webview ---
-    webviewPanel.webview.options = { enableScripts: true }
-    webviewPanel.webview.html = getWebviewContent(bytesPerRow)
+    webviewPanel.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [],
+    }
+    webviewPanel.webview.html = getWebviewContent(
+      bytesPerRow,
+      webviewPanel.webview.cspSource
+    )
 
     // Send initial data to the webview
     await this.sendViewportData(session)
@@ -395,27 +831,34 @@ export class HexEditorProvider
     await this.startSessionSubscriptions(session)
 
     // --- Handle messages FROM the webview ---
+    const panelDisposables: vscode.Disposable[] = []
+
     webviewPanel.webview.onDidReceiveMessage(
       (msg) => this.handleWebviewMessage(session, msg),
       undefined,
-      this.context.subscriptions
+      panelDisposables
     )
 
     // Track which editor is active (for command routing)
-    webviewPanel.onDidChangeViewState(() => {
-      if (webviewPanel.active) {
-        this.activeSession = session
-        this.updateEditCommandContexts(session)
-      } else if (this.activeSession === session) {
-        this.activeSession = undefined
-        this.updateEditCommandContexts(undefined)
-      }
-    })
+    webviewPanel.onDidChangeViewState(
+      () => {
+        if (webviewPanel.active) {
+          this.activeSession = session
+          this.updateEditCommandContexts(session)
+        } else if (this.activeSession === session) {
+          this.activeSession = undefined
+          this.updateEditCommandContexts(undefined)
+        }
+      },
+      undefined,
+      panelDisposables
+    )
 
     // --- Cleanup on close ---
     webviewPanel.onDidDispose(async () => {
+      session.disposed = true
+      vscode.Disposable.from(...panelDisposables).dispose()
       this.sessions.delete(uri.toString())
-      this.documents.delete(uri.toString())
       if (this.activeSession === session) {
         this.activeSession = undefined
         this.updateEditCommandContexts(undefined)
@@ -452,8 +895,13 @@ export class HexEditorProvider
     if (!session) {
       return
     }
+    if (destination.scheme !== 'file') {
+      throw new Error('OmegaEdit Hex Editor can only save to local files')
+    }
     await saveSession(session.sessionId, destination.fsPath, IOFlags.OVERWRITE)
     session.restoredFromBackup = false
+    session.history.markSaved()
+    this.postEditState(session)
   }
 
   async revertCustomDocument(
@@ -519,7 +967,7 @@ export class HexEditorProvider
           return
         }
 
-        session.panel.webview.postMessage({
+        this.postWebviewMessage(session, {
           type: 'fileSizeChanged',
           fileSize: context.model.fileSize,
         })
@@ -542,9 +990,13 @@ export class HexEditorProvider
   /** Re-read bytesPerRow from config and refresh all open editors */
   refreshBytesPerRow(): void {
     const config = vscode.workspace.getConfiguration('omegaEdit')
-    const bytesPerRow = config.get<number>('bytesPerRow', 16)
+    const bytesPerRow = normalizeBytesPerRow(config.get('bytesPerRow'))
     for (const session of this.sessions.values()) {
-      session.panel.webview.html = getWebviewContent(bytesPerRow)
+      session.bytesPerRow = bytesPerRow
+      session.panel.webview.html = getWebviewContent(
+        bytesPerRow,
+        session.panel.webview.cspSource
+      )
       session.capacity = this.getViewportCapacity(bytesPerRow)
       this.sendViewportData(session)
       this.postEditState(session)
@@ -553,7 +1005,7 @@ export class HexEditorProvider
 
   async exportActiveChangeScript(targetUri?: vscode.Uri): Promise<void> {
     if (!this.activeSession) {
-      vscode.window.showWarningMessage('Open an OmegaEdit editor first')
+      void vscode.window.showWarningMessage('Open an OmegaEdit editor first')
       return
     }
 
@@ -576,16 +1028,17 @@ export class HexEditorProvider
       'utf8'
     )
     await vscode.workspace.fs.writeFile(scriptUri, content)
-    vscode.window.showInformationMessage(
+    void vscode.window.showInformationMessage(
       `Change script saved to ${scriptUri.fsPath}`
     )
   }
 
   async replayActiveChangeScript(sourceUri?: vscode.Uri): Promise<void> {
     if (!this.activeSession) {
-      vscode.window.showWarningMessage('Open an OmegaEdit editor first')
+      void vscode.window.showWarningMessage('Open an OmegaEdit editor first')
       return
     }
+    const session = this.activeSession
 
     const scriptUri =
       sourceUri ??
@@ -601,34 +1054,50 @@ export class HexEditorProvider
     }
 
     const content = await vscode.workspace.fs.readFile(scriptUri)
-    const changes = JSON.parse(
-      Buffer.from(content).toString('utf8')
-    ) as ChangeRecord[]
-    await this.replayChanges(this.activeSession, changes)
-    vscode.window.showInformationMessage(`Replayed ${changes.length} change(s)`)
+    let changes: ChangeRecord[]
+    try {
+      changes = parseChangeScript(content)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      void vscode.window.showErrorMessage(
+        `Invalid OmegaEdit change script: ${message}`
+      )
+      return
+    }
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Replaying ${changes.length} change(s)…`,
+        cancellable: false,
+      },
+      () => this.replayChanges(session, changes)
+    )
+    void vscode.window.showInformationMessage(
+      `Replayed ${changes.length} change(s)`
+    )
   }
 
   async createActiveCheckpoint(): Promise<void> {
     if (!this.activeSession) {
-      vscode.window.showWarningMessage('Open an OmegaEdit editor first')
+      void vscode.window.showWarningMessage('Open an OmegaEdit editor first')
       return
     }
 
     const count = await this.createSessionCheckpoint(this.activeSession)
-    vscode.window.showInformationMessage(
+    void vscode.window.showInformationMessage(
       `OmegaEdit checkpoint created (${count} total)`
     )
   }
 
   async rollbackActiveCheckpoint(): Promise<void> {
     if (!this.activeSession) {
-      vscode.window.showWarningMessage('Open an OmegaEdit editor first')
+      void vscode.window.showWarningMessage('Open an OmegaEdit editor first')
       return
     }
 
     const rolledBack = await this.rollbackCheckpoint(this.activeSession, true)
     if (rolledBack) {
-      vscode.window.showInformationMessage(
+      void vscode.window.showInformationMessage(
         'Rolled back last OmegaEdit checkpoint'
       )
     }
@@ -636,12 +1105,12 @@ export class HexEditorProvider
 
   async rollbackActiveSession(): Promise<void> {
     if (!this.activeSession) {
-      vscode.window.showWarningMessage('Open an OmegaEdit editor first')
+      void vscode.window.showWarningMessage('Open an OmegaEdit editor first')
       return
     }
 
     await this.rollbackSession(this.activeSession, true)
-    vscode.window.showInformationMessage('Rolled back OmegaEdit session')
+    void vscode.window.showInformationMessage('Rolled back OmegaEdit session')
   }
 
   // â”€â”€ Event Subscriptions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -654,13 +1123,47 @@ export class HexEditorProvider
 
   // â”€â”€ Viewport Data â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
+  private postWebviewMessage(session: EditorSession, message: unknown): void {
+    if (session.disposed) {
+      return
+    }
+
+    try {
+      void session.panel.webview
+        .postMessage(message)
+        .then(undefined, (error) => {
+          if (
+            error instanceof Error &&
+            error.message.includes('Webview is disposed')
+          ) {
+            session.disposed = true
+          }
+        })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes('Webview is disposed')
+      ) {
+        session.disposed = true
+        return
+      }
+      throw error
+    }
+  }
+
   /** Fetch current viewport data and send it to the webview */
   private async sendViewportData(session: EditorSession): Promise<void> {
+    if (session.disposed || session.scope.isDisposed) {
+      return
+    }
     const fetchStartedAt = Date.now()
     const resp = await getViewportData(session.viewportId)
+    if (session.disposed || session.scope.isDisposed) {
+      return
+    }
     const fetchDurationMs = Date.now() - fetchStartedAt
     const data = resp.getData_asU8()
-    session.panel.webview.postMessage({
+    this.postWebviewMessage(session, {
       type: 'viewportData',
       offset: resp.getOffset(),
       visibleOffset: session.offset,
@@ -698,7 +1201,7 @@ export class HexEditorProvider
     if (this.activeSession === session) {
       this.updateEditCommandContexts(session)
     }
-    session.panel.webview.postMessage({
+    this.postWebviewMessage(session, {
       type: 'editState',
       ...editState,
       isDirty: editState.isDirty || !!session.restoredFromBackup,
@@ -722,18 +1225,23 @@ export class HexEditorProvider
       CONTEXT_CAN_REDO,
       !!editState?.canRedo
     )
+    void vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_HAS_PENDING_CHANGES,
+      !!session && (!!editState?.isDirty || !!session.restoredFromBackup)
+    )
   }
 
   private async sendTransformPlugins(session: EditorSession): Promise<void> {
     try {
       const plugins = await listTransformPlugins()
-      session.panel.webview.postMessage({
+      this.postWebviewMessage(session, {
         type: 'transformPlugins',
         plugins: plugins.map(serializeTransformPlugin),
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      session.panel.webview.postMessage({
+      this.postWebviewMessage(session, {
         type: 'transformPlugins',
         plugins: [],
         error: message,
@@ -801,7 +1309,7 @@ export class HexEditorProvider
       }
     }
 
-    session.panel.webview.postMessage({
+    this.postWebviewMessage(session, {
       type: 'transformComplete',
       pluginId: response.pluginId,
       offset: response.offset,
@@ -831,7 +1339,7 @@ export class HexEditorProvider
             byte.toString(16).toUpperCase().padStart(2, '0')
           ).join(' ')
     await vscode.env.clipboard.writeText(clipboardText)
-    session.panel.webview.postMessage({
+    this.postWebviewMessage(session, {
       type: 'clipboardComplete',
       action,
       byteCount: bytes.byteLength,
@@ -851,7 +1359,11 @@ export class HexEditorProvider
     )
     const clampedLength = Math.max(
       0,
-      Math.min(request.length, Math.max(0, session.fileSize - clampedOffset))
+      Math.min(
+        request.length,
+        MAX_ANALYSIS_PROFILE_BYTES,
+        Math.max(0, session.fileSize - clampedOffset)
+      )
     )
     const startedAt = Date.now()
 
@@ -859,7 +1371,7 @@ export class HexEditorProvider
       if (session.pendingAnalysisProfile) {
         return
       }
-      session.panel.webview.postMessage({
+      this.postWebviewMessage(session, {
         type: 'analysisProfile',
         requestKey: request.requestKey,
         scopeLabel: request.scopeLabel,
@@ -889,7 +1401,11 @@ export class HexEditorProvider
       profileSession(session.sessionId, clampedOffset, clampedLength),
       getByteOrderMark(session.sessionId, clampedOffset),
     ])
-    if (session.pendingAnalysisProfile || session.scope.isDisposed) {
+    if (
+      session.pendingAnalysisProfile ||
+      session.scope.isDisposed ||
+      session.disposed
+    ) {
       return
     }
 
@@ -900,15 +1416,15 @@ export class HexEditorProvider
       getContentType(session.sessionId, 0, contentTypeSampleLength),
       getLanguage(session.sessionId, clampedOffset, clampedLength, bomName),
     ])
-    if (session.pendingAnalysisProfile || session.scope.isDisposed) {
+    if (
+      session.pendingAnalysisProfile ||
+      session.scope.isDisposed ||
+      session.disposed
+    ) {
       return
     }
 
-    if (session.scope.isDisposed) {
-      return
-    }
-
-    session.panel.webview.postMessage({
+    this.postWebviewMessage(session, {
       type: 'analysisProfile',
       requestKey: request.requestKey,
       scopeLabel: request.scopeLabel,
@@ -942,7 +1458,7 @@ export class HexEditorProvider
       session.analysisProfileTask = this.processAnalysisProfileQueue(session)
         .catch((err) => {
           const message = err instanceof Error ? err.message : String(err)
-          vscode.window.showErrorMessage(`OmegaEdit error: ${message}`)
+          void vscode.window.showErrorMessage(`OmegaEdit error: ${message}`)
         })
         .finally(() => {
           session.analysisProfileTask = undefined
@@ -973,6 +1489,29 @@ export class HexEditorProvider
     return counts[0]?.getCount() ?? 0
   }
 
+  private async resetSessionState(
+    session: EditorSession,
+    restoredFromBackup: boolean,
+    markDirty: boolean,
+    scrollToStart: boolean
+  ): Promise<void> {
+    session.history = new EditorHistoryController()
+    session.search = new EditorSearchController(session.sessionId)
+    session.restoredFromBackup = restoredFromBackup
+    this.clearSearchState(session)
+    this.postEditState(session)
+    if (scrollToStart) {
+      // scrollTo repositions the server-side viewport; sendViewportData alone
+      // would leave the server viewport at the old position.
+      await this.scrollTo(session, 0)
+    } else {
+      await this.sendViewportData(session)
+    }
+    if (markDirty) {
+      this.notifyDocumentChanged(session)
+    }
+  }
+
   private async createSessionCheckpoint(
     session: EditorSession
   ): Promise<number> {
@@ -981,12 +1520,7 @@ export class HexEditorProvider
     const sessionSyncVersion = session.sessionSyncVersion
     const count = await createCheckpoint(session.sessionId)
     await this.waitForSessionSync(session, sessionSyncVersion)
-    session.history = new EditorHistoryController()
-    session.search = new EditorSearchController(session.sessionId)
-    session.restoredFromBackup = wasDirty
-    this.clearSearchState(session)
-    this.postEditState(session)
-    await this.sendViewportData(session)
+    await this.resetSessionState(session, wasDirty, false, false)
     return count
   }
 
@@ -996,22 +1530,16 @@ export class HexEditorProvider
   ): Promise<boolean> {
     const checkpointCount = await this.getCheckpointCount(session)
     if (checkpointCount <= 0) {
-      vscode.window.showWarningMessage('No OmegaEdit checkpoint to roll back')
+      void vscode.window.showWarningMessage(
+        'No OmegaEdit checkpoint to roll back'
+      )
       return false
     }
 
     const sessionSyncVersion = session.sessionSyncVersion
     await destroyLastCheckpoint(session.sessionId)
     await this.waitForSessionSync(session, sessionSyncVersion)
-    session.history = new EditorHistoryController()
-    session.search = new EditorSearchController(session.sessionId)
-    session.restoredFromBackup = markDirty
-    this.clearSearchState(session)
-    this.postEditState(session)
-    await this.sendViewportData(session)
-    if (markDirty) {
-      this.notifyDocumentChanged(session)
-    }
+    await this.resetSessionState(session, markDirty, markDirty, false)
     return true
   }
 
@@ -1027,21 +1555,12 @@ export class HexEditorProvider
     }
     await clear(session.sessionId)
     await this.waitForSessionSync(session, sessionSyncVersion)
-    session.history = new EditorHistoryController()
-    session.search = new EditorSearchController(session.sessionId)
-    session.restoredFromBackup = markDirty
-    session.offset = 0
-    this.clearSearchState(session)
-    this.postEditState(session)
-    await this.sendViewportData(session)
-    if (markDirty) {
-      this.notifyDocumentChanged(session)
-    }
+    await this.resetSessionState(session, markDirty, markDirty, true)
   }
 
   private clearSearchState(session: EditorSession): void {
     if (session.search.clear()) {
-      session.panel.webview.postMessage({ type: 'searchStateCleared' })
+      this.postWebviewMessage(session, { type: 'searchStateCleared' })
     }
   }
 
@@ -1218,7 +1737,7 @@ export class HexEditorProvider
 
   private broadcastServerHealth(payload: ServerHealthState): void {
     for (const session of this.sessions.values()) {
-      session.panel.webview.postMessage(payload)
+      this.postWebviewMessage(session, payload)
     }
   }
 
@@ -1324,16 +1843,13 @@ export class HexEditorProvider
           break
         }
         case 'OVERWRITE': {
-          const serial = await overwrite(
-            session.sessionId,
-            change.offset,
-            Buffer.from(change.data, 'hex')
-          )
+          const buf = Buffer.from(change.data, 'hex')
+          const serial = await overwrite(session.sessionId, change.offset, buf)
           session.history.recordLocalChange({
             serial,
             kind: 'OVERWRITE',
             offset: change.offset,
-            length: Buffer.from(change.data, 'hex').length,
+            length: buf.length,
             data: change.data,
           })
           this.postEditState(session)
@@ -1401,8 +1917,7 @@ export class HexEditorProvider
       return
     }
 
-    const config = vscode.workspace.getConfiguration('omegaEdit')
-    const bytesPerRow = config.get<number>('bytesPerRow', 16)
+    const bytesPerRow = session.bytesPerRow
     const viewportRows = Math.max(32, session.visibleRows || 32)
     const bufferedRows = Math.max(
       viewportRows,
@@ -1476,16 +1991,21 @@ export class HexEditorProvider
 
   private async handleWebviewMessage(
     session: EditorSession,
-    msg: WebviewMessage
+    rawMessage: unknown
   ): Promise<void> {
+    const msg = normalizeWebviewMessage(session, rawMessage)
+    if (!msg || session.scope.isDisposed || session.disposed) {
+      return
+    }
+
     try {
       switch (msg.type) {
         // --- Scrolling ---
         case 'scroll': {
-          const config = vscode.workspace.getConfiguration('omegaEdit')
-          const bytesPerRow = config.get<number>('bytesPerRow', 16)
           const delta =
-            msg.direction === 'up' ? -bytesPerRow * 4 : bytesPerRow * 4
+            msg.direction === 'up'
+              ? -session.bytesPerRow * 4
+              : session.bytesPerRow * 4
           await this.scrollTo(session, session.offset + delta)
           break
         }
@@ -1581,7 +2101,7 @@ export class HexEditorProvider
           this.notifyDocumentChanged(session)
           await this.waitForSessionSync(session, sessionSyncVersion)
           this.clearSearchState(session)
-          session.panel.webview.postMessage({
+          this.postWebviewMessage(session, {
             type: 'cutComplete',
             offset: msg.offset,
           })
@@ -1654,7 +2174,7 @@ export class HexEditorProvider
               msg.length,
               msg.data
             )
-            session.panel.webview.postMessage({
+            this.postWebviewMessage(session, {
               type: 'replaceComplete',
               scope: 'single',
               replacedOffset: msg.offset,
@@ -1700,7 +2220,7 @@ export class HexEditorProvider
               this.notifyDocumentChanged(session)
             }
 
-            session.panel.webview.postMessage({
+            this.postWebviewMessage(session, {
               type: 'replaceComplete',
               scope: 'all',
               selectionOffset: result.selectionOffset,
@@ -1768,7 +2288,7 @@ export class HexEditorProvider
             caseInsensitive: msg.caseInsensitive ?? false,
             isReverse: msg.isReverse ?? false,
           })
-          session.panel.webview.postMessage({
+          this.postWebviewMessage(session, {
             type: 'searchResults',
             mode: result.mode,
             matches: result.matches,
@@ -1796,7 +2316,7 @@ export class HexEditorProvider
             anchorOffset: msg.offset,
             fileSize: session.fileSize,
           })
-          session.panel.webview.postMessage({
+          this.postWebviewMessage(session, {
             type: 'searchNavigationResult',
             offset: navigation.offset,
             patternLength: navigation.patternLength,
@@ -1809,7 +2329,7 @@ export class HexEditorProvider
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      vscode.window.showErrorMessage(`OmegaEdit error: ${message}`)
+      void vscode.window.showErrorMessage(`OmegaEdit error: ${message}`)
     }
   }
 }

--- a/examples/vscode-extension/src/webview.ts
+++ b/examples/vscode-extension/src/webview.ts
@@ -30,11 +30,38 @@
  *   └─────────────────────────────────────────────────────────┘
  */
 
-export function getWebviewContent(bytesPerRow: number): string {
+import * as crypto from 'node:crypto'
+
+const VALID_BYTES_PER_ROW = new Set([8, 16, 32])
+
+function normalizeBytesPerRow(bytesPerRow: number): number {
+  return VALID_BYTES_PER_ROW.has(bytesPerRow) ? bytesPerRow : 16
+}
+
+function createNonce(): string {
+  return crypto.randomBytes(16).toString('base64')
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export function getWebviewContent(
+  requestedBytesPerRow: number,
+  cspSource = "'self'",
+  nonce = createNonce()
+): string {
+  const bytesPerRow = normalizeBytesPerRow(requestedBytesPerRow)
   const groupSize = 8
   const byteCellWidth = 22
   const byteGap = 6
   const groupGap = 4
+  const escapedCspSource = escapeHtmlAttribute(cspSource)
+  const escapedNonce = escapeHtmlAttribute(nonce)
   const groupSeparators = Math.floor((bytesPerRow - 1) / groupSize)
   const hexColumnWidth =
     bytesPerRow * byteCellWidth +
@@ -45,6 +72,7 @@ export function getWebviewContent(bytesPerRow: number): string {
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${escapedCspSource} data:; style-src ${escapedCspSource} 'unsafe-inline'; script-src 'nonce-${escapedNonce}';">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Ωedit™ Hex Editor</title>
 <style>
@@ -72,7 +100,8 @@ export function getWebviewContent(bytesPerRow: number): string {
     --ascii-muted-fg: color-mix(in srgb, var(--ascii-fg) 45%, var(--fg) 55%);
     --mono: var(--vscode-editor-font-family, 'Consolas', 'Courier New', monospace);
     --font-size: var(--vscode-editor-font-size, 13px);
-    --contrast-border: var(--vscode-contrastActiveBorder, transparent);
+    --accent-frame: var(--vscode-contrastActiveBorder, #cca700);
+    --accent-frame-bg: color-mix(in srgb, var(--accent-frame) 16%, transparent);
     --offset-col-width: 80px;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -175,7 +204,7 @@ export function getWebviewContent(bytesPerRow: number): string {
     display: none;
     width: min(520px, calc(100% - 36px));
     padding: 4px;
-    border: 1px solid var(--contrast-border);
+    border: 1px solid var(--accent-frame);
     background: var(--vscode-editorWidget-background, var(--toolbar-bg));
     color: var(--vscode-editorWidget-foreground, var(--fg));
     box-shadow: 0 0 8px 2px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.3));
@@ -208,7 +237,7 @@ export function getWebviewContent(bytesPerRow: number): string {
     border-radius: 2px;
   }
   .find-widget input[type="text"]:focus {
-    outline: 1px solid var(--button-bg);
+    outline: 1px solid var(--accent-frame);
   }
   .find-widget label {
     display: inline-flex;
@@ -320,13 +349,19 @@ export function getWebviewContent(bytesPerRow: number): string {
   .hex-byte:hover {
     background: var(--selected);
     color: var(--selected-fg);
-    outline: 1px solid var(--contrast-border);
+    outline: 1px solid var(--accent-frame);
     outline-offset: -1px;
   }
   .hex-byte.selected {
     background: var(--selected);
     color: var(--selected-fg);
-    outline: 1px solid var(--contrast-border);
+    outline: 1px solid var(--accent-frame);
+    outline-offset: -1px;
+  }
+  .hex-byte.inspector-anchor {
+    background: var(--accent-frame-bg);
+    color: var(--fg);
+    outline: 1px solid var(--accent-frame);
     outline-offset: -1px;
   }
   .hex-byte.match {
@@ -353,13 +388,19 @@ export function getWebviewContent(bytesPerRow: number): string {
   .ascii-char:hover {
     background: var(--selected);
     color: var(--selected-fg);
-    outline: 1px solid var(--contrast-border);
+    outline: 1px solid var(--accent-frame);
     outline-offset: -1px;
   }
   .ascii-char.selected {
     background: var(--selected);
     color: var(--selected-fg);
-    outline: 1px solid var(--contrast-border);
+    outline: 1px solid var(--accent-frame);
+    outline-offset: -1px;
+  }
+  .ascii-char.inspector-anchor {
+    background: var(--accent-frame-bg);
+    color: var(--fg);
+    outline: 1px solid var(--accent-frame);
     outline-offset: -1px;
   }
   .ascii-char.match {
@@ -489,10 +530,16 @@ export function getWebviewContent(bytesPerRow: number): string {
   .analysis-panel.active {
     display: block;
   }
+  .analysis-section {
+    position: relative;
+  }
   .analysis-section + .analysis-section {
     margin-top: 14px;
     padding-top: 12px;
     border-top: 1px solid var(--border);
+  }
+  .analysis-section.dragging {
+    opacity: 0.62;
   }
   .analysis-section-title {
     color: var(--fg);
@@ -559,6 +606,11 @@ export function getWebviewContent(bytesPerRow: number): string {
   .analysis-section-heading .analysis-section-title {
     margin-bottom: 0;
   }
+  .analysis-section-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
   .analysis-mini-button {
     background: transparent;
     border: 1px solid var(--border);
@@ -569,6 +621,42 @@ export function getWebviewContent(bytesPerRow: number): string {
   }
   .analysis-mini-button:hover {
     background: var(--input-bg);
+  }
+  .analysis-drag-handle {
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    display: inline-grid;
+    place-items: center;
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--offset-fg);
+    cursor: grab;
+  }
+  .analysis-drag-handle:hover,
+  .analysis-drag-handle:focus {
+    background: var(--input-bg);
+    color: var(--fg);
+    outline: none;
+  }
+  .analysis-drag-handle:focus-visible {
+    outline: 1px solid var(--accent-frame);
+    outline-offset: 1px;
+  }
+  .analysis-drag-handle.dragging {
+    border-color: var(--accent-frame);
+    background: var(--accent-frame-bg);
+    color: var(--fg);
+    cursor: grabbing;
+  }
+  .analysis-drag-handle::before {
+    content: '';
+    width: 11px;
+    height: 14px;
+    background-image: radial-gradient(currentColor 1px, transparent 1.5px);
+    background-size: 5px 5px;
+    background-position: 0 0;
+    opacity: 0.82;
   }
   .frequency-chart {
     position: relative;
@@ -692,6 +780,11 @@ export function getWebviewContent(bytesPerRow: number): string {
   }
   .status-inline-button:hover {
     background: var(--input-bg);
+  }
+  .status-inline-button.active {
+    border-color: var(--accent-frame);
+    background: var(--accent-frame-bg);
+    color: var(--fg);
   }
   .status-action {
     color: var(--vscode-terminal-ansiYellow, #dcdcaa);
@@ -838,7 +931,7 @@ export function getWebviewContent(bytesPerRow: number): string {
     font-size: 11px;
   }
 
-  /* Hover Inspector */
+  /* Inspector Pane */
   .byte-inspector-popover {
     position: fixed;
     left: 0;
@@ -861,18 +954,17 @@ export function getWebviewContent(bytesPerRow: number): string {
   .byte-inspector-popover.active {
     display: block;
   }
-  .byte-inspector-popover.pinned {
-    border-color: var(--button-bg);
-    box-shadow:
-      0 12px 28px rgba(0, 0, 0, 0.34),
-      0 0 0 1px color-mix(in srgb, var(--button-bg) 40%, transparent);
-  }
   .byte-inspector-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
     margin-bottom: 8px;
+    cursor: grab;
+    user-select: none;
+  }
+  .byte-inspector-header.dragging {
+    cursor: grabbing;
   }
   .byte-inspector-title {
     color: var(--fg);
@@ -880,7 +972,13 @@ export function getWebviewContent(bytesPerRow: number): string {
     font-weight: 600;
   }
   .byte-inspector-meta {
-    color: var(--offset-fg);
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 4px;
+    border: 1px solid var(--accent-frame);
+    border-radius: 2px;
+    background: var(--accent-frame-bg);
+    color: var(--fg);
     font-size: 10px;
   }
   .byte-inspector-actions {
@@ -888,11 +986,6 @@ export function getWebviewContent(bytesPerRow: number): string {
     align-items: center;
     gap: 4px;
     flex: 0 0 auto;
-  }
-  .byte-inspector-actions .active {
-    border-color: var(--button-bg);
-    background: color-mix(in srgb, var(--button-bg) 26%, transparent);
-    color: var(--fg);
   }
   .byte-inspector-grid {
     display: grid;
@@ -930,8 +1023,8 @@ export function getWebviewContent(bytesPerRow: number): string {
   }
   button.byte-inspector-value:hover,
   button.byte-inspector-value:focus {
-    border-color: var(--button-bg);
-    background: color-mix(in srgb, var(--button-bg) 18%, transparent);
+    border-color: var(--accent-frame);
+    background: var(--accent-frame-bg);
     outline: none;
   }
   .byte-inspector-value.readonly {
@@ -955,6 +1048,9 @@ export function getWebviewContent(bytesPerRow: number): string {
   }
   .byte-inspector-edit input.invalid {
     border-color: var(--vscode-inputValidation-errorBorder, #f14c4c);
+  }
+  .byte-inspector-edit input:focus {
+    outline: 1px solid var(--accent-frame);
   }
   .byte-inspector-edit button {
     flex: 0 0 auto;
@@ -1185,40 +1281,61 @@ export function getWebviewContent(bytesPerRow: number): string {
       </span>
     </div>
     <div class="analysis-body">
-      <section class="analysis-panel active" id="profilePanel" role="tabpanel" aria-labelledby="profileTab">
-        <div class="analysis-section">
-          <div class="analysis-section-title">Viewport</div>
+      <section class="analysis-panel active" id="profilePanel" role="tabpanel" aria-labelledby="profileTab" data-analysis-panel="profile">
+        <div class="analysis-section" data-analysis-section="viewport">
+          <div class="analysis-section-heading">
+            <div class="analysis-section-title">Viewport</div>
+            <button class="analysis-drag-handle" type="button" data-analysis-drag="true" title="Drag to reorder. Arrow keys move while focused." aria-label="Move Viewport analysis section"></button>
+          </div>
           <div class="analysis-metrics" id="profileViewportMetrics"></div>
         </div>
-        <div class="analysis-section">
-          <div class="analysis-section-title">Byte Classes</div>
+        <div class="analysis-section" data-analysis-section="classes">
+          <div class="analysis-section-heading">
+            <div class="analysis-section-title">Byte Classes</div>
+            <button class="analysis-drag-handle" type="button" data-analysis-drag="true" title="Drag to reorder. Arrow keys move while focused." aria-label="Move Byte Classes analysis section"></button>
+          </div>
           <div class="analysis-bars" id="profileClassBars"></div>
         </div>
-        <div class="analysis-section">
-          <div class="analysis-section-title">Data Profile</div>
+        <div class="analysis-section" data-analysis-section="data">
+          <div class="analysis-section-heading">
+            <div class="analysis-section-title">Data Profile</div>
+            <button class="analysis-drag-handle" type="button" data-analysis-drag="true" title="Drag to reorder. Arrow keys move while focused." aria-label="Move Data Profile analysis section"></button>
+          </div>
           <div class="analysis-metrics" id="profileDataMetrics"></div>
         </div>
-        <div class="analysis-section">
+        <div class="analysis-section" data-analysis-section="frequency">
           <div class="analysis-section-heading">
             <div class="analysis-section-title">Frequency</div>
-            <button class="analysis-mini-button" id="profileScaleBtn" title="Toggle frequency scale">Linear</button>
+            <div class="analysis-section-actions">
+              <button class="analysis-mini-button" id="profileScaleBtn" title="Toggle frequency scale">Linear</button>
+              <button class="analysis-drag-handle" type="button" data-analysis-drag="true" title="Drag to reorder. Arrow keys move while focused." aria-label="Move Frequency analysis section"></button>
+            </div>
           </div>
           <div class="frequency-chart" id="profileFrequencyChart"></div>
           <div class="analysis-note" id="profileLimitNote"></div>
           <div class="analysis-bars" id="profileByteBars"></div>
         </div>
       </section>
-      <section class="analysis-panel" id="structurePanel" role="tabpanel" aria-labelledby="structureTab">
-        <div class="analysis-section">
-          <div class="analysis-section-title" id="structureScopeTitle">Visible Bytes</div>
+      <section class="analysis-panel" id="structurePanel" role="tabpanel" aria-labelledby="structureTab" data-analysis-panel="structure">
+        <div class="analysis-section" data-analysis-section="visible">
+          <div class="analysis-section-heading">
+            <div class="analysis-section-title" id="structureScopeTitle">Visible Bytes</div>
+            <button class="analysis-drag-handle" type="button" data-analysis-drag="true" title="Drag to reorder. Arrow keys move while focused." aria-label="Move Visible Bytes analysis section"></button>
+          </div>
           <div class="analysis-metrics" id="structureMetrics"></div>
         </div>
-        <div class="analysis-section">
-          <div class="analysis-section-title">History</div>
+        <div class="analysis-section" data-analysis-section="history">
+          <div class="analysis-section-heading">
+            <div class="analysis-section-title">History</div>
+            <button class="analysis-drag-handle" type="button" data-analysis-drag="true" title="Drag to reorder. Arrow keys move while focused." aria-label="Move History analysis section"></button>
+          </div>
           <div class="analysis-metrics" id="structureHistoryMetrics"></div>
         </div>
-        <div class="analysis-section">
-          <div class="analysis-section-title">Timing</div>
+        <div class="analysis-section" data-analysis-section="timing">
+          <div class="analysis-section-heading">
+            <div class="analysis-section-title">Timing</div>
+            <button class="analysis-drag-handle" type="button" data-analysis-drag="true" title="Drag to reorder. Arrow keys move while focused." aria-label="Move Timing analysis section"></button>
+          </div>
           <div class="analysis-metrics" id="profileTimingMetrics"></div>
         </div>
       </section>
@@ -1293,7 +1410,7 @@ export function getWebviewContent(bytesPerRow: number): string {
   </div>
 </div>
 
-<script>
+<script nonce="${escapedNonce}">
 (function () {
   // VS Code webview API
   const vscode = acquireVsCodeApi()
@@ -1305,7 +1422,10 @@ export function getWebviewContent(bytesPerRow: number): string {
   const MIN_SCROLLBAR_THUMB_HEIGHT = 20
   const MAX_PROFILE_BYTES = 64 * 1024
   const INSPECTOR_LOOKAHEAD_BYTES = 8
-  const INSPECTOR_HOVER_DELAY_MS = 420
+  const DEFAULT_ANALYSIS_SECTION_ORDER = {
+    profile: ['viewport', 'classes', 'data', 'frequency'],
+    structure: ['visible', 'history', 'timing'],
+  }
 
   // ── State ───────────────────────────────────────────
   let bufferOffset = 0
@@ -1342,6 +1462,10 @@ export function getWebviewContent(bytesPerRow: number): string {
   let hoveredRowIndex = -1
   let replaceSummaryActive = false
   let analysisMode = 'profile'
+  let analysisSectionOrder = normalizeAnalysisSectionOrder(
+    vscode.getState?.()?.analysisSectionOrder
+  )
+  let analysisDragState = null
   let hoveredFrequencyBar = null
   let viewportSequence = 0
   let lastRenderDurationMs = 0
@@ -1360,12 +1484,15 @@ export function getWebviewContent(bytesPerRow: number): string {
   let transformPluginsRequested = false
   let byteInspectorOffset = -1
   let byteInspectorAnchor = null
-  let byteInspectorHideTimer = null
-  let byteInspectorHoverTimer = null
+  let byteInspectorCandidateOffset = -1
+  let byteInspectorCandidateAnchor = null
   let byteInspectorEditKey = ''
   let byteInspectorEditValue = ''
   let byteInspectorEditError = ''
-  let byteInspectorPinned = false
+  let byteInspectorDragging = false
+  let byteInspectorDragOffsetX = 0
+  let byteInspectorDragOffsetY = 0
+  let byteInspectorManuallyPositioned = false
   let pasteContext = null
   const transformOptionsByPluginId = new Map()
   const renderSamples = []
@@ -1425,6 +1552,7 @@ export function getWebviewContent(bytesPerRow: number): string {
   const transformOptionsField = document.getElementById('transformOptionsField')
   const transformOptionsApply = document.getElementById('transformOptionsApply')
   const transformOptionsCancel = document.getElementById('transformOptionsCancel')
+  const analysisPane = document.getElementById('analysisPane')
   const profileTab = document.getElementById('profileTab')
   const structureTab = document.getElementById('structureTab')
   const profilePanel = document.getElementById('profilePanel')
@@ -1610,6 +1738,26 @@ export function getWebviewContent(bytesPerRow: number): string {
       return []
     }
     return viewportData.slice(index, Math.min(index + length, viewportLength, fileSize - bufferOffset))
+  }
+
+  function byteElementForOffset(offset, pane = activePane) {
+    if (offset < 0) {
+      return null
+    }
+
+    return hexContainer.querySelector('[data-offset="' + offset + '"][data-pane="' + pane + '"]') ??
+      hexContainer.querySelector('[data-offset="' + offset + '"]')
+  }
+
+  function resolveByteInspectorAnchor(offset, preferredAnchor = null) {
+    if (
+      preferredAnchor?.isConnected &&
+      parseInt(preferredAnchor.dataset.offset, 10) === offset
+    ) {
+      return preferredAnchor
+    }
+
+    return byteElementForOffset(offset, preferredAnchor?.dataset?.pane ?? activePane)
   }
 
   function parseBigIntInput(raw) {
@@ -1934,6 +2082,170 @@ export function getWebviewContent(bytesPerRow: number): string {
       read: (bytes, le) => makeDataView(bytes).getFloat64(0, le).toString(),
     },
   ]
+
+  function normalizeAnalysisSectionOrder(rawOrder) {
+    const order = {}
+    Object.entries(DEFAULT_ANALYSIS_SECTION_ORDER).forEach(([panelName, defaults]) => {
+      const saved = Array.isArray(rawOrder?.[panelName]) ? rawOrder[panelName] : []
+      const next = []
+      saved.forEach((sectionId) => {
+        if (defaults.includes(sectionId) && !next.includes(sectionId)) {
+          next.push(sectionId)
+        }
+      })
+      defaults.forEach((sectionId) => {
+        if (!next.includes(sectionId)) {
+          next.push(sectionId)
+        }
+      })
+      order[panelName] = next
+    })
+    return order
+  }
+
+  function analysisPanelElement(panelName) {
+    return panelName === 'structure' ? structurePanel : profilePanel
+  }
+
+  function getAnalysisSection(panelName, sectionId) {
+    return analysisPanelElement(panelName)?.querySelector(
+      '[data-analysis-section="' + sectionId + '"]'
+    ) ?? null
+  }
+
+  function analysisSectionOrderSnapshot() {
+    return {
+      profile: analysisSectionOrder.profile.slice(),
+      structure: analysisSectionOrder.structure.slice(),
+    }
+  }
+
+  function saveAnalysisSectionOrder() {
+    vscode.setState?.({
+      ...(vscode.getState?.() ?? {}),
+      analysisSectionOrder: analysisSectionOrderSnapshot(),
+    })
+  }
+
+  function applyAnalysisSectionOrder(panelName) {
+    const panel = analysisPanelElement(panelName)
+    if (!panel) {
+      return
+    }
+
+    analysisSectionOrder[panelName].forEach((sectionId) => {
+      const section = getAnalysisSection(panelName, sectionId)
+      if (section) {
+        panel.appendChild(section)
+      }
+    })
+  }
+
+  function applyAnalysisSectionOrders() {
+    Object.keys(DEFAULT_ANALYSIS_SECTION_ORDER).forEach(applyAnalysisSectionOrder)
+  }
+
+  function moveAnalysisSection(panelName, sectionId, targetId, placeAfter) {
+    if (!sectionId || !targetId || sectionId === targetId) {
+      return false
+    }
+
+    const order = analysisSectionOrder[panelName]
+    const fromIndex = order.indexOf(sectionId)
+    if (fromIndex < 0 || !order.includes(targetId)) {
+      return false
+    }
+
+    order.splice(fromIndex, 1)
+    const targetIndex = order.indexOf(targetId)
+    order.splice(targetIndex + (placeAfter ? 1 : 0), 0, sectionId)
+    applyAnalysisSectionOrder(panelName)
+    saveAnalysisSectionOrder()
+    return true
+  }
+
+  function moveAnalysisSectionByDelta(panelName, sectionId, delta) {
+    const order = analysisSectionOrder[panelName]
+    const fromIndex = order.indexOf(sectionId)
+    if (fromIndex < 0) {
+      return false
+    }
+
+    const toIndex = clamp(0, fromIndex + delta, order.length - 1)
+    if (toIndex === fromIndex) {
+      return false
+    }
+
+    order.splice(fromIndex, 1)
+    order.splice(toIndex, 0, sectionId)
+    applyAnalysisSectionOrder(panelName)
+    saveAnalysisSectionOrder()
+    getAnalysisSection(panelName, sectionId)
+      ?.querySelector('[data-analysis-drag]')
+      ?.focus()
+    return true
+  }
+
+  function stopAnalysisSectionDrag(pointerId) {
+    if (!analysisDragState) {
+      return
+    }
+
+    analysisDragState.section.classList.remove('dragging')
+    analysisDragState.handle.classList.remove('dragging')
+    if (
+      typeof pointerId === 'number' &&
+      analysisDragState.handle.hasPointerCapture?.(pointerId)
+    ) {
+      analysisDragState.handle.releasePointerCapture(pointerId)
+    }
+    analysisDragState = null
+  }
+
+  function scrollAnalysisPaneDuringDrag(event) {
+    const body = analysisDragState?.section.closest('.analysis-body')
+    if (!body) {
+      return
+    }
+
+    const rect = body.getBoundingClientRect()
+    const edgeSize = 28
+    if (event.clientY < rect.top + edgeSize) {
+      body.scrollTop -= 14
+    } else if (event.clientY > rect.bottom - edgeSize) {
+      body.scrollTop += 14
+    }
+  }
+
+  function handleAnalysisSectionDragMove(event) {
+    if (!analysisDragState) {
+      return
+    }
+
+    event.preventDefault()
+    scrollAnalysisPaneDuringDrag(event)
+    const target = document
+      .elementFromPoint(event.clientX, event.clientY)
+      ?.closest('[data-analysis-section]')
+    if (!target || target === analysisDragState.section) {
+      return
+    }
+
+    const targetPanelName = target.closest('[data-analysis-panel]')
+      ?.dataset.analysisPanel
+    if (targetPanelName !== analysisDragState.panelName) {
+      return
+    }
+
+    const targetId = target.dataset.analysisSection
+    const rect = target.getBoundingClientRect()
+    moveAnalysisSection(
+      analysisDragState.panelName,
+      analysisDragState.sectionId,
+      targetId,
+      event.clientY > rect.top + rect.height / 2
+    )
+  }
 
   function renderMetricRows(target, rows) {
     target.innerHTML = rows
@@ -2417,11 +2729,19 @@ export function getWebviewContent(bytesPerRow: number): string {
       renderMetricRows(profileDataMetrics, [
         { label: 'Scope', value: '-' },
         { label: 'Bytes', value: '-' },
+        { label: 'DOS EOL', value: '-' },
         { label: 'Mode', value: '-' },
         { label: 'ASCII', value: '-' },
         { label: 'Content', value: '-' },
         { label: 'Language', value: '-' },
         { label: 'BOM', value: '-' },
+        { label: 'BOM Bytes', value: '-' },
+        { label: '1B Chars', value: '-' },
+        { label: '2B Chars', value: '-' },
+        { label: '3B Chars', value: '-' },
+        { label: '4B Chars', value: '-' },
+        { label: 'Invalid', value: '-' },
+        { label: 'Profile', value: '-' },
       ])
       profileLimitNote.textContent = ''
       profileFrequencyChart.innerHTML =
@@ -2438,6 +2758,7 @@ export function getWebviewContent(bytesPerRow: number): string {
       ? (latestDataProfile.numAscii / byteTotal) * 100
       : 0
     const characterCount = latestDataProfile.characterCount ?? {}
+    const dosEolCount = latestDataProfile.byteProfile[256] ?? 0
     const topProfileBytes = latestDataProfile.byteProfile
       .slice(0, 256)
       .map((count, byte) => ({ byte, count }))
@@ -2453,11 +2774,17 @@ export function getWebviewContent(bytesPerRow: number): string {
     renderMetricRows(profileDataMetrics, [
       { label: 'Scope', value: latestDataProfile.scopeLabel },
       { label: 'Bytes', value: byteTotal.toLocaleString() },
+      { label: 'DOS EOL', value: dosEolCount.toLocaleString() },
       { label: 'Mode', value: formatModeByte(modeByte, byteTotal) },
       { label: 'ASCII', value: latestDataProfile.numAscii.toLocaleString() + ' / ' + formatPercent(asciiPercent) },
       { label: 'Content', value: latestDataProfile.contentType || '-' },
       { label: 'Language', value: latestDataProfile.language || '-' },
       { label: 'BOM', value: characterCount.byteOrderMark || '-' },
+      { label: 'BOM Bytes', value: (characterCount.byteOrderMarkBytes ?? 0).toLocaleString() },
+      { label: '1B Chars', value: (characterCount.singleByteCount ?? 0).toLocaleString() },
+      { label: '2B Chars', value: (characterCount.doubleByteCount ?? 0).toLocaleString() },
+      { label: '3B Chars', value: (characterCount.tripleByteCount ?? 0).toLocaleString() },
+      { label: '4B Chars', value: (characterCount.quadByteCount ?? 0).toLocaleString() },
       { label: 'Invalid', value: (characterCount.invalidBytes ?? 0).toLocaleString() },
       { label: 'Profile', value: formatDuration(latestDataProfile.durationMs) },
     ])
@@ -2933,11 +3260,11 @@ export function getWebviewContent(bytesPerRow: number): string {
       transformPlugins
       .map((plugin) => {
         const label = escapeHtml(plugin.name || plugin.id)
-        const title = escapeHtml(
+        const title = escapeAttribute(
           (plugin.description || plugin.id) +
           ' (' + transformOperationLabel(plugin.operation) + ')'
         )
-        return '<option value="' + escapeHtml(plugin.id) + '" title="' + title + '">' + label + '</option>'
+        return '<option value="' + escapeAttribute(plugin.id) + '" title="' + title + '">' + label + '</option>'
       })
       .join('')
 
@@ -3081,49 +3408,23 @@ export function getWebviewContent(bytesPerRow: number): string {
       ' | u32' + endianLabel + ' ' + (u32 === null ? '-' : u32.toLocaleString())
   }
 
-  function cancelByteInspectorTimers() {
-    if (byteInspectorHoverTimer) {
-      clearTimeout(byteInspectorHoverTimer)
-      byteInspectorHoverTimer = null
-    }
-    if (byteInspectorHideTimer) {
-      clearTimeout(byteInspectorHideTimer)
-      byteInspectorHideTimer = null
-    }
-  }
-
   function hideByteInspector() {
-    cancelByteInspectorTimers()
     byteInspector.classList.remove('active')
-    byteInspector.classList.remove('pinned')
     byteInspector.innerHTML = ''
     byteInspectorOffset = -1
     byteInspectorAnchor = null
     byteInspectorEditKey = ''
     byteInspectorEditValue = ''
     byteInspectorEditError = ''
-    byteInspectorPinned = false
-  }
-
-  function scheduleByteInspectorHide() {
-    if (byteInspectorPinned) {
-      return
-    }
-    if (byteInspectorHideTimer) {
-      clearTimeout(byteInspectorHideTimer)
-    }
-    byteInspectorHideTimer = setTimeout(() => {
-      if (!byteInspector.matches(':hover')) {
-        hideByteInspector()
-      }
-    }, 160)
+    byteInspectorManuallyPositioned = false
+    updateRenderedInspectorAnchor()
   }
 
   function positionByteInspector(anchor) {
     if (!anchor || !byteInspector.classList.contains('active')) {
       return
     }
-    if (byteInspectorPinned && byteInspector.style.left && byteInspector.style.top) {
+    if (byteInspectorManuallyPositioned) {
       return
     }
 
@@ -3158,7 +3459,6 @@ export function getWebviewContent(bytesPerRow: number): string {
 
     const le = inspectorLittleEndian
     const endianLabel = le ? 'LE' : 'BE'
-    const pinnedLabel = byteInspectorPinned ? 'Pinned' : 'Pin'
     let rows = ''
 
     for (const field of inspectorFields) {
@@ -3194,10 +3494,9 @@ export function getWebviewContent(bytesPerRow: number): string {
       '<div class="byte-inspector-header">' +
         '<span>' +
           '<span class="byte-inspector-title">' + escapeHtml(formatOffsetDisplay(byteInspectorOffset)) + '</span>' +
-          '<span class="byte-inspector-meta"> ' + escapeHtml(bytesToSpacedHex(bytes)) + '</span>' +
+          '<span class="byte-inspector-meta">' + escapeHtml(bytesToSpacedHex(bytes)) + '</span>' +
         '</span>' +
         '<span class="byte-inspector-actions">' +
-          '<button class="status-inline-button' + (byteInspectorPinned ? ' active' : '') + '" data-inspector-pin="true" title="Toggle pinned inspector with Space">' + pinnedLabel + '</button>' +
           '<button class="status-inline-button" data-inspector-endian="true" title="Toggle inspector endianness">' + endianLabel + '</button>' +
         '</span>' +
       '</div>' +
@@ -3205,7 +3504,11 @@ export function getWebviewContent(bytesPerRow: number): string {
       '<div class="byte-inspector-error">' + escapeHtml(byteInspectorEditError) + '</div>'
 
     byteInspector.classList.add('active')
-    byteInspector.classList.toggle('pinned', byteInspectorPinned)
+    byteInspectorAnchor = resolveByteInspectorAnchor(
+      byteInspectorOffset,
+      byteInspectorAnchor
+    )
+    updateRenderedInspectorAnchor()
     positionByteInspector(byteInspectorAnchor)
 
     const input = document.getElementById('byteInspectorInput')
@@ -3216,38 +3519,49 @@ export function getWebviewContent(bytesPerRow: number): string {
   }
 
   function showByteInspector(offset, anchor) {
-    cancelByteInspectorTimers()
+    const resolvedAnchor = resolveByteInspectorAnchor(offset, anchor)
+    if (!resolvedAnchor) {
+      return false
+    }
     byteInspectorOffset = offset
-    byteInspectorAnchor = anchor
+    byteInspectorAnchor = resolvedAnchor
     byteInspectorEditKey = ''
     byteInspectorEditValue = ''
     byteInspectorEditError = ''
-    byteInspectorPinned = false
+    byteInspectorManuallyPositioned = false
     renderByteInspector()
+    return true
   }
 
-  function scheduleByteInspector(offset, anchor) {
-    if (byteInspectorPinned) {
-      return
+  function setByteInspectorCandidate(offset, anchor) {
+    byteInspectorCandidateOffset = offset
+    byteInspectorCandidateAnchor = anchor
+  }
+
+  function clearByteInspectorCandidate() {
+    byteInspectorCandidateOffset = -1
+    byteInspectorCandidateAnchor = null
+  }
+
+  function byteInspectorLaunchTarget() {
+    const activeInspector = byteInspector.classList.contains('active')
+    const offset = activeInspector && byteInspectorOffset >= 0
+      ? byteInspectorOffset
+      : byteInspectorCandidateOffset >= 0
+        ? byteInspectorCandidateOffset
+        : selectedOffset
+
+    if (offset < 0 || getInspectorBytes(offset).length === 0) {
+      return null
     }
-    if (isPointerSelecting || !anchor) {
-      hideByteInspector()
-      return
-    }
-    if (byteInspectorOffset === offset && byteInspector.classList.contains('active')) {
-      byteInspectorAnchor = anchor
-      positionByteInspector(anchor)
-      return
-    }
-    if (byteInspector.classList.contains('active')) {
-      hideByteInspector()
-    }
-    if (byteInspectorHoverTimer) {
-      clearTimeout(byteInspectorHoverTimer)
-    }
-    byteInspectorHoverTimer = setTimeout(() => {
-      showByteInspector(offset, anchor)
-    }, INSPECTOR_HOVER_DELAY_MS)
+
+    const preferredAnchor = activeInspector && offset === byteInspectorOffset
+      ? byteInspectorAnchor
+      : byteInspectorCandidateOffset === offset
+        ? byteInspectorCandidateAnchor
+        : null
+    const anchor = resolveByteInspectorAnchor(offset, preferredAnchor)
+    return anchor ? { offset, anchor } : null
   }
 
   function commitByteInspectorEdit(fieldKey) {
@@ -3267,14 +3581,10 @@ export function getWebviewContent(bytesPerRow: number): string {
       })
       selectRange(byteInspectorOffset, data.length / 2)
       updateActionStatus('Wrote ' + (data.length / 2).toLocaleString() + ' byte(s)')
-      if (byteInspectorPinned) {
-        byteInspectorEditKey = ''
-        byteInspectorEditValue = ''
-        byteInspectorEditError = ''
-        renderByteInspector()
-      } else {
-        hideByteInspector()
-      }
+      byteInspectorEditKey = ''
+      byteInspectorEditValue = ''
+      byteInspectorEditError = ''
+      renderByteInspector()
     } catch (error) {
       byteInspectorEditValue = input.value
       byteInspectorEditError = error instanceof Error ? error.message : String(error)
@@ -3282,14 +3592,32 @@ export function getWebviewContent(bytesPerRow: number): string {
     }
   }
 
-  function toggleByteInspectorPinned(forcePinned) {
-    if (!byteInspector.classList.contains('active')) {
+  function toggleByteInspector() {
+    if (byteInspector.classList.contains('active')) {
+      hideByteInspector()
+      return true
+    }
+    const target = byteInspectorLaunchTarget()
+    if (!target) {
+      return false
+    }
+    return showByteInspector(target.offset, target.anchor)
+  }
+
+  function stopByteInspectorDrag(pointerId) {
+    if (!byteInspectorDragging) {
       return
     }
-    byteInspectorPinned =
-      typeof forcePinned === 'boolean' ? forcePinned : !byteInspectorPinned
-    cancelByteInspectorTimers()
-    renderByteInspector()
+    byteInspectorDragging = false
+    byteInspector
+      .querySelector('.byte-inspector-header')
+      ?.classList.remove('dragging')
+    if (
+      typeof pointerId === 'number' &&
+      byteInspector.hasPointerCapture?.(pointerId)
+    ) {
+      byteInspector.releasePointerCapture(pointerId)
+    }
   }
 
   function updateProgressStatus() {
@@ -3541,6 +3869,26 @@ export function getWebviewContent(bytesPerRow: number): string {
       const offset = parseInt(el.dataset.offset, 10)
       el.classList.toggle('selected', !Number.isNaN(offset) && offsetIsSelected(offset))
     })
+  }
+
+  function updateRenderedInspectorAnchor() {
+    if (!hexContainer) {
+      return
+    }
+
+    hexContainer
+      .querySelectorAll('.inspector-anchor')
+      .forEach((el) => el.classList.remove('inspector-anchor'))
+
+    const hasActiveInspector =
+      byteInspectorOffset >= 0 && byteInspector.classList.contains('active')
+    if (!hasActiveInspector) {
+      return
+    }
+
+    hexContainer
+      .querySelectorAll('[data-offset="' + byteInspectorOffset + '"]')
+      .forEach((el) => el.classList.add('inspector-anchor'))
   }
 
   function selectOffset(offset, extendSelection = false) {
@@ -4521,25 +4869,25 @@ export function getWebviewContent(bytesPerRow: number): string {
   hexContainer.addEventListener('pointermove', (e) => {
     const target = e.target.closest('[data-offset]')
     if (!target) {
+      clearByteInspectorCandidate()
       updateHoverHighlights(-1, -1)
-      scheduleByteInspectorHide()
       return
     }
 
     const offset = parseInt(target.dataset.offset, 10)
     if (Number.isNaN(offset)) {
+      clearByteInspectorCandidate()
       updateHoverHighlights(-1, -1)
-      scheduleByteInspectorHide()
       return
     }
 
+    setByteInspectorCandidate(offset, target)
     const row = target.closest('.hex-row')
     const rowIndex = row ? parseInt(row.dataset.rowIndex, 10) : -1
     updateHoverHighlights(
       Number.isNaN(rowIndex) ? -1 : rowIndex,
       offset % BYTES_PER_ROW
     )
-    scheduleByteInspector(offset, target)
 
     if (isPointerSelecting && (e.buttons & 1) === 1) {
       selectOffset(offset, true)
@@ -4547,8 +4895,8 @@ export function getWebviewContent(bytesPerRow: number): string {
   })
 
   hexContainer.addEventListener('pointerleave', () => {
+    clearByteInspectorCandidate()
     updateHoverHighlights(-1, -1)
-    scheduleByteInspectorHide()
   })
 
   hexContainer.addEventListener('pointerdown', (e) => {
@@ -4567,6 +4915,7 @@ export function getWebviewContent(bytesPerRow: number): string {
     }
 
     e.preventDefault()
+    setByteInspectorCandidate(offset, target)
     hideByteInspector()
     setActivePane(target.dataset.pane)
     selectOffset(offset, e.shiftKey)
@@ -4642,6 +4991,12 @@ export function getWebviewContent(bytesPerRow: number): string {
   // ── Keyboard Shortcuts ──────────────────────────────
 
   document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && transformOptionsDialog.classList.contains('active')) {
+      e.preventDefault()
+      closeTransformOptionsDialog()
+      return
+    }
+
     if (isEditableTarget(e.target)) {
       return
     }
@@ -4649,9 +5004,10 @@ export function getWebviewContent(bytesPerRow: number): string {
     if (e.key === 'Escape' && pastePopover.classList.contains('active')) {
       e.preventDefault()
       hidePastePopover()
-    } else if (e.key === ' ' && byteInspector.classList.contains('active')) {
-      e.preventDefault()
-      toggleByteInspectorPinned()
+    } else if (e.shiftKey && e.key === ' ') {
+      if (toggleByteInspector()) {
+        e.preventDefault()
+      }
     } else if (e.key === 'Escape' && byteInspector.classList.contains('active')) {
       e.preventDefault()
       hideByteInspector()
@@ -4881,17 +5237,60 @@ export function getWebviewContent(bytesPerRow: number): string {
     frequencyScale = frequencyScale === 'log' ? 'linear' : 'log'
     updateProfileAnalysis()
   })
-  profileFrequencyChart.addEventListener('pointermove', updateFrequencyTooltip)
-  profileFrequencyChart.addEventListener('pointerleave', hideFrequencyTooltip)
-  byteInspector.addEventListener('pointerenter', cancelByteInspectorTimers)
-  byteInspector.addEventListener('pointerleave', scheduleByteInspectorHide)
-  byteInspector.addEventListener('click', (e) => {
-    const pinToggle = e.target.closest('[data-inspector-pin]')
-    if (pinToggle) {
-      toggleByteInspectorPinned()
+  analysisPane.addEventListener('pointerdown', (e) => {
+    const handle = e.target.closest('[data-analysis-drag]')
+    if (!handle || e.button !== 0) {
       return
     }
 
+    const section = handle.closest('[data-analysis-section]')
+    const panel = section?.closest('[data-analysis-panel]')
+    const panelName = panel?.dataset.analysisPanel
+    const sectionId = section?.dataset.analysisSection
+    if (!section || !panelName || !sectionId) {
+      return
+    }
+
+    e.preventDefault()
+    analysisDragState = {
+      handle,
+      panelName,
+      section,
+      sectionId,
+    }
+    section.classList.add('dragging')
+    handle.classList.add('dragging')
+    handle.setPointerCapture(e.pointerId)
+  })
+  analysisPane.addEventListener('pointermove', handleAnalysisSectionDragMove)
+  analysisPane.addEventListener('pointerup', (e) => {
+    stopAnalysisSectionDrag(e.pointerId)
+  })
+  analysisPane.addEventListener('pointercancel', (e) => {
+    stopAnalysisSectionDrag(e.pointerId)
+  })
+  analysisPane.addEventListener('keydown', (e) => {
+    const handle = e.target.closest('[data-analysis-drag]')
+    if (!handle) {
+      return
+    }
+
+    const section = handle.closest('[data-analysis-section]')
+    const panelName = section?.closest('[data-analysis-panel]')?.dataset.analysisPanel
+    const sectionId = section?.dataset.analysisSection
+    if (!panelName || !sectionId) {
+      return
+    }
+
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      if (moveAnalysisSectionByDelta(panelName, sectionId, e.key === 'ArrowUp' ? -1 : 1)) {
+        e.preventDefault()
+      }
+    }
+  })
+  profileFrequencyChart.addEventListener('pointermove', updateFrequencyTooltip)
+  profileFrequencyChart.addEventListener('pointerleave', hideFrequencyTooltip)
+  byteInspector.addEventListener('click', (e) => {
     const endianToggle = e.target.closest('[data-inspector-endian]')
     if (endianToggle) {
       inspectorLittleEndian = !inspectorLittleEndian
@@ -4941,15 +5340,41 @@ export function getWebviewContent(bytesPerRow: number): string {
         byteInspectorEditValue = ''
         byteInspectorEditError = ''
         renderByteInspector()
-      } else if (byteInspectorPinned) {
-        toggleByteInspectorPinned(false)
       } else {
         hideByteInspector()
       }
-    } else if (e.key === ' ' && e.target.id !== 'byteInspectorInput') {
+    } else if (e.shiftKey && e.key === ' ' && e.target.id !== 'byteInspectorInput') {
       e.preventDefault()
-      toggleByteInspectorPinned()
+      toggleByteInspector()
     }
+  })
+  byteInspector.addEventListener('pointerdown', (e) => {
+    const header = e.target.closest('.byte-inspector-header')
+    if (!header || e.button !== 0) {
+      return
+    }
+    e.preventDefault()
+    byteInspectorDragging = true
+    byteInspectorDragOffsetX = e.clientX - parseFloat(byteInspector.style.left || '0')
+    byteInspectorDragOffsetY = e.clientY - parseFloat(byteInspector.style.top || '0')
+    header.classList.add('dragging')
+    byteInspector.setPointerCapture(e.pointerId)
+  })
+  byteInspector.addEventListener('pointermove', (e) => {
+    if (!byteInspectorDragging) {
+      return
+    }
+    const newLeft = clamp(0, e.clientX - byteInspectorDragOffsetX, window.innerWidth - byteInspector.offsetWidth)
+    const newTop = clamp(0, e.clientY - byteInspectorDragOffsetY, window.innerHeight - byteInspector.offsetHeight)
+    byteInspector.style.left = newLeft + 'px'
+    byteInspector.style.top = newTop + 'px'
+    byteInspectorManuallyPositioned = true
+  })
+  byteInspector.addEventListener('pointerup', (e) => {
+    stopByteInspectorDrag(e.pointerId)
+  })
+  byteInspector.addEventListener('pointercancel', (e) => {
+    stopByteInspectorDrag(e.pointerId)
   })
   bytesPerRowSelect.addEventListener('change', () => {
     const nextBytesPerRow = parseInt(bytesPerRowSelect.value, 10)
@@ -5142,6 +5567,7 @@ export function getWebviewContent(bytesPerRow: number): string {
   updateOffsetStatus()
   updateSelectedStatus()
   updateProgressStatus()
+  applyAnalysisSectionOrders()
   updateAnalysisTabs()
   updateAnalysisPanels()
   renderColumnHeader()

--- a/examples/vscode-extension/tests/extension.test.js
+++ b/examples/vscode-extension/tests/extension.test.js
@@ -65,6 +65,10 @@ test('package.json matches shared extension constants', () => {
     OMEGA_EDIT_EXPORT_CHANGE_SCRIPT_COMMAND
   )
   assert.equal(
+    packageJson.contributes.commands[4].enablement,
+    'omegaEdit.hexEditorActive && omegaEdit.hasPendingChanges'
+  )
+  assert.equal(
     packageJson.contributes.commands[5].command,
     OMEGA_EDIT_REPLAY_CHANGE_SCRIPT_COMMAND
   )
@@ -188,6 +192,39 @@ test('compiled extension entrypoints exist after build', () => {
 test('webview HTML includes core controls and configured row width', () => {
   const html = getWebviewContent(32)
 
+  assert.match(html, /http-equiv="Content-Security-Policy"/)
+  assert.match(html, /default-src 'none'/)
+  assert.match(html, /img-src 'self' data:/)
+  assert.match(html, /style-src 'self' 'unsafe-inline'/)
+  assert.doesNotMatch(html, /&#39;self&#39;/)
+  assert.match(html, /script-src 'nonce-[^']+'/)
+  assert.match(html, /<script nonce="[^"]+">/)
+  assert.match(
+    html,
+    /--accent-frame: var\(--vscode-contrastActiveBorder, #cca700\);/
+  )
+  assert.match(html, /\.byte-inspector-header \{[\s\S]*cursor: grab;/)
+  assert.doesNotMatch(html, /data-inspector-pin/)
+  assert.match(
+    html,
+    /\.status-inline-button\.active \{[\s\S]*border-color: var\(--accent-frame\);/
+  )
+  assert.match(
+    html,
+    /button\.byte-inspector-value:hover,[\s\S]*border-color: var\(--accent-frame\);/
+  )
+  assert.match(
+    html,
+    /\.byte-inspector-meta \{[\s\S]*border: 1px solid var\(--accent-frame\);/
+  )
+  assert.match(
+    html,
+    /\.hex-byte\.inspector-anchor \{[\s\S]*background: var\(--accent-frame-bg\);/
+  )
+  assert.match(
+    html,
+    /\.ascii-char\.inspector-anchor \{[\s\S]*background: var\(--accent-frame-bg\);/
+  )
   assert.match(html, /const BYTES_PER_ROW = 32/)
   assert.match(html, /id="hexContainer"/)
   assert.match(html, /id="hexHeader"/)
@@ -226,6 +263,13 @@ test('webview HTML includes core controls and configured row width', () => {
   assert.match(html, /id="serverHealthBadge"/)
   assert.match(html, /id="serverHealthMetrics"/)
   assert.match(html, /id="analysisPane"/)
+  assert.match(html, /data-analysis-panel="profile"/)
+  assert.match(html, /data-analysis-panel="structure"/)
+  assert.match(html, /data-analysis-section="viewport"/)
+  assert.match(html, /data-analysis-section="frequency"/)
+  assert.match(html, /data-analysis-section="timing"/)
+  assert.match(html, /data-analysis-drag="true"/)
+  assert.match(html, /\.analysis-drag-handle \{[\s\S]*cursor: grab;/)
   assert.match(html, /id="profileTab"/)
   assert.match(html, /id="structureTab"/)
   assert.match(html, /aria-controls="profilePanel"/)
@@ -333,6 +377,15 @@ test('webview HTML includes core controls and configured row width', () => {
   assert.match(html, /function renderTransformOptionsDialog\(\)/)
   assert.match(html, /transformSelect\.addEventListener\('pointerdown'/)
   assert.match(html, /transformSelect\.addEventListener\('change'/)
+  assert.match(
+    html,
+    /e\.key === 'Escape' && transformOptionsDialog\.classList\.contains\('active'\)[\s\S]*closeTransformOptionsDialog\(\)/
+  )
+  assert.match(
+    html,
+    /e\.shiftKey && e\.key === ' '\) \{[\s\S]*if \(toggleByteInspector\(\)\)/
+  )
+  assert.doesNotMatch(html, /Toggle pinned inspector/)
   assert.match(html, /function useTransformOptionExample\(index\)/)
   assert.match(html, /function advertisedTransformExamples\(plugin\)/)
   assert.match(
@@ -442,6 +495,18 @@ test('webview HTML includes core controls and configured row width', () => {
   assert.match(html, /function updateDirtyStatus\(isDirty\)/)
   assert.match(html, /function updateInspectorEndianLabel\(\)/)
   assert.match(html, /function updateInspectorStatus\(\)/)
+  assert.match(html, /function updateRenderedInspectorAnchor\(\)/)
+  assert.match(html, /querySelectorAll\('\.inspector-anchor'\)/)
+  assert.match(
+    html,
+    /querySelectorAll\('\[data-offset="' \+ byteInspectorOffset/
+  )
+  assert.match(html, /function byteInspectorLaunchTarget\(\)/)
+  assert.match(html, /function stopByteInspectorDrag\(pointerId\)/)
+  assert.match(
+    html,
+    /byteInspector\.addEventListener\('pointercancel'[\s\S]*stopByteInspectorDrag\(e\.pointerId\)/
+  )
   assert.match(html, /inspectorEndianBtn\.addEventListener\('click'/)
   assert.match(html, /inspectorLittleEndian = !inspectorLittleEndian/)
   assert.match(html, /u16' \+ endianLabel/)
@@ -478,6 +543,46 @@ test('webview HTML includes core controls and configured row width', () => {
   assert.match(html, /case 'analysisProfile'/)
   assert.match(html, /byteProfile/)
   assert.match(html, /characterCount/)
+  assert.match(html, /label: 'DOS EOL', value: dosEolCount\.toLocaleString\(\)/)
+  assert.match(
+    html,
+    /const dosEolCount = latestDataProfile\.byteProfile\[256\] \?\? 0/
+  )
+  assert.match(
+    html,
+    /label: 'BOM Bytes', value: \(characterCount\.byteOrderMarkBytes \?\? 0\)\.toLocaleString\(\)/
+  )
+  assert.match(
+    html,
+    /label: '1B Chars', value: \(characterCount\.singleByteCount \?\? 0\)\.toLocaleString\(\)/
+  )
+  assert.match(
+    html,
+    /label: '2B Chars', value: \(characterCount\.doubleByteCount \?\? 0\)\.toLocaleString\(\)/
+  )
+  assert.match(
+    html,
+    /label: '3B Chars', value: \(characterCount\.tripleByteCount \?\? 0\)\.toLocaleString\(\)/
+  )
+  assert.match(
+    html,
+    /label: '4B Chars', value: \(characterCount\.quadByteCount \?\? 0\)\.toLocaleString\(\)/
+  )
+  assert.match(html, /DEFAULT_ANALYSIS_SECTION_ORDER/)
+  assert.match(html, /function normalizeAnalysisSectionOrder\(rawOrder\)/)
+  assert.match(
+    html,
+    /function moveAnalysisSection\(panelName, sectionId, targetId, placeAfter\)/
+  )
+  assert.match(
+    html,
+    /function moveAnalysisSectionByDelta\(panelName, sectionId, delta\)/
+  )
+  assert.match(html, /function handleAnalysisSectionDragMove\(event\)/)
+  assert.match(html, /analysisPane\.addEventListener\('pointerdown'/)
+  assert.match(html, /analysisPane\.addEventListener\('pointercancel'/)
+  assert.match(html, /analysisPane\.addEventListener\('keydown'/)
+  assert.match(html, /vscode\.setState\?\.\(/)
   assert.match(html, /profileTab\.addEventListener\('click'/)
   assert.match(html, /structureTab\.addEventListener\('click'/)
   assert.match(html, /profileScaleBtn\.addEventListener\('click'/)


### PR DESCRIPTION
## Summary

- Remove hover-triggered inspector - the mouse-over delay was unreliable; replaced exclusively with Shift+Space
- Remove Pin button - pinning is now implicit; header retains only the endianness toggle
- Add drag-to-move - the inspector header is draggable; position locks after first drag, resets on re-open
- Esc always closes the inspector

## Test plan

- [ ] Shift+Space opens inspector at hovered or selected byte
- [ ] Shift+Space again closes it
- [ ] Dragging the header repositions the pane and it stays put on re-render
- [ ] Esc dismisses the pane
- [ ] Inline field edits commit and keep the pane open
- [ ] Esc inside an edit field cancels without closing the pane
- [ ] Endianness toggle still works
- [ ] No hover-triggered popups appear on mouse-over

Generated with Claude Code