### PR TITLE
Use Unix sockets on POSIX

### DIFF
--- a/examples/vscode-extension/README.md
+++ b/examples/vscode-extension/README.md
@@ -75,7 +75,7 @@ Current implementation note:
 - `EditorSessionModel` owns live session metadata and sync waiters.
 - `EditorHistoryController` and `EditorSearchController` own the reusable undo/save-state and large-search behavior.
 
-1. `activate()` reads the `omegaEdit.serverPort` setting and starts the bundled native server through `@omega-edit/client`.
+1. `activate()` starts the bundled native server through `@omega-edit/client`, using a Unix domain socket by default on macOS/Linux and TCP on Windows or when a port is explicitly configured. On Linux, the socket path is created under `XDG_RUNTIME_DIR` when available. Windows stays on TCP until the Node/gRPC stack supports Windows AF_UNIX reliably.
 2. Opening a file creates an Ωedit™ session and viewport, then uses the client-managed heartbeat and subscription helpers for the steady-state connection wiring.
 3. The native server now uses server-managed checkpoint directories under the host temp directory for auto-managed sessions, which keeps checkpoint artifacts out of the source file's folder and makes cleanup predictable.
 4. The webview drives edits, navigation, search, replace, and transforms through the provider, while native VS Code actions handle undo, redo, save, save-as, and status-bar presentation. The provider pushes back reactive state updates for the viewport, Structure-pane undo/redo counts, dirty state, replace counts, transform results, and server health. Transform option help, examples, defaults, and JSON Schema validation come from the plugin metadata rather than hardcoded webview logic.
@@ -95,7 +95,7 @@ This mode decision is made only when the user runs an explicit search. If a repl
 
 | Setting                 | Default | Description                                                                |
 | ----------------------- | ------- | -------------------------------------------------------------------------- |
-| `omegaEdit.serverPort`  | `9000`  | gRPC server port                                                           |
+| `omegaEdit.serverPort`  | `9000`  | TCP gRPC server port; setting this explicitly opts out of the default macOS/Linux Unix socket transport |
 | `omegaEdit.logLevel`    | `info`  | Client log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`) |
 | `omegaEdit.bytesPerRow` | `16`    | Bytes displayed per row (8 / 16 / 32)                                      |
 | `omegaEdit.transformPluginDirectories` | `[]` | Native transform plugin directories; local build plugin folders are auto-detected when this is empty |

--- a/examples/vscode-extension/package.nls.json
+++ b/examples/vscode-extension/package.nls.json
@@ -3,7 +3,7 @@
   "omegaEdit.description": "A minimal reference hex/data editor VS Code extension powered by Ωedit™",
   "omegaEdit.customEditor.displayName": "Ωedit™ Hex Editor",
   "omegaEdit.configuration.title": "Ωedit™ Hex Editor",
-  "omegaEdit.configuration.serverPort.description": "Port for the OmegaEdit gRPC server",
+  "omegaEdit.configuration.serverPort.description": "TCP port for the OmegaEdit gRPC server; explicitly setting it opts out of Unix socket transport on macOS/Linux",
   "omegaEdit.configuration.logLevel.description": "Log level for the OmegaEdit client",
   "omegaEdit.configuration.bytesPerRow.description": "Number of bytes displayed per row in the hex view",
   "omegaEdit.configuration.transformPluginDirectories.description": "Directories containing OmegaEdit transform plugin shared libraries",

--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getClient, startServer, stopServerGraceful } from '@omega-edit/client'
+import {
+  getClient,
+  startServer,
+  startServerUnixSocket,
+  stopServerGraceful,
+} from '@omega-edit/client'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
@@ -45,9 +50,13 @@ import {
 import { HexEditorProvider } from './hexEditorProvider'
 
 let activeProvider: HexEditorProvider | undefined
+let activeServerSocketPath: string | undefined
 
 const DEFAULT_SERVER_PORT = 9000
 const SERVER_PORT_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_PORT'
+const SERVER_SOCKET_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_SOCKET'
+const UNIX_SOCKET_UNSUPPORTED_MESSAGE =
+  'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
 const VALID_LOG_LEVELS = new Set([
   'trace',
   'debug',
@@ -56,6 +65,19 @@ const VALID_LOG_LEVELS = new Set([
   'error',
   'fatal',
 ])
+
+type ServerConnection =
+  | { kind: 'tcp'; port: number }
+  | {
+      kind: 'unix'
+      port: number
+      socketPath: string
+    }
+
+interface StartedServer {
+  connection: ServerConnection
+  serverPid: number | undefined
+}
 
 function parseServerPort(value: unknown): number | undefined {
   if (typeof value === 'number') {
@@ -212,6 +234,48 @@ function isTestRuntime(): boolean {
   return process.env.NODE_ENV === 'test'
 }
 
+function hasExplicitServerPortConfiguration(
+  config: vscode.WorkspaceConfiguration
+): boolean {
+  const inspected = config.inspect<unknown>('serverPort')
+  return !!(
+    inspected &&
+    (inspected.globalValue !== undefined ||
+      inspected.workspaceValue !== undefined ||
+      inspected.workspaceFolderValue !== undefined ||
+      inspected.globalLanguageValue !== undefined ||
+      inspected.workspaceLanguageValue !== undefined ||
+      inspected.workspaceFolderLanguageValue !== undefined)
+  )
+}
+
+function platformCanAttemptUnixSocket(): boolean {
+  return process.platform === 'darwin' || process.platform === 'linux'
+}
+
+function resolveServerSocketOverride(): string | undefined {
+  const value = process.env[SERVER_SOCKET_OVERRIDE_ENV]?.trim()
+  return value && value.length > 0 ? value : undefined
+}
+
+function getDefaultServerSocketDirectory(): string {
+  if (process.platform === 'linux') {
+    const xdgRuntimeDir = process.env.XDG_RUNTIME_DIR?.trim()
+    if (xdgRuntimeDir && path.isAbsolute(xdgRuntimeDir)) {
+      return path.join(xdgRuntimeDir, 'omega-edit')
+    }
+  }
+
+  return os.tmpdir()
+}
+
+function getDefaultServerSocketPath(): string {
+  return path.join(
+    getDefaultServerSocketDirectory(),
+    `omega-edit-vscode-${process.pid}.sock`
+  )
+}
+
 function resolveServerPort(config: vscode.WorkspaceConfiguration): number {
   const envPort = parseServerPort(process.env[SERVER_PORT_OVERRIDE_ENV])
   if (envPort !== undefined) {
@@ -221,6 +285,110 @@ function resolveServerPort(config: vscode.WorkspaceConfiguration): number {
   return (
     parseServerPort(config.get<unknown>('serverPort')) ?? DEFAULT_SERVER_PORT
   )
+}
+
+function resolveServerConnection(
+  config: vscode.WorkspaceConfiguration
+): ServerConnection {
+  const socketOverride = resolveServerSocketOverride()
+  if (socketOverride !== undefined) {
+    if (!platformCanAttemptUnixSocket()) {
+      throw new Error(UNIX_SOCKET_UNSUPPORTED_MESSAGE)
+    }
+
+    return {
+      kind: 'unix',
+      port: DEFAULT_SERVER_PORT,
+      socketPath: socketOverride,
+    }
+  }
+
+  const envPort = parseServerPort(process.env[SERVER_PORT_OVERRIDE_ENV])
+  if (envPort !== undefined) {
+    return { kind: 'tcp', port: envPort }
+  }
+
+  if (hasExplicitServerPortConfiguration(config)) {
+    const configuredPort = parseServerPort(config.get<unknown>('serverPort'))
+    if (configuredPort !== undefined) {
+      return { kind: 'tcp', port: configuredPort }
+    }
+  }
+
+  if (platformCanAttemptUnixSocket()) {
+    return {
+      kind: 'unix',
+      port: DEFAULT_SERVER_PORT,
+      socketPath: getDefaultServerSocketPath(),
+    }
+  }
+
+  return { kind: 'tcp', port: resolveServerPort(config) }
+}
+
+function toErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function toTcpConnection(connection: ServerConnection): ServerConnection {
+  return { kind: 'tcp', port: connection.port }
+}
+
+function removeServerSocketFile(socketPath: string): void {
+  try {
+    fs.unlinkSync(socketPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn(
+        `Failed to remove OmegaEdit server socket ${socketPath}: ${toErrorMessage(err)}`
+      )
+    }
+  }
+}
+
+async function startTcpServerConnection(
+  connection: ServerConnection,
+  transformPluginDirectories: string[]
+): Promise<StartedServer> {
+  const tcpConnection = toTcpConnection(connection)
+  return {
+    connection: tcpConnection,
+    serverPid: await startServer(tcpConnection.port, undefined, undefined, {
+      transformPluginDirectories,
+    }),
+  }
+}
+
+async function startServerConnection(
+  connection: ServerConnection,
+  transformPluginDirectories: string[]
+): Promise<StartedServer> {
+  if (connection.kind === 'tcp') {
+    return startTcpServerConnection(connection, transformPluginDirectories)
+  }
+
+  return {
+    connection,
+    serverPid: await startServerUnixSocket(
+      connection.socketPath,
+      undefined,
+      true,
+      connection.port,
+      undefined,
+      { transformPluginDirectories }
+    ),
+  }
+}
+
+async function connectToServer(connection: ServerConnection): Promise<void> {
+  if (connection.kind === 'unix') {
+    await getClient(connection.port, undefined, {
+      socketPath: connection.socketPath,
+    })
+    return
+  }
+
+  await getClient(connection.port)
 }
 
 function resolveLogLevel(config: vscode.WorkspaceConfiguration): string {
@@ -280,7 +448,18 @@ export async function activate(
   context: vscode.ExtensionContext
 ): Promise<OmegaEditExtensionApi | undefined> {
   const config = vscode.workspace.getConfiguration('omegaEdit')
-  const port = resolveServerPort(config)
+
+  let connection: ServerConnection
+  try {
+    connection = resolveServerConnection(config)
+  } catch (err) {
+    reportActivationError(
+      vscode.l10n.t('Failed to start Ωedit™ server: {message}', {
+        message: toErrorMessage(err),
+      })
+    )
+    return
+  }
 
   const logLevel = resolveLogLevel(config)
   process.env.OMEGA_EDIT_CLIENT_LOG_LEVEL = logLevel
@@ -289,40 +468,62 @@ export async function activate(
     config
   )
 
-  let serverPid: number | undefined
+  let startedServer: StartedServer
   try {
-    serverPid = await startServer(port, undefined, undefined, {
-      transformPluginDirectories,
-    })
-    if (serverPid && !isTestRuntime()) {
-      void vscode.window.showInformationMessage(
-        vscode.l10n.t('Ωedit™ server started on port {port} (pid {pid})', {
-          port,
-          pid: serverPid,
-        })
-      )
-    }
+    startedServer = await startServerConnection(
+      connection,
+      transformPluginDirectories
+    )
+    activeServerSocketPath =
+      startedServer.connection.kind === 'unix'
+        ? startedServer.connection.socketPath
+        : undefined
   } catch (err) {
     reportActivationError(
       vscode.l10n.t('Failed to start Ωedit™ server: {message}', {
-        message: err instanceof Error ? err.message : String(err),
+        message: toErrorMessage(err),
       })
     )
     return
   }
 
   try {
-    await getClient(port)
+    await connectToServer(startedServer.connection)
   } catch {
     try {
       await stopServerGraceful()
     } catch {
       // Best effort cleanup; activation will report the connection failure.
     }
+    if (startedServer.connection.kind === 'unix') {
+      removeServerSocketFile(startedServer.connection.socketPath)
+      activeServerSocketPath = undefined
+    }
     reportActivationError(
       vscode.l10n.t('Ωedit™ server started but is not reachable')
     )
     return
+  }
+
+  if (startedServer.serverPid && !isTestRuntime()) {
+    if (startedServer.connection.kind === 'unix') {
+      void vscode.window.showInformationMessage(
+        vscode.l10n.t(
+          'Ωedit™ server started on Unix socket {socketPath} (pid {pid})',
+          {
+            socketPath: startedServer.connection.socketPath,
+            pid: startedServer.serverPid,
+          }
+        )
+      )
+    } else {
+      void vscode.window.showInformationMessage(
+        vscode.l10n.t('Ωedit™ server started on port {port} (pid {pid})', {
+          port: startedServer.connection.port,
+          pid: startedServer.serverPid,
+        })
+      )
+    }
   }
 
   const provider = new HexEditorProvider(context)
@@ -517,11 +718,17 @@ export async function activate(
 
 export async function deactivate(): Promise<void> {
   activeProvider = undefined
+  const socketPath = activeServerSocketPath
+  activeServerSocketPath = undefined
 
   try {
     await stopServerGraceful()
   } catch {
     // Server may already be stopped; swallow errors during deactivation.
+  }
+
+  if (socketPath) {
+    removeServerSocketFile(socketPath)
   }
 }
 

--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -53,6 +53,7 @@ let activeProvider: HexEditorProvider | undefined
 let activeServerSocketPath: string | undefined
 
 const DEFAULT_SERVER_PORT = 9000
+const DARWIN_UNIX_SOCKET_PATH_MAX_BYTES = 103
 const SERVER_PORT_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_PORT'
 const SERVER_SOCKET_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_SOCKET'
 const UNIX_SOCKET_UNSUPPORTED_MESSAGE =
@@ -276,6 +277,19 @@ function getDefaultServerSocketPath(): string {
   )
 }
 
+function assertSupportedUnixSocketPath(socketPath: string): void {
+  if (process.platform !== 'darwin') {
+    return
+  }
+
+  const pathBytes = Buffer.byteLength(socketPath)
+  if (pathBytes > DARWIN_UNIX_SOCKET_PATH_MAX_BYTES) {
+    throw new Error(
+      `Unix socket path is too long for macOS: ${pathBytes} bytes (maximum ${DARWIN_UNIX_SOCKET_PATH_MAX_BYTES})`
+    )
+  }
+}
+
 function resolveServerPort(config: vscode.WorkspaceConfiguration): number {
   const envPort = parseServerPort(process.env[SERVER_PORT_OVERRIDE_ENV])
   if (envPort !== undefined) {
@@ -295,6 +309,7 @@ function resolveServerConnection(
     if (!platformCanAttemptUnixSocket()) {
       throw new Error(UNIX_SOCKET_UNSUPPORTED_MESSAGE)
     }
+    assertSupportedUnixSocketPath(socketOverride)
 
     return {
       kind: 'unix',
@@ -316,10 +331,12 @@ function resolveServerConnection(
   }
 
   if (platformCanAttemptUnixSocket()) {
+    const socketPath = getDefaultServerSocketPath()
+    assertSupportedUnixSocketPath(socketPath)
     return {
       kind: 'unix',
       port: DEFAULT_SERVER_PORT,
-      socketPath: getDefaultServerSocketPath(),
+      socketPath,
     }
   }
 

--- a/examples/vscode-extension/src/extension.ts
+++ b/examples/vscode-extension/src/extension.ts
@@ -16,7 +16,9 @@ import {
   getClient,
   startServer,
   startServerUnixSocket,
+  stopProcessUsingPID,
   stopServerGraceful,
+  WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE,
 } from '@omega-edit/client'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
@@ -50,14 +52,14 @@ import {
 import { HexEditorProvider } from './hexEditorProvider'
 
 let activeProvider: HexEditorProvider | undefined
+let activeServerConnection: ServerConnection | undefined
+let activeServerPid: number | undefined
 let activeServerSocketPath: string | undefined
 
 const DEFAULT_SERVER_PORT = 9000
 const DARWIN_UNIX_SOCKET_PATH_MAX_BYTES = 103
 const SERVER_PORT_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_PORT'
 const SERVER_SOCKET_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_SOCKET'
-const UNIX_SOCKET_UNSUPPORTED_MESSAGE =
-  'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
 const VALID_LOG_LEVELS = new Set([
   'trace',
   'debug',
@@ -260,6 +262,10 @@ function resolveServerSocketOverride(): string | undefined {
 }
 
 function getDefaultServerSocketDirectory(): string {
+  if (process.platform === 'darwin') {
+    return path.join('/tmp', 'omega-edit')
+  }
+
   if (process.platform === 'linux') {
     const xdgRuntimeDir = process.env.XDG_RUNTIME_DIR?.trim()
     if (xdgRuntimeDir && path.isAbsolute(xdgRuntimeDir)) {
@@ -307,7 +313,7 @@ function resolveServerConnection(
   const socketOverride = resolveServerSocketOverride()
   if (socketOverride !== undefined) {
     if (!platformCanAttemptUnixSocket()) {
-      throw new Error(UNIX_SOCKET_UNSUPPORTED_MESSAGE)
+      throw new Error(WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE)
     }
     assertSupportedUnixSocketPath(socketOverride)
 
@@ -408,6 +414,33 @@ async function connectToServer(connection: ServerConnection): Promise<void> {
   await getClient(connection.port)
 }
 
+async function stopServerConnectionGraceful(
+  connection: ServerConnection | undefined,
+  serverPid: number | undefined
+): Promise<boolean> {
+  try {
+    if (connection) {
+      await connectToServer(connection)
+    }
+    await stopServerGraceful()
+    return true
+  } catch (err) {
+    if (serverPid !== undefined && serverPid) {
+      try {
+        return await stopProcessUsingPID(serverPid)
+      } catch (pidErr) {
+        console.warn(
+          `Failed to stop OmegaEdit server process ${serverPid}: ${toErrorMessage(pidErr)}`
+        )
+      }
+    } else {
+      console.warn(`Failed to stop OmegaEdit server: ${toErrorMessage(err)}`)
+    }
+  }
+
+  return false
+}
+
 function resolveLogLevel(config: vscode.WorkspaceConfiguration): string {
   const value = config.get<unknown>('logLevel', 'info')
   return typeof value === 'string' && VALID_LOG_LEVELS.has(value)
@@ -491,6 +524,8 @@ export async function activate(
       connection,
       transformPluginDirectories
     )
+    activeServerConnection = startedServer.connection
+    activeServerPid = startedServer.serverPid
     activeServerSocketPath =
       startedServer.connection.kind === 'unix'
         ? startedServer.connection.socketPath
@@ -507,15 +542,16 @@ export async function activate(
   try {
     await connectToServer(startedServer.connection)
   } catch {
-    try {
-      await stopServerGraceful()
-    } catch {
-      // Best effort cleanup; activation will report the connection failure.
-    }
-    if (startedServer.connection.kind === 'unix') {
+    const stopped = await stopServerConnectionGraceful(
+      startedServer.connection,
+      startedServer.serverPid
+    )
+    if (stopped && startedServer.connection.kind === 'unix') {
       removeServerSocketFile(startedServer.connection.socketPath)
-      activeServerSocketPath = undefined
     }
+    activeServerConnection = undefined
+    activeServerPid = undefined
+    activeServerSocketPath = undefined
     reportActivationError(
       vscode.l10n.t('Ωedit™ server started but is not reachable')
     )
@@ -735,16 +771,16 @@ export async function activate(
 
 export async function deactivate(): Promise<void> {
   activeProvider = undefined
+  const connection = activeServerConnection
+  const serverPid = activeServerPid
   const socketPath = activeServerSocketPath
+  activeServerConnection = undefined
+  activeServerPid = undefined
   activeServerSocketPath = undefined
 
-  try {
-    await stopServerGraceful()
-  } catch {
-    // Server may already be stopped; swallow errors during deactivation.
-  }
+  const stopped = await stopServerConnectionGraceful(connection, serverPid)
 
-  if (socketPath) {
+  if (stopped && socketPath) {
     removeServerSocketFile(socketPath)
   }
 }

--- a/examples/vscode-extension/tests/extension.test.js
+++ b/examples/vscode-extension/tests/extension.test.js
@@ -1035,10 +1035,8 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(extensionJs, /resolveServerConnection/)
   assert.match(extensionJs, /OMEGA_EDIT_SERVER_SOCKET/)
   assert.match(extensionJs, /XDG_RUNTIME_DIR/)
-  assert.match(
-    extensionJs,
-    /Unix domain sockets are not supported on Windows by the current Node\/gRPC stack/
-  )
+  assert.match(extensionJs, /WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE/)
+  assert.match(extensionJs, /\/tmp['"],\s*['"]omega-edit/)
   assert.match(extensionJs, /process\.platform === ['"]darwin['"]/)
   assert.match(extensionJs, /process\.platform === ['"]linux['"]/)
   assert.doesNotMatch(extensionJs, /platformAllowsUnixSocketFallback/)

--- a/examples/vscode-extension/tests/extension.test.js
+++ b/examples/vscode-extension/tests/extension.test.js
@@ -1032,9 +1032,27 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(extensionJs, /getDefaultTransformPluginDirectories/)
   assert.match(extensionJs, /_build_core['"],\s*['"]plugins['"],\s*['"]plugins/)
   assert.match(extensionJs, /directoryHasTransformPlugin/)
+  assert.match(extensionJs, /resolveServerConnection/)
+  assert.match(extensionJs, /OMEGA_EDIT_SERVER_SOCKET/)
+  assert.match(extensionJs, /XDG_RUNTIME_DIR/)
   assert.match(
     extensionJs,
-    /startServer\)\(port,\s*undefined,\s*undefined,\s*\{\s*transformPluginDirectories/
+    /Unix domain sockets are not supported on Windows by the current Node\/gRPC stack/
+  )
+  assert.match(extensionJs, /process\.platform === ['"]darwin['"]/)
+  assert.match(extensionJs, /process\.platform === ['"]linux['"]/)
+  assert.doesNotMatch(extensionJs, /platformAllowsUnixSocketFallback/)
+  assert.doesNotMatch(extensionJs, /process\.platform === ['"]win32['"]/)
+  assert.match(extensionJs, /startTcpServerConnection/)
+  assert.doesNotMatch(extensionJs, /fallbackReason/)
+  assert.match(extensionJs, /startServerUnixSocket/)
+  assert.match(
+    extensionJs,
+    /startServer\)\(\s*tcpConnection\.port,\s*undefined,\s*undefined,\s*\{\s*transformPluginDirectories/
+  )
+  assert.match(
+    extensionJs,
+    /getClient\)\(connection\.port,\s*undefined,\s*\{\s*socketPath:\s*connection\.socketPath/
   )
 })
 

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -17,19 +17,5 @@
  * limitations under the License.
  */
 
-export * from './change'
-export * from './client'
-export * from './constants'
-export * from './editor_history'
-export * from './editor_scoped_session'
-export * from './editor_search'
-export * from './editor_session_model'
-export * from './logger'
-export * from './server'
-export * from './session'
-export * from './subscriptions'
-export * from './version'
-export * from './viewport'
-
-// generated files from protoc
-export * from './proto'
+export const WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE =
+  'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'

--- a/packages/client/src/protobuf_ts/client.ts
+++ b/packages/client/src/protobuf_ts/client.ts
@@ -20,6 +20,7 @@
 import * as grpc from '@grpc/grpc-js'
 import { EditorClient } from '../omega_edit_grpc_pb'
 import { getLogger } from '../logger'
+import { WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE } from '../constants'
 
 export interface ClientConnectionOptions {
   serverUri?: string
@@ -104,9 +105,7 @@ function isUnixSocketTarget(uri: string): boolean {
 
 function assertWindowsAllowsUnixSocketTarget(uri: string): void {
   if (process.platform === 'win32' && isUnixSocketTarget(uri)) {
-    throw new Error(
-      'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
-    )
+    throw new Error(WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE)
   }
 }
 

--- a/packages/client/src/protobuf_ts/client.ts
+++ b/packages/client/src/protobuf_ts/client.ts
@@ -98,6 +98,18 @@ function normalizeUnixSocketTarget(socket: string): string {
   return `unix:${socket}`
 }
 
+function isUnixSocketTarget(uri: string): boolean {
+  return uri.startsWith('unix:')
+}
+
+function assertWindowsAllowsUnixSocketTarget(uri: string): void {
+  if (process.platform === 'win32' && isUnixSocketTarget(uri)) {
+    throw new Error(
+      'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
+    )
+  }
+}
+
 function resolveCandidates(
   port: number,
   host: string,
@@ -112,6 +124,7 @@ function resolveCandidates(
   const tcpUri = `${host}:${port}`
 
   if (options?.serverUri) {
+    assertWindowsAllowsUnixSocketTarget(options.serverUri)
     return {
       requestKey: options.serverUri,
       candidates: [options.serverUri],
@@ -120,6 +133,7 @@ function resolveCandidates(
 
   if (options?.socketPath) {
     const socketUri = normalizeUnixSocketTarget(options.socketPath)
+    assertWindowsAllowsUnixSocketTarget(socketUri)
     const candidates = options.allowTcpFallback
       ? [socketUri, tcpUri]
       : [socketUri]
@@ -134,6 +148,7 @@ function resolveCandidates(
   const serverSocket = process.env.OMEGA_EDIT_SERVER_SOCKET
 
   if (serverUri) {
+    assertWindowsAllowsUnixSocketTarget(serverUri)
     return {
       requestKey: serverUri,
       candidates: [serverUri],
@@ -142,6 +157,7 @@ function resolveCandidates(
 
   if (serverSocket) {
     const socketUri = normalizeUnixSocketTarget(serverSocket)
+    assertWindowsAllowsUnixSocketTarget(socketUri)
     const candidates = [socketUri, tcpUri]
     return {
       requestKey: candidates.join('|'),

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -894,6 +894,53 @@ export async function startServerUnixSocket(
   const log = getLogger()
   log.debug(logMetadata)
 
+  const cleanupFailedUnixSocketStart = async (
+    serverPid: number | undefined
+  ) => {
+    let shouldRemoveSocket = true
+
+    if (serverPid !== undefined && serverPid) {
+      try {
+        shouldRemoveSocket = await stopProcessUsingPID(serverPid)
+      } catch (err) {
+        shouldRemoveSocket = false
+        log.warn({
+          ...logMetadata,
+          err: {
+            msg:
+              err instanceof Error
+                ? err.message
+                : `failed to stop server process ${serverPid}`,
+          },
+        })
+      }
+    }
+
+    if (!shouldRemoveSocket) {
+      return
+    }
+
+    try {
+      fs.unlinkSync(socketPath)
+      log.debug({
+        ...logMetadata,
+        msg: 'Removed unix socket after failed startup',
+      })
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        log.warn({
+          ...logMetadata,
+          err: {
+            msg:
+              err instanceof Error
+                ? err.message
+                : 'failed to remove unix socket after failed startup',
+          },
+        })
+      }
+    }
+  }
+
   if (process.platform === 'win32') {
     const errMsg =
       'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
@@ -1035,9 +1082,7 @@ export async function startServerUnixSocket(
       socketWaitMs
     )
   } catch (err) {
-    if (pid !== undefined && pid) {
-      await stopProcessUsingPID(pid)
-    }
+    await cleanupFailedUnixSocketStart(pid)
     throw err
   }
   log.debug({
@@ -1045,47 +1090,47 @@ export async function startServerUnixSocket(
     state: 'online',
   })
 
-  if (pidFile) {
-    const pidFromFile = await getServerPid(pidFile)
+  try {
+    if (pidFile) {
+      const pidFromFile = await getServerPid(pidFile)
 
-    if (pidFromFile !== pid) {
-      const errMsg = `Error pid from pidFile(${pidFromFile}) and pid(${pid}) from server script do not match`
-      log.error({
-        ...logMetadata,
-        err: {
-          msg: errMsg,
-          pid: pid,
-          pidFromFile: pidFromFile,
-        },
-      })
-      throw new Error(errMsg)
+      if (pidFromFile !== pid) {
+        const errMsg = `Error pid from pidFile(${pidFromFile}) and pid(${pid}) from server script do not match`
+        log.error({
+          ...logMetadata,
+          err: {
+            msg: errMsg,
+            pid: pid,
+            pidFromFile: pidFromFile,
+          },
+        })
+        throw new Error(errMsg)
+      }
     }
-  }
 
-  if (pid !== undefined && pid) {
-    log.debug({
-      ...logMetadata,
-      pid: pid,
-    })
-    try {
+    if (pid !== undefined && pid) {
+      log.debug({
+        ...logMetadata,
+        pid: pid,
+      })
       await getClient(port, host, {
         socketPath,
         allowTcpFallback: !udsOnly,
       })
-    } catch (err) {
-      await stopProcessUsingPID(pid)
-      throw err
+      return pid
+    } else {
+      const errMsg = 'Error getting server pid'
+      log.error({
+        ...logMetadata,
+        err: {
+          msg: errMsg,
+        },
+      })
+      throw new Error(errMsg)
     }
-    return pid
-  } else {
-    const errMsg = 'Error getting server pid'
-    log.error({
-      ...logMetadata,
-      err: {
-        msg: errMsg,
-      },
-    })
-    throw new Error(errMsg)
+  } catch (err) {
+    await cleanupFailedUnixSocketStart(pid)
+    throw err
   }
 }
 

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -200,6 +200,8 @@ async function waitForFileToExistWhileProcessRuns(
     }
 
     const check = async () => {
+      if (settled) return
+
       try {
         await fs.promises.stat(filePath)
         finish(() => {
@@ -216,6 +218,8 @@ async function waitForFileToExistWhileProcessRuns(
         // keep waiting
       }
 
+      if (settled) return
+
       if (Date.now() - start >= timeout) {
         finish(() => {
           const errMsg = `File does not exist after ${timeout} milliseconds`
@@ -229,6 +233,8 @@ async function waitForFileToExistWhileProcessRuns(
         })
         return
       }
+
+      if (settled) return
 
       timer = setTimeout(check, FILE_EXISTENCE_POLL_INTERVAL_MS)
     }

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -33,7 +33,7 @@ import {
   ServerControlKind,
   ServerControlStatus,
 } from './protobuf_ts/generated/omega_edit/v1/omega_edit'
-import { execFile } from 'child_process'
+import { execFile, type ChildProcess } from 'child_process'
 import { promisify } from 'util'
 import {
   requireOptionalSafeIntegerOutput,
@@ -142,6 +142,103 @@ export async function waitForFileToExist(
       }
 
       timer = setTimeout(check, FILE_EXISTENCE_POLL_INTERVAL_MS)
+    }
+
+    check()
+  })
+}
+
+async function waitForFileToExistWhileProcessRuns(
+  filePath: string,
+  childProcess: ChildProcess,
+  timeout: number
+): Promise<boolean> {
+  const log = getLogger()
+  log.debug({
+    fn: 'waitForFileToExistWhileProcessRuns',
+    file: filePath,
+    pid: childProcess.pid,
+  })
+
+  let timer: NodeJS.Timeout | undefined
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const start = Date.now()
+
+    const cleanup = () => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = undefined
+      }
+      childProcess.off('exit', onExit)
+      childProcess.off('error', onError)
+    }
+
+    const finish = (callback: () => void) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      callback()
+    }
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      finish(() => {
+        const errMsg = `Server process exited before ${filePath} existed (code ${code ?? 'unknown'}${signal ? `, signal ${signal}` : ''})`
+        log.error({
+          fn: 'waitForFileToExistWhileProcessRuns',
+          file: filePath,
+          pid: childProcess.pid,
+          err: { msg: errMsg },
+        })
+        reject(new Error(errMsg))
+      })
+    }
+
+    const onError = (err: Error) => {
+      finish(() => reject(err))
+    }
+
+    const check = async () => {
+      try {
+        await fs.promises.stat(filePath)
+        finish(() => {
+          log.debug({
+            fn: 'waitForFileToExistWhileProcessRuns',
+            file: filePath,
+            exists: true,
+            pid: childProcess.pid,
+          })
+          resolve(true)
+        })
+        return
+      } catch {
+        // keep waiting
+      }
+
+      if (Date.now() - start >= timeout) {
+        finish(() => {
+          const errMsg = `File does not exist after ${timeout} milliseconds`
+          log.error({
+            fn: 'waitForFileToExistWhileProcessRuns',
+            file: filePath,
+            pid: childProcess.pid,
+            err: { msg: errMsg },
+          })
+          reject(new Error(errMsg))
+        })
+        return
+      }
+
+      timer = setTimeout(check, FILE_EXISTENCE_POLL_INTERVAL_MS)
+    }
+
+    childProcess.once('exit', onExit)
+    childProcess.once('error', onError)
+
+    if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+      onExit(childProcess.exitCode, childProcess.signalCode)
+      return
     }
 
     check()
@@ -730,7 +827,7 @@ export async function startServer(
   if (pidFile) {
     const pidFromFile = await getServerPid(pidFile)
 
-    if (pidFromFile !== pid && process.platform !== 'win32') {
+    if (pidFromFile !== pid) {
       const errMsg = `Error pid from pidFile(${pidFromFile}) and pid(${pid}) from server script do not match`
       log.error({
         ...logMetadata,
@@ -790,6 +887,18 @@ export async function startServerUnixSocket(
   }
   const log = getLogger()
   log.debug(logMetadata)
+
+  if (process.platform === 'win32') {
+    const errMsg =
+      'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
+    log.error({
+      ...logMetadata,
+      err: {
+        msg: errMsg,
+      },
+    })
+    throw new Error(errMsg)
+  }
 
   const socketDir = path.dirname(socketPath)
   if (socketDir && socketDir !== '.') {
@@ -903,7 +1012,8 @@ export async function startServerUnixSocket(
     args.push(`--pidfile=${pidFile}`)
   }
 
-  const { pid } = await runServerWithArgs(args, heartbeat)
+  const serverProcess = await runServerWithArgs(args, heartbeat)
+  const { pid } = serverProcess
 
   log.debug({
     ...logMetadata,
@@ -912,7 +1022,18 @@ export async function startServerUnixSocket(
   const socketWaitMs = Number(
     process.env.OMEGA_EDIT_SERVER_SOCKET_WAIT_MS || '20000'
   )
-  await waitForFileToExist(socketPath, socketWaitMs)
+  try {
+    await waitForFileToExistWhileProcessRuns(
+      socketPath,
+      serverProcess,
+      socketWaitMs
+    )
+  } catch (err) {
+    if (pid !== undefined && pid) {
+      await stopProcessUsingPID(pid)
+    }
+    throw err
+  }
   log.debug({
     ...logMetadata,
     state: 'online',
@@ -921,7 +1042,7 @@ export async function startServerUnixSocket(
   if (pidFile) {
     const pidFromFile = await getServerPid(pidFile)
 
-    if (pidFromFile !== pid && process.platform !== 'win32') {
+    if (pidFromFile !== pid) {
       const errMsg = `Error pid from pidFile(${pidFromFile}) and pid(${pid}) from server script do not match`
       log.error({
         ...logMetadata,
@@ -940,7 +1061,15 @@ export async function startServerUnixSocket(
       ...logMetadata,
       pid: pid,
     })
-    await getClient(port, host, { socketPath })
+    try {
+      await getClient(port, host, {
+        socketPath,
+        allowTcpFallback: !udsOnly,
+      })
+    } catch (err) {
+      await stopProcessUsingPID(pid)
+      throw err
+    }
     return pid
   } else {
     const errMsg = 'Error getting server pid'

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -33,6 +33,7 @@ import {
   ServerControlKind,
   ServerControlStatus,
 } from './protobuf_ts/generated/omega_edit/v1/omega_edit'
+import { WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE } from './constants'
 import { execFile, type ChildProcess } from 'child_process'
 import { promisify } from 'util'
 import {
@@ -942,8 +943,7 @@ export async function startServerUnixSocket(
   }
 
   if (process.platform === 'win32') {
-    const errMsg =
-      'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
+    const errMsg = WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE
     log.error({
       ...logMetadata,
       err: {

--- a/packages/client/tests/specs/clientUtilities.spec.ts
+++ b/packages/client/tests/specs/clientUtilities.spec.ts
@@ -22,7 +22,11 @@ import * as net from 'net'
 import * as os from 'os'
 import * as path from 'path'
 import { expect, initChai } from './common.js'
-import { overrideProperty, silenceClientLogger } from './mockHelpers.js'
+import {
+  overrideProperty,
+  silenceClientLogger,
+  withPlatform,
+} from './mockHelpers.js'
 import { getModuleCompat } from './moduleCompat.js'
 
 const { require } = getModuleCompat(import.meta.url)
@@ -74,25 +78,6 @@ describe('Client Utilities', () => {
       process.env.OMEGA_EDIT_SERVER_SOCKET = originalServerSocket
     }
   })
-
-  const withPlatform = async (
-    platform: NodeJS.Platform,
-    run: () => Promise<void>
-  ) => {
-    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', {
-      configurable: true,
-      value: platform,
-    })
-
-    try {
-      await run()
-    } finally {
-      if (descriptor) {
-        Object.defineProperty(process, 'platform', descriptor)
-      }
-    }
-  }
 
   const removeDirWithRetry = async (dirPath: string) => {
     // Temp directory cleanup is best-effort on Windows where logger handles can lag.

--- a/packages/client/tests/specs/clientUtilities.spec.ts
+++ b/packages/client/tests/specs/clientUtilities.spec.ts
@@ -75,6 +75,25 @@ describe('Client Utilities', () => {
     }
   })
 
+  const withPlatform = async (
+    platform: NodeJS.Platform,
+    run: () => Promise<void>
+  ) => {
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: platform,
+    })
+
+    try {
+      await run()
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(process, 'platform', descriptor)
+      }
+    }
+  }
+
   const removeDirWithRetry = async (dirPath: string) => {
     // Temp directory cleanup is best-effort on Windows where logger handles can lag.
     const lockCodes = new Set(['ENOTEMPTY', 'EPERM', 'EBUSY', 'EACCES'])
@@ -271,13 +290,87 @@ describe('Client Utilities', () => {
     )
 
     try {
-      process.env.OMEGA_EDIT_SERVER_SOCKET = 'relative.sock'
-      delete process.env.OMEGA_EDIT_SERVER_URI
+      await withPlatform('linux', async () => {
+        process.env.OMEGA_EDIT_SERVER_SOCKET = 'relative.sock'
+        delete process.env.OMEGA_EDIT_SERVER_URI
 
-      const client = await clientModule.getClient(9310, '127.0.0.1')
-      expect(client).to.be.instanceOf(FakeEditorClient)
-      expect(uris).to.deep.equal(['unix:relative.sock', '127.0.0.1:9310'])
-      expect(closedUris).to.deep.equal(['unix:relative.sock'])
+        const client = await clientModule.getClient(9310, '127.0.0.1')
+        expect(client).to.be.instanceOf(FakeEditorClient)
+        expect(uris).to.deep.equal(['unix:relative.sock', '127.0.0.1:9310'])
+        expect(closedUris).to.deep.equal(['unix:relative.sock'])
+      })
+    } finally {
+      resetClient()
+      restoreCreateInsecure()
+      restoreEditorClient()
+    }
+  })
+
+  it('should reject unix socket client targets immediately on Windows', async () => {
+    resetClient()
+    delete process.env.OMEGA_EDIT_SERVER_URI
+    delete process.env.OMEGA_EDIT_SERVER_SOCKET
+    const uris: string[] = []
+    const unsupportedMessage =
+      'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
+
+    class FakeEditorClient {
+      constructor(uri: string) {
+        uris.push(uri)
+      }
+
+      waitForReady(_deadline: unknown, callback: (err?: Error) => void) {
+        callback()
+      }
+
+      close() {}
+    }
+
+    const restoreEditorClient = overrideProperty(
+      grpcClientModule as Record<string, any>,
+      'EditorClient',
+      FakeEditorClient
+    )
+    const restoreCreateInsecure = overrideProperty(
+      grpcModule.credentials as Record<string, any>,
+      'createInsecure',
+      () => ({})
+    )
+
+    try {
+      await withPlatform('win32', async () => {
+        try {
+          await clientModule.getClient(9310, '127.0.0.1', {
+            socketPath: 'relative.sock',
+            allowTcpFallback: true,
+          })
+          expect.fail('getClient should reject explicit Windows socket paths')
+        } catch (err) {
+          expect((err as Error).message).to.equal(unsupportedMessage)
+        }
+
+        process.env.OMEGA_EDIT_SERVER_SOCKET = 'relative.sock'
+        try {
+          await clientModule.getClient(9310, '127.0.0.1')
+          expect.fail('getClient should reject Windows socket env targets')
+        } catch (err) {
+          expect((err as Error).message).to.equal(unsupportedMessage)
+        } finally {
+          delete process.env.OMEGA_EDIT_SERVER_SOCKET
+        }
+
+        process.env.OMEGA_EDIT_SERVER_URI = 'unix:relative.sock'
+        try {
+          await clientModule.getClient(9310, '127.0.0.1')
+          expect.fail('getClient should reject Windows unix URI targets')
+        } catch (err) {
+          expect((err as Error).message).to.equal(unsupportedMessage)
+        } finally {
+          delete process.env.OMEGA_EDIT_SERVER_URI
+        }
+      })
+
+      expect(uris).to.deep.equal([])
     } finally {
       resetClient()
       restoreCreateInsecure()
@@ -363,21 +456,23 @@ describe('Client Utilities', () => {
     )
 
     try {
-      const tcpClient = await clientModule.getClient(9314, '127.0.0.1')
-      const socketClient = await clientModule.getClient(9314, '127.0.0.1', {
-        socketPath: 'relative.sock',
-      })
-
-      expect(socketClient).to.not.equal(tcpClient)
-      expect(await clientModule.getClient(9314, '127.0.0.1')).to.equal(
-        tcpClient
-      )
-      expect(
-        await clientModule.getClient(9314, '127.0.0.1', {
+      await withPlatform('linux', async () => {
+        const tcpClient = await clientModule.getClient(9314, '127.0.0.1')
+        const socketClient = await clientModule.getClient(9314, '127.0.0.1', {
           socketPath: 'relative.sock',
         })
-      ).to.equal(socketClient)
-      expect(uris).to.deep.equal(['127.0.0.1:9314', 'unix:relative.sock'])
+
+        expect(socketClient).to.not.equal(tcpClient)
+        expect(await clientModule.getClient(9314, '127.0.0.1')).to.equal(
+          tcpClient
+        )
+        expect(
+          await clientModule.getClient(9314, '127.0.0.1', {
+            socketPath: 'relative.sock',
+          })
+        ).to.equal(socketClient)
+        expect(uris).to.deep.equal(['127.0.0.1:9314', 'unix:relative.sock'])
+      })
 
       resetClient()
       expect(closedUris.sort()).to.deep.equal([
@@ -517,10 +612,12 @@ describe('Client Utilities', () => {
     )
 
     try {
-      process.env.OMEGA_EDIT_SERVER_SOCKET = '/tmp/omega-edit.sock'
-      delete process.env.OMEGA_EDIT_SERVER_URI
+      await withPlatform('linux', async () => {
+        process.env.OMEGA_EDIT_SERVER_SOCKET = '/tmp/omega-edit.sock'
+        delete process.env.OMEGA_EDIT_SERVER_URI
 
-      await clientModule.getClient(9311, '127.0.0.1')
+        await clientModule.getClient(9311, '127.0.0.1')
+      })
       expect.fail('getClient should reject when every candidate fails')
     } catch (err) {
       expect((err as Error).message).to.equal('127.0.0.1:9311 unavailable')

--- a/packages/client/tests/specs/clientUtilities.spec.ts
+++ b/packages/client/tests/specs/clientUtilities.spec.ts
@@ -47,6 +47,7 @@ const {
   stopProcessUsingPID,
   waitForFileToExist,
   waitForReady,
+  WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE,
 } = clientPackage
 
 describe('Client Utilities', () => {
@@ -309,9 +310,6 @@ describe('Client Utilities', () => {
     delete process.env.OMEGA_EDIT_SERVER_URI
     delete process.env.OMEGA_EDIT_SERVER_SOCKET
     const uris: string[] = []
-    const unsupportedMessage =
-      'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
-
     class FakeEditorClient {
       constructor(uri: string) {
         uris.push(uri)
@@ -344,7 +342,9 @@ describe('Client Utilities', () => {
           })
           expect.fail('getClient should reject explicit Windows socket paths')
         } catch (err) {
-          expect((err as Error).message).to.equal(unsupportedMessage)
+          expect((err as Error).message).to.equal(
+            WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE
+          )
         }
 
         process.env.OMEGA_EDIT_SERVER_SOCKET = 'relative.sock'
@@ -352,7 +352,9 @@ describe('Client Utilities', () => {
           await clientModule.getClient(9310, '127.0.0.1')
           expect.fail('getClient should reject Windows socket env targets')
         } catch (err) {
-          expect((err as Error).message).to.equal(unsupportedMessage)
+          expect((err as Error).message).to.equal(
+            WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE
+          )
         } finally {
           delete process.env.OMEGA_EDIT_SERVER_SOCKET
         }
@@ -362,7 +364,9 @@ describe('Client Utilities', () => {
           await clientModule.getClient(9310, '127.0.0.1')
           expect.fail('getClient should reject Windows unix URI targets')
         } catch (err) {
-          expect((err as Error).message).to.equal(unsupportedMessage)
+          expect((err as Error).message).to.equal(
+            WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE
+          )
         } finally {
           delete process.env.OMEGA_EDIT_SERVER_URI
         }

--- a/packages/client/tests/specs/clientUtilities.spec.ts
+++ b/packages/client/tests/specs/clientUtilities.spec.ts
@@ -236,6 +236,19 @@ describe('Client Utilities', () => {
     }
   })
 
+  it('should restore the platform descriptor after platform overrides', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    expect(descriptor).to.not.equal(undefined)
+
+    await withPlatform('linux', async () => {
+      expect(process.platform).to.equal('linux')
+    })
+
+    expect(Object.getOwnPropertyDescriptor(process, 'platform')).to.deep.equal(
+      descriptor
+    )
+  })
+
   it('should fall back from a unix socket candidate to TCP client creation', async () => {
     resetClient()
     const uris: string[] = []

--- a/packages/client/tests/specs/mockHelpers.ts
+++ b/packages/client/tests/specs/mockHelpers.ts
@@ -17,17 +17,27 @@ export async function withPlatform(
   run: () => Promise<void>
 ): Promise<void> {
   const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
-  Object.defineProperty(process, 'platform', {
-    configurable: true,
+  if (!descriptor || !descriptor.configurable) {
+    throw new Error('process.platform cannot be overridden in this runtime')
+  }
+
+  const overrideDescriptor: PropertyDescriptor = {
+    configurable: descriptor.configurable,
+    enumerable: descriptor.enumerable,
     value: platform,
+  }
+  if ('writable' in descriptor) {
+    overrideDescriptor.writable = descriptor.writable
+  }
+
+  Object.defineProperty(process, 'platform', {
+    ...overrideDescriptor,
   })
 
   try {
     await run()
   } finally {
-    if (descriptor) {
-      Object.defineProperty(process, 'platform', descriptor)
-    }
+    Object.defineProperty(process, 'platform', descriptor)
   }
 }
 

--- a/packages/client/tests/specs/mockHelpers.ts
+++ b/packages/client/tests/specs/mockHelpers.ts
@@ -12,6 +12,25 @@ export function overrideProperty(
   }
 }
 
+export async function withPlatform(
+  platform: NodeJS.Platform,
+  run: () => Promise<void>
+): Promise<void> {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  try {
+    await run()
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(process, 'platform', descriptor)
+    }
+  }
+}
+
 export function makeObjectIdResponse(id: string) {
   return {
     getId() {

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -48,6 +48,7 @@ const {
   stopProcessUsingPID,
   stopServiceOnPort,
   stopServerImmediate,
+  WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE,
 } = clientPackage
 
 describe('Server Edge Cases', () => {
@@ -1034,16 +1035,15 @@ describe('Server Edge Cases', () => {
       `omega-edit-windows-uds-${process.pid}-${Date.now()}`
     )
     const socketPath = path.join(socketDir, 'omega-edit.sock')
-    const unsupportedMessage =
-      'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
-
     try {
       await withPlatform('win32', async () => {
         await serverModule.startServerUnixSocket(socketPath)
       })
       expect.fail('startServerUnixSocket should reject on Windows')
     } catch (err) {
-      expect((err as Error).message).to.equal(unsupportedMessage)
+      expect((err as Error).message).to.equal(
+        WINDOWS_UNIX_SOCKET_UNSUPPORTED_MESSAGE
+      )
       expect(fs.existsSync(socketDir)).to.equal(false)
     } finally {
       fs.rmSync(socketDir, { recursive: true, force: true })

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -22,7 +22,11 @@ import * as os from 'os'
 import * as path from 'path'
 import { status as GrpcStatus } from '@grpc/grpc-js'
 import { expect, initChai } from './common.js'
-import { overrideProperty, silenceClientLogger } from './mockHelpers.js'
+import {
+  overrideProperty,
+  silenceClientLogger,
+  withPlatform,
+} from './mockHelpers.js'
 import { getModuleCompat } from './moduleCompat.js'
 
 const { require } = getModuleCompat(import.meta.url)
@@ -87,25 +91,6 @@ describe('Server Edge Cases', () => {
   after(() => {
     restoreLogger()
   })
-
-  const withPlatform = async (
-    platform: NodeJS.Platform,
-    run: () => Promise<void>
-  ) => {
-    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', {
-      configurable: true,
-      value: platform,
-    })
-
-    try {
-      await run()
-    } finally {
-      if (descriptor) {
-        Object.defineProperty(process, 'platform', descriptor)
-      }
-    }
-  }
 
   it('should start a source server with a stale pid file and query info endpoints', async () => {
     delete process.env.OMEGA_EDIT_SERVER_URI

--- a/packages/client/tests/specs/serverEdgeCases.spec.ts
+++ b/packages/client/tests/specs/serverEdgeCases.spec.ts
@@ -88,6 +88,25 @@ describe('Server Edge Cases', () => {
     restoreLogger()
   })
 
+  const withPlatform = async (
+    platform: NodeJS.Platform,
+    run: () => Promise<void>
+  ) => {
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: platform,
+    })
+
+    try {
+      await run()
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(process, 'platform', descriptor)
+      }
+    }
+  }
+
   it('should start a source server with a stale pid file and query info endpoints', async () => {
     delete process.env.OMEGA_EDIT_SERVER_URI
     delete process.env.OMEGA_EDIT_SERVER_SOCKET
@@ -1010,7 +1029,9 @@ describe('Server Edge Cases', () => {
     )
 
     try {
-      await serverModule.startServerUnixSocket(socketPath)
+      await withPlatform('linux', async () => {
+        await serverModule.startServerUnixSocket(socketPath)
+      })
       expect.fail(
         'startServerUnixSocket should reject when stale socket cleanup fails'
       )
@@ -1021,4 +1042,26 @@ describe('Server Edge Cases', () => {
       fs.rmSync(tempDir, { recursive: true, force: true })
     }
   }).timeout(7000)
+
+  it('should reject unix socket startup immediately on Windows', async () => {
+    const socketDir = path.join(
+      os.tmpdir(),
+      `omega-edit-windows-uds-${process.pid}-${Date.now()}`
+    )
+    const socketPath = path.join(socketDir, 'omega-edit.sock')
+    const unsupportedMessage =
+      'Unix domain sockets are not supported on Windows by the current Node/gRPC stack'
+
+    try {
+      await withPlatform('win32', async () => {
+        await serverModule.startServerUnixSocket(socketPath)
+      })
+      expect.fail('startServerUnixSocket should reject on Windows')
+    } catch (err) {
+      expect((err as Error).message).to.equal(unsupportedMessage)
+      expect(fs.existsSync(socketDir)).to.equal(false)
+    } finally {
+      fs.rmSync(socketDir, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Use Unix domain sockets by default only on macOS/Linux in the VS Code extension, with Linux sockets under XDG_RUNTIME_DIR when available.
- Keep Windows on TCP and reject explicit Windows UDS requests before spawning or waiting on gRPC readiness.
- Add client/server regression coverage for immediate Windows refusal and preserve POSIX socket behavior in simulated tests.

## Why
Windows AF_UNIX exists at the OS level on this machine, but the current Node/grpc-js path cannot connect reliably. Trying UDS first wastes extension startup time before falling back to TCP.

## Validation
- git diff --check origin/main...HEAD
- yarn build
- yarn lint
- yarn test:client
- npm run compile:extension
- npm run lint
- npm run test:unit
- npm run test:integration