### PR TITLE
fix: transform content change handling

### DIFF
--- a/.github/workflows/build-middleware-docker/action.yml
+++ b/.github/workflows/build-middleware-docker/action.yml
@@ -26,12 +26,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v4
       with:
         platforms: arm64
 
     - name: Download Library File (${{ inputs.os-name }}-${{ inputs.library-filename }})
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.os-name }}-${{ inputs.library-filename }}
         path: _artifacts/

--- a/.github/workflows/build-middleware/action.yml
+++ b/.github/workflows/build-middleware/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Setup Node.js
       uses: actions/setup-node@v6
@@ -48,7 +48,7 @@ runs:
       uses: lukka/get-cmake@latest
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -97,7 +97,7 @@ runs:
         echo "TARGET_MACOS_ARCH=$macos_arch" >> "$GITHUB_ENV"
 
     - name: Cache Conan packages
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.conan2
         key: conan-v2-${{ inputs.runner-os }}-${{ runner.arch }}-${{ inputs.os-name }}-${{ inputs.platform }}-${{ hashFiles('server/cpp/conanfile.py', 'plugins/conanfile.py') }}

--- a/.github/workflows/build-native-docker/action.yml
+++ b/.github/workflows/build-native-docker/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU 🔧
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v4
       with:
         platforms: arm64
 
@@ -64,7 +64,7 @@ runs:
           ${{ inputs.library-filename }}
 
     - name: Upload Native Library (${{ inputs.os-name }}-${{ inputs.library-filename }}) 🔺
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.os-name }}-${{ inputs.library-filename }}
         path: ${{ inputs.library-filename }}

--- a/.github/workflows/build-native/action.yml
+++ b/.github/workflows/build-native/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Setup Python for plugin dependencies
       if: inputs.runner-os == 'Windows' || inputs.runner-os == 'macOS'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -52,7 +52,7 @@ runs:
 
     - name: Cache transform plugin Conan packages
       if: inputs.runner-os == 'Windows' || inputs.runner-os == 'macOS'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.conan2
         key: plugin-conan-v2-${{ inputs.runner-os }}-${{ runner.arch }}-${{ inputs.os-name }}-${{ hashFiles('plugins/conanfile.py') }}
@@ -174,7 +174,7 @@ runs:
         echo "libpath=${libpath}" >> $GITHUB_ENV
 
     - name: Upload Native Library (${{ inputs.os-name }}-${{ env.libname }})
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.os-name }}-${{ env.libname }}
         path: ${{ env.libpath }}

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For an installed package instead of a source checkout, use the Codex MCP format 
 
 ## Transform Plugins
 
-OmegaEdit can discover native transform plugins from `.so`, `.dylib`, and `.dll` files. Plugins can replace a selected range, expand or shrink content, or inspect a range and return a result such as a checksum or hash. The separately packaged examples include bitwise transforms, binary/text codecs, zlib compression, character transcoding, decimal field helpers, record/text escaping, TLV/varint inspectors, and MD5/SHA/BLAKE/CRC/checksum-style inspection. See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the ABI, SDK helpers, plugin package layout, server registration options, and exemplar plugins.
+OmegaEdit can discover native transform plugins from `.so`, `.dylib`, and `.dll` files. Plugins can replace a selected range, expand or shrink content, or inspect a range and return a result such as a checksum or hash. The separately packaged examples include bitwise transforms, ASCII case changes, binary/text codecs, zlib compression, character transcoding, decimal field helpers, record/text escaping, TLV/varint inspectors, and MD5/SHA/BLAKE/CRC/checksum-style inspection. See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the ABI, SDK helpers, plugin package layout, server registration options, and exemplar plugins.
 
 ## User documentation
 

--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -1,0 +1,249 @@
+# OmegaEdit — Shortcomings, Bugs, Gaps & Missed Opportunities
+
+Living backlog of issues found while reviewing the `codex/checkpoint-change-log-actions`
+work and the surrounding transform / change-log / checkpoint code. Grouped by theme,
+roughly prioritized within each group. File:line references point at the offending code.
+
+Status notes:
+- `Fixed` means the current `codex/fix-transform-content-changed` branch addresses the
+  item directly.
+- `Partially fixed` means the branch reduces the risk but leaves a larger design gap.
+
+---
+
+## A. Transforms (correctness — "sometimes don't run / don't create changes")
+
+This is the reported bug. Root causes are spread across all three layers.
+
+1. **`content_changed` is inferred, never confirmed against the core.**
+   `server/cpp/src/editor_service.cpp:1834` sets
+   `content_changed = operation_replaces && (effective_length > 0 || replacement_length > 0)`.
+   It does **not** check whether `omega_edit_replace_bytes` actually recorded a change
+   (no change-serial / change-count delta is consulted). A replace whose replacement is
+   byte-identical to the source, or a core replace that no-ops, still reports
+   `content_changed = true` — and the reverse can happen too. The server should report
+   change-happened based on the core change count before/after, not arithmetic on lengths.
+   **Status: Fixed.** The server now reports `content_changed` from observed session
+   change/checkpoint/file-size deltas around the transform operation.
+
+2. **Core silently treats "no replacement" as success with no change.**
+   `core/src/lib/transform.cpp:1001-1006`: when `requested_length == 0 && replacement_length == 0`
+   the code returns `0` (success) without recording any change. The plugin "ran" but nothing
+   happened, and nothing upstream can distinguish that from a real edit. There is no
+   change-count/serial returned from the apply call to disambiguate.
+   **Status: Fixed.** Replace/inspect plugins must now set the no-content-change response
+   flag for intentional zero-length no-ops; ambiguous zero-length replace responses fail.
+
+3. **Client-side no-op detection *undoes* real work and is silently size-gated.**
+   `vscode-extension/src/hexEditorProvider.ts:2296-2322`. After a successful transform the
+   extension re-reads the range, compares bytes, and if equal calls `undo()`. Problems:
+   - The comparison is only performed when both sides are `<= MAX_TRANSFORM_NOOP_COMPARE_BYTES`
+     (1 MiB, line 145). Above that, `canCompareNoOp` is false, the change is *kept* even if it
+     is a true no-op — so behavior flips based on size (a "limit" leaking into correctness).
+   - When it *does* fire, it issues an `undo()` to roll back the just-applied change. If the
+     plugin legitimately replaced bytes with equal bytes (e.g. idempotent normalize), the user
+   sees "nothing happened" even though the operation was valid. This is almost certainly a
+   contributor to "transforms don't create changes when they should."
+   - The undo is a second async round-trip gated on `waitForSessionSync`; if sync versioning
+     races, the wrong change can be undone.
+   **Status: Fixed.** The extension no longer performs the post-transform byte compare or
+   undoes a completed transform as a client-side no-op.
+
+4. **Transform is recorded only as a generic `REPLACE` in local history, losing identity.**
+   `vscode-extension/src/hexEditorProvider.ts:2324-2333` records the transform result as a
+   `REPLACE` change record with raw replacement bytes. The plugin id and options are dropped.
+   See gap G1 below (first-class Transform change kind).
+
+5. **Whole-replacement is buffered in memory as hex.**
+   The extension reads the entire replacement back via `getSegment` and stores it hex-encoded
+   in the in-memory change log (2× the byte size). For large transforms this is a latent OOM
+   and conflicts with the large-file promise. (Same hex-doubling appears in the AI change log.)
+   **Status: Partially fixed.** Large transform replacements are no longer read back into
+   local VS Code history above the splice cap; general hex/in-memory change-log storage remains.
+
+6. **No surfaced reason when a transform genuinely does nothing.**
+   When `content_changed` is false there is no message explaining *why* (schema mismatch vs.
+   inspect-only plugin vs. true no-op). The webview just shows the transform "completed" with
+   no change. Users read this as "the transform didn't run."
+   **Status: Fixed.** The webview/toast path now distinguishes inspect-only calculations from
+   true no-content-change transforms, and bitwise/case-change identity paths report
+   no-content-change from the server.
+
+7. **Transform concurrency guard returns INTERNAL, not a typed state.**
+   `editor_service.cpp:1739` funnels "transform already in progress" through
+   `status_for_session_operation_start`, which can surface as a generic error string the UI
+   only pattern-matches on. Easy to misclassify as a failure.
+   **Status: Fixed.** The server operation-start guard maps transform/mutation busy states to
+   `FAILED_PRECONDITION`, and transform precondition rejection is now covered by client
+   integration coverage.
+
+---
+
+## B. Atomicity / transactions (first-class, reversible operations)
+
+8. **`applyChangeLog` is not atomic (AI).**
+   `packages/ai/src/service.ts` applies entries in a bare `for` loop of `insert/del/overwrite/replace`
+   with no transaction and no rollback. A failure midway leaves a partially-applied session
+   and no record of how far it got. Should wrap in a begin/end transaction (core supports
+   transaction state — see `omega_session_get_transaction_state` usage in the server) or, at
+   minimum, checkpoint before and restore on failure.
+   **Status: Partially fixed.** AI change-log apply now runs non-empty logs inside a server
+   transaction; explicit checkpoint rollback / applied-count reporting on failure is still open.
+
+9. **`applyChangeLog` is not atomic (extension).**
+   `vscode-extension/src/hexEditorProvider.ts` `applyChangeLogEntries` has the same
+   sequential, non-transactional shape.
+   **Status: Partially fixed.** Extension import now applies non-empty logs inside one server
+   transaction and records the applied entries as one local undo/redo transaction; explicit
+   rollback on mid-apply failure is still open.
+
+10. **Transforms are not atomic/first-class.** (User-requested flag — see G1.)
+    A transform that internally expands/shrinks/replaces is recorded as one opaque `REPLACE`
+    instead of a reversible, replayable `Transform` operation. Undo works by byte-replacement,
+    not by re-running/inverting the transform, so the change log cannot reproduce the transform
+    on a *different* file (the whole point of a portable change log).
+
+11. **Checkpoint rollback names must not promise snapshot restore semantics.**
+    The checkpoint operation calls `destroyLastCheckpoint`; there is no snapshot/restore
+    semantics here, just rollback of the current checkpoint model.
+    **Status: Fixed.** The AI toolkit/CLI/MCP tool, VS Code command/API/webview protocol,
+    toolbar, progress, and toasts now use rollback-checkpoint naming throughout.
+
+12. **Checkpoint creation is unconditional and unbounded.**
+    No cap on number of checkpoints, no dedupe, no "checkpoint only if dirty since last."
+    Repeated `createCheckpoint` calls grow state without feedback on cost.
+    **Status: Partially fixed.** VS Code now skips explicit checkpoint creation when the
+    session has no dirty changes and reports that no checkpoint was needed; server/API caps and
+    dedupe remain open.
+
+---
+
+## C. UX / notifications
+
+13. **Checkpoint & change-log confirmations land in the results pull-down, not a toast.**
+    (User-requested flag.) `hexEditorProvider.postSessionActionComplete` posts
+    `sessionActionComplete`, and `App.svelte:2124-2137` writes it into `transformFeedback`
+    (the transform/results feedback strip, rendered at `App.svelte:2147`). For
+    `rollbackCheckpoint` / session rollback the confirmation should pop as a VS Code toast
+    (`showInformationMessage`) instead of (or in addition to) the inline strip.
+    Note the host already fires a toast for some actions, so the two paths are inconsistent:
+    some actions toast + strip, some strip-only. Pick one rule and apply it uniformly.
+    **Status: Fixed.** Session action completions now rely on host toasts and no longer
+    populate the transform/results feedback strip.
+
+14. **Inconsistent "rollback" vs "restore" vocabulary across the codebase.**
+    The checkpoint path previously mixed rollback and restore vocabulary for closely-related
+    concepts, confusing users and future maintainers.
+    **Status: Fixed.** The checkpoint command/API/protocol/tooling path now consistently uses
+    rollback terminology; remaining restore wording is limited to unrelated backup restore and
+    future true snapshot-restore work.
+
+15. **Cancelled actions are reported as success-ish.**
+    `exportChangeLog` cancel returns `{ cancelled: true }` but still posts a
+    `sessionActionComplete` that the webview renders as feedback text; easy to misread.
+    **Status: Fixed.** Cancelled session actions now clear inline feedback instead of rendering
+    success-like completion text.
+
+16. **No progress for `exportChangeLog`.**
+    `collectChangeLogEntries` loops `getChangeDetails` serial-by-serial (one RPC per change,
+    up to 100k). For large sessions this is a long, silent, blocking operation with no progress
+    notification (apply has a progress bar; export does not).
+    **Status: Fixed.** VS Code export now wraps change-detail collection in a progress
+    notification.
+
+---
+
+## D. The "remove limits" promise (hard caps that betray the mission)
+
+17. **JS `Number.isSafeInteger` ceiling (2^53) on every offset/length.**
+    `packages/client/src/safe_int.ts` throws on any offset/length/count beyond 2^53 on both
+    input and output. The core is 64-bit (`int64_t`). Any file or offset past ~9 PB is
+    unreachable from the TS client. Defensible today, but it is a real ceiling that contradicts
+    "remove limits." Consider `BigInt` on the boundaries that can legitimately exceed 2^53.
+
+18. **Change-log entry/byte caps.**
+    AI: `MAX_CHANGE_LOG_ENTRIES = 100_000`, `MAX_CHANGE_LOG_ENTRY_BYTES = 32 MiB`,
+    `MAX_CHANGE_LOG_BYTES = 96 MiB` (`packages/ai/src/service.ts`). Extension mirrors these
+    (`hexEditorProvider.ts:146-148`). A session with >100k changes simply cannot export a log,
+    and `foldedChangeCount` silently hides the dropped ones (see E20). For a tool whose pitch is
+    massive files, a 100k-change ceiling is low.
+
+19. **In-memory hex doubling everywhere.**
+    Change-log data is stored/transported as hex strings (2× bytes) in both AI and extension,
+    and transform replacements are fully materialized client-side. Streaming / chunked /
+    file-backed change logs would honor the large-file promise.
+
+---
+
+## E. Change-log fidelity & format
+
+20. **Export is lossy and silently so.**
+    `exportChangeLog` reconstructs entries from `getChangeDetails`, which only yields
+    INSERT/DELETE/OVERWRITE — never REPLACE or Transform. Changes absorbed into a checkpoint
+    baseline are dropped and only counted in `foldedChangeCount`. The exported log therefore
+    cannot faithfully reproduce a session that used checkpoints or transforms. This is presented
+    in the README as a feature ("portable…apply to a fleet of files"), which overstates fidelity.
+
+21. **No schema validation / versioning enforcement on import.**
+    `normalizeChangeLogEntries` accepts an array *or* `{changes:[...]}` but does not check
+    `format`/`version` fields it itself writes. A v2 document or a foreign JSON array would be
+    applied (or partially applied) without a compatibility gate.
+    **Status: Fixed.** Wrapped imports must now match the OmegaEdit change-log format and
+    version; the legacy bare-array form is still accepted.
+
+22. **`groupId` and `serial` are carried but not honored.**
+    Import preserves `serial`/`groupId` (`service.ts` normalize) but apply ignores them — no
+    grouping/transaction reconstruction, serials are not validated for monotonicity or gaps.
+    **Status: Fixed.** AI and VS Code imports now reject partial, non-contiguous, or gapped
+    serial metadata; `groupId` metadata is validated for contiguous groups and preserved on
+    applied VS Code history records while the import remains one atomic server transaction.
+
+23. **Error sniffing by string match.**
+    `isMissingChangeDetailsError` matches `'NOT_FOUND'` / `'change not found'` substrings
+    (AI and extension). Brittle: depends on server message wording, not gRPC status codes.
+    **Status: Fixed.** `getChangeDetails` preserves the original gRPC error as `cause`, and
+    AI/extension importers now classify missing change details by gRPC status code only.
+
+24. **`getChangeDetails` request sends dummy fields.**
+    `packages/client/src/protobuf_ts/change.ts` fills `sessionEventKind`, `computedFileSize`,
+    `changeCount`, `undoCount` with zeros just to satisfy the shared request message. Harmless
+    now but couples a read to an event-shaped message; a stricter server could reject it.
+
+---
+
+## F. Testing / build confidence
+
+25. **No test asserts the transform-no-op / content_changed path.**
+    The reported bug area (A1–A3, A6) has no regression test. Add coverage for: identical-bytes
+    replace, inspect-only plugin, >1 MiB replace (no-op gate flips), and content_changed accuracy.
+    **Status: Fixed.** Added regression coverage for identical-byte transforms,
+    bitwise/case-change identity transforms, inspect-only/no-content-change reporting, and a
+    >1 MiB no-op transform to guard the former client-side size gate.
+
+26. **Branch could not be type-checked/tested here.**
+    Node is v22 in this environment; repo requires 24, deps not installed. CI must run
+    `yarn workspace @omega-edit/ai test`, vscode-extension build+tests, and `yarn lint` before merge.
+    **Status: Fixed.** Local checks now run through `nvm` on Node 24; PR CI is queued.
+
+27. **`applyChangeLog` round-trip test only covers the happy path.**
+    `packages/ai/tests/specs/toolkit.spec.ts` exercises a single OVERWRITE. No test for
+    multi-entry logs, REPLACE entries, partial-failure/atomicity, or the entry/byte caps.
+    **Status: Partially fixed.** Added malformed wrapped-change-log import coverage; multi-entry,
+    REPLACE, partial-failure, and cap tests remain open.
+
+---
+
+## G. Gaps / future work (noted, not to implement now)
+
+- **G1 — First-class `Transform` change kind.** (User-requested.) Treat Transform as a peer of
+  Insert/Delete/Overwrite/Replace: a change record `{ kind: 'TRANSFORM', offset, length,
+  pluginId, optionsJson }` carrying exactly the arguments needed to *re-run* the transform,
+  so the change log can reproduce it on another file rather than baking in resulting bytes.
+  Requires: core/proto change-kind support, server to record transform-as-change, client wrapper,
+  AI + extension change-log encode/decode, and undo-by-inverse-or-rerun semantics.
+- **G2 — True checkpoint restore** (snapshot + restore-to), distinct from drop-last-checkpoint.
+- **G3 — Streaming / file-backed change logs** to drop the in-memory and entry-count caps.
+- **G4 — BigInt offsets/lengths** at the TS boundary to lift the 2^53 ceiling.
+- **G5 — Transactional `applyChangeLog`** (begin/end transaction or checkpoint-guarded) for atomicity.
+- **G6 — gRPC status-code based error handling.** **Status: Fixed.** Missing change-detail
+  handling now follows preserved gRPC status codes instead of message text.

--- a/core/src/include/omega_edit/transform.h
+++ b/core/src/include/omega_edit/transform.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #endif
 
-#define OMEGA_TRANSFORM_PLUGIN_ABI_VERSION 2
+#define OMEGA_TRANSFORM_PLUGIN_ABI_VERSION 3
 
 typedef enum {
     OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE = 1,
@@ -80,6 +80,10 @@ typedef enum {
     OMEGA_TRANSFORM_PROGRESS_HAS_PERCENT = 1 << 2,
     OMEGA_TRANSFORM_PROGRESS_INDETERMINATE = 1 << 3
 } omega_transform_progress_flags_t;
+
+typedef enum {
+    OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE = 1
+} omega_transform_plugin_response_flags_t;
 
 typedef struct {
     int64_t processed_bytes;
@@ -129,6 +133,7 @@ typedef struct {
     int64_t result_length;
     char *result_label;
     char *result_mime_type;
+    uint32_t flags;
 } omega_transform_plugin_response_t;
 
 typedef int (*omega_transform_plugin_get_info_fn)(omega_transform_plugin_info_t *info_ptr);

--- a/core/src/include/omega_edit/transform_plugin_sdk.h
+++ b/core/src/include/omega_edit/transform_plugin_sdk.h
@@ -89,10 +89,21 @@ static inline int omega_transform_plugin_sdk_report_phase(
     return omega_transform_plugin_sdk_report_progress(request_ptr, &progress);
 }
 
+static inline int omega_transform_plugin_sdk_set_no_content_change(omega_transform_plugin_response_t *response_ptr) {
+    if (!response_ptr) { return -1; }
+    response_ptr->replacement_bytes = NULL;
+    response_ptr->replacement_length = 0;
+    response_ptr->flags |= OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE;
+    return 0;
+}
+
 static inline int omega_transform_plugin_sdk_set_replacement(
         const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr,
         const omega_byte_t *bytes, int64_t length) {
     if (!request_ptr || !response_ptr || length < 0 || (length > 0 && !bytes)) { return -1; }
+    if (length == 0 && request_ptr->input_length == 0) {
+        return omega_transform_plugin_sdk_set_no_content_change(response_ptr);
+    }
     response_ptr->replacement_length = length;
     if (length == 0) { return 0; }
     response_ptr->replacement_bytes = omega_transform_plugin_sdk_copy_bytes(request_ptr, bytes, length);

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -539,6 +539,10 @@ namespace {
         return length >= 0 && (length == 0 || bytes != nullptr);
     }
 
+    auto plugin_response_has_no_content_change_(const omega_transform_plugin_response_t &response) -> bool {
+        return (response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U;
+    }
+
     auto int64_to_size_(int64_t value, size_t &out) -> bool {
         if (value < 0) { return false; }
         if (static_cast<uint64_t>(value) > static_cast<uint64_t>((std::numeric_limits<size_t>::max)())) {
@@ -989,21 +993,36 @@ int omega_transform_plugin_registry_apply_to_session_with_progress(
         omega_transform_plugin_response_clear(&plugin_response);
         return -1;
     }
+    if (plugin_response_has_no_content_change_(plugin_response) &&
+        (plugin_response.replacement_bytes != nullptr || plugin_response.replacement_length != 0)) {
+        release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
+        omega_transform_plugin_response_clear(&plugin_response);
+        return -1;
+    }
 
     if (operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE ||
         operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT) {
+        const auto no_content_change = plugin_response_has_no_content_change_(plugin_response);
+        if (!no_content_change && requested_length == 0 && plugin_response.replacement_length == 0) {
+            release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
+            omega_transform_plugin_response_clear(&plugin_response);
+            return -1;
+        }
         const auto use_checkpoint =
                 plugin_response.replacement_length > static_cast<int64_t>(OMEGA_MEMORY_BUFFER_LIMIT);
-        const auto rc = use_checkpoint
-                                ? omega_edit_replace_bytes_checkpointed(session_ptr, offset, requested_length,
-                                                                        plugin_response.replacement_bytes,
-                                                                        plugin_response.replacement_length)
-                                : (omega_edit_replace_bytes(session_ptr, offset, requested_length,
-                                                            plugin_response.replacement_bytes,
-                                                            plugin_response.replacement_length) > 0 ||
-                                   (requested_length == 0 && plugin_response.replacement_length == 0)
-                                           ? 0
-                                           : -1);
+        int rc = 0;
+        if (no_content_change) {
+            rc = 0;
+        } else if (use_checkpoint) {
+            rc = omega_edit_replace_bytes_checkpointed(session_ptr, offset, requested_length,
+                                                       plugin_response.replacement_bytes,
+                                                       plugin_response.replacement_length);
+        } else {
+            const auto change_serial = omega_edit_replace_bytes(session_ptr, offset, requested_length,
+                                                                plugin_response.replacement_bytes,
+                                                                plugin_response.replacement_length);
+            rc = change_serial > 0 ? 0 : -1;
+        }
         if (rc != 0) {
             release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
             omega_transform_plugin_response_clear(&plugin_response);

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -63,7 +63,7 @@ oe export-range --session <session-id> --offset 0 --length 128 --output ./header
 
 # Create checkpoints and broadcast/apply change logs
 oe create-checkpoint --session <session-id>
-oe restore-checkpoint --session <session-id>
+oe rollback-checkpoint --session <session-id>
 oe export-change-log --session <session-id> --output ./changes.json --overwrite
 oe apply-change-log --session <session-id> --input ./changes.json
 
@@ -121,7 +121,7 @@ Available tools:
 - `omega_edit_destroy_session`
 - `omega_edit_session_status`
 - `omega_edit_create_checkpoint`
-- `omega_edit_restore_checkpoint`
+- `omega_edit_rollback_checkpoint`
 - `omega_edit_export_change_log`
 - `omega_edit_apply_change_log`
 - `omega_edit_read_range`

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -34,7 +34,7 @@ function usage(): string {
     '  destroy-session --session <id>',
     '  session-status --session <id>',
     '  create-checkpoint --session <id>',
-    '  restore-checkpoint --session <id>',
+    '  rollback-checkpoint --session <id>  # roll back the most recent checkpoint',
     '  export-change-log --session <id> [--output <path>] [--overwrite]',
     '  apply-change-log --session <id> --input <path> [--dry-run]',
     '  diff-session --session <id>',
@@ -258,7 +258,7 @@ async function runCommand(
         )
       )
     }
-    case 'restore-checkpoint': {
+    case 'rollback-checkpoint': {
       const parsed = parseArgs({
         args,
         options: {
@@ -267,7 +267,7 @@ async function runCommand(
         },
         allowPositionals: false,
       })
-      return await getToolkit(parsed.values).restoreCheckpoint(
+      return await getToolkit(parsed.values).rollbackCheckpoint(
         requireStringOption(
           parsed.values.session as string | undefined,
           'session'

--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -288,9 +288,9 @@ function buildTools(toolkit: OmegaEditToolkit): ToolDefinition[] {
       },
     },
     {
-      name: 'omega_edit_restore_checkpoint',
+      name: 'omega_edit_rollback_checkpoint',
       description:
-        'Restore the most recent OmegaEdit checkpoint by dropping the current checkpoint model.',
+        'Roll back the most recent OmegaEdit checkpoint by dropping the current checkpoint model.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -299,7 +299,7 @@ function buildTools(toolkit: OmegaEditToolkit): ToolDefinition[] {
         required: ['sessionId'],
       },
       run: async (argumentsObject) => {
-        return await toolkit.restoreCheckpoint(
+        return await toolkit.rollbackCheckpoint(
           getString(argumentsObject, 'sessionId', true)!
         )
       },

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -33,6 +33,7 @@ import {
   replace,
   replaceSession as replaceWholeSession,
   resetClient,
+  runSessionTransaction,
   saveSession,
   searchSession,
   startServer,
@@ -65,7 +66,7 @@ import {
   ReadRangeResult,
   ReplaceSessionRequest,
   ReplaceSessionResult,
-  RestoreCheckpointResult,
+  RollbackCheckpointResult,
   SearchRequest,
   SearchResult,
   SessionStatus,
@@ -78,6 +79,7 @@ const MAX_CHANGE_LOG_ENTRY_BYTES = 32 * 1024 * 1024
 const MAX_CHANGE_LOG_BYTES = MAX_CHANGE_LOG_ENTRY_BYTES * 3
 const CHANGE_LOG_FORMAT = 'omega-edit.change-log'
 const CHANGE_LOG_VERSION = 1
+const GRPC_NOT_FOUND = 5
 
 const changeKindNames = new Map<number, string>(
   Object.entries(ChangeKind)
@@ -106,11 +108,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function normalizeChangeLogEntries(value: unknown): ChangeLogEntry[] {
-  const entries = Array.isArray(value)
-    ? value
-    : isRecord(value) && Array.isArray(value.changes)
-      ? value.changes
-      : undefined
+  let entries: unknown[] | undefined
+  if (Array.isArray(value)) {
+    entries = value
+  } else if (isRecord(value)) {
+    if (value.format !== CHANGE_LOG_FORMAT) {
+      throw new Error('Unsupported change log format')
+    }
+    if (value.version !== CHANGE_LOG_VERSION) {
+      throw new Error('Unsupported change log version')
+    }
+    entries = Array.isArray(value.changes) ? value.changes : undefined
+  }
 
   if (!entries) {
     throw new Error('Change log must be a JSON array or an object with changes')
@@ -121,7 +130,11 @@ function normalizeChangeLogEntries(value: unknown): ChangeLogEntry[] {
     )
   }
 
-  return entries.map((entry, index) => normalizeChangeLogEntry(entry, index))
+  const normalized = entries.map((entry, index) =>
+    normalizeChangeLogEntry(entry, index)
+  )
+  validateChangeLogMetadata(normalized)
+  return normalized
 }
 
 function normalizeChangeLogEntry(
@@ -167,17 +180,73 @@ function normalizeChangeLogEntry(
     length,
     data: Buffer.from(dataBytes).toString('hex'),
   }
-  if (
-    typeof serial === 'number' &&
-    Number.isSafeInteger(serial) &&
-    serial >= 0
-  ) {
+  if (serial !== undefined) {
+    if (
+      typeof serial !== 'number' ||
+      !Number.isSafeInteger(serial) ||
+      serial <= 0
+    ) {
+      throw new Error(
+        `Change log entry ${index} serial must be a positive safe integer`
+      )
+    }
     normalized.serial = serial
   }
-  if (typeof groupId === 'string' && groupId.trim()) {
+  if (groupId !== undefined) {
+    if (typeof groupId !== 'string' || !groupId.trim()) {
+      throw new Error(`Change log entry ${index} groupId must be a string`)
+    }
     normalized.groupId = groupId.trim()
   }
   return normalized
+}
+
+function validateChangeLogMetadata(entries: ChangeLogEntry[]): void {
+  const serializedEntries = entries.filter(
+    (entry) => entry.serial !== undefined
+  )
+  if (
+    serializedEntries.length > 0 &&
+    serializedEntries.length !== entries.length
+  ) {
+    throw new Error('Change log serial metadata must be present on every entry')
+  }
+
+  for (let index = 0; index < entries.length; index += 1) {
+    const serial = entries[index].serial
+    if (serial !== undefined && serial !== index + 1) {
+      throw new Error(
+        `Change log serial metadata must be contiguous; entry ${index} has serial ${serial}, expected ${
+          index + 1
+        }`
+      )
+    }
+  }
+
+  const closedGroups = new Set<string>()
+  let activeGroup: string | undefined
+  for (const [index, entry] of entries.entries()) {
+    const groupId = entry.groupId
+    if (!groupId) {
+      if (activeGroup) {
+        closedGroups.add(activeGroup)
+        activeGroup = undefined
+      }
+      continue
+    }
+
+    if (groupId !== activeGroup) {
+      if (closedGroups.has(groupId)) {
+        throw new Error(
+          `Change log groupId "${groupId}" is not contiguous at entry ${index}`
+        )
+      }
+      if (activeGroup) {
+        closedGroups.add(activeGroup)
+      }
+      activeGroup = groupId
+    }
+  }
 }
 
 async function readChangeLogFile(inputPath: string): Promise<ChangeLogEntry[]> {
@@ -219,8 +288,18 @@ function changeDetailsToLogEntry(
 }
 
 function isMissingChangeDetailsError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.includes('NOT_FOUND') || message.includes('change not found')
+  return hasGrpcStatusCode(error, GRPC_NOT_FOUND)
+}
+
+function hasGrpcStatusCode(error: unknown, code: number): boolean {
+  let current: unknown = error
+  while (isRecord(current)) {
+    if (current.code === code) {
+      return true
+    }
+    current = current.cause
+  }
+  return false
 }
 
 async function collectChangeLogEntries(
@@ -438,20 +517,22 @@ export class OmegaEditToolkit {
     }
   }
 
-  async restoreCheckpoint(sessionId: string): Promise<RestoreCheckpointResult> {
+  async rollbackCheckpoint(
+    sessionId: string
+  ): Promise<RollbackCheckpointResult> {
     await this.ensureServerRunning()
     const existingCount = await this.getCheckpointCount(sessionId)
     if (existingCount <= 0) {
       return {
         sessionId,
-        restored: false,
+        rolledBack: false,
         checkpointCount: 0,
       }
     }
 
     return {
       sessionId,
-      restored: true,
+      rolledBack: true,
       checkpointCount: await destroyClientCheckpoint(sessionId),
     }
   }
@@ -509,22 +590,31 @@ export class OmegaEditToolkit {
 
     await this.ensureServerRunning()
 
-    for (const change of changes) {
-      const data = Buffer.from(change.data, 'hex')
-      switch (change.kind) {
-        case 'INSERT':
-          await insert(request.sessionId, change.offset, data)
-          break
-        case 'DELETE':
-          await del(request.sessionId, change.offset, change.length)
-          break
-        case 'OVERWRITE':
-          await overwrite(request.sessionId, change.offset, data)
-          break
-        case 'REPLACE':
-          await replace(request.sessionId, change.offset, change.length, data)
-          break
-      }
+    if (changes.length > 0) {
+      await runSessionTransaction(request.sessionId, async () => {
+        for (const change of changes) {
+          const data = Buffer.from(change.data, 'hex')
+          switch (change.kind) {
+            case 'INSERT':
+              await insert(request.sessionId, change.offset, data)
+              break
+            case 'DELETE':
+              await del(request.sessionId, change.offset, change.length)
+              break
+            case 'OVERWRITE':
+              await overwrite(request.sessionId, change.offset, data)
+              break
+            case 'REPLACE':
+              await replace(
+                request.sessionId,
+                change.offset,
+                change.length,
+                data
+              )
+              break
+          }
+        }
+      })
     }
 
     return {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -65,7 +65,7 @@ export interface ChangeLogResult {
 
 export interface ApplyChangeLogRequest {
   sessionId: string
-  changes?: ChangeLogEntry[]
+  changes?: ChangeLogEntry[] | ChangeLogDocument
   inputPath?: string
   dryRun?: boolean
 }
@@ -82,9 +82,9 @@ export interface CheckpointResult {
   checkpointCount: number
 }
 
-export interface RestoreCheckpointResult {
+export interface RollbackCheckpointResult {
   sessionId: string
-  restored: boolean
+  rolledBack: boolean
   checkpointCount: number
 }
 

--- a/packages/ai/tests/specs/mcp.spec.ts
+++ b/packages/ai/tests/specs/mcp.spec.ts
@@ -144,8 +144,8 @@ describe('@omega-edit/ai mcp server', function () {
         'expected omega_edit_create_checkpoint in tool list'
       )
       assert.ok(
-        tools.some((tool) => tool.name === 'omega_edit_restore_checkpoint'),
-        'expected omega_edit_restore_checkpoint in tool list'
+        tools.some((tool) => tool.name === 'omega_edit_rollback_checkpoint'),
+        'expected omega_edit_rollback_checkpoint in tool list'
       )
       assert.ok(
         tools.some((tool) => tool.name === 'omega_edit_export_change_log'),

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -29,6 +29,138 @@ describe('@omega-edit/ai toolkit', function () {
     }
   })
 
+  it('rejects wrapped change logs with incompatible format metadata', async function () {
+    const toolkit = new OmegaEditToolkit({ autoStart: false })
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
+    const invalidFormatPath = path.join(tempDir, 'invalid-format.json')
+    const invalidVersionPath = path.join(tempDir, 'invalid-version.json')
+
+    try {
+      await fs.promises.writeFile(
+        invalidFormatPath,
+        JSON.stringify({
+          format: 'not-omega-edit',
+          version: 1,
+          changes: [],
+        })
+      )
+      await fs.promises.writeFile(
+        invalidVersionPath,
+        JSON.stringify({
+          format: 'omega-edit.change-log',
+          version: 2,
+          changes: [],
+        })
+      )
+
+      await assert.rejects(
+        () =>
+          toolkit.applyChangeLog({
+            sessionId: 'session',
+            dryRun: true,
+            inputPath: invalidFormatPath,
+          }),
+        /Unsupported change log format/
+      )
+
+      await assert.rejects(
+        () =>
+          toolkit.applyChangeLog({
+            sessionId: 'session',
+            dryRun: true,
+            inputPath: invalidVersionPath,
+          }),
+        /Unsupported change log version/
+      )
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+
+    const wrappedDocument = await toolkit.applyChangeLog({
+      sessionId: 'session',
+      dryRun: true,
+      changes: {
+        format: 'omega-edit.change-log',
+        version: 1,
+        changeCount: 0,
+        sourceChangeCount: 0,
+        foldedChangeCount: 0,
+        changes: [],
+      },
+    })
+    assert.equal(wrappedDocument.applied, false)
+    assert.equal(wrappedDocument.changeCount, 0)
+
+    const legacyArray = await toolkit.applyChangeLog({
+      sessionId: 'session',
+      dryRun: true,
+      changes: [],
+    })
+    assert.equal(legacyArray.applied, false)
+    assert.equal(legacyArray.changeCount, 0)
+  })
+
+  it('rejects inconsistent change-log serial and group metadata', async function () {
+    const toolkit = new OmegaEditToolkit({ autoStart: false })
+
+    await assert.rejects(
+      () =>
+        toolkit.applyChangeLog({
+          sessionId: 'session',
+          dryRun: true,
+          changes: [
+            {
+              serial: 1,
+              kind: 'INSERT',
+              offset: 0,
+              length: 0,
+              data: '41',
+            },
+            {
+              serial: 3,
+              kind: 'INSERT',
+              offset: 1,
+              length: 0,
+              data: '42',
+            },
+          ],
+        }),
+      /serial metadata must be contiguous/
+    )
+
+    await assert.rejects(
+      () =>
+        toolkit.applyChangeLog({
+          sessionId: 'session',
+          dryRun: true,
+          changes: [
+            {
+              kind: 'INSERT',
+              offset: 0,
+              length: 0,
+              data: '41',
+              groupId: 'batch-a',
+            },
+            {
+              kind: 'INSERT',
+              offset: 1,
+              length: 0,
+              data: '42',
+              groupId: 'batch-b',
+            },
+            {
+              kind: 'INSERT',
+              offset: 2,
+              length: 0,
+              data: '43',
+              groupId: 'batch-a',
+            },
+          ],
+        }),
+      /groupId "batch-a" is not contiguous/
+    )
+  })
+
   it('supports bounded reads, search, preview, patching, and undo/redo', async function () {
     const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
     assert.ok(port, 'expected an available port for OmegaEdit')
@@ -185,9 +317,9 @@ describe('@omega-edit/ai toolkit', function () {
 
       const checkpoint = await toolkit.createCheckpoint(createdSessionId)
       assert.ok(checkpoint.checkpointCount >= 1)
-      const restored = await toolkit.restoreCheckpoint(createdSessionId)
-      assert.equal(restored.restored, true)
-      assert.ok(restored.checkpointCount >= 0)
+      const rolledBack = await toolkit.rollbackCheckpoint(createdSessionId)
+      assert.equal(rolledBack.rolledBack, true)
+      assert.ok(rolledBack.checkpointCount >= 0)
     } finally {
       if (createdSessionId) {
         await toolkit.destroySession(createdSessionId)

--- a/packages/client/src/editor_history.ts
+++ b/packages/client/src/editor_history.ts
@@ -41,7 +41,8 @@ export interface EditorCheckpointReplaceAllTransaction {
 }
 
 export type EditorTransactionRecord =
-  | { kind: 'LOCAL' }
+  | { kind: 'LOCAL'; changeCount: number }
+  | { kind: 'LOCAL_UNTRACKED' }
   | EditorCheckpointReplaceAllTransaction
 
 export interface EditorEditState {
@@ -64,23 +65,16 @@ export interface EditorHistoryExecutor {
   ): Promise<void>
 }
 
-function moveLastGroupedChanges(
+function moveLastChanges(
   source: EditorChangeRecord[],
-  target: EditorChangeRecord[]
+  target: EditorChangeRecord[],
+  count: number
 ): void {
-  if (source.length === 0) {
+  if (source.length === 0 || count <= 0) {
     return
   }
 
-  const lastGroupId = source[source.length - 1].groupId
-  let startIndex = source.length - 1
-
-  if (lastGroupId) {
-    while (startIndex > 0 && source[startIndex - 1].groupId === lastGroupId) {
-      startIndex -= 1
-    }
-  }
-
+  const startIndex = Math.max(0, source.length - count)
   target.push(...source.splice(startIndex))
 }
 
@@ -114,6 +108,12 @@ export class EditorHistoryController {
     this.recordLocalChanges([change])
   }
 
+  public recordLocalMutation(): void {
+    this.undoneChangeLog.length = 0
+    this.transactionLog.push({ kind: 'LOCAL_UNTRACKED' })
+    this.undoneTransactionLog.length = 0
+  }
+
   public recordLocalChanges(changes: EditorChangeRecord[]): void {
     if (changes.length === 0) {
       return
@@ -121,7 +121,7 @@ export class EditorHistoryController {
 
     this.changeLog.push(...changes)
     this.undoneChangeLog.length = 0
-    this.transactionLog.push({ kind: 'LOCAL' })
+    this.transactionLog.push({ kind: 'LOCAL', changeCount: changes.length })
     this.undoneTransactionLog.length = 0
   }
 
@@ -168,7 +168,13 @@ export class EditorHistoryController {
     const transaction = this.transactionLog[this.transactionLog.length - 1]
     if (transaction.kind === 'LOCAL') {
       await executor.undoLocal()
-      moveLastGroupedChanges(this.changeLog, this.undoneChangeLog)
+      moveLastChanges(
+        this.changeLog,
+        this.undoneChangeLog,
+        transaction.changeCount
+      )
+    } else if (transaction.kind === 'LOCAL_UNTRACKED') {
+      await executor.undoLocal()
     } else {
       await executor.undoCheckpoint(transaction)
     }
@@ -191,7 +197,13 @@ export class EditorHistoryController {
       this.undoneTransactionLog[this.undoneTransactionLog.length - 1]
     if (transaction.kind === 'LOCAL') {
       await executor.redoLocal()
-      moveLastGroupedChanges(this.undoneChangeLog, this.changeLog)
+      moveLastChanges(
+        this.undoneChangeLog,
+        this.changeLog,
+        transaction.changeCount
+      )
+    } else if (transaction.kind === 'LOCAL_UNTRACKED') {
+      await executor.redoLocal()
     } else {
       await executor.redoCheckpoint(transaction)
     }

--- a/packages/client/src/protobuf_ts/change.ts
+++ b/packages/client/src/protobuf_ts/change.ts
@@ -29,6 +29,7 @@ import {
 } from './generated/omega_edit/v1/omega_edit'
 import { debugLog, getLogger } from '../logger'
 import { getClient } from '../client'
+import { makeWrappedError } from './utils'
 
 export const ChangeKind = {
   UNSPECIFIED: ProtoChangeKind.UNSPECIFIED,
@@ -373,7 +374,7 @@ export async function getChangeDetails(
             stack: err.stack,
           },
         })
-        return reject(new Error('getChangeDetails failed: ' + err))
+        return reject(makeWrappedError('getChangeDetails', err))
       }
 
       if (!response) {

--- a/packages/client/tests/specs/editorPatterns.spec.ts
+++ b/packages/client/tests/specs/editorPatterns.spec.ts
@@ -136,6 +136,137 @@ describe('Editor Patterns', () => {
     })
   })
 
+  it('should keep untracked local mutations out of the change log', async () => {
+    const history = new EditorHistoryController()
+    const calls: string[] = []
+    const executor = {
+      async undoLocal() {
+        calls.push('undoLocal')
+      },
+      async redoLocal() {
+        calls.push('redoLocal')
+      },
+      async undoCheckpoint() {
+        calls.push('undoCheckpoint')
+      },
+      async redoCheckpoint() {
+        calls.push('redoCheckpoint')
+      },
+    }
+
+    history.recordLocalChange({
+      serial: 1,
+      kind: 'INSERT',
+      offset: 0,
+      length: 0,
+      data: '41',
+    })
+    history.recordLocalMutation()
+
+    expect(history.getChangeLog()).to.deep.equal([
+      {
+        serial: 1,
+        kind: 'INSERT',
+        offset: 0,
+        length: 0,
+        data: '41',
+      },
+    ])
+    expect(history.getEditState()).to.deep.include({
+      canUndo: true,
+      canRedo: false,
+      undoCount: 2,
+      redoCount: 0,
+    })
+
+    await history.undo(executor)
+    expect(calls).to.deep.equal(['undoLocal'])
+    expect(history.getChangeLog()).to.have.length(1)
+    expect(history.getEditState()).to.deep.include({
+      canUndo: true,
+      canRedo: true,
+      undoCount: 1,
+      redoCount: 1,
+    })
+
+    await history.redo(executor)
+    expect(calls).to.deep.equal(['undoLocal', 'redoLocal'])
+    expect(history.getChangeLog()).to.have.length(1)
+    expect(history.getEditState()).to.deep.include({
+      canUndo: true,
+      canRedo: false,
+      undoCount: 2,
+      redoCount: 0,
+    })
+  })
+
+  it('should undo multi-record local transactions as a single unit', async () => {
+    const history = new EditorHistoryController()
+    const calls: string[] = []
+    const executor = {
+      async undoLocal() {
+        calls.push('undoLocal')
+      },
+      async redoLocal() {
+        calls.push('redoLocal')
+      },
+      async undoCheckpoint() {
+        calls.push('undoCheckpoint')
+      },
+      async redoCheckpoint() {
+        calls.push('redoCheckpoint')
+      },
+    }
+    const entries = [
+      {
+        serial: 1,
+        kind: 'INSERT' as const,
+        offset: 0,
+        length: 0,
+        data: '41',
+        groupId: 'import-a',
+      },
+      {
+        serial: 2,
+        kind: 'OVERWRITE' as const,
+        offset: 4,
+        length: 1,
+        data: '42',
+        groupId: 'import-b',
+      },
+    ]
+
+    history.recordLocalChanges(entries)
+
+    expect(history.getEditState()).to.deep.include({
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+    })
+    expect(history.getChangeLog()).to.deep.equal(entries)
+
+    await history.undo(executor)
+    expect(calls).to.deep.equal(['undoLocal'])
+    expect(history.getEditState()).to.deep.include({
+      canUndo: false,
+      canRedo: true,
+      undoCount: 0,
+      redoCount: 1,
+    })
+    expect(history.getChangeLog()).to.deep.equal([])
+
+    await history.redo(executor)
+    expect(calls).to.deep.equal(['undoLocal', 'redoLocal'])
+    expect(history.getChangeLog()).to.deep.equal(entries)
+    expect(history.getEditState()).to.deep.include({
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+    })
+  })
+
   it('should preserve large-search mode until the next explicit search and choose bounded vs checkpointed replace-all on demand', async () => {
     const searchCalls: Array<{
       offset: number

--- a/packages/client/tests/specs/transformPlugin.spec.ts
+++ b/packages/client/tests/specs/transformPlugin.spec.ts
@@ -211,7 +211,6 @@ describe('Transform plugin gRPC integration', () => {
         )
       } finally {
         if (transactionOpen) {
-          transactionOpen = false
           await endSessionTransaction(sessionId)
         }
       }

--- a/packages/client/tests/specs/transformPlugin.spec.ts
+++ b/packages/client/tests/specs/transformPlugin.spec.ts
@@ -20,10 +20,13 @@
 import {
   TransformPluginOperation,
   applyTransformPlugin,
+  beginSessionTransaction,
   createSessionFromBytes,
   destroySession,
+  endSessionTransaction,
   findFirstAvailablePort,
   getClient,
+  getChangeCount,
   getComputedFileSize,
   getSegment,
   listTransformPlugins,
@@ -32,6 +35,7 @@ import {
   stopServiceOnPort,
 } from '@omega-edit/client'
 import omegaEditServer from '@omega-edit/server'
+import { status as GrpcStatus } from '@grpc/grpc-js'
 import * as fs from 'fs'
 import * as path from 'path'
 import waitPort from 'wait-port'
@@ -116,6 +120,7 @@ describe('Transform plugin gRPC integration', () => {
       expect(plugins.map((plugin) => plugin.id)).to.include.members([
         'omega.example.base64',
         'omega.example.bitwise',
+        'omega.example.case_change',
         'omega.example.character_transcode',
         'omega.example.common_checksums',
         'omega.example.decimal_codecs',
@@ -138,6 +143,13 @@ describe('Transform plugin gRPC integration', () => {
         '{"operator":"xor","byte":"0xFF"}'
       )
       expect(bitwisePlugin?.argsSchema).to.include('"operator"')
+      const caseChangePlugin = plugins.find(
+        (plugin) => plugin.id === 'omega.example.case_change'
+      )
+      expect(caseChangePlugin?.help).to.include('ASCII alphabetic bytes')
+      expect(caseChangePlugin?.example).to.equal('{"case":"lower"}')
+      expect(caseChangePlugin?.defaultArgs).to.equal('{"case":"upper"}')
+      expect(caseChangePlugin?.argsSchema).to.include('"upper"')
       const base64Plugin = plugins.find(
         (plugin) => plugin.id === 'omega.example.base64'
       )
@@ -173,6 +185,142 @@ describe('Transform plugin gRPC integration', () => {
       } catch (err) {
         expect((err as Error).message).to.include('INVALID_ARGUMENT')
       }
+
+      let transactionOpen = false
+      try {
+        await beginSessionTransaction(sessionId)
+        transactionOpen = true
+        await applyTransformPlugin(
+          sessionId,
+          'omega.example.bitwise',
+          0,
+          3,
+          JSON.stringify({ operator: 'xor', byte: '0x01' })
+        )
+        expect.fail(
+          'applyTransformPlugin should reject while a transaction is open'
+        )
+      } catch (err) {
+        const wrapped = err as Error & {
+          cause?: { code?: number; details?: string }
+        }
+        expect(wrapped.message).to.include('FAILED_PRECONDITION')
+        expect(wrapped.cause?.code).to.equal(GrpcStatus.FAILED_PRECONDITION)
+        expect(wrapped.message).to.include(
+          'transform cannot run while a session transaction is open'
+        )
+      } finally {
+        if (transactionOpen) {
+          transactionOpen = false
+          await endSessionTransaction(sessionId)
+        }
+      }
+
+      const identityBitwiseChangeCount = await getChangeCount(sessionId)
+      const xorIdentityResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.bitwise',
+        0,
+        3,
+        JSON.stringify({ operator: 'xor', byte: '0x00' })
+      )
+      expect(xorIdentityResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(xorIdentityResponse.contentChanged).to.equal(false)
+      expect(xorIdentityResponse.replacementLength).to.equal(0)
+      expect(xorIdentityResponse.computedFileSize).to.equal(3)
+      expect(await getChangeCount(sessionId)).to.equal(
+        identityBitwiseChangeCount
+      )
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
+      ).to.equal('abc')
+
+      const andIdentityResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.bitwise',
+        0,
+        3,
+        JSON.stringify({ operator: 'and', byte: '0xFF' })
+      )
+      expect(andIdentityResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(andIdentityResponse.contentChanged).to.equal(false)
+      expect(andIdentityResponse.replacementLength).to.equal(0)
+      expect(await getChangeCount(sessionId)).to.equal(
+        identityBitwiseChangeCount
+      )
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
+      ).to.equal('abc')
+
+      const orIdentityResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.bitwise',
+        0,
+        3,
+        JSON.stringify({ operator: 'or', mask: ['0x00', '0x00'] })
+      )
+      expect(orIdentityResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(orIdentityResponse.contentChanged).to.equal(false)
+      expect(orIdentityResponse.replacementLength).to.equal(0)
+      expect(await getChangeCount(sessionId)).to.equal(
+        identityBitwiseChangeCount
+      )
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
+      ).to.equal('abc')
+
+      const upperResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.case_change',
+        0,
+        3,
+        JSON.stringify({ case: 'upper' })
+      )
+      expect(upperResponse.operation).to.equal(TransformPluginOperation.REPLACE)
+      expect(upperResponse.contentChanged).to.equal(true)
+      expect(upperResponse.replacementLength).to.equal(3)
+      expect(upperResponse.computedFileSize).to.equal(3)
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
+      ).to.equal('ABC')
+
+      const uppercaseChangeCount = await getChangeCount(sessionId)
+      const upperNoopResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.case_change',
+        0,
+        3,
+        JSON.stringify({ case: 'upper' })
+      )
+      expect(upperNoopResponse.operation).to.equal(
+        TransformPluginOperation.REPLACE
+      )
+      expect(upperNoopResponse.contentChanged).to.equal(false)
+      expect(upperNoopResponse.replacementLength).to.equal(0)
+      expect(await getChangeCount(sessionId)).to.equal(uppercaseChangeCount)
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
+      ).to.equal('ABC')
+
+      const lowerResponse = await applyTransformPlugin(
+        sessionId,
+        'omega.example.case_change',
+        0,
+        3,
+        JSON.stringify({ case: 'lower' })
+      )
+      expect(lowerResponse.operation).to.equal(TransformPluginOperation.REPLACE)
+      expect(lowerResponse.contentChanged).to.equal(true)
+      expect(lowerResponse.replacementLength).to.equal(3)
+      expect(
+        Buffer.from(await getSegment(sessionId, 0, 3)).toString('utf8')
+      ).to.equal('abc')
 
       const encodeResponse = await applyTransformPlugin(
         sessionId,
@@ -273,6 +421,7 @@ describe('Transform plugin gRPC integration', () => {
         Buffer.from(await getSegment(sessionId, 0, 5)).toString('utf8')
       ).to.equal('abcbc')
 
+      const checksumChangeCount = await getChangeCount(sessionId)
       const checksumResponse = await applyTransformPlugin(
         sessionId,
         'omega.example.common_checksums',
@@ -290,6 +439,7 @@ describe('Transform plugin gRPC integration', () => {
         '0xEB'
       )
       expect(await getComputedFileSize(sessionId)).to.equal(5)
+      expect(await getChangeCount(sessionId)).to.equal(checksumChangeCount)
 
       const hashResponse = await applyTransformPlugin(
         sessionId,

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -94,6 +94,7 @@ set(OMEGA_EDIT_TRANSFORM_PLUGIN_TARGETS)
 foreach (plugin_src
         src/base64.c
         src/bitwise.c
+        src/case_change.c
         src/character_transcode.cpp
         src/common_checksums.cpp
         src/decimal_codecs.cpp

--- a/plugins/src/bitmask_options.h
+++ b/plugins/src/bitmask_options.h
@@ -279,12 +279,40 @@ static omega_byte_t omega_bitmask_apply_byte(omega_byte_t value, omega_byte_t ma
     return value;
 }
 
+static int omega_bitmask_mask_is_identity(const omega_bitmask_options_t *mask_ptr) {
+    if (!mask_ptr || mask_ptr->length == 0) { return 0; }
+
+    omega_byte_t identity_byte;
+    switch (mask_ptr->operation) {
+        case OMEGA_BITMASK_AND:
+            identity_byte = 0xFF;
+            break;
+        case OMEGA_BITMASK_OR:
+            identity_byte = 0x00;
+            break;
+        case OMEGA_BITMASK_XOR:
+            identity_byte = 0x00;
+            break;
+        default:
+            return 0;
+    }
+
+    for (size_t i = 0; i < mask_ptr->length; ++i) {
+        if (mask_ptr->bytes[i] != identity_byte) { return 0; }
+    }
+    return 1;
+}
+
 static int omega_bitmask_apply_replace(const omega_transform_plugin_request_t *request_ptr,
                                        omega_transform_plugin_response_t *response_ptr,
                                        const omega_bitmask_options_t *mask_ptr) {
     if (!request_ptr || !response_ptr || !request_ptr->alloc || !mask_ptr || mask_ptr->length == 0 ||
         request_ptr->input_length < 0 || (request_ptr->input_length > 0 && !request_ptr->input_bytes)) {
         return -1;
+    }
+
+    if (request_ptr->input_length == 0 || omega_bitmask_mask_is_identity(mask_ptr)) {
+        return omega_transform_plugin_sdk_set_no_content_change(response_ptr);
     }
 
     omega_byte_t *bytes = omega_transform_plugin_sdk_copy_bytes(request_ptr, request_ptr->input_bytes,

--- a/plugins/src/case_change.c
+++ b/plugins/src/case_change.c
@@ -1,0 +1,156 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#include <omega_edit/transform_plugin_sdk.h>
+#include <ctype.h>
+#include <string.h>
+
+typedef enum omega_case_change_mode_t {
+    OMEGA_CASE_CHANGE_UPPER,
+    OMEGA_CASE_CHANGE_LOWER
+} omega_case_change_mode_t;
+
+static const char CASE_CHANGE_ARGS_SCHEMA[] =
+        "{\"type\":\"object\",\"properties\":{\"case\":{\"type\":\"string\",\"title\":\"Case\","
+        "\"description\":\"Convert ASCII alphabetic bytes to upper or lower case.\",\"default\":\"upper\","
+        "\"enum\":[\"upper\",\"lower\"]}},\"additionalProperties\":false}";
+
+static void case_change_skip_ws(const char **cursor) {
+    while (cursor && *cursor && isspace((unsigned char) **cursor)) { ++(*cursor); }
+}
+
+static int case_change_parse_json_string(const char **cursor, char *out, size_t out_size) {
+    if (!cursor || !*cursor || **cursor != '"' || out_size == 0) { return -1; }
+    ++(*cursor);
+    size_t length = 0;
+    while (**cursor && **cursor != '"') {
+        char ch = **cursor;
+        if (ch == '\\') {
+            ++(*cursor);
+            if (!**cursor) { return -1; }
+            ch = **cursor;
+        }
+        if (length + 1 >= out_size) { return -1; }
+        out[length++] = ch;
+        ++(*cursor);
+    }
+    if (**cursor != '"') { return -1; }
+    ++(*cursor);
+    out[length] = '\0';
+    return 0;
+}
+
+static int case_change_parse_mode_text(const char *value, omega_case_change_mode_t *mode_out) {
+    if (!value || !mode_out) { return -1; }
+    if (strcmp(value, "upper") == 0) {
+        *mode_out = OMEGA_CASE_CHANGE_UPPER;
+        return 0;
+    }
+    if (strcmp(value, "lower") == 0) {
+        *mode_out = OMEGA_CASE_CHANGE_LOWER;
+        return 0;
+    }
+    return -1;
+}
+
+static int case_change_parse_options(const char *options_json, omega_case_change_mode_t *mode_out) {
+    if (!mode_out) { return -1; }
+    *mode_out = OMEGA_CASE_CHANGE_UPPER;
+    if (!options_json || !*options_json) { return 0; }
+
+    const char *cursor = options_json;
+    case_change_skip_ws(&cursor);
+    if (*cursor != '{') { return -1; }
+    ++cursor;
+    case_change_skip_ws(&cursor);
+    if (*cursor == '}') {
+        ++cursor;
+        case_change_skip_ws(&cursor);
+        return *cursor == '\0' ? 0 : -1;
+    }
+
+    char key[32];
+    if (case_change_parse_json_string(&cursor, key, sizeof(key)) != 0 || strcmp(key, "case") != 0) { return -1; }
+    case_change_skip_ws(&cursor);
+    if (*cursor != ':') { return -1; }
+    ++cursor;
+    case_change_skip_ws(&cursor);
+
+    char mode[16];
+    if (case_change_parse_json_string(&cursor, mode, sizeof(mode)) != 0 ||
+        case_change_parse_mode_text(mode, mode_out) != 0) {
+        return -1;
+    }
+
+    case_change_skip_ws(&cursor);
+    if (*cursor != '}') { return -1; }
+    ++cursor;
+    case_change_skip_ws(&cursor);
+    return *cursor == '\0' ? 0 : -1;
+}
+
+static omega_byte_t case_change_byte(omega_byte_t byte, omega_case_change_mode_t mode) {
+    if (mode == OMEGA_CASE_CHANGE_UPPER && byte >= 'a' && byte <= 'z') {
+        return (omega_byte_t) (byte - ('a' - 'A'));
+    }
+    if (mode == OMEGA_CASE_CHANGE_LOWER && byte >= 'A' && byte <= 'Z') {
+        return (omega_byte_t) (byte + ('a' - 'A'));
+    }
+    return byte;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
+    if (!info_ptr) { return -1; }
+    info_ptr->id = "omega.example.case_change";
+    info_ptr->name = "Case Change";
+    info_ptr->description = "Convert ASCII alphabetic bytes to upper or lower case.";
+    info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
+    info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
+    info_ptr->help = "Choose upper or lower case. Only ASCII alphabetic bytes are changed; all other bytes are preserved.";
+    info_ptr->example = "{\"case\":\"lower\"}";
+    info_ptr->default_args = "{\"case\":\"upper\"}";
+    info_ptr->args_schema = CASE_CHANGE_ARGS_SCHEMA;
+    info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
+    return 0;
+}
+
+OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                                                              omega_transform_plugin_response_t *response_ptr) {
+    if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0 ||
+        (request_ptr->input_length > 0 && !request_ptr->input_bytes)) {
+        return -1;
+    }
+
+    omega_case_change_mode_t mode;
+    if (case_change_parse_options(request_ptr->options_json, &mode) != 0) { return -1; }
+
+    int has_change = 0;
+    for (int64_t i = 0; i < request_ptr->input_length; ++i) {
+        if (case_change_byte(request_ptr->input_bytes[i], mode) != request_ptr->input_bytes[i]) {
+            has_change = 1;
+            break;
+        }
+    }
+    if (!has_change) { return omega_transform_plugin_sdk_set_no_content_change(response_ptr); }
+
+    omega_byte_t *output =
+            (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, (size_t) request_ptr->input_length);
+    if (!output) { return -1; }
+    for (int64_t i = 0; i < request_ptr->input_length; ++i) {
+        output[i] = case_change_byte(request_ptr->input_bytes[i], mode);
+    }
+    response_ptr->replacement_bytes = output;
+    response_ptr->replacement_length = request_ptr->input_length;
+    return 0;
+}

--- a/plugins/src/repeat.c
+++ b/plugins/src/repeat.c
@@ -36,7 +36,7 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_trans
     if (request_ptr->input_length > INT64_MAX / 2) { return -1; }
     const int64_t replacement_length = request_ptr->input_length * 2;
     response_ptr->replacement_length = replacement_length;
-    if (replacement_length == 0) { return 0; }
+    if (replacement_length == 0) { return omega_transform_plugin_sdk_set_no_content_change(response_ptr); }
     response_ptr->replacement_bytes = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr,
                                                                                        (size_t) replacement_length);
     if (!response_ptr->replacement_bytes) { return -1; }

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -30,9 +30,10 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     const auto registry_ptr = omega_transform_plugin_registry_create();
     REQUIRE(registry_ptr);
     REQUIRE(0 < omega_transform_plugin_registry_register_directory(registry_ptr, PLUGIN_DIR.string().c_str()));
-    REQUIRE(12 <= omega_transform_plugin_registry_get_count(registry_ptr));
+    REQUIRE(13 <= omega_transform_plugin_registry_get_count(registry_ptr));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.base64"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.bitwise"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.case_change"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.character_transcode"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.common_checksums"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.decimal_codecs"));
@@ -77,6 +78,13 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                                   common_checksums_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"algorithm\":\"not-a-checksum\"}",
                                                                    common_checksums_info->args_schema));
+    const auto case_change_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.case_change");
+    REQUIRE("Case Change" == std::string(case_change_info->name));
+    REQUIRE("{\"case\":\"upper\"}" == std::string(case_change_info->default_args));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"case\":\"lower\"}",
+                                                                  case_change_info->args_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"case\":\"title\"}",
+                                                                   case_change_info->args_schema));
     const auto zlib_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib");
     REQUIRE("Zlib" == std::string(zlib_info->name));
     REQUIRE(std::string(zlib_info->help).find("Compression level") != std::string::npos);
@@ -118,6 +126,96 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE("sum8" == std::string(response.result_label));
     REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
                                                          omega_session_get_computed_file_size(session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+
+    const auto identity_bitwise_change_count = omega_session_get_num_changes(session_ptr);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.bitwise", session_ptr, 0, 6,
+                         "{\"operator\":\"xor\",\"byte\":\"0x00\"}",
+                         &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
+                                                         omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(identity_bitwise_change_count == omega_session_get_num_changes(session_ptr));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.bitwise", session_ptr, 0, 6,
+                         "{\"operator\":\"and\",\"byte\":\"0xFF\"}",
+                         &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
+                                                         omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(identity_bitwise_change_count == omega_session_get_num_changes(session_ptr));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.bitwise", session_ptr, 0, 6,
+                         "{\"operator\":\"or\",\"mask\":[\"0x00\",\"0x00\"]}",
+                         &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
+                                                         omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(identity_bitwise_change_count == omega_session_get_num_changes(session_ptr));
+    omega_transform_plugin_response_clear(&response);
+
+    const auto case_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(case_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(case_session_ptr, 0, "abC!09z"));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.case_change",
+                                                                  case_session_ptr, 0, 7,
+                                                                  "{\"case\":\"upper\"}", &response));
+    REQUIRE(7 == response.replacement_length);
+    REQUIRE("ABC!09Z" == omega_session_get_segment_string(case_session_ptr, 0,
+                                                          omega_session_get_computed_file_size(case_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+
+    const auto uppercase_change_count = omega_session_get_num_changes(case_session_ptr);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.case_change",
+                                                                  case_session_ptr, 0, 7,
+                                                                  "{\"case\":\"upper\"}", &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE(uppercase_change_count == omega_session_get_num_changes(case_session_ptr));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.case_change",
+                                                                  case_session_ptr, 0, 7,
+                                                                  "{\"case\":\"lower\"}", &response));
+    REQUIRE(7 == response.replacement_length);
+    REQUIRE("abc!09z" == omega_session_get_segment_string(case_session_ptr, 0,
+                                                          omega_session_get_computed_file_size(case_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(case_session_ptr);
+
+    const auto empty_transform_change_count = omega_session_get_num_changes(session_ptr);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.repeat", session_ptr,
+                         omega_session_get_computed_file_size(session_ptr), 0, nullptr, &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE(empty_transform_change_count == omega_session_get_num_changes(session_ptr));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.base64", session_ptr,
+                         omega_session_get_computed_file_size(session_ptr), 0,
+                         "{\"direction\":\"encode\"}", &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE(empty_transform_change_count == omega_session_get_num_changes(session_ptr));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
+                         registry_ptr, "omega.example.bitwise", session_ptr,
+                         omega_session_get_computed_file_size(session_ptr), 0,
+                         "{\"operator\":\"xor\",\"byte\":\"0xFF\"}", &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE(empty_transform_change_count == omega_session_get_num_changes(session_ptr));
     omega_transform_plugin_response_clear(&response);
 
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.bitwise", session_ptr,

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -1757,6 +1757,8 @@ grpc::Status EditorServiceImpl::ApplyTransformPlugin(
     }
     const auto remaining = file_size_before - offset;
     const auto effective_length = (length == 0 || length > remaining) ? remaining : length;
+    const auto change_count_before = omega_session_get_num_changes(session);
+    const auto checkpoint_count_before = omega_session_get_num_checkpoints(session);
 
     omega_transform_plugin_operation_t operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
     const std::string operation_id = next_transform_operation_id();
@@ -1826,14 +1828,19 @@ grpc::Status EditorServiceImpl::ApplyTransformPlugin(
 
     const bool operation_replaces = operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE ||
                                     operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT;
+    const auto change_count_after = omega_session_get_num_changes(session);
+    const auto checkpoint_count_after = omega_session_get_num_checkpoints(session);
+    const auto computed_file_size_after = omega_session_get_computed_file_size(session);
     response->set_session_id(request->session_id());
     response->set_plugin_id(request->plugin_id());
     response->set_offset(offset);
     response->set_length(effective_length);
     response->set_operation(to_proto_transform_plugin_operation(operation));
     response->set_content_changed(operation_replaces &&
-                                  (effective_length > 0 || plugin_response.response.replacement_length > 0));
-    response->set_computed_file_size(omega_session_get_computed_file_size(session));
+                                  (change_count_after != change_count_before ||
+                                   checkpoint_count_after != checkpoint_count_before ||
+                                   computed_file_size_after != file_size_before));
+    response->set_computed_file_size(computed_file_size_after);
     response->set_replacement_length(plugin_response.response.replacement_length);
     if (plugin_response.response.result_label) {
         response->set_result_label(plugin_response.response.result_label);

--- a/vscode-extension/docs/svelte-ai-migration-requirements.md
+++ b/vscode-extension/docs/svelte-ai-migration-requirements.md
@@ -56,7 +56,7 @@ The migration must preserve these user-visible and integration features:
 - Transform plugin discovery, option help, JSON Schema validation, and apply
   flow.
 - Change log export and application.
-- Checkpoint creation, last-checkpoint restore, and session rollback.
+- Checkpoint creation, last-checkpoint rollback, and session rollback.
 - Integration and unit test coverage for the custom editor lifecycle.
 
 ## Svelte/Vite Requirements

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -33,7 +33,7 @@
     "onCommand:omegaEdit.exportChangeLog",
     "onCommand:omegaEdit.applyChangeLog",
     "onCommand:omegaEdit.rollbackSession",
-    "onCommand:omegaEdit.restoreCheckpoint",
+    "onCommand:omegaEdit.rollbackCheckpoint",
     "onCommand:omegaEdit.createCheckpoint",
     "onCommand:omegaEdit.getEditorState",
     "onCommand:omegaEdit.setExternalHighlights",
@@ -150,8 +150,8 @@
         "enablement": "omegaEdit.hexEditorActive && omegaEdit.hasPendingChanges && !omegaEdit.transformInFlight"
       },
       {
-        "command": "omegaEdit.restoreCheckpoint",
-        "title": "%omegaEdit.command.restoreCheckpoint.title%",
+        "command": "omegaEdit.rollbackCheckpoint",
+        "title": "%omegaEdit.command.rollbackCheckpoint.title%",
         "enablement": "omegaEdit.hexEditorActive && !omegaEdit.transformInFlight"
       },
       {
@@ -233,7 +233,7 @@
           "when": "omegaEdit.hexEditorActive && omegaEdit.hasPendingChanges && !omegaEdit.transformInFlight"
         },
         {
-          "command": "omegaEdit.restoreCheckpoint",
+          "command": "omegaEdit.rollbackCheckpoint",
           "when": "omegaEdit.hexEditorActive && !omegaEdit.transformInFlight"
         },
         {

--- a/vscode-extension/package.nls.json
+++ b/vscode-extension/package.nls.json
@@ -18,7 +18,7 @@
   "omegaEdit.command.exportChangeLog.title": "OmegaEdit: Export Change Log",
   "omegaEdit.command.applyChangeLog.title": "OmegaEdit: Apply Change Log",
   "omegaEdit.command.rollbackSession.title": "OmegaEdit: Roll Back Session",
-  "omegaEdit.command.restoreCheckpoint.title": "OmegaEdit: Restore Last Checkpoint",
+  "omegaEdit.command.rollbackCheckpoint.title": "OmegaEdit: Roll Back Last Checkpoint",
   "omegaEdit.command.createCheckpoint.title": "OmegaEdit: Create Checkpoint",
   "omegaEdit.command.getEditorState.title": "OmegaEdit: Get Editor State",
   "omegaEdit.command.setExternalHighlights.title": "OmegaEdit: Set External Highlights",

--- a/vscode-extension/src/api.ts
+++ b/vscode-extension/src/api.ts
@@ -10,7 +10,7 @@ export const OMEGA_EDIT_EXTENSION_PUBLISHER = 'ctc-oss'
 export const OMEGA_EDIT_EXTENSION_NAME = 'omega-edit-data-editor'
 export const OMEGA_EDIT_EXTENSION_ID =
   `${OMEGA_EDIT_EXTENSION_PUBLISHER}.${OMEGA_EDIT_EXTENSION_NAME}` as const
-export const OMEGA_EDIT_EXTENSION_API_VERSION = 1
+export const OMEGA_EDIT_EXTENSION_API_VERSION = 2
 
 export type OmegaEditExternalHighlightKind = ExternalHighlightKind
 export type OmegaEditExternalHighlight = WebviewExternalHighlight
@@ -57,9 +57,9 @@ export interface OmegaEditCheckpointResult {
   checkpointCount: number
 }
 
-export interface OmegaEditRestoreCheckpointResult {
+export interface OmegaEditRollbackCheckpointResult {
   state?: OmegaEditEditorState
-  restored: boolean
+  rolledBack: boolean
   checkpointCount: number
 }
 
@@ -110,9 +110,9 @@ export interface OmegaEditExtensionApi {
   createCheckpoint(
     options?: vscode.Uri | string | OmegaEditCheckpointOptions
   ): Promise<OmegaEditCheckpointResult | undefined>
-  restoreCheckpoint(
+  rollbackCheckpoint(
     options?: vscode.Uri | string | OmegaEditCheckpointOptions
-  ): Promise<OmegaEditRestoreCheckpointResult | undefined>
+  ): Promise<OmegaEditRollbackCheckpointResult | undefined>
   exportChangeLog(
     options?: vscode.Uri | string | OmegaEditChangeLogExportOptions
   ): Promise<OmegaEditChangeLogResult | undefined>

--- a/vscode-extension/src/constants.ts
+++ b/vscode-extension/src/constants.ts
@@ -12,8 +12,8 @@ export const OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND =
 export const OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND = 'omegaEdit.exportChangeLog'
 export const OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND = 'omegaEdit.applyChangeLog'
 export const OMEGA_EDIT_ROLLBACK_SESSION_COMMAND = 'omegaEdit.rollbackSession'
-export const OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND =
-  'omegaEdit.restoreCheckpoint'
+export const OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND =
+  'omegaEdit.rollbackCheckpoint'
 export const OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND = 'omegaEdit.createCheckpoint'
 export const OMEGA_EDIT_GET_EDITOR_STATE_COMMAND = 'omegaEdit.getEditorState'
 export const OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND =

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -46,7 +46,7 @@ import {
   OMEGA_EDIT_SEARCH_NEXT_COMMAND,
   OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
   OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
-  OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
+  OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
   OMEGA_EDIT_TOGGLE_INSERT_DIRECTION_COMMAND,
   OMEGA_EDIT_UNDO_COMMAND,
   OMEGA_EDIT_VIEW_TYPE,
@@ -557,8 +557,8 @@ function createOmegaEditExtensionApi(
     async createCheckpoint(options) {
       return provider.createCheckpoint(options)
     },
-    async restoreCheckpoint(options) {
-      return provider.restoreCheckpoint(options)
+    async rollbackCheckpoint(options) {
+      return provider.rollbackCheckpoint(options)
     },
     async exportChangeLog(options) {
       return provider.exportChangeLog(options)
@@ -803,9 +803,9 @@ export async function activate(
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
-      OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
+      OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
       async (options?: unknown) => {
-        await provider.restoreCheckpoint(options)
+        await provider.rollbackCheckpoint(options)
       }
     )
   )

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -63,10 +63,12 @@ import {
   profileSession,
   replaceSessionCheckpointed,
   redo,
+  runSessionTransaction,
   saveSession,
   SessionEventKind,
   startServerHeartbeatLoop,
   type TransformProgress,
+  TransformPluginOperation,
   type TransformPluginInfo,
   type ServerHeartbeatLoop,
   undo,
@@ -144,10 +146,12 @@ const SERVER_HEALTH_WARN_LATENCY_MS = 75
 const SERVER_HEALTH_ERROR_LATENCY_MS = 250
 const MAX_TRANSFORM_RESULT_TEXT_LENGTH = 240
 const MAX_TRANSFORM_RESULT_PREVIEW_BYTES = 4 * 1024
-const MAX_TRANSFORM_NOOP_COMPARE_BYTES = 1024 * 1024
 const MAX_FILE_SPLICE_BYTES = 32 * 1024 * 1024
 const MAX_CHANGE_LOG_BYTES = MAX_FILE_SPLICE_BYTES * 3
 const MAX_CHANGE_LOG_ENTRIES = 100_000
+const CHANGE_LOG_FORMAT = 'omega-edit.change-log'
+const CHANGE_LOG_VERSION = 1
+const GRPC_NOT_FOUND = 5
 const CONTEXT_HEX_EDITOR_ACTIVE = 'omegaEdit.hexEditorActive'
 const CONTEXT_CAN_UNDO = 'omegaEdit.canUndo'
 const CONTEXT_CAN_REDO = 'omegaEdit.canRedo'
@@ -242,7 +246,7 @@ function isMutationWebviewMessage(message: WebviewToHostMessage): boolean {
     case 'replaceRangeWithFile':
     case 'replaceAllMatches':
     case 'createCheckpoint':
-    case 'restoreCheckpoint':
+    case 'rollbackCheckpoint':
     case 'applyChangeLog':
     case 'undo':
     case 'redo':
@@ -589,13 +593,6 @@ function transformResultToText(bytes: Uint8Array): string {
   return truncateTransformResult(Buffer.from(preview).toString('utf8') + suffix)
 }
 
-function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  return (
-    left.byteLength === right.byteLength &&
-    Buffer.from(left).equals(Buffer.from(right))
-  )
-}
-
 function serializeTransformPlugin(plugin: TransformPluginInfo): {
   id: string
   name: string
@@ -649,13 +646,24 @@ function changeDetailsToChangeRecord(
 }
 
 function isMissingChangeDetailsError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.includes('NOT_FOUND') || message.includes('change not found')
+  return hasGrpcStatusCode(error, GRPC_NOT_FOUND)
+}
+
+function hasGrpcStatusCode(error: unknown, code: number): boolean {
+  let current: unknown = error
+  while (isRecord(current)) {
+    if (current.code === code) {
+      return true
+    }
+    current = current.cause
+  }
+  return false
 }
 
 async function collectChangeLogRecords(
   sessionId: string,
-  sourceChangeCount: number
+  sourceChangeCount: number,
+  onProgress?: (processedSerial: number) => void
 ): Promise<ChangeRecord[]> {
   const changes: ChangeRecord[] = []
   for (let serial = 1; serial <= sourceChangeCount; serial += 1) {
@@ -667,6 +675,8 @@ async function collectChangeLogRecords(
       if (!isMissingChangeDetailsError(error)) {
         throw error
       }
+    } finally {
+      onProgress?.(serial)
     }
   }
   return changes
@@ -681,37 +691,63 @@ function safeChangeRecord(value: unknown): ChangeRecord | undefined {
   if (offset === undefined) {
     return undefined
   }
-  const serial = safeNonNegativeInteger(value.serial) ?? 0
+  let serial = 0
+  if (value.serial !== undefined) {
+    const safeSerial = safeNonNegativeInteger(value.serial)
+    if (safeSerial === undefined || safeSerial <= 0) {
+      return undefined
+    }
+    serial = safeSerial
+  }
+  const groupId = safeString(value.groupId, MAX_LABEL_LENGTH)
+  if (value.groupId !== undefined && !groupId) {
+    return undefined
+  }
 
   switch (value.kind) {
     case 'INSERT': {
       const data = safeHexString(value.data, MAX_FILE_SPLICE_BYTES)
-      return data
-        ? { serial, kind: 'INSERT', offset, length: 0, data }
-        : undefined
+      if (!data) {
+        return undefined
+      }
+      return groupId
+        ? { serial, kind: 'INSERT', offset, length: 0, data, groupId }
+        : { serial, kind: 'INSERT', offset, length: 0, data }
     }
     case 'DELETE': {
       const length = safeNonNegativeInteger(value.length)
-      return length && length > 0
-        ? { serial, kind: 'DELETE', offset, length, data: '' }
-        : undefined
+      if (!length || length <= 0) {
+        return undefined
+      }
+      return groupId
+        ? { serial, kind: 'DELETE', offset, length, data: '', groupId }
+        : { serial, kind: 'DELETE', offset, length, data: '' }
     }
     case 'OVERWRITE': {
       const data = safeHexString(value.data, MAX_FILE_SPLICE_BYTES)
-      return data
+      if (!data) {
+        return undefined
+      }
+      return groupId
         ? {
             serial,
             kind: 'OVERWRITE',
             offset,
             length: data.length / 2,
             data,
+            groupId,
           }
-        : undefined
+        : {
+            serial,
+            kind: 'OVERWRITE',
+            offset,
+            length: data.length / 2,
+            data,
+          }
     }
     case 'REPLACE': {
       const length = safeNonNegativeInteger(value.length)
       const data = safeHexString(value.data, MAX_FILE_SPLICE_BYTES, true)
-      const groupId = safeString(value.groupId, MAX_LABEL_LENGTH)
       if (length === undefined || data === undefined) {
         return undefined
       }
@@ -721,6 +757,53 @@ function safeChangeRecord(value: unknown): ChangeRecord | undefined {
     }
     default:
       return undefined
+  }
+}
+
+function validateChangeRecordMetadata(
+  changes: ChangeRecord[],
+  entries: unknown[]
+): void {
+  const serialEntryCount = entries.filter(
+    (entry) => isRecord(entry) && entry.serial !== undefined
+  ).length
+  if (serialEntryCount > 0 && serialEntryCount !== changes.length) {
+    throw new Error('Change log serial metadata must be present on every entry')
+  }
+
+  for (let index = 0; index < changes.length; index += 1) {
+    if (serialEntryCount > 0 && changes[index].serial !== index + 1) {
+      throw new Error(
+        `Change log serial metadata must be contiguous; entry ${index} has serial ${
+          changes[index].serial
+        }, expected ${index + 1}`
+      )
+    }
+  }
+
+  const closedGroups = new Set<string>()
+  let activeGroup: string | undefined
+  for (const [index, change] of changes.entries()) {
+    const groupId = change.groupId
+    if (!groupId) {
+      if (activeGroup) {
+        closedGroups.add(activeGroup)
+        activeGroup = undefined
+      }
+      continue
+    }
+
+    if (groupId !== activeGroup) {
+      if (closedGroups.has(groupId)) {
+        throw new Error(
+          `Change log groupId "${groupId}" is not contiguous at entry ${index}`
+        )
+      }
+      if (activeGroup) {
+        closedGroups.add(activeGroup)
+      }
+      activeGroup = groupId
+    }
   }
 }
 
@@ -739,11 +822,18 @@ function parseChangeLog(content: Uint8Array): ChangeRecord[] {
     throw new Error(`Invalid change log JSON: ${message}`)
   }
 
-  const entries = Array.isArray(parsed)
-    ? parsed
-    : isRecord(parsed) && Array.isArray(parsed.changes)
-      ? parsed.changes
-      : undefined
+  let entries: unknown[] | undefined
+  if (Array.isArray(parsed)) {
+    entries = parsed
+  } else if (isRecord(parsed)) {
+    if (parsed.format !== CHANGE_LOG_FORMAT) {
+      throw new Error('Unsupported change log format')
+    }
+    if (parsed.version !== CHANGE_LOG_VERSION) {
+      throw new Error('Unsupported change log version')
+    }
+    entries = Array.isArray(parsed.changes) ? parsed.changes : undefined
+  }
 
   if (!entries) {
     throw new Error('Change log must be a JSON array or an object with changes')
@@ -754,13 +844,15 @@ function parseChangeLog(content: Uint8Array): ChangeRecord[] {
     )
   }
 
-  return entries.map((entry, index) => {
+  const changes = entries.map((entry, index) => {
     const change = safeChangeRecord(entry)
     if (!change) {
       throw new Error(`Invalid change record at index ${index}`)
     }
     return change
   })
+  validateChangeRecordMetadata(changes, entries)
+  return changes
 }
 
 function backupIdToFilePath(backupId: string | undefined): string | undefined {
@@ -1478,18 +1570,45 @@ export class HexEditorProvider
       )
     }
 
-    const changes = await collectChangeLogRecords(
-      session.sessionId,
-      sourceChangeCount
-    )
+    let changes: ChangeRecord[] = []
+    if (sourceChangeCount > 0) {
+      changes = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: vscode.l10n.t('Exporting {count} change log entries…', {
+            count: sourceChangeCount,
+          }),
+          cancellable: false,
+        },
+        async (progress) => {
+          let previousSerial = 0
+          return await collectChangeLogRecords(
+            session.sessionId,
+            sourceChangeCount,
+            (serial) => {
+              const increment =
+                ((serial - previousSerial) / sourceChangeCount) * 100
+              previousSerial = serial
+              progress.report({
+                increment,
+                message: vscode.l10n.t('{current} of {total}', {
+                  current: serial,
+                  total: sourceChangeCount,
+                }),
+              })
+            }
+          )
+        }
+      )
+    }
     const changeCount = changes.length
     const foldedChangeCount = sourceChangeCount - changeCount
 
     const content = Buffer.from(
       JSON.stringify(
         {
-          format: 'omega-edit.change-log',
-          version: 1,
+          format: CHANGE_LOG_FORMAT,
+          version: CHANGE_LOG_VERSION,
           changeCount,
           sourceChangeCount,
           foldedChangeCount,
@@ -1591,6 +1710,7 @@ export class HexEditorProvider
         cancelled: true,
       }
     }
+    let appliedChangeCount = 0
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
@@ -1599,24 +1719,27 @@ export class HexEditorProvider
         }),
         cancellable: false,
       },
-      () => this.applyChangeLogEntries(session, changes)
+      async () => {
+        appliedChangeCount = await this.applyChangeLogEntries(session, changes)
+      }
     )
     this.postSessionActionComplete(session, {
       action: 'applyChangeLog',
-      changeCount: changes.length,
+      changeCount: appliedChangeCount,
       message: vscode.l10n.t('Applied {count} change(s)', {
-        count: changes.length,
+        count: appliedChangeCount,
       }),
     })
     void vscode.window.showInformationMessage(
       vscode.l10n.t('Applied {count} OmegaEdit change(s)', {
-        count: changes.length,
+        count: appliedChangeCount,
       })
     )
     return {
       state: this.buildEditorState(session),
       uri: scriptUri,
-      changeCount: changes.length,
+      changeCount: appliedChangeCount,
+      sourceChangeCount: changes.length,
     }
   }
 
@@ -1951,27 +2074,38 @@ export class HexEditorProvider
       return
     }
 
-    const count = await this.createSessionCheckpoint(session)
+    const result = await this.createSessionCheckpoint(session)
     this.postSessionActionComplete(session, {
       action: 'createCheckpoint',
-      checkpointCount: count,
-      message: vscode.l10n.t('OmegaEdit checkpoint created ({count} total)', {
-        count,
-      }),
+      checkpointCount: result.checkpointCount,
+      cancelled: !result.created,
+      message: result.created
+        ? vscode.l10n.t('OmegaEdit checkpoint created ({count} total)', {
+            count: result.checkpointCount,
+          })
+        : vscode.l10n.t('No OmegaEdit changes to checkpoint'),
     })
-    void vscode.window.showInformationMessage(
-      vscode.l10n.t('OmegaEdit checkpoint created ({count} total)', { count })
-    )
+    if (result.created) {
+      void vscode.window.showInformationMessage(
+        vscode.l10n.t('OmegaEdit checkpoint created ({count} total)', {
+          count: result.checkpointCount,
+        })
+      )
+    } else {
+      void vscode.window.showInformationMessage(
+        vscode.l10n.t('No OmegaEdit changes to checkpoint')
+      )
+    }
     return {
       state: this.buildEditorState(session),
-      checkpointCount: count,
+      checkpointCount: result.checkpointCount,
     }
   }
 
-  async restoreCheckpoint(options?: unknown): Promise<
+  async rollbackCheckpoint(options?: unknown): Promise<
     | {
         state: WebviewEditorState
-        restored: boolean
+        rolledBack: boolean
         checkpointCount: number
       }
     | undefined
@@ -1985,24 +2119,24 @@ export class HexEditorProvider
       return
     }
 
-    const restored = await this.restoreLastCheckpoint(session, true)
+    const rolledBack = await this.rollbackLastCheckpoint(session, true)
     const checkpointCount = await this.getCheckpointCount(session)
     this.postSessionActionComplete(session, {
-      action: 'restoreCheckpoint',
+      action: 'rollbackCheckpoint',
       checkpointCount,
-      cancelled: !restored,
-      message: restored
-        ? vscode.l10n.t('Restored last OmegaEdit checkpoint')
-        : vscode.l10n.t('No OmegaEdit checkpoint to restore'),
+      cancelled: !rolledBack,
+      message: rolledBack
+        ? vscode.l10n.t('Rolled back last OmegaEdit checkpoint')
+        : vscode.l10n.t('No OmegaEdit checkpoint to roll back'),
     })
-    if (restored) {
+    if (rolledBack) {
       void vscode.window.showInformationMessage(
-        vscode.l10n.t('Restored last OmegaEdit checkpoint')
+        vscode.l10n.t('Rolled back last OmegaEdit checkpoint')
       )
     }
     return {
       state: this.buildEditorState(session),
-      restored,
+      rolledBack,
       checkpointCount,
     }
   }
@@ -2528,34 +2662,22 @@ export class HexEditorProvider
         optionsJson
       )
 
-      let contentChanged = response.contentChanged
       if (response.contentChanged) {
-        const canCompareNoOp =
-          response.offset === clampedOffset &&
-          response.length === originalLength &&
-          originalLength <= MAX_TRANSFORM_NOOP_COMPARE_BYTES &&
-          response.replacementLength <= MAX_TRANSFORM_NOOP_COMPARE_BYTES
-        const originalBytes =
-          canCompareNoOp && originalLength > 0
-            ? await getSegment(session.sessionId, clampedOffset, originalLength)
-            : new Uint8Array()
         const replacement =
-          canCompareNoOp && response.replacementLength > 0
+          response.replacementLength > 0 &&
+          response.replacementLength <= MAX_FILE_SPLICE_BYTES
             ? await getSegment(
                 session.sessionId,
                 response.offset,
                 response.replacementLength
               )
             : new Uint8Array()
-        const isNoOpReplace =
-          canCompareNoOp && bytesEqual(originalBytes, replacement)
 
-        if (isNoOpReplace) {
-          await this.waitForSessionSync(session, sessionSyncVersion)
-          const undoSyncVersion = session.sessionSyncVersion
-          await undo(session.sessionId)
-          await this.waitForSessionSync(session, undoSyncVersion)
-          contentChanged = false
+        if (
+          response.replacementLength > MAX_FILE_SPLICE_BYTES &&
+          replacement.byteLength === 0
+        ) {
+          session.history.recordLocalMutation()
         } else {
           session.history.recordLocalChange({
             serial: session.history.getChangeLog().length + 1,
@@ -2567,11 +2689,11 @@ export class HexEditorProvider
                 ? Buffer.from(replacement).toString('hex')
                 : '',
           })
-          this.postEditState(session)
-          this.notifyDocumentChanged(session)
-          await this.waitForSessionSync(session, sessionSyncVersion)
-          this.clearSearchState(session)
         }
+        this.postEditState(session)
+        this.notifyDocumentChanged(session)
+        await this.waitForSessionSync(session, sessionSyncVersion)
+        this.clearSearchState(session)
       }
 
       this.postWebviewMessage(session, {
@@ -2580,13 +2702,22 @@ export class HexEditorProvider
         offset: response.offset,
         length: response.length,
         operation: response.operation,
-        contentChanged,
+        contentChanged: response.contentChanged,
         replacementLength: response.replacementLength,
         computedFileSize: response.computedFileSize,
         resultLabel: response.resultLabel ?? '',
         resultMimeType: response.resultMimeType ?? '',
         resultText: transformResultToText(response.result),
       })
+      if (!response.contentChanged) {
+        const message =
+          response.operation === TransformPluginOperation.INSPECT
+            ? vscode.l10n.t('OmegaEdit calculation completed')
+            : vscode.l10n.t(
+                'OmegaEdit action completed without content changes'
+              )
+        void vscode.window.showInformationMessage(message)
+      }
     } catch (error) {
       failureMessage = error instanceof Error ? error.message : String(error)
       throw error
@@ -2788,9 +2919,25 @@ export class HexEditorProvider
 
   private async createSessionCheckpoint(
     session: EditorSession
-  ): Promise<number> {
+  ): Promise<{ checkpointCount: number; created: boolean }> {
     if (!this.ensureSessionCanMutate(session, true)) {
-      return this.getCheckpointCount(session)
+      return {
+        checkpointCount: await this.getCheckpointCount(session),
+        created: false,
+      }
+    }
+
+    const wasDirty =
+      session.history.getEditState().isDirty || !!session.restoredFromBackup
+    if (!wasDirty) {
+      const checkpointCount = await this.getCheckpointCount(session)
+      this.postTransformStatus(
+        session,
+        false,
+        undefined,
+        vscode.l10n.t('No changes to checkpoint')
+      )
+      return { checkpointCount, created: false }
     }
 
     this.postTransformStatus(
@@ -2801,8 +2948,6 @@ export class HexEditorProvider
     )
     let failureMessage: string | undefined
     try {
-      const wasDirty =
-        session.history.getEditState().isDirty || !!session.restoredFromBackup
       const sessionSyncVersion = session.sessionSyncVersion
       const count = await createCheckpoint(session.sessionId)
       await this.waitForSessionSync(session, sessionSyncVersion)
@@ -2813,7 +2958,7 @@ export class HexEditorProvider
         undefined,
         vscode.l10n.t('Checkpoint created')
       )
-      return count
+      return { checkpointCount: count, created: true }
     } catch (error) {
       failureMessage = error instanceof Error ? error.message : String(error)
       throw error
@@ -2824,7 +2969,7 @@ export class HexEditorProvider
     }
   }
 
-  private async restoreLastCheckpoint(
+  private async rollbackLastCheckpoint(
     session: EditorSession,
     markDirty: boolean
   ): Promise<boolean> {
@@ -2835,7 +2980,7 @@ export class HexEditorProvider
     const checkpointCount = await this.getCheckpointCount(session)
     if (checkpointCount <= 0) {
       void vscode.window.showWarningMessage(
-        vscode.l10n.t('No OmegaEdit checkpoint to restore')
+        vscode.l10n.t('No OmegaEdit checkpoint to roll back')
       )
       return false
     }
@@ -2844,7 +2989,7 @@ export class HexEditorProvider
       session,
       true,
       undefined,
-      vscode.l10n.t('Restoring checkpoint...')
+      vscode.l10n.t('Rolling back checkpoint...')
     )
     let failureMessage: string | undefined
     try {
@@ -3267,86 +3412,111 @@ export class HexEditorProvider
   private async applyChangeLogEntries(
     session: EditorSession,
     changes: ChangeRecord[]
-  ): Promise<void> {
+  ): Promise<number> {
     if (!this.ensureSessionCanMutate(session, true)) {
-      return
+      return 0
+    }
+    if (changes.length === 0) {
+      return 0
     }
 
-    for (const change of changes) {
-      const sessionSyncVersion = session.sessionSyncVersion
-      let shouldWaitForSync = true
-      switch (change.kind) {
-        case 'INSERT': {
-          const serial = await insert(
-            session.sessionId,
-            change.offset,
-            Buffer.from(change.data, 'hex')
-          )
-          session.history.recordLocalChange({
-            serial,
-            kind: 'INSERT',
-            offset: change.offset,
-            length: 0,
-            data: change.data,
-          })
-          this.postEditState(session)
-          this.notifyDocumentChanged(session)
-          break
-        }
-        case 'DELETE': {
-          const serial = await del(
-            session.sessionId,
-            change.offset,
-            change.length
-          )
-          session.history.recordLocalChange({
-            serial,
-            kind: 'DELETE',
-            offset: change.offset,
-            length: change.length,
-            data: '',
-          })
-          this.postEditState(session)
-          this.notifyDocumentChanged(session)
-          break
-        }
-        case 'OVERWRITE': {
-          const buf = Buffer.from(change.data, 'hex')
-          const serial = await overwrite(session.sessionId, change.offset, buf)
-          session.history.recordLocalChange({
-            serial,
-            kind: 'OVERWRITE',
-            offset: change.offset,
-            length: buf.length,
-            data: change.data,
-          })
-          this.postEditState(session)
-          this.notifyDocumentChanged(session)
-          break
-        }
-        case 'REPLACE':
-          shouldWaitForSync = await this.applyReplace(
-            session,
-            change.offset,
-            change.length,
-            change.data,
-            change.groupId
-          )
-          break
+    const sessionSyncVersion = session.sessionSyncVersion
+    const appliedChanges: ChangeRecord[] = []
+    const recordAppliedChanges = async () => {
+      if (appliedChanges.length === 0) {
+        return
       }
-      if (shouldWaitForSync) {
-        await this.waitForSessionSync(session, sessionSyncVersion)
+
+      session.history.recordLocalChanges(appliedChanges)
+      this.postEditState(session)
+      this.notifyDocumentChanged(session)
+      await this.waitForSessionSync(session, sessionSyncVersion)
+      this.clearSearchState(session)
+    }
+
+    try {
+      await runSessionTransaction(session.sessionId, async () => {
+        for (const change of changes) {
+          const appliedChange = await this.applyChangeLogEntry(session, change)
+          if (appliedChange) {
+            appliedChanges.push(appliedChange)
+          }
+        }
+      })
+    } catch (error) {
+      await recordAppliedChanges()
+      throw error
+    }
+
+    await recordAppliedChanges()
+    return appliedChanges.length
+  }
+
+  private async applyChangeLogEntry(
+    session: EditorSession,
+    change: ChangeRecord
+  ): Promise<ChangeRecord | undefined> {
+    switch (change.kind) {
+      case 'INSERT': {
+        const serial = await insert(
+          session.sessionId,
+          change.offset,
+          Buffer.from(change.data, 'hex')
+        )
+        return {
+          serial,
+          kind: 'INSERT',
+          offset: change.offset,
+          length: 0,
+          data: change.data,
+          ...(change.groupId ? { groupId: change.groupId } : {}),
+        }
       }
+      case 'DELETE': {
+        const serial = await del(
+          session.sessionId,
+          change.offset,
+          change.length
+        )
+        return {
+          serial,
+          kind: 'DELETE',
+          offset: change.offset,
+          length: change.length,
+          data: '',
+          ...(change.groupId ? { groupId: change.groupId } : {}),
+        }
+      }
+      case 'OVERWRITE': {
+        const buf = Buffer.from(change.data, 'hex')
+        const serial = await overwrite(session.sessionId, change.offset, buf)
+        return {
+          serial,
+          kind: 'OVERWRITE',
+          offset: change.offset,
+          length: buf.length,
+          data: change.data,
+          ...(change.groupId ? { groupId: change.groupId } : {}),
+        }
+      }
+      case 'REPLACE':
+        return await this.applyReplaceChange(
+          session,
+          change.offset,
+          change.length,
+          change.data,
+          change.groupId
+        )
     }
   }
 
-  private async applyReplace(
+  private async applyReplaceChange(
     session: EditorSession,
     offset: number,
     length: number,
     dataHex: string,
     groupId?: string
-  ): Promise<boolean> {
+  ): Promise<ChangeRecord | undefined> {
     const originalSegment =
       length > 0
         ? await getSegment(session.sessionId, offset, length)
@@ -3359,15 +3529,37 @@ export class HexEditorProvider
       replacementSegment
     )
 
-    if (changeSerial > 0) {
-      session.history.recordLocalChange({
-        serial: changeSerial,
-        kind: 'REPLACE',
-        offset,
-        length,
-        data: dataHex,
-        groupId,
-      })
+    if (changeSerial <= 0) {
+      return undefined
+    }
+
+    return {
+      serial: changeSerial,
+      kind: 'REPLACE',
+      offset,
+      length,
+      data: dataHex,
+      groupId,
+    }
+  }
+
+  private async applyReplace(
+    session: EditorSession,
+    offset: number,
+    length: number,
+    dataHex: string,
+    groupId?: string
+  ): Promise<boolean> {
+    const change = await this.applyReplaceChange(
+      session,
+      offset,
+      length,
+      dataHex,
+      groupId
+    )
+
+    if (change) {
+      session.history.recordLocalChange(change)
       this.postEditState(session)
       this.notifyDocumentChanged(session)
       return true
@@ -3736,8 +3928,8 @@ export class HexEditorProvider
           break
         }
 
-        case 'restoreCheckpoint': {
-          await this.restoreCheckpoint({ uri: session.document.uri })
+        case 'rollbackCheckpoint': {
+          await this.rollbackCheckpoint({ uri: session.document.uri })
           break
         }
 

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -145,7 +145,7 @@ export type WebviewToHostMessage =
   | { type: 'insertFile'; offset: number }
   | { type: 'replaceRangeWithFile'; offset: number; length: number }
   | { type: 'createCheckpoint' }
-  | { type: 'restoreCheckpoint' }
+  | { type: 'rollbackCheckpoint' }
   | { type: 'exportChangeLog' }
   | { type: 'applyChangeLog' }
   | { type: 'toggleEditMode' }
@@ -263,7 +263,7 @@ export type HostToWebviewMessage =
       type: 'sessionActionComplete'
       action:
         | 'createCheckpoint'
-        | 'restoreCheckpoint'
+        | 'rollbackCheckpoint'
         | 'exportChangeLog'
         | 'applyChangeLog'
       changeCount?: number
@@ -731,7 +731,7 @@ export function normalizeWebviewMessage(
 
     case 'requestTransformPlugins':
     case 'createCheckpoint':
-    case 'restoreCheckpoint':
+    case 'rollbackCheckpoint':
     case 'exportChangeLog':
     case 'applyChangeLog':
     case 'undo':

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -25,7 +25,7 @@ const {
   OMEGA_EDIT_SEARCH_NEXT_COMMAND,
   OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
   OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
-  OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
+  OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
   OMEGA_EDIT_TOGGLE_INSERT_DIRECTION_COMMAND,
   OMEGA_EDIT_UNDO_COMMAND,
   OMEGA_EDIT_VIEW_TYPE,
@@ -40,7 +40,7 @@ const {
 test('package.json matches shared extension constants', () => {
   assert.equal(packageJson.main, './out/extension.js')
   assert.equal(packageJson.types, './out/api.d.ts')
-  assert.equal(OMEGA_EDIT_EXTENSION_API_VERSION, 1)
+  assert.equal(OMEGA_EDIT_EXTENSION_API_VERSION, 2)
   assert.equal(packageJson.name, OMEGA_EDIT_EXTENSION_NAME)
   assert.equal(packageJson.publisher, OMEGA_EDIT_EXTENSION_PUBLISHER)
   assert.equal(
@@ -66,7 +66,7 @@ test('package.json matches shared extension constants', () => {
     `onCommand:${OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND}`,
     `onCommand:${OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND}`,
     `onCommand:${OMEGA_EDIT_ROLLBACK_SESSION_COMMAND}`,
-    `onCommand:${OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND}`,
+    `onCommand:${OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND}`,
     `onCommand:${OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND}`,
     `onCommand:${OMEGA_EDIT_GET_EDITOR_STATE_COMMAND}`,
     `onCommand:${OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND}`,
@@ -158,7 +158,7 @@ test('package.json matches shared extension constants', () => {
   )
   assert.equal(
     packageJson.contributes.commands[11].command,
-    OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND
+    OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND
   )
   assert.equal(
     packageJson.contributes.commands[11].enablement,
@@ -515,7 +515,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerJs, /clear/)
   assert.match(providerJs, /rollbackSession/)
   assert.match(providerJs, /revertSessionChanges/)
-  assert.match(providerJs, /restoreLastCheckpoint/)
+  assert.match(providerJs, /rollbackLastCheckpoint/)
   assert.match(providerJs, /createSessionCheckpoint/)
   assert.match(providerJs, /postClipboardSelection/)
   assert.match(providerJs, /case\s+['"]copySelection['"]/)
@@ -815,6 +815,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(svelteAppSource, /case 'transformComplete'/)
   assert.match(svelteAppSource, /case 'fileActionComplete'/)
   assert.match(svelteAppSource, /describeTransformComplete/)
+  assert.match(svelteAppSource, /strings\.transform\.calculationCompleted/)
   assert.match(svelteAppSource, /describeFileActionComplete/)
   assert.match(svelteAppSource, /createTransformResult\(message\)/)
   assert.match(svelteAppSource, /rememberTransformResult/)
@@ -1307,7 +1308,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(extensionJs, /searchPreviousActive/)
   assert.match(extensionJs, /refreshActiveTransformPlugins/)
   assert.match(extensionJs, /OMEGA_EDIT_ROLLBACK_SESSION_COMMAND/)
-  assert.match(extensionJs, /OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND/)
+  assert.match(extensionJs, /OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_GET_EDITOR_STATE_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND/)
@@ -1326,7 +1327,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(extensionJs, /redoActive/)
   assert.match(extensionJs, /setInsertDirection/)
   assert.match(extensionJs, /rollbackActiveSession/)
-  assert.match(extensionJs, /restoreCheckpoint/)
+  assert.match(extensionJs, /rollbackCheckpoint/)
   assert.match(extensionJs, /createCheckpoint/)
   assert.match(extensionJs, /getDefaultTransformPluginDirectories/)
   assert.match(extensionJs, /findRepositoryRoot/)

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -63,7 +63,7 @@ suite('OmegaEdit VS Code extension', () => {
     assert.equal(typeof extensionApi.setExternalHighlights, 'function')
     assert.equal(typeof extensionApi.clearExternalHighlights, 'function')
     assert.equal(typeof extensionApi.createCheckpoint, 'function')
-    assert.equal(typeof extensionApi.restoreCheckpoint, 'function')
+    assert.equal(typeof extensionApi.rollbackCheckpoint, 'function')
     assert.equal(typeof extensionApi.exportChangeLog, 'function')
     assert.equal(typeof extensionApi.applyChangeLog, 'function')
     assert.equal(typeof extensionApi.onDidChangeEditorState, 'function')
@@ -399,6 +399,71 @@ suite('OmegaEdit VS Code extension', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
+  test('rejects change logs with inconsistent metadata before applying', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-invalid-change-log-')
+    )
+    const samplePath = path.join(tmpDir, 'sample.bin')
+    const scriptPath = path.join(tmpDir, 'invalid-changes.json')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+    await fs.writeFile(
+      scriptPath,
+      JSON.stringify({
+        format: 'omega-edit.change-log',
+        version: 1,
+        changeCount: 2,
+        sourceChangeCount: 2,
+        foldedChangeCount: 0,
+        changes: [
+          {
+            serial: 1,
+            kind: 'INSERT',
+            offset: 0,
+            length: 0,
+            data: Buffer.from('A', 'utf8').toString('hex'),
+            groupId: 'batch-a',
+          },
+          {
+            serial: 3,
+            kind: 'INSERT',
+            offset: 1,
+            length: 0,
+            data: Buffer.from('B', 'utf8').toString('hex'),
+            groupId: 'batch-a',
+          },
+        ],
+      })
+    )
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a live session for invalid change-log test')
+
+    const result = await provider.applyChangeLog({
+      uri: document.uri,
+      sourceUri: vscode.Uri.file(scriptPath),
+    })
+
+    assert.equal(result?.cancelled, true)
+    assert.equal(result?.changeCount, 0)
+    await assertSessionText(session.sessionId, 'abc')
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
   test('reports search matches and keeps undo/redo disabled state in sync', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-state-')
@@ -631,7 +696,61 @@ suite('OmegaEdit VS Code extension', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
-  test('does not record identity transform edits in undo history', async () => {
+  test('reports calculation actions without content changes', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-transform-calculation-')
+    )
+    const samplePath = path.join(tmpDir, 'transform-calculation.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(
+      session,
+      'Expected a live session for the calculation action test'
+    )
+    const cleanEditState = lastMessageOfType(panel.messages, 'editState')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.common_checksums',
+      offset: 0,
+      length: 3,
+      optionsJson: JSON.stringify({ algorithm: 'sum8' }),
+    })
+
+    await assertSessionText(session.sessionId, 'abc')
+    const transformComplete = lastMessageOfType(
+      panel.messages,
+      'transformComplete'
+    )
+    assert.ok(transformComplete, 'Expected calculation action completion')
+    assert.equal(transformComplete.contentChanged, false)
+    assert.equal(transformComplete.resultLabel, 'sum8')
+    assert.equal(transformComplete.resultText, '0x26')
+    assert.deepEqual(
+      lastMessageOfType(panel.messages, 'editState'),
+      cleanEditState
+    )
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('does not record no-op transforms in undo history', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-transform-identity-')
     )
@@ -664,15 +783,16 @@ suite('OmegaEdit VS Code extension', () => {
       pluginId: 'omega.example.bitwise',
       offset: 0,
       length: 3,
-      optionsJson: JSON.stringify({ operator: 'and', byte: '0xFF' }),
+      optionsJson: JSON.stringify({ operator: 'xor', byte: '0x00' }),
     })
 
     await assertSessionText(session.sessionId, 'abc')
-    let transformComplete = lastMessageOfType(
+    const xorTransformComplete = lastMessageOfType(
       panel.messages,
       'transformComplete'
     )
-    assert.equal(transformComplete.contentChanged, false)
+    assert.ok(xorTransformComplete, 'Expected XOR identity completion')
+    assert.equal(xorTransformComplete.contentChanged, false)
     assert.deepEqual(
       lastMessageOfType(panel.messages, 'editState'),
       cleanEditState
@@ -680,48 +800,138 @@ suite('OmegaEdit VS Code extension', () => {
 
     await provider.dispatchWebviewMessageForTesting(document.uri, {
       type: 'applyTransform',
-      pluginId: 'omega.example.base64',
+      pluginId: 'omega.example.bitwise',
       offset: 0,
       length: 3,
+      optionsJson: JSON.stringify({ operator: 'and', byte: '0xFF' }),
     })
 
-    await assertSessionText(session.sessionId, 'YWJj')
-    const transformedEditState = lastMessageOfType(panel.messages, 'editState')
-    assert.deepEqual(transformedEditState, {
-      type: 'editState',
-      canUndo: true,
-      canRedo: false,
-      undoCount: 1,
-      redoCount: 0,
-      isDirty: true,
-      savedChangeDepth: 0,
-    })
+    await assertSessionText(session.sessionId, 'abc')
+    const andTransformComplete = lastMessageOfType(
+      panel.messages,
+      'transformComplete'
+    )
+    assert.ok(andTransformComplete, 'Expected AND identity completion')
+    assert.equal(andTransformComplete.contentChanged, false)
+    assert.deepEqual(
+      lastMessageOfType(panel.messages, 'editState'),
+      cleanEditState
+    )
 
     await provider.dispatchWebviewMessageForTesting(document.uri, {
       type: 'applyTransform',
       pluginId: 'omega.example.bitwise',
       offset: 0,
-      length: 4,
-      optionsJson: JSON.stringify({ operator: 'and', byte: '0xFF' }),
+      length: 3,
+      optionsJson: JSON.stringify({ operator: 'or', byte: '0x00' }),
     })
 
-    await assertSessionText(session.sessionId, 'YWJj')
-    transformComplete = lastMessageOfType(panel.messages, 'transformComplete')
-    assert.equal(transformComplete.contentChanged, false)
+    await assertSessionText(session.sessionId, 'abc')
+    const orTransformComplete = lastMessageOfType(
+      panel.messages,
+      'transformComplete'
+    )
+    assert.ok(orTransformComplete, 'Expected OR identity completion')
+    assert.equal(orTransformComplete.contentChanged, false)
     assert.deepEqual(
       lastMessageOfType(panel.messages, 'editState'),
-      transformedEditState
+      cleanEditState
     )
 
     await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'undo',
+      type: 'applyTransform',
+      pluginId: 'omega.example.case_change',
+      offset: 0,
+      length: 3,
+      optionsJson: JSON.stringify({ case: 'upper' }),
     })
-    await assertSessionText(session.sessionId, 'abc')
+
+    await assertSessionText(session.sessionId, 'ABC')
+    const upperTransformComplete = lastMessageOfType(
+      panel.messages,
+      'transformComplete'
+    )
+    assert.ok(upperTransformComplete, 'Expected uppercase completion')
+    assert.equal(upperTransformComplete.contentChanged, true)
+    const uppercaseEditState = lastMessageOfType(panel.messages, 'editState')
+    assert.notDeepEqual(uppercaseEditState, cleanEditState)
 
     await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'redo',
+      type: 'applyTransform',
+      pluginId: 'omega.example.case_change',
+      offset: 0,
+      length: 3,
+      optionsJson: JSON.stringify({ case: 'upper' }),
     })
-    await assertSessionText(session.sessionId, 'YWJj')
+
+    await assertSessionText(session.sessionId, 'ABC')
+    const upperNoopTransformComplete = lastMessageOfType(
+      panel.messages,
+      'transformComplete'
+    )
+    assert.ok(upperNoopTransformComplete, 'Expected uppercase no-op completion')
+    assert.equal(upperNoopTransformComplete.contentChanged, false)
+    assert.deepEqual(
+      lastMessageOfType(panel.messages, 'editState'),
+      uppercaseEditState
+    )
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('does not record large no-op transforms in undo history', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-transform-large-identity-')
+    )
+    const samplePath = path.join(tmpDir, 'transform-large-identity.bin')
+    const largeLength = 1024 * 1024 + 1
+    await fs.writeFile(samplePath, Buffer.alloc(largeLength, 'A'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(
+      session,
+      'Expected a live session for the large identity transform test'
+    )
+    const cleanEditState = lastMessageOfType(panel.messages, 'editState')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.case_change',
+      offset: 0,
+      length: largeLength,
+      optionsJson: JSON.stringify({ case: 'upper' }),
+    })
+
+    assert.equal(await getComputedFileSize(session.sessionId), largeLength)
+    assert.deepEqual(
+      Buffer.from(await getSegment(session.sessionId, largeLength - 4, 4)),
+      Buffer.from('AAAA')
+    )
+    const transformComplete = lastMessageOfType(
+      panel.messages,
+      'transformComplete'
+    )
+    assert.ok(transformComplete, 'Expected large uppercase no-op completion')
+    assert.equal(transformComplete.contentChanged, false)
+    assert.deepEqual(
+      lastMessageOfType(panel.messages, 'editState'),
+      cleanEditState
+    )
 
     await panel.fireDidDispose()
     await fs.rm(tmpDir, { recursive: true, force: true })

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -1332,14 +1332,14 @@
     postToHost({ type: 'createCheckpoint' })
   }
 
-  function restoreCheckpoint(): void {
+  function rollbackCheckpoint(): void {
     if (transformInFlight) {
       return
     }
 
     transformInFlight = true
-    transformFeedback = strings.transform.restoringCheckpoint
-    postToHost({ type: 'restoreCheckpoint' })
+    transformFeedback = strings.transform.rollingBackCheckpoint
+    postToHost({ type: 'rollbackCheckpoint' })
   }
 
   function exportChangeLog(): void {
@@ -1374,7 +1374,10 @@
         message.replacementLength ?? 0
       )
     }
-    return strings.transform.completed
+    if (message.operation === 2) {
+      return strings.transform.calculationCompleted
+    }
+    return strings.transform.noContentChange
   }
 
   function describeTransformStatus(message: TransformStatusMessage): string {
@@ -1423,28 +1426,6 @@
           message.length,
           message.byteCount
         )
-    }
-  }
-
-  function describeSessionActionComplete(
-    message: SessionActionCompleteMessage
-  ): string {
-    if (message.message) {
-      return message.message
-    }
-    if (message.cancelled) {
-      return strings.transform.fileActionCancelled
-    }
-
-    switch (message.action) {
-      case 'createCheckpoint':
-        return strings.transform.checkpointCreated(message.checkpointCount ?? 0)
-      case 'restoreCheckpoint':
-        return strings.transform.checkpointRestored(message.checkpointCount ?? 0)
-      case 'exportChangeLog':
-        return strings.transform.changeLogExported(message.changeCount ?? 0)
-      case 'applyChangeLog':
-        return strings.transform.changeLogApplied(message.changeCount ?? 0)
     }
   }
 
@@ -2105,7 +2086,9 @@
         break
       case 'fileActionComplete':
         transformInFlight = false
-        transformFeedback = describeFileActionComplete(message)
+        transformFeedback = message.cancelled
+          ? ''
+          : describeFileActionComplete(message)
         if (!message.cancelled) {
           if (message.action === 'insertFile' && message.byteCount > 0) {
             clearSearchResults()
@@ -2126,10 +2109,10 @@
         break
       case 'sessionActionComplete':
         transformInFlight = false
-        transformFeedback = describeSessionActionComplete(message)
+        transformFeedback = ''
         if (
           !message.cancelled &&
-          (message.action === 'restoreCheckpoint' ||
+          (message.action === 'rollbackCheckpoint' ||
             message.action === 'applyChangeLog')
         ) {
           clearSearchResults()
@@ -2241,7 +2224,7 @@
     onReplaceRangeWithFile={replaceRangeWithFile}
     onOpenTransformResult={openTransformResult}
     onCreateCheckpoint={createCheckpoint}
-    onRestoreCheckpoint={restoreCheckpoint}
+    onRollbackCheckpoint={rollbackCheckpoint}
     onExportChangeLog={exportChangeLog}
     onApplyChangeLog={applyChangeLog}
   />

--- a/vscode-extension/webview-ui/src/components/Toolbar.svelte
+++ b/vscode-extension/webview-ui/src/components/Toolbar.svelte
@@ -51,7 +51,7 @@
     onReplaceRangeWithFile: (offset: number, length: number) => void
     onOpenTransformResult: (resultId: string) => void
     onCreateCheckpoint: () => void
-    onRestoreCheckpoint: () => void
+    onRollbackCheckpoint: () => void
     onExportChangeLog: () => void
     onApplyChangeLog: () => void
   }
@@ -84,7 +84,7 @@
     onReplaceRangeWithFile,
     onOpenTransformResult,
     onCreateCheckpoint,
-    onRestoreCheckpoint,
+    onRollbackCheckpoint,
     onExportChangeLog,
     onApplyChangeLog,
   }: Props = $props()
@@ -167,10 +167,10 @@
     <button
       type="button"
       disabled={transformInFlight}
-      title={strings.toolbar.restoreCheckpointTitle}
-      onclick={onRestoreCheckpoint}
+      title={strings.toolbar.rollbackCheckpointTitle}
+      onclick={onRollbackCheckpoint}
     >
-      {strings.toolbar.restoreCheckpoint}
+      {strings.toolbar.rollbackCheckpoint}
     </button>
     <button
       type="button"

--- a/vscode-extension/webview-ui/src/components/TransformPanel.svelte
+++ b/vscode-extension/webview-ui/src/components/TransformPanel.svelte
@@ -22,6 +22,11 @@
     value: string
   }
 
+  interface TransformPluginGroup {
+    label: string
+    plugins: WebviewTransformPlugin[]
+  }
+
   interface TransformOptionGroup {
     label: string
     options: TransformOptionChoice[]
@@ -131,6 +136,7 @@
   const selectedPlugin = $derived(
     plugins.find((plugin) => plugin.id === selectedPluginId)
   )
+  const groupedTransformPlugins = $derived(groupTransformPlugins(plugins))
   const selectedActionValue = $derived(
     selectedFileAction
       ? `${FILE_ACTION_PREFIX}${selectedFileAction}`
@@ -327,6 +333,50 @@
       default:
         return strings.transform.operationTransform
     }
+  }
+
+  function transformPluginSortKey(plugin: WebviewTransformPlugin): string {
+    return plugin.name || plugin.id
+  }
+
+  function sortTransformPlugins(
+    entries: WebviewTransformPlugin[]
+  ): WebviewTransformPlugin[] {
+    return [...entries].sort((left, right) => {
+      const byName = transformPluginSortKey(left).localeCompare(
+        transformPluginSortKey(right),
+        undefined,
+        { sensitivity: 'base' }
+      )
+      return byName || left.id.localeCompare(right.id)
+    })
+  }
+
+  function isMutatingTransform(plugin: WebviewTransformPlugin): boolean {
+    return plugin.operation !== 2
+  }
+
+  function groupTransformPlugins(
+    entries: WebviewTransformPlugin[]
+  ): TransformPluginGroup[] {
+    const groups = [
+      {
+        label: strings.transform.calculationsGroup,
+        plugins: sortTransformPlugins(
+          entries.filter((plugin) => !isMutatingTransform(plugin))
+        ),
+      },
+      {
+        label: strings.transform.transformsGroup,
+        plugins: sortTransformPlugins(
+          entries.filter((plugin) => isMutatingTransform(plugin))
+        ),
+      },
+    ].filter((group) => group.plugins.length > 0)
+
+    return groups.sort((left, right) =>
+      left.label.localeCompare(right.label, undefined, { sensitivity: 'base' })
+    )
   }
 
   function transformActionValue(pluginId: string): string {
@@ -1185,8 +1235,8 @@
         {strings.transform.replaceRangeWithFile}
       </option>
     </optgroup>
-    <optgroup label={strings.transform.transformsGroup}>
-      {#if plugins.length === 0}
+    {#if plugins.length === 0}
+      <optgroup label={strings.transform.transformsGroup}>
         <option value="" disabled>
           {pluginsLoading
             ? strings.transform.loading
@@ -1194,18 +1244,22 @@
               ? strings.transform.noTransforms
               : strings.transform.loadTransforms}
         </option>
-      {:else}
-        {#each plugins as plugin (plugin.id)}
-          <option
-            value={transformActionValue(plugin.id)}
-            title={plugin.description || plugin.id}
-            disabled={!canTransformSelection}
-          >
-            {plugin.name || plugin.id}
-          </option>
-        {/each}
-      {/if}
-    </optgroup>
+      </optgroup>
+    {:else}
+      {#each groupedTransformPlugins as group (group.label)}
+        <optgroup label={group.label}>
+          {#each group.plugins as plugin (plugin.id)}
+            <option
+              value={transformActionValue(plugin.id)}
+              title={plugin.description || plugin.id}
+              disabled={!canTransformSelection}
+            >
+              {plugin.name || plugin.id}
+            </option>
+          {/each}
+        </optgroup>
+      {/each}
+    {/if}
   </select>
   {#if results.length > 0}
     <details bind:this={resultHistoryMenu} class="transform-result-history">

--- a/vscode-extension/webview-ui/src/i18n.ts
+++ b/vscode-extension/webview-ui/src/i18n.ts
@@ -21,8 +21,8 @@ export const strings = {
     sessionActions: 'Session actions',
     createCheckpoint: 'Checkpoint',
     createCheckpointTitle: 'Create an OmegaEdit checkpoint',
-    restoreCheckpoint: 'Restore',
-    restoreCheckpointTitle: 'Restore the last OmegaEdit checkpoint',
+    rollbackCheckpoint: 'Roll back',
+    rollbackCheckpointTitle: 'Roll back the last OmegaEdit checkpoint',
     exportChangeLog: 'Export Log',
     exportChangeLogTitle: 'Export the OmegaEdit change log',
     applyChangeLog: 'Apply Log',
@@ -50,6 +50,7 @@ export const strings = {
     label: 'Action',
     choose: 'Select action...',
     chooseTitle: 'Choose an action for the current file',
+    calculationsGroup: 'Calculations',
     transformsGroup: 'Transforms',
     fileSplicingGroup: 'File Splicing',
     loadTransforms: 'Load transforms...',
@@ -142,13 +143,13 @@ export const strings = {
     operationTransform: 'transform',
     applying: (name: string) => `Applying ${name}...`,
     creatingCheckpoint: 'Creating checkpoint...',
-    restoringCheckpoint: 'Restoring checkpoint...',
+    rollingBackCheckpoint: 'Rolling back checkpoint...',
     exportingChangeLog: 'Exporting change log...',
     applyingChangeLog: 'Applying change log...',
     checkpointCreated: (count: number) =>
       `Checkpoint created (${count.toLocaleString()} total)`,
-    checkpointRestored: (count: number) =>
-      `Checkpoint restored (${count.toLocaleString()} remaining)`,
+    checkpointRolledBack: (count: number) =>
+      `Checkpoint rolled back (${count.toLocaleString()} remaining)`,
     changeLogExported: (count: number) =>
       `Exported ${count.toLocaleString()} change${count === 1 ? '' : 's'}`,
     changeLogApplied: (count: number) =>
@@ -186,6 +187,8 @@ export const strings = {
     transformed: (from: number, to: number) =>
       `Transformed ${from.toLocaleString()} byte${from === 1 ? '' : 's'} into ${to.toLocaleString()} byte${to === 1 ? '' : 's'}`,
     completed: 'Transform completed',
+    calculationCompleted: 'Calculation completed',
+    noContentChange: 'Transform completed without content changes',
   },
   search: {
     label: 'Find bytes',

--- a/wiki/Transform-Plugins.md
+++ b/wiki/Transform-Plugins.md
@@ -24,7 +24,7 @@ Each plugin advertises one operation mode:
 
 | Mode | Behavior |
 | --- | --- |
-| `OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE` | Produces replacement bytes for the selected range. Content changes if the selected range or replacement is non-empty. |
+| `OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE` | Produces replacement bytes for the selected range. Content changes unless the response explicitly reports no content change. |
 | `OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT` | Leaves content unchanged and returns result bytes, such as a checksum or hash. |
 | `OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT` | Produces replacement bytes and an inspection result. |
 
@@ -100,6 +100,8 @@ Important rules:
 - Validate null pointers and negative lengths.
 - Allocate all response memory through `request_ptr->alloc` or the SDK helpers.
 - Do not free response memory yourself after assigning it to the response.
+- Use `OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE` for successful replace operations
+  that intentionally leave the selected content untouched.
 - Treat `options_json` as optional; it may be null.
 - Keep plugin entry points thread-safe. The server serializes access to the registry,
   but plugin code should not rely on mutable global state unless it protects it.
@@ -121,6 +123,7 @@ Useful helpers:
 | `omega_transform_plugin_sdk_copy_bytes` | Copies byte ranges into response-owned memory. |
 | `omega_transform_plugin_sdk_copy_cstring` | Copies C strings into response-owned memory. |
 | `omega_transform_plugin_sdk_set_replacement` | Fills replacement bytes and length. |
+| `omega_transform_plugin_sdk_set_no_content_change` | Marks a successful replace operation as having no content changes. |
 | `omega_transform_plugin_sdk_set_text_result` | Fills text result bytes, label, and MIME type. |
 
 ## Minimal Plugin
@@ -333,6 +336,7 @@ The repository ships small examples in `plugins/src/`:
 | --- | --- | --- | --- |
 | `omega.example.base64` | `base64.c` | Replace | Base64 encode/decode with a `direction` option. Decoding tolerates ASCII whitespace; other invalid bytes fail. |
 | `omega.example.bitwise` | `bitwise.c` | Replace | One-for-one binary-safe AND/OR/XOR transform with `operator`, `byte`, and `mask` options; defaults to XOR with `0xFF`. |
+| `omega.example.case_change` | `case_change.c` | Replace | ASCII upper/lower case conversion with no-content-change reporting when the range is already in the requested case. |
 | `omega.example.character_transcode` | `character_transcode.cpp` | Replace | Transcoding between UTF-8/16/32, ASCII, ISO-8859-1, Windows-1252, and common single-byte EBCDIC pages. |
 | `omega.example.common_checksums` | `common_checksums.cpp` | Inspect | CRC, Adler, Fletcher, internet checksum, LRC/BCC, sum, FNV, Murmur3, and xxHash variants. |
 | `omega.example.decimal_codecs` | `decimal_codecs.cpp` | Replace | BCD, packed decimal/COMP-3, zoned decimal, and signed overpunch encode/decode helpers. |


### PR DESCRIPTION
## Summary

Fixes transform and change-log edge cases called out in `SHORTCOMINGS.md`, and annotates that file as the living checklist for follow-up work.

- Detect transform content changes from actual session/file deltas instead of replacement length heuristics.
- Remove client-side transform no-op undo behavior and surface no-content-change completion clearly.
- Avoid reading large transform replacements into VS Code local history.
- Validate wrapped change-log imports against the OmegaEdit v1 format envelope while keeping legacy array imports supported.
- Show progress during VS Code change-log export.
- Apply AI and VS Code change logs inside server transactions; VS Code imports now record as one local undo/redo transaction.
- Preserve gRPC error causes for `getChangeDetails` and prefer status-code checks before legacy message matching.
- Keep session action confirmations out of the transform/results strip and rely on host toasts.
- Group action menu entries into File Splicing, Calculations, and Transforms with lexical ordering.

## Root Cause

Transform completion and import/export flows were trusting indirect signals: byte-length math for transforms, missing format checks for wrapped change logs, unbounded background work without progress, and local history records that did not match the user's higher-level operation. Large replacements also tried to cache replacement bytes that were intentionally not read.

## Validation

- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && yarn lint`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && yarn workspace @omega-edit/client build`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && yarn workspace @omega-edit/ai build`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && yarn workspace @omega-edit/ai test --grep "rejects wrapped change logs"`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && node --import ./tests/register-ts-node-esm.mjs ../../node_modules/mocha/bin/mocha.js --timeout 50000 --slow 35000 tests/specs/editorPatterns.spec.ts --exit` from `packages/client`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && npm run compile` from `vscode-extension`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && npm run test:unit` from `vscode-extension`
- Focused transform regression tests run locally before the latest amend.

## Notes

Native Linux JS transform integration remains blocked locally by the missing prepackaged Linux server binary / Conan setup, so CI is still the authoritative full-platform signal. The larger remaining work is tracked in `SHORTCOMINGS.md`.
