### PR TITLE
Add digest transform plugins

### DIFF
--- a/.github/workflows/build-middleware/action.yml
+++ b/.github/workflows/build-middleware/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Skip running client tests (e.g., during release builds)'
     required: false
     default: 'false'
+  platform:
+    description: 'Target platform label (e.g., macos-x64, macos-arm64)'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -61,21 +65,57 @@ runs:
       shell: bash
       run: echo "CONAN_MSBUILD_VS_CONF=-c tools.microsoft.msbuild:vs_version=18" >> "$GITHUB_ENV"
 
+    - name: Resolve macOS target architecture
+      if: inputs.runner-os == 'macOS'
+      shell: bash
+      run: |
+        conan_arch=""
+        macos_arch=""
+        platform="${{ inputs.platform }}"
+        os_name="${{ inputs.os-name }}"
+
+        if [[ "$platform" == *"-x64" ]] || [[ "$os_name" == *"-x64" ]]; then
+          conan_arch="x86_64"
+          macos_arch="x86_64"
+        elif [[ "$platform" == *"-arm64" ]] || [[ "$os_name" == *"-arm64" ]]; then
+          conan_arch="armv8"
+          macos_arch="arm64"
+        elif [ "$RUNNER_ARCH" = "X64" ]; then
+          conan_arch="x86_64"
+          macos_arch="x86_64"
+        elif [ "$RUNNER_ARCH" = "ARM64" ]; then
+          conan_arch="armv8"
+          macos_arch="arm64"
+        fi
+
+        if [ -z "$conan_arch" ] || [ -z "$macos_arch" ]; then
+          echo "ERROR: Unable to resolve macOS target architecture for platform '${platform}' and os-name '${os_name}'" >&2
+          exit 1
+        fi
+
+        echo "TARGET_CONAN_ARCH=$conan_arch" >> "$GITHUB_ENV"
+        echo "TARGET_MACOS_ARCH=$macos_arch" >> "$GITHUB_ENV"
+
     - name: Cache Conan packages
       uses: actions/cache@v4
       with:
         path: ~/.conan2
-        key: conan-${{ inputs.os-name }}-${{ hashFiles('server/cpp/conanfile.py', 'plugins/conanfile.py') }}
+        key: conan-v2-${{ inputs.runner-os }}-${{ runner.arch }}-${{ inputs.os-name }}-${{ inputs.platform }}-${{ hashFiles('server/cpp/conanfile.py', 'plugins/conanfile.py') }}
         restore-keys: |
-          conan-${{ inputs.os-name }}-
+          conan-v2-${{ inputs.runner-os }}-${{ runner.arch }}-${{ inputs.os-name }}-${{ inputs.platform }}-
 
     - name: Install transform plugin dependencies via Conan
-      if: inputs.runner-os == 'Windows'
+      if: inputs.runner-os == 'Windows' || inputs.runner-os == 'macOS'
       shell: bash
       run: |
+        conan_arch=()
+        if [ "${{ inputs.runner-os }}" == "macOS" ]; then
+          conan_arch=("-s:h" "arch=${TARGET_CONAN_ARCH}")
+        fi
         conan install plugins --output-folder=_build_core/plugin-conan \
           --build=missing \
           -s build_type=Release \
+          "${conan_arch[@]}" \
           ${CONAN_MSBUILD_VS_CONF:-} \
           -c tools.cmake.cmaketoolchain:generator=Ninja
 
@@ -84,14 +124,17 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y zlib1g-dev
+        sudo apt-get install -y libssl-dev zlib1g-dev
 
     - name: Build omega_edit core library and transform plugins (static)
       shell: bash
       run: |
         cmake_args=()
-        if [ "${{ inputs.runner-os }}" == "Windows" ]; then
+        if [ "${{ inputs.runner-os }}" == "Windows" ] || [ "${{ inputs.runner-os }}" == "macOS" ]; then
           cmake_args+=("-DCMAKE_TOOLCHAIN_FILE=$(pwd)/_build_core/plugin-conan/conan_toolchain.cmake")
+        fi
+        if [ "${{ inputs.runner-os }}" == "macOS" ]; then
+          cmake_args+=("-DCMAKE_OSX_ARCHITECTURES=${TARGET_MACOS_ARCH}")
         fi
         cmake -G Ninja -S . -B _build_core \
           -DCMAKE_BUILD_TYPE=Release \
@@ -110,10 +153,15 @@ runs:
       shell: bash
       run: |
         cd server/cpp
+        conan_arch=()
+        if [ "${{ inputs.runner-os }}" == "macOS" ]; then
+          conan_arch=("-s:h" "arch=${TARGET_CONAN_ARCH}")
+        fi
         conan install . --output-folder=build \
           --build=missing \
           -s build_type=Release \
           -s compiler.cppstd=17 \
+          "${conan_arch[@]}" \
           ${CONAN_MSBUILD_VS_CONF:-} \
           -c tools.cmake.cmaketoolchain:generator=Ninja
 
@@ -128,14 +176,20 @@ runs:
       shell: bash
       run: |
         cd server/cpp
+        cmake_args=()
+        if [ "${{ inputs.runner-os }}" == "macOS" ]; then
+          cmake_args+=("-DCMAKE_OSX_ARCHITECTURES=${TARGET_MACOS_ARCH}")
+        fi
         cmake --preset conan-release \
           -DOE_LIB_DIR="$OE_LIB_DIR" \
           -DCMAKE_PREFIX_PATH="$OE_PREFIX" \
+          "${cmake_args[@]}" \
           || cmake -G Ninja -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="build/conan_toolchain.cmake" \
             -DOE_LIB_DIR="$OE_LIB_DIR" \
-            -DCMAKE_PREFIX_PATH="$OE_PREFIX"
+            -DCMAKE_PREFIX_PATH="$OE_PREFIX" \
+            "${cmake_args[@]}"
         cmake --build build --config Release
         cd ../..
         echo "CPP_SERVER_BINARY=$(pwd)/server/cpp/build/omega-edit-grpc-server$([ '${{ inputs.runner-os }}' == 'Windows' ] && echo '.exe' || echo '')" >> $GITHUB_ENV

--- a/.github/workflows/build-native-docker/action.yml
+++ b/.github/workflows/build-native-docker/action.yml
@@ -47,7 +47,12 @@ runs:
 
     - name: Perform cmake operators 🔧
       shell: bash
-      run: docker exec omega-edit-${{ inputs.os-name }}-cont bash -c "(make clean || true) && make TYPE=Release all"
+      run: |
+        docker exec omega-edit-${{ inputs.os-name }}-cont bash -c "\
+          if command -v apt-get >/dev/null 2>&1; then \
+            apt-get update && apt-get install -y libssl-dev zlib1g-dev; \
+          fi; \
+          (make clean || true) && make TYPE=Release all"
 
     - name: Copy library file from docker container 🔻
       shell: bash

--- a/.github/workflows/build-native/action.yml
+++ b/.github/workflows/build-native/action.yml
@@ -30,18 +30,18 @@ runs:
       uses: lukka/get-cmake@latest
 
     - name: Setup Python for plugin dependencies
-      if: inputs.runner-os == 'Windows'
+      if: inputs.runner-os == 'Windows' || inputs.runner-os == 'macOS'
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
     - name: Install Conan for plugin dependencies
-      if: inputs.runner-os == 'Windows'
+      if: inputs.runner-os == 'Windows' || inputs.runner-os == 'macOS'
       shell: bash
       run: pip install conan
 
     - name: Detect Conan profile for plugin dependencies
-      if: inputs.runner-os == 'Windows'
+      if: inputs.runner-os == 'Windows' || inputs.runner-os == 'macOS'
       shell: bash
       run: conan profile detect --force
 
@@ -51,21 +51,34 @@ runs:
       run: echo "CONAN_MSBUILD_VS_CONF=-c tools.microsoft.msbuild:vs_version=18" >> "$GITHUB_ENV"
 
     - name: Cache transform plugin Conan packages
-      if: inputs.runner-os == 'Windows'
+      if: inputs.runner-os == 'Windows' || inputs.runner-os == 'macOS'
       uses: actions/cache@v4
       with:
         path: ~/.conan2
-        key: plugin-conan-${{ inputs.os-name }}-${{ hashFiles('plugins/conanfile.py') }}
+        key: plugin-conan-v2-${{ inputs.runner-os }}-${{ runner.arch }}-${{ inputs.os-name }}-${{ hashFiles('plugins/conanfile.py') }}
         restore-keys: |
-          plugin-conan-${{ inputs.os-name }}-
+          plugin-conan-v2-${{ inputs.runner-os }}-${{ runner.arch }}-${{ inputs.os-name }}-
 
     - name: Install transform plugin dependencies via Conan
-      if: inputs.runner-os == 'Windows'
+      if: inputs.runner-os == 'Windows' || inputs.runner-os == 'macOS'
       shell: bash
       run: |
+        conan_arch=()
+        if [ "${{ inputs.runner-os }}" == "macOS" ]; then
+          if echo "${{ inputs.os-name }}" | grep -q -- "-x64"; then
+            conan_arch=("-s:h" "arch=x86_64")
+          elif echo "${{ inputs.os-name }}" | grep -q -- "-arm64"; then
+            conan_arch=("-s:h" "arch=armv8")
+          elif [ "$RUNNER_ARCH" = "X64" ]; then
+            conan_arch=("-s:h" "arch=x86_64")
+          elif [ "$RUNNER_ARCH" = "ARM64" ]; then
+            conan_arch=("-s:h" "arch=armv8")
+          fi
+        fi
         conan install plugins --output-folder=build/plugin-conan \
           --build=missing \
           -s build_type=Release \
+          "${conan_arch[@]}" \
           ${CONAN_MSBUILD_VS_CONF:-} \
           -c tools.cmake.cmaketoolchain:generator=Ninja
 
@@ -74,7 +87,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y zlib1g-dev
+        sudo apt-get install -y libssl-dev zlib1g-dev
 
     - name: Set install path
       shell: bash
@@ -87,11 +100,21 @@ runs:
       shell: bash
       run: |
         cmake_args=()
-        if [ "${{ inputs.runner-os }}" == "Windows" ]; then
+        if [ "${{ inputs.runner-os }}" == "Windows" ] || [ "${{ inputs.runner-os }}" == "macOS" ]; then
           cmake_args+=("-DCMAKE_TOOLCHAIN_FILE=$(pwd)/build/plugin-conan/conan_toolchain.cmake")
         fi
         if [ "${{ inputs.runner-os }}" == "macOS" ]; then
-          cmake --preset ci -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" "${cmake_args[@]}"
+          macos_arch="$RUNNER_ARCH"
+          if echo "${{ inputs.os-name }}" | grep -q -- "-x64"; then
+            macos_arch="x86_64"
+          elif echo "${{ inputs.os-name }}" | grep -q -- "-arm64"; then
+            macos_arch="arm64"
+          elif [ "$RUNNER_ARCH" = "X64" ]; then
+            macos_arch="x86_64"
+          elif [ "$RUNNER_ARCH" = "ARM64" ]; then
+            macos_arch="arm64"
+          fi
+          cmake --preset ci -DCMAKE_OSX_ARCHITECTURES="$macos_arch" "${cmake_args[@]}"
         else
           cmake --preset ci "${cmake_args[@]}"
         fi
@@ -127,14 +150,22 @@ runs:
 
           if [ -n "${slice_arch}" ]; then
             echo "Extracting macOS slice ${slice_arch} from ${libpath}"
-            lipo -info "${libpath}"
-            thin_dir=$(mktemp -d)
-            thin_path="${thin_dir}/${libname}"
-            if ! lipo "${libpath}" -extract "${slice_arch}" -output "${thin_path}"; then
-              echo "ERROR: failed to extract ${slice_arch} slice via lipo" >&2
-              exit 1
+            lipo_info="$(lipo -info "${libpath}")"
+            echo "$lipo_info"
+            if echo "$lipo_info" | grep -q "Non-fat"; then
+              if ! echo "$lipo_info" | grep -q "architecture: ${slice_arch}"; then
+                echo "ERROR: ${libpath} is not ${slice_arch}" >&2
+                exit 1
+              fi
+            else
+              thin_dir=$(mktemp -d)
+              thin_path="${thin_dir}/${libname}"
+              if ! lipo "${libpath}" -extract "${slice_arch}" -output "${thin_path}"; then
+                echo "ERROR: failed to extract ${slice_arch} slice via lipo" >&2
+                exit 1
+              fi
+              libpath="${thin_path}"
             fi
-            libpath="${thin_path}"
           fi
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,7 @@ jobs:
         with:
           runner-os: ${{ matrix.runner-os }}
           os-name: ${{ matrix.os }}
+          platform: ${{ matrix.platform }}
           skip-tests: 'true'
 
       - name: Rename binary with platform suffix

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,7 @@ jobs:
         with:
           runner-os: ${{ matrix.runner-os }}
           os-name: ${{ matrix.os }}
+          platform: ${{ matrix.platform }}
           skip-tests: 'true'
 
       - name: Rename binary with platform suffix
@@ -359,7 +360,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install lcov and transform plugin dependencies
-        run: sudo apt-get update && sudo apt-get install -y lcov zlib1g-dev
+        run: sudo apt-get update && sudo apt-get install -y lcov libssl-dev zlib1g-dev
 
       - name: Build with coverage instrumentation
         run: |
@@ -415,9 +416,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.conan2
-          key: conan-coverage-${{ hashFiles('server/cpp/conanfile.py') }}
+          key: conan-coverage-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('server/cpp/conanfile.py') }}
           restore-keys: |
-            conan-coverage-
+            conan-coverage-v2-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Build C++ gRPC server for client tests
         run: |

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For an installed package instead of a source checkout, use the Codex MCP format 
 
 ## Transform Plugins
 
-OmegaEdit can discover native transform plugins from `.so`, `.dylib`, and `.dll` files. Plugins can replace a selected range, expand or shrink content, or inspect a range and return a result such as a checksum or hash. The separately packaged examples include one-for-one bitwise transforms, base64 encode/decode, zlib compress/decompress, expansion/shrink behavior, and inspect-only results. See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the ABI, SDK helpers, plugin package layout, server registration options, and exemplar plugins.
+OmegaEdit can discover native transform plugins from `.so`, `.dylib`, and `.dll` files. Plugins can replace a selected range, expand or shrink content, or inspect a range and return a result such as a checksum or hash. The separately packaged examples include bitwise transforms, binary/text codecs, zlib compression, character transcoding, decimal field helpers, record/text escaping, TLV/varint inspectors, and MD5/SHA/BLAKE/CRC/checksum-style inspection. See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the ABI, SDK helpers, plugin package layout, server registration options, and exemplar plugins.
 
 ## User documentation
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -53,6 +53,7 @@ oe patch --session <session-id> --offset 8 --hex 0000000d
 # Discover and run native transform plugins
 oe list-transform-plugins
 oe apply-transform-plugin --session <session-id> --plugin omega.example.checksum8 --offset 0 --length 128
+oe apply-transform-plugin --session <session-id> --plugin omega.example.sha256 --offset 0 --length 128
 oe apply-transform-plugin --session <session-id> --plugin omega.example.base64_encode --offset 0 --length 128
 oe apply-transform-plugin --session <session-id> --plugin omega.example.zlib_compress --offset 0 --length 128 --options-json '{"level":9}'
 
@@ -66,7 +67,8 @@ oe undo --session <session-id>
 
 Transform plugins are registered when the native server starts. See the
 [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins)
-for the ABI, SDK helpers, plugin directory layout, and exemplar plugin IDs.
+for the ABI, SDK helpers, plugin directory layout, and exemplar plugin IDs for
+codecs, transcodes, record/message helpers, and digest/checksum inspectors.
 
 All CLI commands emit JSON to stdout and return non-zero exit codes on failure.
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -243,7 +243,8 @@ Start the server with `transformPluginDirectories` or `--transform-plugin-dir`
 before listing or applying plugins. See the
 [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins)
 for ABI, SDK, plugin package layout, and exemplar plugin details, including base64
-encode/decode, zlib compress/decompress, and inspect-only hash examples.
+encode/decode, text codecs, character transcoding, zlib compress/decompress,
+record/message helpers, and inspect-only digest/checksum examples.
 
 ### Logging
 

--- a/packages/client/tests/specs/transformPlugin.spec.ts
+++ b/packages/client/tests/specs/transformPlugin.spec.ts
@@ -117,8 +117,25 @@ describe('Transform plugin gRPC integration', () => {
         'omega.example.and',
         'omega.example.base64_decode',
         'omega.example.base64_encode',
+        'omega.example.blake2b512',
+        'omega.example.blake2s256',
+        'omega.example.character_transcode',
+        'omega.example.common_checksums',
+        'omega.example.decimal_codecs',
+        'omega.example.endian_swap',
+        'omega.example.format_inspectors',
         'omega.example.fnv1a64',
+        'omega.example.md5',
         'omega.example.or',
+        'omega.example.record_text_helpers',
+        'omega.example.sha1',
+        'omega.example.sha224',
+        'omega.example.sha256',
+        'omega.example.sha3_256',
+        'omega.example.sha3_512',
+        'omega.example.sha384',
+        'omega.example.sha512',
+        'omega.example.text_codecs',
         'omega.example.zlib_compress',
         'omega.example.zlib_decompress',
         'omega.example.xor',
@@ -288,6 +305,23 @@ describe('Transform plugin gRPC integration', () => {
       expect(hashResponse.resultMimeType).to.equal('text/plain')
       expect(Buffer.from(hashResponse.result).toString('utf8')).to.equal(
         '0x6334A32D761281D8'
+      )
+      expect(await getComputedFileSize(sessionId)).to.equal(5)
+
+      const sha256Response = await applyTransformPlugin(
+        sessionId,
+        'omega.example.sha256',
+        0,
+        5
+      )
+      expect(sha256Response.operation).to.equal(
+        TransformPluginOperation.INSPECT
+      )
+      expect(sha256Response.contentChanged).to.equal(false)
+      expect(sha256Response.resultLabel).to.equal('sha256')
+      expect(sha256Response.resultMimeType).to.equal('text/plain')
+      expect(Buffer.from(sha256Response.result).toString('utf8')).to.equal(
+        'c490aea7e19cad1b8b49dac9c2e02c023c6f21f1379fdd70335f461273f84cc7'
       )
       expect(await getComputedFileSize(sessionId)).to.equal(5)
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -152,8 +152,9 @@ Transform plugin directories can also be supplied with `OMEGA_EDIT_TRANSFORM_PLU
 Use the platform path-list separator (`:` on Unix-like systems, `;` on Windows).
 See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the native ABI,
 SDK helpers, plugin package layout, and exemplar plugins, including base64
-encode/decode, bitwise transforms, zlib compress/decompress, and inspect-only
-hash examples.
+encode/decode, bitwise transforms, zlib compress/decompress, text codecs,
+character transcoding, record/message helpers, and inspect-only digest/checksum
+examples.
 
 ## Platform Support
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -57,6 +57,8 @@ endif()
 if (NOT TARGET omega_edit::omega_edit)
     find_package(omega_edit CONFIG REQUIRED)
 endif()
+set(OPENSSL_USE_STATIC_LIBS TRUE)
+find_package(OpenSSL 3 REQUIRED COMPONENTS Crypto)
 find_package(ZLIB REQUIRED)
 get_target_property(OMEGA_EDIT_INCLUDE_DIRS omega_edit::omega_edit INTERFACE_INCLUDE_DIRECTORIES)
 
@@ -70,8 +72,25 @@ foreach (plugin_src
         src/and.c
         src/base64_decode.c
         src/base64_encode.c
+        src/blake2b512.c
+        src/blake2s256.c
+        src/character_transcode.cpp
+        src/common_checksums.cpp
+        src/decimal_codecs.cpp
+        src/endian_swap.cpp
+        src/format_inspectors.cpp
         src/fnv1a64.c
+        src/md5.c
         src/or.c
+        src/record_text_helpers.cpp
+        src/sha1.c
+        src/sha224.c
+        src/sha256.c
+        src/sha3_256.c
+        src/sha3_512.c
+        src/sha384.c
+        src/sha512.c
+        src/text_codecs.cpp
         src/zlib_compress.c
         src/zlib_decompress.c
         src/xor.c
@@ -83,6 +102,17 @@ foreach (plugin_src
     target_include_directories(${plugin_target} PRIVATE ${OMEGA_EDIT_INCLUDE_DIRS})
     if (plugin_name MATCHES "^zlib_")
         target_link_libraries(${plugin_target} PRIVATE ZLIB::ZLIB)
+    endif()
+    if (plugin_name MATCHES "^(md5|sha1|sha224|sha256|sha384|sha512|sha3_256|sha3_512|blake2b512|blake2s256)$")
+        target_link_libraries(${plugin_target} PRIVATE OpenSSL::Crypto)
+        if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+            target_compile_options(${plugin_target} PRIVATE -fvisibility=hidden)
+        endif()
+        if (UNIX AND NOT APPLE)
+            target_link_options(${plugin_target} PRIVATE "LINKER:--exclude-libs,ALL")
+        elseif (APPLE)
+            target_link_options(${plugin_target} PRIVATE "LINKER:-dead_strip")
+        endif()
     endif()
     set_target_properties(
             ${plugin_target} PROPERTIES

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -3,8 +3,8 @@
 This package builds the exemplar native transform plugins for Omega Edit.
 
 The plugins consume the Omega Edit transform plugin ABI and SDK from the core
-package. Third-party transform dependencies, such as zlib, are owned here rather
-than by the core library.
+package. Third-party transform dependencies, such as zlib and OpenSSL 3, are
+owned here rather than by the core library.
 
 Transform plugin metadata includes a description, help text, example arguments,
 default arguments, and an optional JSON Schema for validating options on both
@@ -12,6 +12,14 @@ the client and native apply path. The bitwise exemplars accept options JSON with
 a single repeated byte or a repeating mask sequence, for example
 `{"byte":"0x42"}` or `{"mask":["0x0F","0xF0"]}`. The zlib compression
 exemplar accepts `{"level":9}`, with valid levels from `-1` through `9`.
+The richer data-format exemplars cover digest/hash inspection, CRC/checksum
+inspection, binary-to-text codecs, character set transcoding, decimal field
+encodings, byte-order swaps, record/text escaping helpers, and lightweight
+format inspectors for TLV-style data. The digest exemplars use OpenSSL 3's EVP
+API to calculate MD5, SHA-1, SHA-2, SHA-3, and BLAKE2 inspect-only text
+results. MD5 and SHA-1 are included for legacy formats, interoperability checks,
+and low-security data inspection workflows; do not use them for
+security-sensitive authentication or integrity decisions.
 
 ## Build
 

--- a/plugins/conanfile.py
+++ b/plugins/conanfile.py
@@ -8,6 +8,7 @@ class OmegaEditTransformPluginsConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
+        self.requires("openssl/3.3.2")
         self.requires("zlib/1.3.1")
 
     def layout(self):

--- a/plugins/src/blake2b512.c
+++ b/plugins/src/blake2b512.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.blake2b512"
+#define OMEGA_DIGEST_PLUGIN_NAME "BLAKE2b-512"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a BLAKE2b-512 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "blake2b-512"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_blake2b512
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/blake2s256.c
+++ b/plugins/src/blake2s256.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.blake2s256"
+#define OMEGA_DIGEST_PLUGIN_NAME "BLAKE2s-256"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a BLAKE2s-256 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "blake2s-256"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_blake2s256
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/character_transcode.cpp
+++ b/plugins/src/character_transcode.cpp
@@ -1,0 +1,403 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include "plugin_options.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr const char *CHARACTER_TRANSCODE_ARGS_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"from\":{\"type\":\"string\",\"pattern\":\"^(ascii|utf-8|utf-16le|utf-"
+        "16be|utf-32le|utf-32be|iso-8859-1|windows-1252|ebcdic-037|ibm037|ebcdic-500|ibm500|ebcdic-1047|ibm1047|"
+        "ebcdic-1140|ibm1140)$\"},\"to\":{\"type\":\"string\",\"pattern\":\"^(ascii|utf-8|utf-16le|utf-16be|utf-32le|"
+        "utf-32be|iso-8859-1|windows-1252|ebcdic-037|ibm037|ebcdic-500|ibm500|ebcdic-1047|ibm1047|ebcdic-1140|"
+        "ibm1140)$\"}},\"additionalProperties\":false}";
+
+bool utf8_append(uint32_t codepoint, std::vector<omega_byte_t> &out) {
+    if (codepoint <= 0x7FU) {
+        out.push_back(static_cast<omega_byte_t>(codepoint));
+    } else if (codepoint <= 0x7FFU) {
+        out.push_back(static_cast<omega_byte_t>(0xC0U | (codepoint >> 6U)));
+        out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
+    } else if (codepoint <= 0xFFFFU) {
+        out.push_back(static_cast<omega_byte_t>(0xE0U | (codepoint >> 12U)));
+        out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 6U) & 0x3FU)));
+        out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
+    } else if (codepoint <= 0x10FFFFU) {
+        out.push_back(static_cast<omega_byte_t>(0xF0U | (codepoint >> 18U)));
+        out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 12U) & 0x3FU)));
+        out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 6U) & 0x3FU)));
+        out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
+    } else {
+        return false;
+    }
+    return true;
+}
+
+bool decode_utf8(const std::vector<omega_byte_t> &input, std::vector<uint32_t> &out) {
+    out.clear();
+    for (size_t i = 0; i < input.size();) {
+        const uint32_t byte = static_cast<uint8_t>(input[i++]);
+        if (byte < 0x80U) {
+            out.push_back(byte);
+        } else if ((byte & 0xE0U) == 0xC0U) {
+            if (byte < 0xC2U || i >= input.size() || (input[i] & 0xC0U) != 0x80U) { return false; }
+            out.push_back(((byte & 0x1FU) << 6U) | (static_cast<uint8_t>(input[i++]) & 0x3FU));
+        } else if ((byte & 0xF0U) == 0xE0U) {
+            if (i + 1 >= input.size() || (input[i] & 0xC0U) != 0x80U || (input[i + 1] & 0xC0U) != 0x80U ||
+                (byte == 0xE0U && static_cast<uint8_t>(input[i]) < 0xA0U) ||
+                (byte == 0xEDU && static_cast<uint8_t>(input[i]) > 0x9FU)) {
+                return false;
+            }
+            out.push_back(((byte & 0x0FU) << 12U) | ((static_cast<uint8_t>(input[i]) & 0x3FU) << 6U) |
+                          (static_cast<uint8_t>(input[i + 1]) & 0x3FU));
+            i += 2;
+        } else if ((byte & 0xF8U) == 0xF0U) {
+            if (byte > 0xF4U || i + 2 >= input.size() || (input[i] & 0xC0U) != 0x80U ||
+                (input[i + 1] & 0xC0U) != 0x80U || (input[i + 2] & 0xC0U) != 0x80U ||
+                (byte == 0xF0U && static_cast<uint8_t>(input[i]) < 0x90U) ||
+                (byte == 0xF4U && static_cast<uint8_t>(input[i]) > 0x8FU)) {
+                return false;
+            }
+            out.push_back(((byte & 0x07U) << 18U) | ((static_cast<uint8_t>(input[i]) & 0x3FU) << 12U) |
+                          ((static_cast<uint8_t>(input[i + 1]) & 0x3FU) << 6U) |
+                          (static_cast<uint8_t>(input[i + 2]) & 0x3FU));
+            i += 3;
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+uint32_t read_word(const std::vector<omega_byte_t> &input, size_t offset, bool little, int bytes) {
+    uint32_t value = 0;
+    if (little) {
+        for (int i = bytes - 1; i >= 0; --i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
+    } else {
+        for (int i = 0; i < bytes; ++i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
+    }
+    return value;
+}
+
+void write_word(uint32_t value, bool little, int bytes, std::vector<omega_byte_t> &out) {
+    if (little) {
+        for (int i = 0; i < bytes; ++i) { out.push_back(static_cast<omega_byte_t>((value >> (8U * i)) & 0xFFU)); }
+    } else {
+        for (int i = bytes - 1; i >= 0; --i) {
+            out.push_back(static_cast<omega_byte_t>((value >> (8U * i)) & 0xFFU));
+        }
+    }
+}
+
+bool decode_utf16(const std::vector<omega_byte_t> &input, bool little, std::vector<uint32_t> &out) {
+    if ((input.size() % 2) != 0) { return false; }
+    out.clear();
+    for (size_t i = 0; i < input.size(); i += 2) {
+        uint32_t word = read_word(input, i, little, 2);
+        if (word >= 0xD800U && word <= 0xDBFFU) {
+            if (i + 3 >= input.size()) { return false; }
+            const uint32_t low = read_word(input, i + 2, little, 2);
+            if (low < 0xDC00U || low > 0xDFFFU) { return false; }
+            word = 0x10000U + (((word - 0xD800U) << 10U) | (low - 0xDC00U));
+            i += 2;
+        }
+        out.push_back(word);
+    }
+    return true;
+}
+
+bool encode_utf16(const std::vector<uint32_t> &input, bool little, std::vector<omega_byte_t> &out) {
+    out.clear();
+    for (const auto codepoint: input) {
+        if (codepoint <= 0xFFFFU) {
+            if (codepoint >= 0xD800U && codepoint <= 0xDFFFU) { return false; }
+            write_word(codepoint, little, 2, out);
+        } else if (codepoint <= 0x10FFFFU) {
+            const uint32_t value = codepoint - 0x10000U;
+            write_word(0xD800U | (value >> 10U), little, 2, out);
+            write_word(0xDC00U | (value & 0x3FFU), little, 2, out);
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool decode_fixed_width(const std::vector<omega_byte_t> &input, bool little, int bytes, std::vector<uint32_t> &out) {
+    if ((input.size() % static_cast<size_t>(bytes)) != 0) { return false; }
+    out.clear();
+    for (size_t i = 0; i < input.size(); i += static_cast<size_t>(bytes)) {
+        out.push_back(read_word(input, i, little, bytes));
+    }
+    return true;
+}
+
+uint32_t cp1252_decode(omega_byte_t byte) {
+    static const std::map<omega_byte_t, uint32_t> extra = {
+            {0x80, 0x20AC}, {0x82, 0x201A}, {0x83, 0x0192}, {0x84, 0x201E}, {0x85, 0x2026},
+            {0x86, 0x2020}, {0x87, 0x2021}, {0x88, 0x02C6}, {0x89, 0x2030}, {0x8A, 0x0160},
+            {0x8B, 0x2039}, {0x8C, 0x0152}, {0x8E, 0x017D}, {0x91, 0x2018}, {0x92, 0x2019},
+            {0x93, 0x201C}, {0x94, 0x201D}, {0x95, 0x2022}, {0x96, 0x2013}, {0x97, 0x2014},
+            {0x98, 0x02DC}, {0x99, 0x2122}, {0x9A, 0x0161}, {0x9B, 0x203A}, {0x9C, 0x0153},
+            {0x9E, 0x017E}, {0x9F, 0x0178}};
+    const auto iter = extra.find(byte);
+    return iter == extra.end() ? byte : iter->second;
+}
+
+bool cp1252_encode(uint32_t codepoint, omega_byte_t &byte) {
+    if ((codepoint <= 0x7FU) || (codepoint >= 0xA0U && codepoint <= 0xFFU)) {
+        byte = static_cast<omega_byte_t>(codepoint);
+        return true;
+    }
+    for (int candidate = 0x80; candidate <= 0x9F; ++candidate) {
+        if (cp1252_decode(static_cast<omega_byte_t>(candidate)) == codepoint) {
+            byte = static_cast<omega_byte_t>(candidate);
+            return true;
+        }
+    }
+    return false;
+}
+
+uint32_t ebcdic037_decode(omega_byte_t byte) {
+    if (byte >= 0x81 && byte <= 0x89) { return 'a' + (byte - 0x81); }
+    if (byte >= 0x91 && byte <= 0x99) { return 'j' + (byte - 0x91); }
+    if (byte >= 0xA2 && byte <= 0xA9) { return 's' + (byte - 0xA2); }
+    if (byte >= 0xC1 && byte <= 0xC9) { return 'A' + (byte - 0xC1); }
+    if (byte >= 0xD1 && byte <= 0xD9) { return 'J' + (byte - 0xD1); }
+    if (byte >= 0xE2 && byte <= 0xE9) { return 'S' + (byte - 0xE2); }
+    if (byte >= 0xF0 && byte <= 0xF9) { return '0' + (byte - 0xF0); }
+    static const std::map<omega_byte_t, uint32_t> punctuation = {
+            {0x40, ' '}, {0x4B, '.'}, {0x4C, '<'}, {0x4D, '('}, {0x4E, '+'}, {0x4F, '|'}, {0x50, '&'},
+            {0x5A, '!'}, {0x5B, '$'}, {0x5C, '*'}, {0x5D, ')'}, {0x5E, ';'}, {0x60, '-'}, {0x61, '/'},
+            {0x6B, ','}, {0x6C, '%'}, {0x6D, '_'}, {0x6E, '>'}, {0x6F, '?'}, {0x79, '`'}, {0x7A, ':'},
+            {0x7B, '#'}, {0x7C, '@'}, {0x7D, '\''}, {0x7E, '='}, {0x7F, '"'}, {0xA1, '~'}, {0xBA, '['},
+            {0xBB, ']'}, {0xC0, '{'}, {0xD0, '}'}, {0xE0, '\\'}};
+    const auto iter = punctuation.find(byte);
+    return iter == punctuation.end() ? 0xFFFDU : iter->second;
+}
+
+uint32_t ebcdic_decode(const std::string &charset, omega_byte_t byte) {
+    if (charset == "ebcdic-500" || charset == "ibm500") {
+        if (byte == 0x4A) { return '['; }
+        if (byte == 0x4F) { return '!'; }
+        if (byte == 0x5A) { return ']'; }
+        if (byte == 0x5F) { return '^'; }
+        if (byte == 0xBB) { return '|'; }
+        return ebcdic037_decode(byte);
+    }
+    if (charset == "ebcdic-1047" || charset == "ibm1047") {
+        if (byte == 0x5F) { return '^'; }
+        if (byte == 0xAD) { return '['; }
+        if (byte == 0xBD) { return ']'; }
+        return ebcdic037_decode(byte);
+    }
+    if ((charset == "ebcdic-1140" || charset == "ibm1140") && byte == 0x9F) { return 0x20ACU; }
+    return ebcdic037_decode(byte);
+}
+
+bool ebcdic037_encode(uint32_t codepoint, omega_byte_t &byte) {
+    if (codepoint >= 'a' && codepoint <= 'i') {
+        byte = static_cast<omega_byte_t>(0x81 + (codepoint - 'a'));
+        return true;
+    }
+    if (codepoint >= 'j' && codepoint <= 'r') {
+        byte = static_cast<omega_byte_t>(0x91 + (codepoint - 'j'));
+        return true;
+    }
+    if (codepoint >= 's' && codepoint <= 'z') {
+        byte = static_cast<omega_byte_t>(0xA2 + (codepoint - 's'));
+        return true;
+    }
+    if (codepoint >= 'A' && codepoint <= 'I') {
+        byte = static_cast<omega_byte_t>(0xC1 + (codepoint - 'A'));
+        return true;
+    }
+    if (codepoint >= 'J' && codepoint <= 'R') {
+        byte = static_cast<omega_byte_t>(0xD1 + (codepoint - 'J'));
+        return true;
+    }
+    if (codepoint >= 'S' && codepoint <= 'Z') {
+        byte = static_cast<omega_byte_t>(0xE2 + (codepoint - 'S'));
+        return true;
+    }
+    if (codepoint >= '0' && codepoint <= '9') {
+        byte = static_cast<omega_byte_t>(0xF0 + (codepoint - '0'));
+        return true;
+    }
+    static const std::map<uint32_t, omega_byte_t> punctuation = {
+            {' ', 0x40}, {'.', 0x4B}, {'<', 0x4C}, {'(', 0x4D}, {'+', 0x4E}, {'|', 0x4F}, {'&', 0x50},
+            {'!', 0x5A}, {'$', 0x5B}, {'*', 0x5C}, {')', 0x5D}, {';', 0x5E}, {'-', 0x60}, {'/', 0x61},
+            {',', 0x6B}, {'%', 0x6C}, {'_', 0x6D}, {'>', 0x6E}, {'?', 0x6F}, {'`', 0x79}, {':', 0x7A},
+            {'#', 0x7B}, {'@', 0x7C}, {'\'', 0x7D}, {'=', 0x7E}, {'"', 0x7F}, {'~', 0xA1}, {'[', 0xBA},
+            {']', 0xBB}, {'{', 0xC0}, {'}', 0xD0}, {'\\', 0xE0}};
+    const auto iter = punctuation.find(codepoint);
+    if (iter == punctuation.end()) { return false; }
+    byte = iter->second;
+    return true;
+}
+
+bool ebcdic_encode(const std::string &charset, uint32_t codepoint, omega_byte_t &byte) {
+    if ((charset == "ebcdic-1140" || charset == "ibm1140") && codepoint == 0x20ACU) {
+        byte = 0x9F;
+        return true;
+    }
+    if (charset == "ebcdic-500" || charset == "ibm500") {
+        if (codepoint == '[') {
+            byte = 0x4A;
+            return true;
+        }
+        if (codepoint == '!') {
+            byte = 0x4F;
+            return true;
+        }
+        if (codepoint == ']') {
+            byte = 0x5A;
+            return true;
+        }
+        if (codepoint == '^') {
+            byte = 0x5F;
+            return true;
+        }
+        if (codepoint == '|') {
+            byte = 0xBB;
+            return true;
+        }
+    }
+    if (charset == "ebcdic-1047" || charset == "ibm1047") {
+        if (codepoint == '^') {
+            byte = 0x5F;
+            return true;
+        }
+        if (codepoint == '[') {
+            byte = 0xAD;
+            return true;
+        }
+        if (codepoint == ']') {
+            byte = 0xBD;
+            return true;
+        }
+    }
+    return ebcdic037_encode(codepoint, byte);
+}
+
+bool is_ebcdic(const std::string &charset) {
+    return charset == "ebcdic-037" || charset == "ibm037" || charset == "ebcdic-500" || charset == "ibm500" ||
+           charset == "ebcdic-1047" || charset == "ibm1047" || charset == "ebcdic-1140" || charset == "ibm1140";
+}
+
+bool decode_charset(const std::vector<omega_byte_t> &input, const std::string &charset, std::vector<uint32_t> &out) {
+    if (charset == "utf-8") { return decode_utf8(input, out); }
+    if (charset == "utf-16le" || charset == "utf-16be") { return decode_utf16(input, charset == "utf-16le", out); }
+    if (charset == "utf-32le" || charset == "utf-32be") {
+        return decode_fixed_width(input, charset == "utf-32le", 4, out);
+    }
+    out.clear();
+    for (const auto byte: input) {
+        if (charset == "ascii") {
+            if (byte > 0x7FU) { return false; }
+            out.push_back(byte);
+        } else if (charset == "iso-8859-1") {
+            out.push_back(byte);
+        } else if (charset == "windows-1252") {
+            const uint32_t codepoint = cp1252_decode(byte);
+            if (codepoint == 0xFFFDU) { return false; }
+            out.push_back(codepoint);
+        } else if (is_ebcdic(charset)) {
+            const uint32_t codepoint = ebcdic_decode(charset, byte);
+            if (codepoint == 0xFFFDU) { return false; }
+            out.push_back(codepoint);
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool encode_charset(const std::vector<uint32_t> &input, const std::string &charset, std::vector<omega_byte_t> &out) {
+    out.clear();
+    if (charset == "utf-8") {
+        for (const auto codepoint: input) {
+            if (!utf8_append(codepoint, out)) { return false; }
+        }
+        return true;
+    }
+    if (charset == "utf-16le" || charset == "utf-16be") { return encode_utf16(input, charset == "utf-16le", out); }
+    if (charset == "utf-32le" || charset == "utf-32be") {
+        for (const auto codepoint: input) { write_word(codepoint, charset == "utf-32le", 4, out); }
+        return true;
+    }
+    for (const auto codepoint: input) {
+        omega_byte_t byte = 0;
+        if (charset == "ascii") {
+            if (codepoint > 0x7FU) { return false; }
+            byte = static_cast<omega_byte_t>(codepoint);
+        } else if (charset == "iso-8859-1") {
+            if (codepoint > 0xFFU) { return false; }
+            byte = static_cast<omega_byte_t>(codepoint);
+        } else if (charset == "windows-1252") {
+            if (!cp1252_encode(codepoint, byte)) { return false; }
+        } else if (is_ebcdic(charset)) {
+            if (!ebcdic_encode(charset, codepoint, byte)) { return false; }
+        } else {
+            return false;
+        }
+        out.push_back(byte);
+    }
+    return true;
+}
+
+} // namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
+        omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = "omega.example.character_transcode";
+    info_ptr->name = "Character Transcode";
+    info_ptr->description = "Transcode common text encodings and single-byte EBCDIC code pages.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK |
+                      OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help =
+            "Options JSON accepts {\"from\":\"ebcdic-037\",\"to\":\"utf-8\"}. Charsets include ascii, utf-8, "
+            "utf-16le/be, utf-32le/be, iso-8859-1, windows-1252, ebcdic-037, ebcdic-500, ebcdic-1047, and "
+            "ebcdic-1140.";
+    info_ptr->example = "{\"from\":\"ebcdic-037\",\"to\":\"utf-8\"}";
+    info_ptr->default_args = "{\"from\":\"utf-8\",\"to\":\"utf-16le\"}";
+    info_ptr->args_schema = CHARACTER_TRANSCODE_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+    std::vector<omega_byte_t> input;
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
+        return -1;
+    }
+    std::map<std::string, std::string> options;
+    if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
+    const std::string from = omega_edit::plugin::option_or(options, "from", "utf-8");
+    const std::string to = omega_edit::plugin::option_or(options, "to", "utf-16le");
+
+    std::vector<uint32_t> codepoints;
+    std::vector<omega_byte_t> output;
+    if (!decode_charset(input, from, codepoints) || !encode_charset(codepoints, to, output)) { return -1; }
+    return omega_edit::plugin::set_replacement(request_ptr, response_ptr, output);
+}

--- a/plugins/src/common_checksums.cpp
+++ b/plugins/src/common_checksums.cpp
@@ -1,0 +1,596 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include "plugin_options.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace {
+
+constexpr const char *CHECKSUM_ARGS_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"algorithm\":{\"type\":\"string\",\"pattern\":\"^(crc32|crc32c|crc32-"
+        "mpeg2|crc32-bzip2|crc16-ibm|crc16-arc|crc16-ccitt-false|crc16-xmodem|crc16-modbus|crc16-kermit|crc8|"
+        "adler32|fletcher16|fletcher32|internet-checksum|lrc|bcc|sum8|sum16|sum32|fnv1a32|fnv1a64|murmur3-32|"
+        "xxhash32|xxhash64)$\"}},\"additionalProperties\":false}";
+
+uint64_t mask_for_width(int width) {
+    return width == 64 ? UINT64_MAX : ((UINT64_C(1) << width) - UINT64_C(1));
+}
+
+uint64_t reflect_bits(uint64_t value, int width) {
+    uint64_t reflected = 0;
+    for (int i = 0; i < width; ++i) {
+        if (value & (UINT64_C(1) << i)) { reflected |= UINT64_C(1) << (width - 1 - i); }
+    }
+    return reflected;
+}
+
+struct crc_model_t {
+    int width;
+    uint64_t polynomial;
+    uint64_t init;
+    uint64_t xor_out;
+    bool refin;
+    bool refout;
+};
+
+uint64_t crc_update(uint64_t state, const crc_model_t &model, const omega_byte_t *bytes, int64_t length) {
+    const uint64_t mask = mask_for_width(model.width);
+    if (model.refin) {
+        const uint64_t reflected_polynomial = reflect_bits(model.polynomial, model.width);
+        for (int64_t i = 0; i < length; ++i) {
+            state ^= static_cast<uint8_t>(bytes[i]);
+            for (int bit = 0; bit < 8; ++bit) {
+                state = (state & 1U) ? ((state >> 1U) ^ reflected_polynomial) : (state >> 1U);
+            }
+            state &= mask;
+        }
+        return state;
+    }
+
+    const uint64_t top_bit = UINT64_C(1) << (model.width - 1);
+    for (int64_t i = 0; i < length; ++i) {
+        state ^= static_cast<uint64_t>(static_cast<uint8_t>(bytes[i])) << (model.width - 8);
+        for (int bit = 0; bit < 8; ++bit) {
+            state = (state & top_bit) ? ((state << 1U) ^ model.polynomial) : (state << 1U);
+        }
+        state &= mask;
+    }
+    return state;
+}
+
+uint64_t crc_finalize(uint64_t state, const crc_model_t &model) {
+    if (model.refin != model.refout) { state = reflect_bits(state, model.width); }
+    return (state ^ model.xor_out) & mask_for_width(model.width);
+}
+
+bool crc_model_for(const std::string &algorithm, crc_model_t &model, int &hex_width) {
+    if (algorithm == "crc32") {
+        model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0xFFFFFFFFU, true, true};
+        hex_width = 8;
+        return true;
+    }
+    if (algorithm == "crc32c") {
+        model = {32, 0x1EDC6F41U, 0xFFFFFFFFU, 0xFFFFFFFFU, true, true};
+        hex_width = 8;
+        return true;
+    }
+    if (algorithm == "crc32-mpeg2") {
+        model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0x00000000U, false, false};
+        hex_width = 8;
+        return true;
+    }
+    if (algorithm == "crc32-bzip2") {
+        model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0xFFFFFFFFU, false, false};
+        hex_width = 8;
+        return true;
+    }
+    if (algorithm == "crc16-ibm" || algorithm == "crc16-arc") {
+        model = {16, 0x8005U, 0x0000U, 0x0000U, true, true};
+        hex_width = 4;
+        return true;
+    }
+    if (algorithm == "crc16-modbus") {
+        model = {16, 0x8005U, 0xFFFFU, 0x0000U, true, true};
+        hex_width = 4;
+        return true;
+    }
+    if (algorithm == "crc16-ccitt-false") {
+        model = {16, 0x1021U, 0xFFFFU, 0x0000U, false, false};
+        hex_width = 4;
+        return true;
+    }
+    if (algorithm == "crc16-xmodem") {
+        model = {16, 0x1021U, 0x0000U, 0x0000U, false, false};
+        hex_width = 4;
+        return true;
+    }
+    if (algorithm == "crc16-kermit") {
+        model = {16, 0x1021U, 0x0000U, 0x0000U, true, true};
+        hex_width = 4;
+        return true;
+    }
+    if (algorithm == "crc8") {
+        model = {8, 0x07U, 0x00U, 0x00U, false, false};
+        hex_width = 2;
+        return true;
+    }
+    return false;
+}
+
+uint32_t rotl32(uint32_t value, int count) {
+    return (value << count) | (value >> (32 - count));
+}
+
+uint64_t rotl64(uint64_t value, int count) {
+    return (value << count) | (value >> (64 - count));
+}
+
+uint32_t read32le(const omega_byte_t *bytes) {
+    return static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8U) |
+           (static_cast<uint32_t>(bytes[2]) << 16U) | (static_cast<uint32_t>(bytes[3]) << 24U);
+}
+
+uint64_t read64le(const omega_byte_t *bytes) {
+    return static_cast<uint64_t>(read32le(bytes)) | (static_cast<uint64_t>(read32le(bytes + 4)) << 32U);
+}
+
+struct murmur3_32_t {
+    uint32_t h = 0;
+    uint64_t length = 0;
+    std::array<omega_byte_t, 4> tail{};
+    size_t tail_length = 0;
+
+    void block(uint32_t k) {
+        k *= 0xcc9e2d51U;
+        k = rotl32(k, 15);
+        k *= 0x1b873593U;
+        h ^= k;
+        h = rotl32(h, 13);
+        h = (h * 5U) + 0xe6546b64U;
+    }
+
+    void update(const omega_byte_t *bytes, int64_t byte_count) {
+        length += static_cast<uint64_t>(byte_count);
+        size_t index = 0;
+        if (tail_length > 0) {
+            while (tail_length < tail.size() && index < static_cast<size_t>(byte_count)) {
+                tail[tail_length++] = bytes[index++];
+            }
+            if (tail_length == tail.size()) {
+                block(read32le(tail.data()));
+                tail_length = 0;
+            }
+        }
+        while (index + 4 <= static_cast<size_t>(byte_count)) {
+            block(read32le(bytes + index));
+            index += 4;
+        }
+        while (index < static_cast<size_t>(byte_count)) { tail[tail_length++] = bytes[index++]; }
+    }
+
+    uint32_t final() const {
+        uint32_t result = h;
+        uint32_t k = 0;
+        switch (tail_length) {
+            case 3:
+                k ^= static_cast<uint32_t>(tail[2]) << 16U;
+                [[fallthrough]];
+            case 2:
+                k ^= static_cast<uint32_t>(tail[1]) << 8U;
+                [[fallthrough]];
+            case 1:
+                k ^= tail[0];
+                k *= 0xcc9e2d51U;
+                k = rotl32(k, 15);
+                k *= 0x1b873593U;
+                result ^= k;
+                break;
+            default:
+                break;
+        }
+        result ^= static_cast<uint32_t>(length);
+        result ^= result >> 16U;
+        result *= 0x85ebca6bU;
+        result ^= result >> 13U;
+        result *= 0xc2b2ae35U;
+        result ^= result >> 16U;
+        return result;
+    }
+};
+
+struct xxhash32_t {
+    static constexpr uint32_t p1 = 2654435761U;
+    static constexpr uint32_t p2 = 2246822519U;
+    static constexpr uint32_t p3 = 3266489917U;
+    static constexpr uint32_t p4 = 668265263U;
+    static constexpr uint32_t p5 = 374761393U;
+
+    uint64_t length = 0;
+    uint32_t v1 = p1 + p2;
+    uint32_t v2 = p2;
+    uint32_t v3 = 0;
+    uint32_t v4 = 0U - p1;
+    std::array<omega_byte_t, 16> memory{};
+    size_t memory_size = 0;
+
+    static uint32_t round(uint32_t acc, uint32_t input) {
+        acc += input * p2;
+        acc = rotl32(acc, 13);
+        return acc * p1;
+    }
+
+    void stripe(const omega_byte_t *bytes) {
+        v1 = round(v1, read32le(bytes));
+        v2 = round(v2, read32le(bytes + 4));
+        v3 = round(v3, read32le(bytes + 8));
+        v4 = round(v4, read32le(bytes + 12));
+    }
+
+    void update(const omega_byte_t *bytes, int64_t byte_count) {
+        length += static_cast<uint64_t>(byte_count);
+        size_t index = 0;
+        if (memory_size + static_cast<size_t>(byte_count) < memory.size()) {
+            std::memcpy(memory.data() + memory_size, bytes, static_cast<size_t>(byte_count));
+            memory_size += static_cast<size_t>(byte_count);
+            return;
+        }
+        if (memory_size > 0) {
+            const size_t fill = memory.size() - memory_size;
+            std::memcpy(memory.data() + memory_size, bytes, fill);
+            stripe(memory.data());
+            index += fill;
+            memory_size = 0;
+        }
+        while (index + memory.size() <= static_cast<size_t>(byte_count)) {
+            stripe(bytes + index);
+            index += memory.size();
+        }
+        if (index < static_cast<size_t>(byte_count)) {
+            memory_size = static_cast<size_t>(byte_count) - index;
+            std::memcpy(memory.data(), bytes + index, memory_size);
+        }
+    }
+
+    uint32_t final() const {
+        uint32_t h = 0;
+        if (length >= 16) {
+            h = rotl32(v1, 1) + rotl32(v2, 7) + rotl32(v3, 12) + rotl32(v4, 18);
+        } else {
+            h = p5;
+        }
+        h += static_cast<uint32_t>(length);
+        size_t index = 0;
+        while (index + 4 <= memory_size) {
+            h += read32le(memory.data() + index) * p3;
+            h = rotl32(h, 17) * p4;
+            index += 4;
+        }
+        while (index < memory_size) {
+            h += memory[index] * p5;
+            h = rotl32(h, 11) * p1;
+            ++index;
+        }
+        h ^= h >> 15U;
+        h *= p2;
+        h ^= h >> 13U;
+        h *= p3;
+        h ^= h >> 16U;
+        return h;
+    }
+};
+
+struct xxhash64_t {
+    static constexpr uint64_t p1 = 11400714785074694791ULL;
+    static constexpr uint64_t p2 = 14029467366897019727ULL;
+    static constexpr uint64_t p3 = 1609587929392839161ULL;
+    static constexpr uint64_t p4 = 9650029242287828579ULL;
+    static constexpr uint64_t p5 = 2870177450012600261ULL;
+
+    uint64_t length = 0;
+    uint64_t v1 = p1 + p2;
+    uint64_t v2 = p2;
+    uint64_t v3 = 0;
+    uint64_t v4 = 0U - p1;
+    std::array<omega_byte_t, 32> memory{};
+    size_t memory_size = 0;
+
+    static uint64_t round(uint64_t acc, uint64_t input) {
+        acc += input * p2;
+        acc = rotl64(acc, 31);
+        return acc * p1;
+    }
+
+    static uint64_t merge_round(uint64_t acc, uint64_t value) {
+        acc ^= round(0, value);
+        return (acc * p1) + p4;
+    }
+
+    void stripe(const omega_byte_t *bytes) {
+        v1 = round(v1, read64le(bytes));
+        v2 = round(v2, read64le(bytes + 8));
+        v3 = round(v3, read64le(bytes + 16));
+        v4 = round(v4, read64le(bytes + 24));
+    }
+
+    void update(const omega_byte_t *bytes, int64_t byte_count) {
+        length += static_cast<uint64_t>(byte_count);
+        size_t index = 0;
+        if (memory_size + static_cast<size_t>(byte_count) < memory.size()) {
+            std::memcpy(memory.data() + memory_size, bytes, static_cast<size_t>(byte_count));
+            memory_size += static_cast<size_t>(byte_count);
+            return;
+        }
+        if (memory_size > 0) {
+            const size_t fill = memory.size() - memory_size;
+            std::memcpy(memory.data() + memory_size, bytes, fill);
+            stripe(memory.data());
+            index += fill;
+            memory_size = 0;
+        }
+        while (index + memory.size() <= static_cast<size_t>(byte_count)) {
+            stripe(bytes + index);
+            index += memory.size();
+        }
+        if (index < static_cast<size_t>(byte_count)) {
+            memory_size = static_cast<size_t>(byte_count) - index;
+            std::memcpy(memory.data(), bytes + index, memory_size);
+        }
+    }
+
+    uint64_t final() const {
+        uint64_t h = 0;
+        if (length >= 32) {
+            h = rotl64(v1, 1) + rotl64(v2, 7) + rotl64(v3, 12) + rotl64(v4, 18);
+            h = merge_round(h, v1);
+            h = merge_round(h, v2);
+            h = merge_round(h, v3);
+            h = merge_round(h, v4);
+        } else {
+            h = p5;
+        }
+        h += length;
+        size_t index = 0;
+        while (index + 8 <= memory_size) {
+            h ^= round(0, read64le(memory.data() + index));
+            h = (rotl64(h, 27) * p1) + p4;
+            index += 8;
+        }
+        if (index + 4 <= memory_size) {
+            h ^= static_cast<uint64_t>(read32le(memory.data() + index)) * p1;
+            h = (rotl64(h, 23) * p2) + p3;
+            index += 4;
+        }
+        while (index < memory_size) {
+            h ^= memory[index] * p5;
+            h = rotl64(h, 11) * p1;
+            ++index;
+        }
+        h ^= h >> 33U;
+        h *= p2;
+        h ^= h >> 29U;
+        h *= p3;
+        h ^= h >> 32U;
+        return h;
+    }
+};
+
+} // namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
+        omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = "omega.example.common_checksums";
+    info_ptr->name = "Common Checksums";
+    info_ptr->description = "Inspect the selected range with common CRC, checksum, and non-cryptographic hash variants.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE |
+                      OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING;
+    info_ptr->help =
+            "Options JSON accepts {\"algorithm\":\"crc32\"}. Algorithms include crc32, crc32c, crc32-mpeg2, "
+            "crc32-bzip2, crc16-ibm, crc16-ccitt-false, crc16-xmodem, crc16-modbus, crc16-kermit, crc8, adler32, "
+            "fletcher16, fletcher32, internet-checksum, lrc, bcc, sum8, sum16, sum32, fnv1a32, fnv1a64, murmur3-32, "
+            "xxhash32, and xxhash64.";
+    info_ptr->example = "{\"algorithm\":\"crc32c\"}";
+    info_ptr->default_args = "{\"algorithm\":\"crc32\"}";
+    info_ptr->args_schema = CHECKSUM_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0 ||
+        request_ptr->session_length < 0) {
+        return -1;
+    }
+
+    std::map<std::string, std::string> options;
+    if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
+    const auto algorithm = omega_edit::plugin::option_or(options, "algorithm", "crc32");
+
+    crc_model_t crc_model{};
+    int crc_hex_width = 0;
+    if (crc_model_for(algorithm, crc_model, crc_hex_width)) {
+        uint64_t crc = crc_model.init;
+        const bool ok = omega_edit::plugin::for_each_chunk(
+                request_ptr, [&](const omega_byte_t *bytes, int64_t length) {
+                    crc = crc_update(crc, crc_model, bytes, length);
+                    return true;
+                });
+        if (!ok) { return -1; }
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(crc_finalize(crc, crc_model),
+                                                                                crc_hex_width));
+    }
+
+    uint32_t adler_a = 1;
+    uint32_t adler_b = 0;
+    uint32_t fletcher_a = 0;
+    uint32_t fletcher_b = 0;
+    uint64_t fletcher32_a = 0;
+    uint64_t fletcher32_b = 0;
+    uint32_t internet_sum = 0;
+    uint32_t sum = 0;
+    uint8_t lrc_sum = 0;
+    uint8_t bcc = 0;
+    uint32_t fnv32 = 2166136261U;
+    uint64_t fnv64 = 14695981039346656037ULL;
+    murmur3_32_t murmur3;
+    xxhash32_t xx32;
+    xxhash64_t xx64;
+    bool have_odd_internet_byte = false;
+    omega_byte_t odd_internet_byte = 0;
+    bool have_odd_fletcher32_byte = false;
+    omega_byte_t odd_fletcher32_byte = 0;
+
+    const bool ok = omega_edit::plugin::for_each_chunk(
+            request_ptr, [&](const omega_byte_t *bytes, int64_t length) {
+                if (algorithm == "murmur3-32") {
+                    murmur3.update(bytes, length);
+                    return true;
+                }
+                if (algorithm == "xxhash32") {
+                    xx32.update(bytes, length);
+                    return true;
+                }
+                if (algorithm == "xxhash64") {
+                    xx64.update(bytes, length);
+                    return true;
+                }
+                for (int64_t i = 0; i < length; ++i) {
+                    const uint8_t byte = static_cast<uint8_t>(bytes[i]);
+                    if (algorithm == "adler32") {
+                        adler_a = (adler_a + byte) % 65521U;
+                        adler_b = (adler_b + adler_a) % 65521U;
+                    } else if (algorithm == "fletcher16") {
+                        fletcher_a = (fletcher_a + byte) % 255U;
+                        fletcher_b = (fletcher_b + fletcher_a) % 255U;
+                    } else if (algorithm == "fletcher32") {
+                        uint16_t word = 0;
+                        if (have_odd_fletcher32_byte) {
+                            word = static_cast<uint16_t>((odd_fletcher32_byte << 8U) | byte);
+                            have_odd_fletcher32_byte = false;
+                        } else if (i + 1 < length) {
+                            word = static_cast<uint16_t>((byte << 8U) | static_cast<uint8_t>(bytes[++i]));
+                        } else {
+                            odd_fletcher32_byte = byte;
+                            have_odd_fletcher32_byte = true;
+                            continue;
+                        }
+                        fletcher32_a = (fletcher32_a + word) % 65535U;
+                        fletcher32_b = (fletcher32_b + fletcher32_a) % 65535U;
+                    } else if (algorithm == "internet-checksum") {
+                        uint16_t word = 0;
+                        if (have_odd_internet_byte) {
+                            word = static_cast<uint16_t>((odd_internet_byte << 8U) | byte);
+                            have_odd_internet_byte = false;
+                        } else if (i + 1 < length) {
+                            word = static_cast<uint16_t>((byte << 8U) | static_cast<uint8_t>(bytes[++i]));
+                        } else {
+                            odd_internet_byte = byte;
+                            have_odd_internet_byte = true;
+                            continue;
+                        }
+                        internet_sum += word;
+                        internet_sum = (internet_sum & 0xFFFFU) + (internet_sum >> 16U);
+                    } else if (algorithm == "lrc") {
+                        lrc_sum = static_cast<uint8_t>(lrc_sum + byte);
+                    } else if (algorithm == "bcc") {
+                        bcc ^= byte;
+                    } else if (algorithm == "sum8" || algorithm == "sum16" || algorithm == "sum32") {
+                        sum += byte;
+                    } else if (algorithm == "fnv1a32") {
+                        fnv32 ^= byte;
+                        fnv32 *= 16777619U;
+                    } else if (algorithm == "fnv1a64") {
+                        fnv64 ^= byte;
+                        fnv64 *= 1099511628211ULL;
+                    } else {
+                        return false;
+                    }
+                }
+                return true;
+            });
+    if (!ok) { return -1; }
+
+    if (algorithm == "adler32") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value((adler_b << 16U) | adler_a, 8));
+    }
+    if (algorithm == "fletcher16") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value((fletcher_b << 8U) | fletcher_a, 4));
+    }
+    if (algorithm == "fletcher32") {
+        if (have_odd_fletcher32_byte) {
+            fletcher32_a = (fletcher32_a + (static_cast<uint16_t>(odd_fletcher32_byte) << 8U)) % 65535U;
+            fletcher32_b = (fletcher32_b + fletcher32_a) % 65535U;
+        }
+        return omega_edit::plugin::set_text_result(
+                request_ptr, response_ptr, algorithm,
+                omega_edit::plugin::hex_value(((fletcher32_b & 0xFFFFU) << 16U) | (fletcher32_a & 0xFFFFU), 8));
+    }
+    if (algorithm == "internet-checksum") {
+        if (have_odd_internet_byte) { internet_sum += static_cast<uint32_t>(odd_internet_byte) << 8U; }
+        while (internet_sum >> 16U) { internet_sum = (internet_sum & 0xFFFFU) + (internet_sum >> 16U); }
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value((~internet_sum) & 0xFFFFU, 4));
+    }
+    if (algorithm == "lrc") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(static_cast<uint8_t>(0U - lrc_sum), 2));
+    }
+    if (algorithm == "bcc") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(bcc, 2));
+    }
+    if (algorithm == "sum8") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(sum & 0xFFU, 2));
+    }
+    if (algorithm == "sum16") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(sum & 0xFFFFU, 4));
+    }
+    if (algorithm == "sum32") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(sum, 8));
+    }
+    if (algorithm == "fnv1a32") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(fnv32, 8));
+    }
+    if (algorithm == "fnv1a64") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(fnv64, 16));
+    }
+    if (algorithm == "murmur3-32") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(murmur3.final(), 8));
+    }
+    if (algorithm == "xxhash32") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(xx32.final(), 8));
+    }
+    if (algorithm == "xxhash64") {
+        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
+                                                   omega_edit::plugin::hex_value(xx64.final(), 16));
+    }
+    return -1;
+}

--- a/plugins/src/decimal_codecs.cpp
+++ b/plugins/src/decimal_codecs.cpp
@@ -1,0 +1,213 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include "plugin_options.hpp"
+
+#include <cctype>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr const char *DECIMAL_CODEC_ARGS_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"codec\":{\"type\":\"string\",\"pattern\":\"^(bcd|packed-decimal|"
+        "comp-3|zoned-decimal|overpunch)$\"},\"direction\":{\"type\":\"string\",\"pattern\":\"^(encode|decode)$\"}},"
+        "\"additionalProperties\":false}";
+
+bool is_ascii_space(omega_byte_t byte) {
+    return std::isspace(static_cast<unsigned char>(byte)) != 0;
+}
+
+bool is_ascii_digit(omega_byte_t byte) {
+    return std::isdigit(static_cast<unsigned char>(byte)) != 0;
+}
+
+bool digits_from_ascii(const std::vector<omega_byte_t> &input, std::string &digits, bool &negative) {
+    digits.clear();
+    negative = false;
+    for (const auto byte: input) {
+        if (byte == '+' || is_ascii_space(byte)) { continue; }
+        if (byte == '-') {
+            negative = true;
+            continue;
+        }
+        if (!is_ascii_digit(byte)) { return false; }
+        digits.push_back(static_cast<char>(byte));
+    }
+    return !digits.empty();
+}
+
+std::vector<omega_byte_t> ascii_bytes(const std::string &text) {
+    return std::vector<omega_byte_t>(text.begin(), text.end());
+}
+
+bool decode_nibble(unsigned int nibble, char &digit) {
+    if (nibble > 9U) { return false; }
+    digit = static_cast<char>('0' + nibble);
+    return true;
+}
+
+bool encode_bcd(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    std::string digits;
+    bool negative = false;
+    if (!digits_from_ascii(input, digits, negative) || negative) { return false; }
+    if ((digits.size() % 2) != 0) { digits.insert(digits.begin(), '0'); }
+    out.clear();
+    for (size_t i = 0; i < digits.size(); i += 2) {
+        out.push_back(static_cast<omega_byte_t>(((digits[i] - '0') << 4U) | (digits[i + 1] - '0')));
+    }
+    return true;
+}
+
+bool decode_bcd(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    std::string digits;
+    for (const auto byte: input) {
+        char high = 0;
+        char low = 0;
+        if (!decode_nibble((byte >> 4U) & 0x0FU, high) || !decode_nibble(byte & 0x0FU, low)) { return false; }
+        digits.push_back(high);
+        digits.push_back(low);
+    }
+    out = ascii_bytes(digits);
+    return true;
+}
+
+bool encode_packed(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    std::string digits;
+    bool negative = false;
+    if (!digits_from_ascii(input, digits, negative)) { return false; }
+    digits.push_back(negative ? 'D' : 'C');
+    if ((digits.size() % 2) != 0) { digits.insert(digits.begin(), '0'); }
+    out.clear();
+    for (size_t i = 0; i < digits.size(); i += 2) {
+        const unsigned int high = digits[i] >= 'A' ? 0x0DU : static_cast<unsigned int>(digits[i] - '0');
+        const unsigned int low = digits[i + 1] >= 'A' ? (digits[i + 1] == 'D' ? 0x0DU : 0x0CU)
+                                                      : static_cast<unsigned int>(digits[i + 1] - '0');
+        out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+    }
+    return true;
+}
+
+bool decode_packed(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    if (input.empty()) { return false; }
+    std::string digits;
+    bool negative = false;
+    for (size_t i = 0; i < input.size(); ++i) {
+        const unsigned int high = (input[i] >> 4U) & 0x0FU;
+        const unsigned int low = input[i] & 0x0FU;
+        char digit = 0;
+        if (!decode_nibble(high, digit)) { return false; }
+        digits.push_back(digit);
+        if (i + 1 == input.size()) {
+            if (low == 0x0DU || low == 0x0BU) {
+                negative = true;
+            } else if (low != 0x0CU && low != 0x0FU) {
+                return false;
+            }
+        } else {
+            if (!decode_nibble(low, digit)) { return false; }
+            digits.push_back(digit);
+        }
+    }
+    if (negative) { digits.insert(digits.begin(), '-'); }
+    out = ascii_bytes(digits);
+    return true;
+}
+
+bool encode_zoned(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out, bool overpunch) {
+    std::string digits;
+    bool negative = false;
+    if (!digits_from_ascii(input, digits, negative)) { return false; }
+    out.clear();
+    for (size_t i = 0; i < digits.size(); ++i) {
+        const unsigned int digit = static_cast<unsigned int>(digits[i] - '0');
+        if (overpunch && i + 1 == digits.size()) {
+            out.push_back(static_cast<omega_byte_t>((negative ? 0xD0U : 0xC0U) | digit));
+        } else {
+            out.push_back(static_cast<omega_byte_t>(0xF0U | digit));
+        }
+    }
+    return true;
+}
+
+bool decode_zoned(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out, bool overpunch) {
+    if (input.empty()) { return false; }
+    std::string digits;
+    bool negative = false;
+    for (size_t i = 0; i < input.size(); ++i) {
+        const unsigned int zone = (input[i] >> 4U) & 0x0FU;
+        const unsigned int digit = input[i] & 0x0FU;
+        if (digit > 9U) { return false; }
+        if (overpunch && i + 1 == input.size()) {
+            if (zone == 0x0DU) {
+                negative = true;
+            } else if (zone != 0x0CU && zone != 0x0FU) {
+                return false;
+            }
+        } else if (zone != 0x0FU) {
+            return false;
+        }
+        digits.push_back(static_cast<char>('0' + digit));
+    }
+    if (negative) { digits.insert(digits.begin(), '-'); }
+    out = ascii_bytes(digits);
+    return true;
+}
+
+} // namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
+        omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = "omega.example.decimal_codecs";
+    info_ptr->name = "Decimal Codecs";
+    info_ptr->description = "Encode or decode BCD, packed decimal/COMP-3, zoned decimal, and signed overpunch fields.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK |
+                      OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help =
+            "Options JSON accepts {\"codec\":\"packed-decimal\",\"direction\":\"encode\"}. Codecs include bcd, "
+            "packed-decimal/comp-3, zoned-decimal, and overpunch.";
+    info_ptr->example = "{\"codec\":\"packed-decimal\",\"direction\":\"encode\"}";
+    info_ptr->default_args = "{\"codec\":\"bcd\",\"direction\":\"encode\"}";
+    info_ptr->args_schema = DECIMAL_CODEC_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+    std::vector<omega_byte_t> input;
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
+        return -1;
+    }
+    std::map<std::string, std::string> options;
+    if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
+    std::string codec = omega_edit::plugin::option_or(options, "codec", "bcd");
+    const std::string direction = omega_edit::plugin::option_or(options, "direction", "encode");
+    if (codec == "comp-3") { codec = "packed-decimal"; }
+
+    std::vector<omega_byte_t> output;
+    bool ok = false;
+    if (codec == "bcd") {
+        ok = direction == "encode" ? encode_bcd(input, output) : decode_bcd(input, output);
+    } else if (codec == "packed-decimal") {
+        ok = direction == "encode" ? encode_packed(input, output) : decode_packed(input, output);
+    } else if (codec == "zoned-decimal") {
+        ok = direction == "encode" ? encode_zoned(input, output, false) : decode_zoned(input, output, false);
+    } else if (codec == "overpunch") {
+        ok = direction == "encode" ? encode_zoned(input, output, true) : decode_zoned(input, output, true);
+    }
+    return ok ? omega_edit::plugin::set_replacement(request_ptr, response_ptr, output) : -1;
+}

--- a/plugins/src/endian_swap.cpp
+++ b/plugins/src/endian_swap.cpp
@@ -1,0 +1,58 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include "plugin_options.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace {
+constexpr const char *ENDIAN_SWAP_ARGS_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"width\":{\"type\":\"integer\",\"minimum\":2,\"maximum\":8}},"
+        "\"additionalProperties\":false}";
+}
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
+        omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = "omega.example.endian_swap";
+    info_ptr->name = "Endian Swap";
+    info_ptr->description = "Reverse byte order in fixed-width 2, 4, or 8 byte fields.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "Options JSON accepts {\"width\":2}, {\"width\":4}, or {\"width\":8}.";
+    info_ptr->example = "{\"width\":4}";
+    info_ptr->default_args = "{\"width\":2}";
+    info_ptr->args_schema = ENDIAN_SWAP_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+    std::vector<omega_byte_t> bytes;
+    if (!omega_edit::plugin::selected_bytes(request_ptr, bytes) || !response_ptr || !request_ptr->alloc) {
+        return -1;
+    }
+    std::map<std::string, std::string> options;
+    if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
+    const int64_t width = omega_edit::plugin::option_int_or(options, "width", 2);
+    if (!(width == 2 || width == 4 || width == 8) || (bytes.size() % static_cast<size_t>(width)) != 0) { return -1; }
+    using difference_type = std::vector<omega_byte_t>::difference_type;
+    for (size_t offset = 0; offset < bytes.size(); offset += static_cast<size_t>(width)) {
+        std::reverse(bytes.begin() + static_cast<difference_type>(offset),
+                     bytes.begin() + static_cast<difference_type>(offset + static_cast<size_t>(width)));
+    }
+    return omega_edit::plugin::set_replacement(request_ptr, response_ptr, bytes);
+}

--- a/plugins/src/format_inspectors.cpp
+++ b/plugins/src/format_inspectors.cpp
@@ -1,0 +1,221 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include "plugin_options.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr const char *FORMAT_INSPECTOR_ARGS_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"format\":{\"type\":\"string\",\"pattern\":\"^(protobuf-varint|asn1-"
+        "ber|asn1-der|tlv)$\"},\"tagBytes\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":4},\"lengthBytes\":{"
+        "\"type\":\"integer\",\"minimum\":1,\"maximum\":4},\"endian\":{\"type\":\"string\",\"pattern\":\"^(big|little)$"
+        "\"}},\"additionalProperties\":false}";
+
+std::string inspect_protobuf_varints(const std::vector<omega_byte_t> &input) {
+    std::ostringstream out;
+    size_t offset = 0;
+    int index = 0;
+    while (offset < input.size()) {
+        const size_t start = offset;
+        uint64_t value = 0;
+        int shift = 0;
+        bool terminated = false;
+        while (offset < input.size() && shift < 64) {
+            const omega_byte_t byte = input[offset++];
+            value |= static_cast<uint64_t>(byte & 0x7FU) << shift;
+            if ((byte & 0x80U) == 0) {
+                terminated = true;
+                break;
+            }
+            shift += 7;
+        }
+        out << "varint[" << index++ << "] offset=" << start << " bytes=" << (offset - start);
+        if (terminated) {
+            out << " value=" << value << "\n";
+        } else {
+            out << " error=unterminated\n";
+            break;
+        }
+    }
+    if (input.empty()) { out << "No bytes selected.\n"; }
+    return out.str();
+}
+
+std::string asn1_class_name(unsigned int tag_class) {
+    switch (tag_class) {
+        case 0:
+            return "universal";
+        case 1:
+            return "application";
+        case 2:
+            return "context";
+        case 3:
+            return "private";
+    }
+    return "unknown";
+}
+
+std::string inspect_asn1(const std::vector<omega_byte_t> &input) {
+    std::ostringstream out;
+    size_t offset = 0;
+    int index = 0;
+    while (offset < input.size()) {
+        const size_t start = offset;
+        const omega_byte_t first = input[offset++];
+        const unsigned int tag_class = (first >> 6U) & 0x03U;
+        const bool constructed = (first & 0x20U) != 0;
+        uint64_t tag = first & 0x1FU;
+        if (tag == 0x1FU) {
+            tag = 0;
+            bool done = false;
+            while (offset < input.size()) {
+                const omega_byte_t byte = input[offset++];
+                tag = (tag << 7U) | (byte & 0x7FU);
+                if ((byte & 0x80U) == 0) {
+                    done = true;
+                    break;
+                }
+            }
+            if (!done) {
+                out << "tlv[" << index << "] offset=" << start << " error=unterminated-high-tag\n";
+                break;
+            }
+        }
+        if (offset >= input.size()) {
+            out << "tlv[" << index << "] offset=" << start << " tag=" << tag << " error=missing-length\n";
+            break;
+        }
+        const omega_byte_t length_byte = input[offset++];
+        bool indefinite = false;
+        uint64_t length = 0;
+        if ((length_byte & 0x80U) == 0) {
+            length = length_byte;
+        } else {
+            const unsigned int length_bytes = length_byte & 0x7FU;
+            if (length_bytes == 0) {
+                indefinite = true;
+            } else if (length_bytes > 8 || offset + length_bytes > input.size()) {
+                out << "tlv[" << index << "] offset=" << start << " tag=" << tag << " error=invalid-length\n";
+                break;
+            } else {
+                for (unsigned int i = 0; i < length_bytes; ++i) { length = (length << 8U) | input[offset++]; }
+            }
+        }
+
+        out << "tlv[" << index++ << "] offset=" << start << " headerBytes=" << (offset - start)
+            << " class=" << asn1_class_name(tag_class) << " constructed=" << (constructed ? "true" : "false")
+            << " tag=" << tag;
+        if (indefinite) {
+            out << " length=indefinite\n";
+            break;
+        }
+        out << " length=" << length;
+        if (offset + length > input.size()) {
+            out << " error=value-truncated\n";
+            break;
+        }
+        out << "\n";
+        offset += static_cast<size_t>(length);
+    }
+    if (input.empty()) { out << "No bytes selected.\n"; }
+    return out.str();
+}
+
+uint64_t read_uint(const std::vector<omega_byte_t> &input, size_t offset, int64_t width, bool little_endian) {
+    uint64_t value = 0;
+    if (little_endian) {
+        for (int64_t i = width - 1; i >= 0; --i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
+    } else {
+        for (int64_t i = 0; i < width; ++i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
+    }
+    return value;
+}
+
+std::string inspect_tlv(const std::vector<omega_byte_t> &input, int64_t tag_bytes, int64_t length_bytes,
+                        bool little_endian) {
+    std::ostringstream out;
+    size_t offset = 0;
+    int index = 0;
+    const auto header = static_cast<size_t>(tag_bytes + length_bytes);
+    while (offset < input.size()) {
+        if (offset + header > input.size()) {
+            out << "tlv[" << index << "] offset=" << offset << " error=truncated-header\n";
+            break;
+        }
+        const uint64_t tag = read_uint(input, offset, tag_bytes, little_endian);
+        const uint64_t length = read_uint(input, offset + static_cast<size_t>(tag_bytes), length_bytes, little_endian);
+        const size_t value_offset = offset + header;
+        out << "tlv[" << index++ << "] offset=" << offset << " tag=" << tag << " length=" << length;
+        if (value_offset + length > input.size()) {
+            out << " error=value-truncated\n";
+            break;
+        }
+        out << "\n";
+        offset = value_offset + static_cast<size_t>(length);
+    }
+    if (input.empty()) { out << "No bytes selected.\n"; }
+    return out.str();
+}
+
+} // namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
+        omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = "omega.example.format_inspectors";
+    info_ptr->name = "Format Inspectors";
+    info_ptr->description = "Inspect protobuf varints, ASN.1 BER/DER TLV headers, and configurable TLV records.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help =
+            "Options JSON accepts {\"format\":\"protobuf-varint\"}, {\"format\":\"asn1-ber\"}, or "
+            "{\"format\":\"tlv\",\"tagBytes\":1,\"lengthBytes\":1,\"endian\":\"big\"}.";
+    info_ptr->example = "{\"format\":\"tlv\",\"tagBytes\":1,\"lengthBytes\":1,\"endian\":\"big\"}";
+    info_ptr->default_args = "{\"format\":\"protobuf-varint\"}";
+    info_ptr->args_schema = FORMAT_INSPECTOR_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+    std::vector<omega_byte_t> input;
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
+        return -1;
+    }
+    std::map<std::string, std::string> options;
+    if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
+    const std::string format = omega_edit::plugin::option_or(options, "format", "protobuf-varint");
+    std::string result;
+    if (format == "protobuf-varint") {
+        result = inspect_protobuf_varints(input);
+    } else if (format == "asn1-ber" || format == "asn1-der") {
+        result = inspect_asn1(input);
+    } else if (format == "tlv") {
+        const int64_t tag_bytes = omega_edit::plugin::option_int_or(options, "tagBytes", 1);
+        const int64_t length_bytes = omega_edit::plugin::option_int_or(options, "lengthBytes", 1);
+        if (tag_bytes < 1 || tag_bytes > 4 || length_bytes < 1 || length_bytes > 4) { return -1; }
+        result = inspect_tlv(input, tag_bytes, length_bytes, omega_edit::plugin::option_or(options, "endian", "big") ==
+                                                                     "little");
+    } else {
+        return -1;
+    }
+    return omega_edit::plugin::set_text_result(request_ptr, response_ptr, format, result);
+}

--- a/plugins/src/md5.c
+++ b/plugins/src/md5.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.md5"
+#define OMEGA_DIGEST_PLUGIN_NAME "MD5"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate an MD5 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "md5"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_md5
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/openssl_digest_plugin.h
+++ b/plugins/src/openssl_digest_plugin.h
@@ -1,0 +1,120 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+/*
+ * Implementation template for OpenSSL digest plugins. Include this file from exactly one translation unit per plugin
+ * target after defining the OMEGA_DIGEST_* macros.
+ */
+
+#ifndef OMEGA_EDIT_OPENSSL_DIGEST_PLUGIN_H
+#define OMEGA_EDIT_OPENSSL_DIGEST_PLUGIN_H
+
+#include <omega_edit/transform_plugin_sdk.h>
+#include <openssl/evp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static const int64_t OMEGA_DIGEST_DEFAULT_CHUNK_SIZE = 64 * 1024;
+static const int64_t OMEGA_DIGEST_MAX_CHUNK_SIZE = 1024 * 1024;
+
+static int64_t omega_digest_chunk_size(int64_t preferred_chunk_size) {
+    if (preferred_chunk_size <= 0) { return OMEGA_DIGEST_DEFAULT_CHUNK_SIZE; }
+    return preferred_chunk_size > OMEGA_DIGEST_MAX_CHUNK_SIZE ? OMEGA_DIGEST_MAX_CHUNK_SIZE : preferred_chunk_size;
+}
+
+static int omega_digest_update(EVP_MD_CTX *context_ptr, const omega_byte_t *bytes, int64_t length) {
+    if (!context_ptr || length < 0 || (length > 0 && !bytes)) { return -1; }
+    if (length == 0) { return 0; }
+    return EVP_DigestUpdate(context_ptr, bytes, (size_t) length) == 1 ? 0 : -1;
+}
+
+static int omega_digest_update_from_request(const omega_transform_plugin_request_t *request_ptr,
+                                            EVP_MD_CTX *context_ptr) {
+    if (!request_ptr || !context_ptr) { return -1; }
+    if (request_ptr->read) {
+        const int64_t chunk_size = omega_digest_chunk_size(request_ptr->preferred_chunk_size);
+        omega_byte_t *buffer = (omega_byte_t *) malloc((size_t) chunk_size);
+        if (!buffer) { return -1; }
+        for (int64_t position = 0; position < request_ptr->session_length;) {
+            const int64_t remaining = request_ptr->session_length - position;
+            const int64_t requested = remaining < chunk_size ? remaining : chunk_size;
+            const int64_t bytes_read =
+                    request_ptr->read(position, buffer, requested, request_ptr->reader_user_data_ptr);
+            if (bytes_read <= 0 || omega_digest_update(context_ptr, buffer, bytes_read) != 0) {
+                free(buffer);
+                return -1;
+            }
+            position += bytes_read;
+        }
+        free(buffer);
+        return 0;
+    }
+
+    return omega_digest_update(context_ptr, request_ptr->input_bytes, request_ptr->input_length);
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = OMEGA_DIGEST_PLUGIN_ID;
+    info_ptr->name = OMEGA_DIGEST_PLUGIN_NAME;
+    info_ptr->description = OMEGA_DIGEST_PLUGIN_DESCRIPTION;
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE |
+                      OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING;
+    info_ptr->help = "No JSON options are used.";
+    info_ptr->example = "";
+    info_ptr->default_args = "";
+    info_ptr->args_schema = OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0 ||
+        request_ptr->session_length < 0) {
+        return -1;
+    }
+
+    const EVP_MD *digest_ptr = OMEGA_DIGEST_EVP_FUNCTION();
+    EVP_MD_CTX *context_ptr = EVP_MD_CTX_new();
+    if (!digest_ptr || !context_ptr) {
+        EVP_MD_CTX_free(context_ptr);
+        return -1;
+    }
+
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int digest_length = 0;
+    if (EVP_DigestInit_ex(context_ptr, digest_ptr, NULL) != 1 ||
+        omega_digest_update_from_request(request_ptr, context_ptr) != 0 ||
+        EVP_DigestFinal_ex(context_ptr, digest, &digest_length) != 1) {
+        EVP_MD_CTX_free(context_ptr);
+        return -1;
+    }
+    EVP_MD_CTX_free(context_ptr);
+
+    static const char hex[] = "0123456789abcdef";
+    char result[(EVP_MAX_MD_SIZE * 2) + 1];
+    for (unsigned int i = 0; i < digest_length; ++i) {
+        result[i * 2] = hex[(digest[i] >> 4) & 0x0F];
+        result[(i * 2) + 1] = hex[digest[i] & 0x0F];
+    }
+    result[digest_length * 2] = '\0';
+
+    return omega_transform_plugin_sdk_set_text_result(request_ptr, response_ptr, OMEGA_DIGEST_PLUGIN_LABEL, result,
+                                                      "text/plain");
+}
+
+#endif// OMEGA_EDIT_OPENSSL_DIGEST_PLUGIN_H

--- a/plugins/src/plugin_options.hpp
+++ b/plugins/src/plugin_options.hpp
@@ -1,0 +1,229 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#ifndef OMEGA_EDIT_PLUGIN_OPTIONS_HPP
+#define OMEGA_EDIT_PLUGIN_OPTIONS_HPP
+
+#include <omega_edit/transform_plugin_sdk.h>
+
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace omega_edit {
+namespace plugin {
+
+inline void skip_ws(const char *&cursor) {
+    while (*cursor && std::isspace(static_cast<unsigned char>(*cursor))) { ++cursor; }
+}
+
+inline bool parse_json_string(const char *&cursor, std::string &out) {
+    if (*cursor != '"') { return false; }
+    ++cursor;
+    out.clear();
+    while (*cursor && *cursor != '"') {
+        char ch = *cursor++;
+        if (ch == '\\') {
+            ch = *cursor++;
+            switch (ch) {
+                case '"':
+                case '\\':
+                case '/':
+                    out.push_back(ch);
+                    break;
+                case 'b':
+                    out.push_back('\b');
+                    break;
+                case 'f':
+                    out.push_back('\f');
+                    break;
+                case 'n':
+                    out.push_back('\n');
+                    break;
+                case 'r':
+                    out.push_back('\r');
+                    break;
+                case 't':
+                    out.push_back('\t');
+                    break;
+                default:
+                    return false;
+            }
+            continue;
+        }
+        out.push_back(ch);
+    }
+    if (*cursor != '"') { return false; }
+    ++cursor;
+    return true;
+}
+
+inline bool skip_json_value(const char *&cursor) {
+    skip_ws(cursor);
+    if (*cursor == '"') {
+        std::string ignored;
+        return parse_json_string(cursor, ignored);
+    }
+    if (*cursor == '{' || *cursor == '[') {
+        const char open = *cursor++;
+        const char close = open == '{' ? '}' : ']';
+        int depth = 1;
+        while (*cursor && depth > 0) {
+            if (*cursor == '"') {
+                std::string ignored;
+                if (!parse_json_string(cursor, ignored)) { return false; }
+                continue;
+            }
+            if (*cursor == open) { ++depth; }
+            if (*cursor == close) { --depth; }
+            ++cursor;
+        }
+        return depth == 0;
+    }
+    while (*cursor && *cursor != ',' && *cursor != '}' && *cursor != ']') { ++cursor; }
+    return true;
+}
+
+inline bool parse_string_options(const char *json, std::map<std::string, std::string> &out) {
+    out.clear();
+    if (!json || !*json) { return true; }
+    const char *cursor = json;
+    skip_ws(cursor);
+    if (*cursor != '{') { return false; }
+    ++cursor;
+    skip_ws(cursor);
+    if (*cursor == '}') {
+        ++cursor;
+        skip_ws(cursor);
+        return *cursor == '\0';
+    }
+    while (*cursor) {
+        std::string key;
+        if (!parse_json_string(cursor, key)) { return false; }
+        skip_ws(cursor);
+        if (*cursor != ':') { return false; }
+        ++cursor;
+        skip_ws(cursor);
+        if (*cursor == '"') {
+            std::string value;
+            if (!parse_json_string(cursor, value)) { return false; }
+            out[key] = value;
+        } else {
+            const char *start = cursor;
+            if (!skip_json_value(cursor)) { return false; }
+            const char *end = cursor;
+            while (end > start && std::isspace(static_cast<unsigned char>(*(end - 1)))) { --end; }
+            out[key] = std::string(start, end);
+        }
+        skip_ws(cursor);
+        if (*cursor == '}') {
+            ++cursor;
+            skip_ws(cursor);
+            return *cursor == '\0';
+        }
+        if (*cursor != ',') { return false; }
+        ++cursor;
+        skip_ws(cursor);
+    }
+    return false;
+}
+
+inline std::string option_or(const std::map<std::string, std::string> &options, const char *key,
+                             const char *fallback) {
+    const auto iter = options.find(key);
+    return iter == options.end() ? std::string(fallback) : iter->second;
+}
+
+inline int64_t option_int_or(const std::map<std::string, std::string> &options, const char *key, int64_t fallback) {
+    const auto iter = options.find(key);
+    if (iter == options.end()) { return fallback; }
+    char *end_ptr = nullptr;
+    const auto parsed = std::strtoll(iter->second.c_str(), &end_ptr, 10);
+    return end_ptr && *end_ptr == '\0' ? parsed : fallback;
+}
+
+inline int set_replacement(const omega_transform_plugin_request_t *request_ptr,
+                           omega_transform_plugin_response_t *response_ptr, const std::vector<omega_byte_t> &bytes) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc) { return -1; }
+    if (bytes.empty()) { return omega_transform_plugin_sdk_set_replacement(request_ptr, response_ptr, nullptr, 0); }
+    auto *copy = static_cast<omega_byte_t *>(omega_transform_plugin_sdk_alloc(request_ptr, bytes.size()));
+    if (!copy) { return -1; }
+    std::memcpy(copy, bytes.data(), bytes.size());
+    response_ptr->replacement_bytes = copy;
+    response_ptr->replacement_length = static_cast<int64_t>(bytes.size());
+    return 0;
+}
+
+inline int set_text_result(const omega_transform_plugin_request_t *request_ptr,
+                           omega_transform_plugin_response_t *response_ptr, const std::string &label,
+                           const std::string &value) {
+    return omega_transform_plugin_sdk_set_text_result(request_ptr, response_ptr, label.c_str(), value.c_str(),
+                                                      "text/plain");
+}
+
+inline bool selected_bytes(const omega_transform_plugin_request_t *request_ptr, std::vector<omega_byte_t> &out) {
+    out.clear();
+    if (!request_ptr || request_ptr->input_length < 0 ||
+        (request_ptr->input_length > 0 && !request_ptr->input_bytes)) {
+        return false;
+    }
+    out.assign(request_ptr->input_bytes, request_ptr->input_bytes + request_ptr->input_length);
+    return true;
+}
+
+inline std::string hex_value(uint64_t value, int width) {
+    std::ostringstream stream;
+    stream << "0x";
+    stream.setf(std::ios::uppercase);
+    stream.fill('0');
+    stream.width(width);
+    stream << std::hex << value;
+    return stream.str();
+}
+
+inline bool for_each_chunk(const omega_transform_plugin_request_t *request_ptr,
+                           const std::function<bool(const omega_byte_t *, int64_t)> &callback) {
+    if (!request_ptr || request_ptr->session_length < 0 || request_ptr->input_length < 0) { return false; }
+    if (!request_ptr->read) {
+        if (request_ptr->input_length > 0 && !request_ptr->input_bytes) { return false; }
+        return callback(request_ptr->input_bytes, request_ptr->input_length);
+    }
+
+    const int64_t max_chunk = 1024 * 1024;
+    const int64_t fallback_chunk = 64 * 1024;
+    int64_t chunk_size = request_ptr->preferred_chunk_size > 0 ? request_ptr->preferred_chunk_size : fallback_chunk;
+    if (chunk_size > max_chunk) { chunk_size = max_chunk; }
+    std::vector<omega_byte_t> buffer(static_cast<size_t>(chunk_size));
+    for (int64_t position = 0; position < request_ptr->session_length;) {
+        const int64_t remaining = request_ptr->session_length - position;
+        const int64_t requested = remaining < chunk_size ? remaining : chunk_size;
+        const int64_t bytes_read =
+                request_ptr->read(position, buffer.data(), requested, request_ptr->reader_user_data_ptr);
+        if (bytes_read <= 0 || bytes_read > requested) { return false; }
+        if (!callback(buffer.data(), bytes_read)) { return false; }
+        position += bytes_read;
+    }
+    return true;
+}
+
+} // namespace plugin
+} // namespace omega_edit
+
+#endif // OMEGA_EDIT_PLUGIN_OPTIONS_HPP

--- a/plugins/src/record_text_helpers.cpp
+++ b/plugins/src/record_text_helpers.cpp
@@ -1,0 +1,321 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include "plugin_options.hpp"
+
+#include <cctype>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr const char *RECORD_TEXT_ARGS_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"action\":{\"type\":\"string\",\"pattern\":\"^(newline-lf|newline-crlf|"
+        "newline-cr|fixed-width-lines|delimiter-escape|delimiter-unescape|csv-quote|csv-unquote|xml-escape|xml-"
+        "unescape|json-escape|json-unescape)$\"},\"width\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":4096},"
+        "\"delimiter\":{\"type\":\"string\"},\"escape\":{\"type\":\"string\"}},\"additionalProperties\":false}";
+
+std::vector<omega_byte_t> text_bytes(const std::string &text) {
+    return std::vector<omega_byte_t>(text.begin(), text.end());
+}
+
+std::string as_text(const std::vector<omega_byte_t> &input) {
+    return std::string(input.begin(), input.end());
+}
+
+int hex_value(omega_byte_t byte) {
+    if (byte >= '0' && byte <= '9') { return byte - '0'; }
+    if (byte >= 'a' && byte <= 'f') { return byte - 'a' + 10; }
+    if (byte >= 'A' && byte <= 'F') { return byte - 'A' + 10; }
+    return -1;
+}
+
+std::vector<omega_byte_t> normalize_newlines(const std::vector<omega_byte_t> &input, const std::string &newline) {
+    std::vector<omega_byte_t> out;
+    for (size_t i = 0; i < input.size(); ++i) {
+        if (input[i] == '\r') {
+            if (i + 1 < input.size() && input[i + 1] == '\n') { ++i; }
+            out.insert(out.end(), newline.begin(), newline.end());
+        } else if (input[i] == '\n') {
+            out.insert(out.end(), newline.begin(), newline.end());
+        } else {
+            out.push_back(input[i]);
+        }
+    }
+    return out;
+}
+
+std::vector<omega_byte_t> fixed_width_lines(const std::vector<omega_byte_t> &input, int64_t width) {
+    std::vector<omega_byte_t> out;
+    for (size_t i = 0; i < input.size(); ++i) {
+        if (i > 0 && (i % static_cast<size_t>(width)) == 0) { out.push_back('\n'); }
+        out.push_back(input[i]);
+    }
+    return out;
+}
+
+std::vector<omega_byte_t> delimiter_escape(const std::vector<omega_byte_t> &input, omega_byte_t delimiter,
+                                           omega_byte_t escape) {
+    std::vector<omega_byte_t> out;
+    for (const auto byte: input) {
+        if (byte == delimiter || byte == escape) { out.push_back(escape); }
+        out.push_back(byte);
+    }
+    return out;
+}
+
+bool delimiter_unescape(const std::vector<omega_byte_t> &input, omega_byte_t escape, std::vector<omega_byte_t> &out) {
+    out.clear();
+    bool escaped = false;
+    for (const auto byte: input) {
+        if (escaped) {
+            out.push_back(byte);
+            escaped = false;
+        } else if (byte == escape) {
+            escaped = true;
+        } else {
+            out.push_back(byte);
+        }
+    }
+    return !escaped;
+}
+
+std::vector<omega_byte_t> csv_quote(const std::vector<omega_byte_t> &input) {
+    std::vector<omega_byte_t> out;
+    out.push_back('"');
+    for (const auto byte: input) {
+        if (byte == '"') { out.push_back('"'); }
+        out.push_back(byte);
+    }
+    out.push_back('"');
+    return out;
+}
+
+bool csv_unquote(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    if (input.size() < 2 || input.front() != '"' || input.back() != '"') { return false; }
+    out.clear();
+    for (size_t i = 1; i + 1 < input.size(); ++i) {
+        if (input[i] == '"') {
+            if (i + 1 >= input.size() - 1 || input[i + 1] != '"') { return false; }
+            ++i;
+        }
+        out.push_back(input[i]);
+    }
+    return true;
+}
+
+std::vector<omega_byte_t> xml_escape(const std::vector<omega_byte_t> &input) {
+    std::string out;
+    for (const auto byte: input) {
+        switch (byte) {
+            case '&':
+                out += "&amp;";
+                break;
+            case '<':
+                out += "&lt;";
+                break;
+            case '>':
+                out += "&gt;";
+                break;
+            case '"':
+                out += "&quot;";
+                break;
+            case '\'':
+                out += "&apos;";
+                break;
+            default:
+                out.push_back(static_cast<char>(byte));
+                break;
+        }
+    }
+    return text_bytes(out);
+}
+
+bool replace_all(std::string &text, const std::string &from, const std::string &to) {
+    size_t pos = 0;
+    while ((pos = text.find(from, pos)) != std::string::npos) {
+        text.replace(pos, from.size(), to);
+        pos += to.size();
+    }
+    return true;
+}
+
+std::vector<omega_byte_t> xml_unescape(const std::vector<omega_byte_t> &input) {
+    std::string text = as_text(input);
+    replace_all(text, "&lt;", "<");
+    replace_all(text, "&gt;", ">");
+    replace_all(text, "&quot;", "\"");
+    replace_all(text, "&apos;", "'");
+    replace_all(text, "&amp;", "&");
+    return text_bytes(text);
+}
+
+std::vector<omega_byte_t> json_escape(const std::vector<omega_byte_t> &input) {
+    std::string out;
+    for (const auto byte: input) {
+        switch (byte) {
+            case '"':
+                out += "\\\"";
+                break;
+            case '\\':
+                out += "\\\\";
+                break;
+            case '\b':
+                out += "\\b";
+                break;
+            case '\f':
+                out += "\\f";
+                break;
+            case '\n':
+                out += "\\n";
+                break;
+            case '\r':
+                out += "\\r";
+                break;
+            case '\t':
+                out += "\\t";
+                break;
+            default:
+                if (byte < 0x20) {
+                    char escaped[7];
+                    std::snprintf(escaped, sizeof(escaped), "\\u%04X", byte);
+                    out += escaped;
+                } else {
+                    out.push_back(static_cast<char>(byte));
+                }
+                break;
+        }
+    }
+    return text_bytes(out);
+}
+
+bool json_unescape(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    out.clear();
+    for (size_t i = 0; i < input.size(); ++i) {
+        if (input[i] != '\\') {
+            out.push_back(input[i]);
+            continue;
+        }
+        if (++i >= input.size()) { return false; }
+        switch (input[i]) {
+            case '"':
+            case '\\':
+            case '/':
+                out.push_back(input[i]);
+                break;
+            case 'b':
+                out.push_back('\b');
+                break;
+            case 'f':
+                out.push_back('\f');
+                break;
+            case 'n':
+                out.push_back('\n');
+                break;
+            case 'r':
+                out.push_back('\r');
+                break;
+            case 't':
+                out.push_back('\t');
+                break;
+            case 'u': {
+                if (i + 4 >= input.size()) { return false; }
+                int value = 0;
+                for (int n = 0; n < 4; ++n) {
+                    const int nibble = hex_value(input[++i]);
+                    if (nibble < 0) { return false; }
+                    value = (value << 4) | nibble;
+                }
+                if (value > 0x7F) { return false; }
+                out.push_back(static_cast<omega_byte_t>(value));
+                break;
+            }
+            default:
+                return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
+        omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = "omega.example.record_text_helpers";
+    info_ptr->name = "Record/Text Helpers";
+    info_ptr->description = "Normalize records and escape or unescape common text container syntaxes.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK |
+                      OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help =
+            "Options JSON accepts actions such as newline-lf, newline-crlf, fixed-width-lines, delimiter-escape, "
+            "csv-quote, xml-escape, and json-escape. Use width for fixed-width-lines and delimiter/escape for "
+            "delimiter helpers.";
+    info_ptr->example = "{\"action\":\"fixed-width-lines\",\"width\":80}";
+    info_ptr->default_args = "{\"action\":\"newline-lf\"}";
+    info_ptr->args_schema = RECORD_TEXT_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+    std::vector<omega_byte_t> input;
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
+        return -1;
+    }
+    std::map<std::string, std::string> options;
+    if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
+    const std::string action = omega_edit::plugin::option_or(options, "action", "newline-lf");
+
+    std::vector<omega_byte_t> output;
+    bool ok = true;
+    if (action == "newline-lf") {
+        output = normalize_newlines(input, "\n");
+    } else if (action == "newline-crlf") {
+        output = normalize_newlines(input, "\r\n");
+    } else if (action == "newline-cr") {
+        output = normalize_newlines(input, "\r");
+    } else if (action == "fixed-width-lines") {
+        const int64_t width = omega_edit::plugin::option_int_or(options, "width", 80);
+        if (width < 1 || width > 4096) { return -1; }
+        output = fixed_width_lines(input, width);
+    } else if (action == "delimiter-escape") {
+        const std::string delimiter = omega_edit::plugin::option_or(options, "delimiter", ",");
+        const std::string escape = omega_edit::plugin::option_or(options, "escape", "\\");
+        if (delimiter.size() != 1 || escape.size() != 1) { return -1; }
+        output = delimiter_escape(input, static_cast<omega_byte_t>(delimiter[0]), static_cast<omega_byte_t>(escape[0]));
+    } else if (action == "delimiter-unescape") {
+        const std::string escape = omega_edit::plugin::option_or(options, "escape", "\\");
+        if (escape.size() != 1) { return -1; }
+        ok = delimiter_unescape(input, static_cast<omega_byte_t>(escape[0]), output);
+    } else if (action == "csv-quote") {
+        output = csv_quote(input);
+    } else if (action == "csv-unquote") {
+        ok = csv_unquote(input, output);
+    } else if (action == "xml-escape") {
+        output = xml_escape(input);
+    } else if (action == "xml-unescape") {
+        output = xml_unescape(input);
+    } else if (action == "json-escape") {
+        output = json_escape(input);
+    } else if (action == "json-unescape") {
+        ok = json_unescape(input, output);
+    } else {
+        return -1;
+    }
+    return ok ? omega_edit::plugin::set_replacement(request_ptr, response_ptr, output) : -1;
+}

--- a/plugins/src/sha1.c
+++ b/plugins/src/sha1.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.sha1"
+#define OMEGA_DIGEST_PLUGIN_NAME "SHA-1"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a SHA-1 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "sha1"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_sha1
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/sha224.c
+++ b/plugins/src/sha224.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.sha224"
+#define OMEGA_DIGEST_PLUGIN_NAME "SHA-224"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a SHA-224 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "sha224"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_sha224
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/sha256.c
+++ b/plugins/src/sha256.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.sha256"
+#define OMEGA_DIGEST_PLUGIN_NAME "SHA-256"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a SHA-256 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "sha256"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_sha256
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/sha384.c
+++ b/plugins/src/sha384.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.sha384"
+#define OMEGA_DIGEST_PLUGIN_NAME "SHA-384"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a SHA-384 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "sha384"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_sha384
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/sha3_256.c
+++ b/plugins/src/sha3_256.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.sha3_256"
+#define OMEGA_DIGEST_PLUGIN_NAME "SHA3-256"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a SHA3-256 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "sha3-256"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_sha3_256
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/sha3_512.c
+++ b/plugins/src/sha3_512.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.sha3_512"
+#define OMEGA_DIGEST_PLUGIN_NAME "SHA3-512"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a SHA3-512 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "sha3-512"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_sha3_512
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/sha512.c
+++ b/plugins/src/sha512.c
@@ -1,0 +1,23 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <openssl/evp.h>
+
+#define OMEGA_DIGEST_PLUGIN_ID "omega.example.sha512"
+#define OMEGA_DIGEST_PLUGIN_NAME "SHA-512"
+#define OMEGA_DIGEST_PLUGIN_DESCRIPTION "Calculate a SHA-512 digest over the selected range."
+#define OMEGA_DIGEST_PLUGIN_LABEL "sha512"
+#define OMEGA_DIGEST_EVP_FUNCTION EVP_sha512
+
+#include "openssl_digest_plugin.h"

--- a/plugins/src/text_codecs.cpp
+++ b/plugins/src/text_codecs.cpp
@@ -1,0 +1,586 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include "plugin_options.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr const char *TEXT_CODEC_ARGS_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"codec\":{\"type\":\"string\",\"pattern\":\"^(hex|base16|base64url|"
+        "base32|base32-crockford|ascii85|base85|z85|base58|percent|url|quoted-printable|uuencode|yenc)$\"},"
+        "\"direction\":{\"type\":\"string\",\"pattern\":\"^(encode|decode)$\"}},\"additionalProperties\":false}";
+
+int hex_value(omega_byte_t byte) {
+    if (byte >= '0' && byte <= '9') { return byte - '0'; }
+    if (byte >= 'a' && byte <= 'f') { return byte - 'a' + 10; }
+    if (byte >= 'A' && byte <= 'F') { return byte - 'A' + 10; }
+    return -1;
+}
+
+bool is_ascii_space(omega_byte_t byte) {
+    return std::isspace(static_cast<unsigned char>(byte)) != 0;
+}
+
+bool is_ascii_alnum(omega_byte_t byte) {
+    return std::isalnum(static_cast<unsigned char>(byte)) != 0;
+}
+
+omega_byte_t uppercase_ascii(omega_byte_t byte) {
+    return static_cast<omega_byte_t>(std::toupper(static_cast<unsigned char>(byte)));
+}
+
+std::vector<omega_byte_t> hex_encode(const std::vector<omega_byte_t> &input) {
+    static constexpr char alphabet[] = "0123456789abcdef";
+    std::vector<omega_byte_t> out;
+    out.reserve(input.size() * 2);
+    for (const auto byte: input) {
+        out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
+        out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
+    }
+    return out;
+}
+
+bool hex_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    out.clear();
+    int high = -1;
+    for (const auto byte: input) {
+        if (is_ascii_space(byte)) { continue; }
+        const int value = hex_value(byte);
+        if (value < 0) { return false; }
+        if (high < 0) {
+            high = value;
+        } else {
+            out.push_back(static_cast<omega_byte_t>((high << 4U) | value));
+            high = -1;
+        }
+    }
+    return high < 0;
+}
+
+std::vector<omega_byte_t> base64url_encode(const std::vector<omega_byte_t> &input) {
+    static constexpr char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    std::vector<omega_byte_t> out;
+    out.reserve(((input.size() + 2) / 3) * 4);
+    for (size_t i = 0; i < input.size();) {
+        const unsigned int a = input[i++];
+        const bool has_b = i < input.size();
+        const unsigned int b = has_b ? input[i++] : 0;
+        const bool has_c = i < input.size();
+        const unsigned int c = has_c ? input[i++] : 0;
+        const unsigned int triple = (a << 16U) | (b << 8U) | c;
+        out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 18U) & 0x3FU]));
+        out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 12U) & 0x3FU]));
+        if (has_b) { out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 6U) & 0x3FU])); }
+        if (has_c) { out.push_back(static_cast<omega_byte_t>(alphabet[triple & 0x3FU])); }
+    }
+    return out;
+}
+
+int base64url_value(omega_byte_t byte) {
+    if (byte >= 'A' && byte <= 'Z') { return byte - 'A'; }
+    if (byte >= 'a' && byte <= 'z') { return byte - 'a' + 26; }
+    if (byte >= '0' && byte <= '9') { return byte - '0' + 52; }
+    if (byte == '-' || byte == '+') { return 62; }
+    if (byte == '_' || byte == '/') { return 63; }
+    if (byte == '=') { return -2; }
+    return -1;
+}
+
+bool base64url_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    std::vector<int> values;
+    size_t padding_count = 0;
+    bool saw_padding = false;
+    for (const auto byte: input) {
+        if (is_ascii_space(byte)) { continue; }
+        const int value = base64url_value(byte);
+        if (value == -1) { return false; }
+        if (value == -2) {
+            saw_padding = true;
+            if (++padding_count > 2) { return false; }
+            continue;
+        }
+        if (saw_padding) { return false; }
+        values.push_back(value);
+    }
+    const size_t value_count = values.size();
+    if ((value_count % 4) == 1) { return false; }
+    if (padding_count > 0) {
+        if (((value_count + padding_count) % 4) != 0) { return false; }
+        if ((padding_count == 1 && (value_count % 4) != 3) ||
+            (padding_count == 2 && (value_count % 4) != 2)) {
+            return false;
+        }
+    }
+    while ((values.size() % 4) != 0) { values.push_back(0); }
+    out.clear();
+    for (size_t i = 0; i < values.size(); i += 4) {
+        const unsigned int triple = (static_cast<unsigned int>(values[i]) << 18U) |
+                                    (static_cast<unsigned int>(values[i + 1]) << 12U) |
+                                    (static_cast<unsigned int>(values[i + 2]) << 6U) |
+                                    static_cast<unsigned int>(values[i + 3]);
+        out.push_back(static_cast<omega_byte_t>((triple >> 16U) & 0xFFU));
+        if (i + 2 < values.size()) { out.push_back(static_cast<omega_byte_t>((triple >> 8U) & 0xFFU)); }
+        if (i + 3 < values.size()) { out.push_back(static_cast<omega_byte_t>(triple & 0xFFU)); }
+    }
+    out.resize((value_count * 6U) / 8U);
+    return true;
+}
+
+std::vector<omega_byte_t> base32_encode(const std::vector<omega_byte_t> &input, bool crockford) {
+    const char *alphabet = crockford ? "0123456789ABCDEFGHJKMNPQRSTVWXYZ" : "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    std::vector<omega_byte_t> out;
+    uint32_t buffer = 0;
+    int bits = 0;
+    for (const auto byte: input) {
+        buffer = (buffer << 8U) | byte;
+        bits += 8;
+        while (bits >= 5) {
+            out.push_back(static_cast<omega_byte_t>(alphabet[(buffer >> (bits - 5)) & 0x1FU]));
+            bits -= 5;
+        }
+    }
+    if (bits > 0) { out.push_back(static_cast<omega_byte_t>(alphabet[(buffer << (5 - bits)) & 0x1FU])); }
+    if (!crockford) {
+        while ((out.size() % 8) != 0) { out.push_back('='); }
+    }
+    return out;
+}
+
+int base32_value(omega_byte_t byte, bool crockford) {
+    byte = uppercase_ascii(byte);
+    if (crockford) {
+        if (byte == 'O') { return 0; }
+        if (byte == 'I' || byte == 'L') { return 1; }
+        static constexpr char alphabet[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+        const char *found = std::find(std::begin(alphabet), std::end(alphabet) - 1, byte);
+        return found == std::end(alphabet) - 1 ? -1 : static_cast<int>(found - alphabet);
+    }
+    if (byte >= 'A' && byte <= 'Z') { return byte - 'A'; }
+    if (byte >= '2' && byte <= '7') { return byte - '2' + 26; }
+    return -1;
+}
+
+bool base32_decode(const std::vector<omega_byte_t> &input, bool crockford, std::vector<omega_byte_t> &out) {
+    out.clear();
+    uint32_t buffer = 0;
+    int bits = 0;
+    for (const auto byte: input) {
+        if (is_ascii_space(byte) || byte == '=') { continue; }
+        const int value = base32_value(byte, crockford);
+        if (value < 0) { return false; }
+        buffer = (buffer << 5U) | static_cast<uint32_t>(value);
+        bits += 5;
+        if (bits >= 8) {
+            out.push_back(static_cast<omega_byte_t>((buffer >> (bits - 8)) & 0xFFU));
+            bits -= 8;
+        }
+    }
+    return true;
+}
+
+std::vector<omega_byte_t> base58_encode(const std::vector<omega_byte_t> &input) {
+    static constexpr char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    std::vector<omega_byte_t> digits(1, 0);
+    for (const auto byte: input) {
+        int carry = byte;
+        for (auto &digit: digits) {
+            carry += digit << 8U;
+            digit = static_cast<omega_byte_t>(carry % 58);
+            carry /= 58;
+        }
+        while (carry) {
+            digits.push_back(static_cast<omega_byte_t>(carry % 58));
+            carry /= 58;
+        }
+    }
+    std::vector<omega_byte_t> out;
+    for (const auto byte: input) {
+        if (byte == 0) {
+            out.push_back('1');
+        } else {
+            break;
+        }
+    }
+    for (auto iter = digits.rbegin(); iter != digits.rend(); ++iter) {
+        out.push_back(static_cast<omega_byte_t>(alphabet[*iter]));
+    }
+    return out;
+}
+
+bool base58_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    static constexpr char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    std::vector<omega_byte_t> bytes(1, 0);
+    for (const auto ch: input) {
+        if (is_ascii_space(ch)) { continue; }
+        const char *found = std::find(std::begin(alphabet), std::end(alphabet) - 1, ch);
+        if (found == std::end(alphabet) - 1) { return false; }
+        int carry = static_cast<int>(found - alphabet);
+        for (auto &byte: bytes) {
+            carry += byte * 58;
+            byte = static_cast<omega_byte_t>(carry & 0xFF);
+            carry >>= 8U;
+        }
+        while (carry) {
+            bytes.push_back(static_cast<omega_byte_t>(carry & 0xFF));
+            carry >>= 8U;
+        }
+    }
+    out.clear();
+    for (const auto ch: input) {
+        if (ch == '1') {
+            out.push_back(0);
+        } else if (!is_ascii_space(ch)) {
+            break;
+        }
+    }
+    for (auto iter = bytes.rbegin(); iter != bytes.rend(); ++iter) { out.push_back(*iter); }
+    return true;
+}
+
+std::vector<omega_byte_t> percent_encode(const std::vector<omega_byte_t> &input) {
+    static constexpr char alphabet[] = "0123456789ABCDEF";
+    std::vector<omega_byte_t> out;
+    for (const auto byte: input) {
+        if (is_ascii_alnum(byte) || byte == '-' || byte == '_' || byte == '.' || byte == '~') {
+            out.push_back(byte);
+        } else {
+            out.push_back('%');
+            out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
+            out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
+        }
+    }
+    return out;
+}
+
+bool percent_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    out.clear();
+    for (size_t i = 0; i < input.size(); ++i) {
+        if (input[i] != '%') {
+            out.push_back(input[i]);
+            continue;
+        }
+        if (i + 2 >= input.size()) { return false; }
+        const int high = hex_value(input[++i]);
+        const int low = hex_value(input[++i]);
+        if (high < 0 || low < 0) { return false; }
+        out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+    }
+    return true;
+}
+
+std::vector<omega_byte_t> quoted_printable_encode(const std::vector<omega_byte_t> &input) {
+    static constexpr char alphabet[] = "0123456789ABCDEF";
+    std::vector<omega_byte_t> out;
+    for (const auto byte: input) {
+        if ((byte >= 33 && byte <= 60) || (byte >= 62 && byte <= 126) || byte == '\t' || byte == ' ') {
+            out.push_back(byte);
+        } else {
+            out.push_back('=');
+            out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
+            out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
+        }
+    }
+    return out;
+}
+
+bool quoted_printable_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    out.clear();
+    for (size_t i = 0; i < input.size(); ++i) {
+        if (input[i] != '=') {
+            out.push_back(input[i]);
+            continue;
+        }
+        if (i + 1 < input.size() && (input[i + 1] == '\r' || input[i + 1] == '\n')) {
+            while (i + 1 < input.size() && (input[i + 1] == '\r' || input[i + 1] == '\n')) { ++i; }
+            continue;
+        }
+        if (i + 2 >= input.size()) { return false; }
+        const int high = hex_value(input[++i]);
+        const int low = hex_value(input[++i]);
+        if (high < 0 || low < 0) { return false; }
+        out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+    }
+    return true;
+}
+
+omega_byte_t uu_char(unsigned int value) {
+    value &= 0x3FU;
+    return static_cast<omega_byte_t>(value == 0 ? '`' : value + 32U);
+}
+
+int uu_value(omega_byte_t byte) {
+    if (byte == '`' || byte == ' ') { return 0; }
+    if (byte >= 33 && byte <= 95) { return (byte - 32) & 0x3F; }
+    return -1;
+}
+
+std::vector<omega_byte_t> uuencode(const std::vector<omega_byte_t> &input) {
+    std::vector<omega_byte_t> out;
+    for (size_t line = 0; line < input.size(); line += 45) {
+        const size_t count = std::min<size_t>(45, input.size() - line);
+        out.push_back(uu_char(static_cast<unsigned int>(count)));
+        for (size_t i = 0; i < count; i += 3) {
+            const unsigned int a = input[line + i];
+            const unsigned int b = i + 1 < count ? input[line + i + 1] : 0;
+            const unsigned int c = i + 2 < count ? input[line + i + 2] : 0;
+            out.push_back(uu_char(a >> 2U));
+            out.push_back(uu_char(((a << 4U) | (b >> 4U))));
+            out.push_back(uu_char(((b << 2U) | (c >> 6U))));
+            out.push_back(uu_char(c));
+        }
+        out.push_back('\n');
+    }
+    out.push_back('`');
+    out.push_back('\n');
+    return out;
+}
+
+bool uudecode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    out.clear();
+    size_t cursor = 0;
+    while (cursor < input.size()) {
+        while (cursor < input.size() && (input[cursor] == '\r' || input[cursor] == '\n')) { ++cursor; }
+        if (cursor >= input.size()) { break; }
+        const int count = uu_value(input[cursor++]);
+        if (count < 0) { return false; }
+        if (count == 0) { return true; }
+        int produced = 0;
+        while (produced < count) {
+            if (cursor + 4 > input.size()) { return false; }
+            const int a = uu_value(input[cursor++]);
+            const int b = uu_value(input[cursor++]);
+            const int c = uu_value(input[cursor++]);
+            const int d = uu_value(input[cursor++]);
+            if (a < 0 || b < 0 || c < 0 || d < 0) { return false; }
+            const omega_byte_t one = static_cast<omega_byte_t>((a << 2U) | (b >> 4U));
+            const omega_byte_t two = static_cast<omega_byte_t>((b << 4U) | (c >> 2U));
+            const omega_byte_t three = static_cast<omega_byte_t>((c << 6U) | d);
+            out.push_back(one);
+            if (++produced < count) {
+                out.push_back(two);
+                ++produced;
+            }
+            if (produced < count) {
+                out.push_back(three);
+                ++produced;
+            }
+        }
+        while (cursor < input.size() && input[cursor] != '\n') { ++cursor; }
+    }
+    return true;
+}
+
+std::vector<omega_byte_t> yenc_encode(const std::vector<omega_byte_t> &input) {
+    std::vector<omega_byte_t> out;
+    for (const auto byte: input) {
+        omega_byte_t encoded = static_cast<omega_byte_t>(byte + 42U);
+        if (encoded == 0 || encoded == '\n' || encoded == '\r' || encoded == '=') {
+            out.push_back('=');
+            encoded = static_cast<omega_byte_t>(encoded + 64U);
+        }
+        out.push_back(encoded);
+    }
+    return out;
+}
+
+bool yenc_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    out.clear();
+    for (size_t i = 0; i < input.size(); ++i) {
+        omega_byte_t byte = input[i];
+        if (byte == '=') {
+            if (++i >= input.size()) { return false; }
+            byte = static_cast<omega_byte_t>(input[i] - 64U);
+        }
+        out.push_back(static_cast<omega_byte_t>(byte - 42U));
+    }
+    return true;
+}
+
+std::vector<omega_byte_t> ascii85_encode(const std::vector<omega_byte_t> &input, bool z85) {
+    static constexpr char z85_alphabet[] =
+            "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
+    std::vector<omega_byte_t> out;
+    for (size_t i = 0; i < input.size(); i += 4) {
+        const size_t count = std::min<size_t>(4, input.size() - i);
+        uint32_t value = 0;
+        for (size_t j = 0; j < 4; ++j) { value = (value << 8U) | (j < count ? input[i + j] : 0); }
+        if (!z85 && count == 4 && value == 0) {
+            out.push_back('z');
+            continue;
+        }
+        std::array<omega_byte_t, 5> encoded{};
+        for (int j = 4; j >= 0; --j) {
+            encoded[static_cast<size_t>(j)] =
+                    static_cast<omega_byte_t>(z85 ? z85_alphabet[value % 85U] : (value % 85U) + 33U);
+            value /= 85U;
+        }
+        const size_t emit = z85 ? 5 : count + 1;
+        out.insert(out.end(), encoded.begin(),
+                   encoded.begin() + static_cast<std::array<omega_byte_t, 5>::difference_type>(emit));
+    }
+    return out;
+}
+
+int ascii85_value(omega_byte_t byte, bool z85) {
+    static constexpr char z85_alphabet[] =
+            "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
+    if (z85) {
+        const char *found = std::find(std::begin(z85_alphabet), std::end(z85_alphabet) - 1, byte);
+        return found == std::end(z85_alphabet) - 1 ? -1 : static_cast<int>(found - z85_alphabet);
+    }
+    return byte >= '!' && byte <= 'u' ? byte - '!' : -1;
+}
+
+bool ascii85_decode(const std::vector<omega_byte_t> &input, bool z85, std::vector<omega_byte_t> &out) {
+    out.clear();
+    std::array<int, 5> group{};
+    int group_size = 0;
+    for (const auto byte: input) {
+        if (is_ascii_space(byte)) { continue; }
+        if (!z85 && byte == 'z') {
+            if (group_size != 0) { return false; }
+            out.insert(out.end(), {0, 0, 0, 0});
+            continue;
+        }
+        const int value = ascii85_value(byte, z85);
+        if (value < 0) { return false; }
+        group[static_cast<size_t>(group_size++)] = value;
+        if (group_size != 5) { continue; }
+        uint32_t decoded = 0;
+        for (const int item: group) { decoded = (decoded * 85U) + static_cast<uint32_t>(item); }
+        out.push_back(static_cast<omega_byte_t>((decoded >> 24U) & 0xFFU));
+        out.push_back(static_cast<omega_byte_t>((decoded >> 16U) & 0xFFU));
+        out.push_back(static_cast<omega_byte_t>((decoded >> 8U) & 0xFFU));
+        out.push_back(static_cast<omega_byte_t>(decoded & 0xFFU));
+        group_size = 0;
+    }
+    if (group_size > 0) {
+        if (z85 || group_size == 1) { return false; }
+        for (int i = group_size; i < 5; ++i) { group[static_cast<size_t>(i)] = 84; }
+        uint32_t decoded = 0;
+        for (const int item: group) { decoded = (decoded * 85U) + static_cast<uint32_t>(item); }
+        for (int i = 0; i < group_size - 1; ++i) {
+            out.push_back(static_cast<omega_byte_t>((decoded >> (24U - (8U * i))) & 0xFFU));
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
+        omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = "omega.example.text_codecs";
+    info_ptr->name = "Text Codecs";
+    info_ptr->description = "Encode or decode common binary-to-text and legacy transfer encodings.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK |
+                      OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help =
+            "Options JSON accepts {\"codec\":\"hex\",\"direction\":\"encode\"}. Codecs include hex/base16, "
+            "base64url, base32, base32-crockford, ascii85/base85, z85, base58, percent/url, quoted-printable, "
+            "uuencode, and yenc.";
+    info_ptr->example = "{\"codec\":\"base32\",\"direction\":\"encode\"}";
+    info_ptr->default_args = "{\"codec\":\"hex\",\"direction\":\"encode\"}";
+    info_ptr->args_schema = TEXT_CODEC_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
+        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+    std::vector<omega_byte_t> input;
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
+        return -1;
+    }
+    std::map<std::string, std::string> options;
+    if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
+    std::string codec = omega_edit::plugin::option_or(options, "codec", "hex");
+    const std::string direction = omega_edit::plugin::option_or(options, "direction", "encode");
+    if (codec == "base16") { codec = "hex"; }
+    if (codec == "url") { codec = "percent"; }
+    if (codec == "base85") { codec = "ascii85"; }
+
+    std::vector<omega_byte_t> output;
+    bool ok = true;
+    if (codec == "hex") {
+        if (direction == "encode") {
+            output = hex_encode(input);
+        } else {
+            ok = hex_decode(input, output);
+        }
+    } else if (codec == "base64url") {
+        if (direction == "encode") {
+            output = base64url_encode(input);
+        } else {
+            ok = base64url_decode(input, output);
+        }
+    } else if (codec == "base32" || codec == "base32-crockford") {
+        const bool crockford = codec == "base32-crockford";
+        if (direction == "encode") {
+            output = base32_encode(input, crockford);
+        } else {
+            ok = base32_decode(input, crockford, output);
+        }
+    } else if (codec == "base58") {
+        if (direction == "encode") {
+            output = base58_encode(input);
+        } else {
+            ok = base58_decode(input, output);
+        }
+    } else if (codec == "percent") {
+        if (direction == "encode") {
+            output = percent_encode(input);
+        } else {
+            ok = percent_decode(input, output);
+        }
+    } else if (codec == "quoted-printable") {
+        if (direction == "encode") {
+            output = quoted_printable_encode(input);
+        } else {
+            ok = quoted_printable_decode(input, output);
+        }
+    } else if (codec == "uuencode") {
+        if (direction == "encode") {
+            output = uuencode(input);
+        } else {
+            ok = uudecode(input, output);
+        }
+    } else if (codec == "yenc") {
+        if (direction == "encode") {
+            output = yenc_encode(input);
+        } else {
+            ok = yenc_decode(input, output);
+        }
+    } else if (codec == "ascii85" || codec == "z85") {
+        const bool z85 = codec == "z85";
+        if (z85 && (input.size() % (direction == "encode" ? 4 : 5)) != 0) { return -1; }
+        if (direction == "encode") {
+            output = ascii85_encode(input, z85);
+        } else {
+            ok = ascii85_decode(input, z85, output);
+        }
+    } else {
+        return -1;
+    }
+    return ok ? omega_edit::plugin::set_replacement(request_ptr, response_ptr, output) : -1;
+}

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -29,12 +29,29 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     const auto registry_ptr = omega_transform_plugin_registry_create();
     REQUIRE(registry_ptr);
     REQUIRE(0 < omega_transform_plugin_registry_register_directory(registry_ptr, PLUGIN_DIR.string().c_str()));
-    REQUIRE(10 <= omega_transform_plugin_registry_get_count(registry_ptr));
+    REQUIRE(16 <= omega_transform_plugin_registry_get_count(registry_ptr));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.and"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.base64_decode"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.base64_encode"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.blake2b512"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.blake2s256"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.character_transcode"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.common_checksums"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.decimal_codecs"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.endian_swap"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.format_inspectors"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.fnv1a64"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.md5"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.or"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.record_text_helpers"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.sha1"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.sha224"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.sha256"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.sha3_256"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.sha3_512"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.sha384"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.sha512"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.text_codecs"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib_compress"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib_decompress"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.xor"));
@@ -68,6 +85,10 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE("{\"level\":-1}" == std::string(zlib_compress_info->default_args));
     REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"level\":9}", zlib_compress_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"level\":10}", zlib_compress_info->args_schema));
+    const auto sha256_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.sha256");
+    REQUIRE("SHA-256" == std::string(sha256_info->name));
+    REQUIRE(std::string(sha256_info->description).find("SHA-256") != std::string::npos);
+    REQUIRE(std::string(OMEGA_TRANSFORM_PLUGIN_NO_ARGS_SCHEMA) == std::string(sha256_info->args_schema));
 
     const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(session_ptr);
@@ -166,6 +187,39 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE("fnv1a64" == std::string(response.result_label));
     omega_transform_plugin_response_clear(&response);
 
+    const auto require_digest_result = [&](const char *plugin_id, const char *label, const char *expected) {
+        REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, plugin_id, codec_session_ptr, 0,
+                                                                      5, nullptr, &response));
+        REQUIRE(static_cast<int64_t>(std::string(expected).size()) == response.result_length);
+        REQUIRE(expected == std::string(reinterpret_cast<const char *>(response.result_bytes),
+                                        static_cast<size_t>(response.result_length)));
+        REQUIRE(label == std::string(response.result_label));
+        omega_transform_plugin_response_clear(&response);
+    };
+
+    require_digest_result("omega.example.md5", "md5", "5d41402abc4b2a76b9719d911017c592");
+    require_digest_result("omega.example.sha1", "sha1", "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
+    require_digest_result("omega.example.sha224", "sha224",
+                          "ea09ae9cc6768c50fcee903ed054556e5bfc8347907f12598aa24193");
+    require_digest_result("omega.example.sha256", "sha256",
+                          "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    require_digest_result("omega.example.sha384", "sha384",
+                          "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f"
+                          "90397bdf5f6a13de828684f");
+    require_digest_result("omega.example.sha512", "sha512",
+                          "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c"
+                          "3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043");
+    require_digest_result("omega.example.sha3_256", "sha3-256",
+                          "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392");
+    require_digest_result("omega.example.sha3_512", "sha3-512",
+                          "75d527c368f2efe848ecf6b073a36767800805e9eef2b1857d5f984f036eb6df891d75f72d9b"
+                          "154518c1cd58835286d1da9a38deba3de98b5a53e5ed78a84976");
+    require_digest_result("omega.example.blake2b512", "blake2b-512",
+                          "e4cfa39a3d37be31c59609e807970799caa68a19bfaa15135f165085e01d41a65ba1e1b146ae"
+                          "b6bd0092b49eac214c103ccfa3a365954bbbe52f74a2b3620c94");
+    require_digest_result("omega.example.blake2s256", "blake2s-256",
+                          "19213bacc58dee6dbde3ceb9a47cbb330b3d86f8cca8997eb00be456f140ca25");
+
     const auto large_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(large_session_ptr);
     const std::vector<omega_byte_t> large_bytes(5 * 1024 * 1024, static_cast<omega_byte_t>(1));
@@ -184,7 +238,172 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(18 == response.result_length);
     REQUIRE("fnv1a64" == std::string(response.result_label));
     omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.sha256",
+                                                                  large_session_ptr, 0, 0, nullptr, &response));
+    REQUIRE(64 == response.result_length);
+    REQUIRE("c283e17a1b90a352c91de2c445b711c5c4126279eff884b8ffc44893576b19ef" ==
+            std::string(reinterpret_cast<const char *>(response.result_bytes),
+                        static_cast<size_t>(response.result_length)));
+    REQUIRE("sha256" == std::string(response.result_label));
+    omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(large_session_ptr);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.common_checksums", codec_session_ptr, 0, 5,
+                         "{\"algorithm\":\"crc32\"}", &response));
+    REQUIRE("0x3610A686" == std::string(reinterpret_cast<const char *>(response.result_bytes),
+                                        static_cast<size_t>(response.result_length)));
+    REQUIRE("crc32" == std::string(response.result_label));
+    omega_transform_plugin_response_clear(&response);
+
+    const auto checksum_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(checksum_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(checksum_session_ptr, 0, "123456789"));
+    const auto require_checksum_result = [&](const char *algorithm, const char *expected) {
+        const std::string options = std::string("{\"algorithm\":\"") + algorithm + "\"}";
+        REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.common_checksums",
+                                                                      checksum_session_ptr, 0, 9, options.c_str(),
+                                                                      &response));
+        REQUIRE(expected == std::string(reinterpret_cast<const char *>(response.result_bytes),
+                                        static_cast<size_t>(response.result_length)));
+        REQUIRE(algorithm == std::string(response.result_label));
+        omega_transform_plugin_response_clear(&response);
+    };
+    require_checksum_result("crc32", "0xCBF43926");
+    require_checksum_result("crc32c", "0xE3069283");
+    require_checksum_result("crc32-mpeg2", "0x0376E6E7");
+    require_checksum_result("crc32-bzip2", "0xFC891918");
+    require_checksum_result("crc16-ibm", "0xBB3D");
+    require_checksum_result("crc16-ccitt-false", "0x29B1");
+    require_checksum_result("crc16-xmodem", "0x31C3");
+    require_checksum_result("crc16-modbus", "0x4B37");
+    require_checksum_result("crc16-kermit", "0x2189");
+    require_checksum_result("crc8", "0xF4");
+    require_checksum_result("adler32", "0x091E01DE");
+    require_checksum_result("fletcher16", "0x1EDE");
+    require_checksum_result("fletcher32", "0x09DF09D5");
+    require_checksum_result("internet-checksum", "0xF62A");
+    require_checksum_result("lrc", "0x23");
+    require_checksum_result("bcc", "0x31");
+    require_checksum_result("sum8", "0xDD");
+    require_checksum_result("sum16", "0x01DD");
+    require_checksum_result("sum32", "0x000001DD");
+    require_checksum_result("fnv1a32", "0xBB86B11C");
+    require_checksum_result("fnv1a64", "0x06D5573923C6CDFC");
+    require_checksum_result("murmur3-32", "0xB4FEF382");
+    require_checksum_result("xxhash32", "0x937BAD67");
+    require_checksum_result("xxhash64", "0x8CB841DB40E6AE83");
+    omega_edit_destroy_session(checksum_session_ptr);
+
+    const auto text_codec_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(text_codec_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(text_codec_session_ptr, 0, "hello"));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.text_codecs", text_codec_session_ptr, 0, 5,
+                         "{\"codec\":\"hex\",\"direction\":\"encode\"}", &response));
+    REQUIRE("68656c6c6f" == omega_session_get_segment_string(text_codec_session_ptr, 0,
+                                                            omega_session_get_computed_file_size(text_codec_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.text_codecs", text_codec_session_ptr, 0, 0,
+                         "{\"codec\":\"hex\",\"direction\":\"decode\"}", &response));
+    REQUIRE("hello" == omega_session_get_segment_string(text_codec_session_ptr, 0,
+                                                        omega_session_get_computed_file_size(text_codec_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.text_codecs", text_codec_session_ptr, 0, 5,
+                         "{\"codec\":\"base64url\",\"direction\":\"encode\"}", &response));
+    REQUIRE("aGVsbG8" == omega_session_get_segment_string(text_codec_session_ptr, 0,
+                                                          omega_session_get_computed_file_size(text_codec_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.text_codecs", text_codec_session_ptr, 0, 0,
+                         "{\"codec\":\"base64url\",\"direction\":\"decode\"}", &response));
+    REQUIRE("hello" == omega_session_get_segment_string(text_codec_session_ptr, 0,
+                                                        omega_session_get_computed_file_size(text_codec_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(text_codec_session_ptr);
+
+    const auto charset_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(charset_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(charset_session_ptr, 0, "ABC"));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.character_transcode", charset_session_ptr, 0, 3,
+                         "{\"from\":\"utf-8\",\"to\":\"ebcdic-037\"}", &response));
+    REQUIRE(std::string({static_cast<char>(0xC1), static_cast<char>(0xC2), static_cast<char>(0xC3)}) ==
+            omega_session_get_segment_string(charset_session_ptr, 0, omega_session_get_computed_file_size(charset_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.character_transcode", charset_session_ptr, 0, 3,
+                         "{\"from\":\"ebcdic-037\",\"to\":\"utf-8\"}", &response));
+    REQUIRE("ABC" == omega_session_get_segment_string(charset_session_ptr, 0,
+                                                      omega_session_get_computed_file_size(charset_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(charset_session_ptr);
+
+    const auto invalid_utf8_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(invalid_utf8_session_ptr);
+    const omega_byte_t overlong_utf8_bytes[] = {0xC0, 0xAF};
+    REQUIRE(0 < omega_edit_insert_bytes(invalid_utf8_session_ptr, 0, overlong_utf8_bytes, 2));
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(
+                          registry_ptr, "omega.example.character_transcode", invalid_utf8_session_ptr, 0, 2,
+                          "{\"from\":\"utf-8\",\"to\":\"utf-16le\"}", &response));
+    omega_edit_destroy_session(invalid_utf8_session_ptr);
+
+    const auto helper_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(helper_session_ptr);
+    const omega_byte_t endian_bytes[] = {1, 2, 3, 4};
+    REQUIRE(0 < omega_edit_insert_bytes(helper_session_ptr, 0, endian_bytes, 4));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.endian_swap",
+                                                                  helper_session_ptr, 0, 4, "{\"width\":2}",
+                                                                  &response));
+    REQUIRE(std::string({2, 1, 4, 3}) ==
+            omega_session_get_segment_string(helper_session_ptr, 0, omega_session_get_computed_file_size(helper_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(helper_session_ptr);
+
+    const auto decimal_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(decimal_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(decimal_session_ptr, 0, "123"));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.decimal_codecs", decimal_session_ptr, 0, 3,
+                         "{\"codec\":\"packed-decimal\",\"direction\":\"encode\"}", &response));
+    REQUIRE(std::string({static_cast<char>(0x12), static_cast<char>(0x3C)}) ==
+            omega_session_get_segment_string(decimal_session_ptr, 0, omega_session_get_computed_file_size(decimal_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(decimal_session_ptr);
+
+    const auto format_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(format_session_ptr);
+    const omega_byte_t varint_bytes[] = {0x96, 0x01};
+    REQUIRE(0 < omega_edit_insert_bytes(format_session_ptr, 0, varint_bytes, 2));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.format_inspectors", format_session_ptr, 0, 2,
+                         "{\"format\":\"protobuf-varint\"}", &response));
+    REQUIRE(std::string(reinterpret_cast<const char *>(response.result_bytes),
+                        static_cast<size_t>(response.result_length)).find("value=150") != std::string::npos);
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(format_session_ptr);
+
+    const auto record_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(record_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(record_session_ptr, 0, "<&"));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.record_text_helpers", record_session_ptr, 0, 2,
+                         "{\"action\":\"xml-escape\"}", &response));
+    REQUIRE("&lt;&amp;" == omega_session_get_segment_string(record_session_ptr, 0,
+                                                           omega_session_get_computed_file_size(record_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(record_session_ptr);
+
+    const auto invalid_csv_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(invalid_csv_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(invalid_csv_session_ptr, 0, "\"abc\"\""));
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(
+                          registry_ptr, "omega.example.record_text_helpers", invalid_csv_session_ptr, 0, 6,
+                          "{\"action\":\"csv-unquote\"}", &response));
+    omega_edit_destroy_session(invalid_csv_session_ptr);
 
     REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib_compress",
                                                                    codec_session_ptr, 0, 5, "{\"level\":10}",

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -212,7 +212,7 @@ This AI tooling is a distinguishing feature of Ωedit™: it exposes the editing
 
 ## Transform Plugins
 
-OmegaEdit can load native `.so`, `.dylib`, and `.dll` transform plugins from registered plugin directories. Plugins can replace a selected byte range, expand or shrink content, or inspect a range and return results such as checksums and hashes. The separately packaged examples include one-for-one bitwise transforms, base64 encode/decode, zlib compress/decompress, expansion/shrink behavior, and inspect-only results. See [Transform Plugins](Transform-Plugins) for the ABI, SDK helpers, plugin package layout, server registration options, and exemplar plugins.
+OmegaEdit can load native `.so`, `.dylib`, and `.dll` transform plugins from registered plugin directories. Plugins can replace a selected byte range, expand or shrink content, or inspect a range and return results such as checksums and hashes. The separately packaged examples include one-for-one bitwise transforms, base64 encode/decode, zlib compress/decompress, MD5/SHA digest calculation, expansion/shrink behavior, and inspect-only results. See [Transform Plugins](Transform-Plugins) for the ABI, SDK helpers, plugin package layout, server registration options, and exemplar plugins.
 
 ## Comparison with Other Editing Engines
 

--- a/wiki/Transform-Plugins.md
+++ b/wiki/Transform-Plugins.md
@@ -205,8 +205,25 @@ plugins/
 |- omega_transform_and.dll
 |- omega_transform_base64_decode.dll
 |- omega_transform_base64_encode.dll
+|- omega_transform_blake2b512.dll
+|- omega_transform_blake2s256.dll
+|- omega_transform_character_transcode.dll
+|- omega_transform_common_checksums.dll
+|- omega_transform_decimal_codecs.dll
+|- omega_transform_endian_swap.dll
+|- omega_transform_format_inspectors.dll
 |- omega_transform_fnv1a64.dll
+|- omega_transform_md5.dll
 |- omega_transform_or.dll
+|- omega_transform_record_text_helpers.dll
+|- omega_transform_sha1.dll
+|- omega_transform_sha224.dll
+|- omega_transform_sha256.dll
+|- omega_transform_sha3_256.dll
+|- omega_transform_sha3_512.dll
+|- omega_transform_sha384.dll
+|- omega_transform_sha512.dll
+|- omega_transform_text_codecs.dll
 |- omega_transform_zlib_compress.dll
 |- omega_transform_zlib_decompress.dll
 |- omega_transform_xor.dll
@@ -303,6 +320,11 @@ oe apply-transform-plugin \
   --length 1024
 oe apply-transform-plugin \
   --session <session-id> \
+  --plugin omega.example.sha256 \
+  --offset 0 \
+  --length 1024
+oe apply-transform-plugin \
+  --session <session-id> \
   --plugin omega.example.zlib_compress \
   --offset 0 \
   --length 1024 \
@@ -323,8 +345,25 @@ The repository ships small examples in `plugins/src/`:
 | `omega.example.and` | `and.c` | Replace | One-for-one binary-safe AND transform. Accepts options JSON like `{"byte":"0x42"}` or a repeating byte sequence using `mask`; defaults to `0xFF`. |
 | `omega.example.base64_encode` | `base64_encode.c` | Replace | Expansion by encoding arbitrary bytes as base64 text. |
 | `omega.example.base64_decode` | `base64_decode.c` | Replace | Shrinking text content back to decoded bytes, with validation. ASCII whitespace is tolerated; other invalid bytes fail. |
+| `omega.example.blake2b512` | `blake2b512.c` | Inspect | BLAKE2b-512 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.blake2s256` | `blake2s256.c` | Inspect | BLAKE2s-256 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.character_transcode` | `character_transcode.cpp` | Replace | Transcoding between UTF-8/16/32, ASCII, ISO-8859-1, Windows-1252, and common single-byte EBCDIC pages. |
+| `omega.example.common_checksums` | `common_checksums.cpp` | Inspect | CRC, Adler, Fletcher, internet checksum, LRC/BCC, sum, FNV, Murmur3, and xxHash variants. |
+| `omega.example.decimal_codecs` | `decimal_codecs.cpp` | Replace | BCD, packed decimal/COMP-3, zoned decimal, and signed overpunch encode/decode helpers. |
+| `omega.example.endian_swap` | `endian_swap.cpp` | Replace | Fixed-width 2/4/8-byte endian swaps. |
+| `omega.example.format_inspectors` | `format_inspectors.cpp` | Inspect | Protobuf varint, ASN.1 BER/DER TLV, and configurable TLV summaries. |
 | `omega.example.fnv1a64` | `fnv1a64.c` | Inspect | 64-bit hash calculation without changing session content. |
+| `omega.example.md5` | `md5.c` | Inspect | MD5 digest calculation using OpenSSL 3 without changing session content. |
 | `omega.example.or` | `or.c` | Replace | One-for-one binary-safe OR transform. Accepts options JSON like `{"byte":"0x42"}` or a repeating byte sequence like `{"mask":["0x01","0x02"]}`; defaults to `0x00`. |
+| `omega.example.record_text_helpers` | `record_text_helpers.cpp` | Replace | Newline normalization, fixed-width lines, delimiter escaping, CSV quoting, XML entities, and JSON string escaping. |
+| `omega.example.sha1` | `sha1.c` | Inspect | SHA-1 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.sha224` | `sha224.c` | Inspect | SHA-224 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.sha256` | `sha256.c` | Inspect | SHA-256 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.sha3_256` | `sha3_256.c` | Inspect | SHA3-256 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.sha3_512` | `sha3_512.c` | Inspect | SHA3-512 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.sha384` | `sha384.c` | Inspect | SHA-384 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.sha512` | `sha512.c` | Inspect | SHA-512 digest calculation using OpenSSL 3 without changing session content. |
+| `omega.example.text_codecs` | `text_codecs.cpp` | Replace | Hex/base16, Base64URL, Base32, Base32-Crockford, Ascii85/Base85, Z85, Base58, percent/URL, quoted-printable, uuencode, and yEnc encode/decode helpers. |
 | `omega.example.zlib_compress` | `zlib_compress.c` | Replace | Compression with zlib, supplied by the plugin package toolchain. Accepts `{"level":9}` with valid levels from `-1` through `9`; defaults to zlib's default compression. |
 | `omega.example.zlib_decompress` | `zlib_decompress.c` | Replace | Decompression with zlib, supplied by the plugin package toolchain. |
 | `omega.example.xor` | `xor.c` | Replace | One-for-one binary-safe XOR transform. Accepts options JSON like `{"byte":"0x42"}` or a repeating byte sequence using `mask`; defaults to `0xFF`. |
@@ -333,7 +372,16 @@ The repository ships small examples in `plugins/src/`:
 
 These examples are intentionally small so they can serve as test fixtures and copyable
 developer starting points. Third-party dependencies belong to the plugin package,
-not the core ABI/loader package; the zlib exemplars use `plugins/conanfile.py`.
+not the core ABI/loader package; the zlib and OpenSSL digest exemplars use
+`plugins/conanfile.py`.
+
+MD5 and SHA-1 are provided for legacy formats, interoperability checks, and
+low-security data inspection workflows. Do not use them for security-sensitive
+authentication or integrity decisions.
+
+The character transcode exemplar focuses on cross-platform single-byte charsets
+and Unicode encodings. DBCS EBCDIC variants should be added from a dedicated
+code-page table source rather than guessed from regional samples.
 
 ## Release Notes for Plugin Authors
 


### PR DESCRIPTION
## Summary
- add inspect-only MD5, SHA-1, SHA-224, SHA-256, SHA-384, and SHA-512 transform plugins using OpenSSL 3 EVP
- link digest plugins against static OpenSSL Crypto and wire Linux/macOS/Windows build dependencies
- update native/client transform tests and plugin docs

## Verification
- cmake -G Ninja -S . -B .codex-tmp/hash-plugin-build -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DBUILD_DOCS=OFF -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON
- cmake --build .codex-tmp/hash-plugin-build --target omega_transform_plugin_tests --config Debug
- ctest -C Debug --test-dir .codex-tmp/hash-plugin-build/plugins --output-on-failure
- ldd .codex-tmp/hash-plugin-build/core/src/tests/plugins/omega_transform_sha256.so
- yarn workspace @omega-edit/client lint
- yarn workspace @omega-edit/client build
- git diff --check