### PR TITLE
feat: add webview i18n language support

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -104,6 +104,7 @@ This mode decision is made only when the user runs an explicit search. If a repl
 | `omegaEdit.serverPort`  | `9000`  | TCP gRPC server port; setting this explicitly opts out of the default macOS/Linux Unix socket transport |
 | `omegaEdit.logLevel`    | `info`  | Client log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`) |
 | `omegaEdit.bytesPerRow` | `16`    | Bytes displayed per row (8 / 16 / 32)                                      |
+| `omegaEdit.language`    | `auto`  | Svelte data editor UI language (`auto` follows VS Code; explicit options include `en` and `es`) |
 | `omegaEdit.transformPluginDirectories` | `[]` | Native transform plugin directories; local build plugin folders are auto-detected when this is empty |
 
 ## Keyboard Shortcuts
@@ -234,9 +235,22 @@ instance, and host/build metadata, while live server metrics remain in Analysis
 > Structure > Server. The inspector is collapsible, inspector values highlight
 their participating bytes in both grid panes, offsets can be shown in hex or
 decimal, and the Analysis side pane supports reorderable and collapsible
-sections. The webview derives visible rows from the editor pane height, clamps
-virtual scrolling at file boundaries, and keeps UI strings in an i18n string
-table.
+sections. The webview derives visible rows from the editor pane height and
+clamps virtual scrolling at file boundaries.
+
+The Svelte webview localizes visible UI through
+`webview-ui/src/i18n.ts`. The `omegaEdit.language` setting defaults to `auto`,
+which follows VS Code's active display language from `vscode.env.language`.
+Setting it to an explicit supported language such as `en` or `es` overrides the
+webview language and makes localization easy to test without changing VS Code's
+global display language. The selected language is passed into the webview HTML,
+which sets the document `lang`, text direction, and selected string table before
+Svelte mounts. English is the complete fallback locale, and locale entries such
+as the initial `es` table may override only the strings they translate. New
+Svelte UI should continue to read labels, titles, validation text, and
+locale-sensitive decimal number formatting from the i18n helpers instead of
+adding visible literals directly in components. VS Code contribution strings
+remain in `package.nls.json`.
 
 Generic parser/debugger integrations can call `omegaEdit.getEditorState`,
 `omegaEdit.setExternalHighlights`, and `omegaEdit.clearExternalHighlights` to

--- a/vscode-extension/docs/svelte-ai-migration-requirements.md
+++ b/vscode-extension/docs/svelte-ai-migration-requirements.md
@@ -304,8 +304,15 @@ from the OmegaEdit host/server path.
 - The data inspector is collapsible and offsets can be displayed in either hex
   or decimal.
 - Svelte-visible strings live in `webview-ui/src/i18n.ts`; VS Code contribution
-  strings live in `package.nls.json`.
+  strings live in `package.nls.json`. The Svelte webview selects its string
+  table from `omegaEdit.language`, using the host-provided
+  `vscode.env.language` when that setting is `auto`. It sets document `lang`
+  and text direction before mounting and falls back to English for untranslated
+  entries. Keep explicit language options narrow to languages present in the
+  webview locale table so localization remains easy to test.
 - New UI work should not add visible literals directly to Svelte components.
+  Use the i18n helpers for labels, titles, validation text, and
+  locale-sensitive decimal number formatting.
 - Svelte components in the migrated webview use Svelte 5 runes (`$props`,
   `$state`, `$derived`, and `$effect`) as the standard reactivity model. New
   Svelte work should not add legacy `export let` props, `$:` reactive

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -66,6 +66,16 @@
           ],
           "description": "%omegaEdit.configuration.bytesPerRow.description%"
         },
+        "omegaEdit.language": {
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "en",
+            "es"
+          ],
+          "description": "%omegaEdit.configuration.language.description%"
+        },
         "omegaEdit.transformPluginDirectories": {
           "type": "array",
           "default": [],

--- a/vscode-extension/package.nls.json
+++ b/vscode-extension/package.nls.json
@@ -6,6 +6,7 @@
   "omegaEdit.configuration.serverPort.description": "TCP port for the OmegaEdit gRPC server; explicitly setting it opts out of Unix socket transport on macOS/Linux",
   "omegaEdit.configuration.logLevel.description": "Log level for the OmegaEdit client",
   "omegaEdit.configuration.bytesPerRow.description": "Number of bytes displayed per row in the hex view",
+  "omegaEdit.configuration.language.description": "Language for the Svelte data editor UI. Use auto to follow VS Code's display language.",
   "omegaEdit.configuration.transformPluginDirectories.description": "Directories containing OmegaEdit transform plugin shared libraries",
   "omegaEdit.command.openInHexEditor.title": "OmegaEdit: Open in Data Editor",
   "omegaEdit.command.goToOffset.title": "OmegaEdit: Go to Offset",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -846,6 +846,9 @@ export async function activate(
       if (event.affectsConfiguration('omegaEdit.bytesPerRow')) {
         provider.refreshBytesPerRow()
       }
+      if (event.affectsConfiguration('omegaEdit.language')) {
+        provider.refreshLanguage()
+      }
     })
   )
 

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -1537,6 +1537,22 @@ export class HexEditorProvider
     }
   }
 
+  /** Re-render open webviews after the UI language setting changes. */
+  refreshLanguage(): void {
+    for (const session of this.sessions.values()) {
+      session.panel.webview.options = {
+        ...session.panel.webview.options,
+        localResourceRoots: this.getLocalResourceRoots(),
+      }
+      session.panel.webview.html = this.renderWebviewHtml(
+        session.panel.webview,
+        session.bytesPerRow
+      )
+      this.sendViewportData(session)
+      this.postEditState(session)
+    }
+  }
+
   async exportChangeLog(options?: unknown): Promise<
     | {
         state: WebviewEditorState

--- a/vscode-extension/src/svelteWebview.ts
+++ b/vscode-extension/src/svelteWebview.ts
@@ -17,6 +17,9 @@ import * as vscode from 'vscode'
 import { type BytesPerRow, normalizeBytesPerRow } from './webviewProtocol'
 
 const SVELTE_WEBVIEW_OUT_DIR = ['out', 'svelte-webview'] as const
+const AUTO_WEBVIEW_LANGUAGE = 'auto'
+const SUPPORTED_WEBVIEW_LANGUAGES = new Set(['en', 'es'])
+const RTL_LANGUAGES = new Set(['ar', 'fa', 'he', 'ps', 'ur'])
 
 function escapeHtmlAttribute(value: string): string {
   return value
@@ -35,6 +38,32 @@ function escapeHtmlText(value: string): string {
 
 function nonce(): string {
   return crypto.randomBytes(16).toString('base64')
+}
+
+function textDirectionForLanguage(language: string): 'ltr' | 'rtl' {
+  const [baseLanguage] = language
+    .trim()
+    .replace(/_/g, '-')
+    .toLowerCase()
+    .split('-')
+  return RTL_LANGUAGES.has(baseLanguage) ? 'rtl' : 'ltr'
+}
+
+function normalizeLanguage(language: string): string {
+  return language.trim().replace(/_/g, '-').toLowerCase()
+}
+
+function resolveWebviewLanguage(): string {
+  const config = vscode.workspace.getConfiguration('omegaEdit')
+  const configuredLanguage = normalizeLanguage(
+    config.get<string>('language', AUTO_WEBVIEW_LANGUAGE)
+  )
+  if (configuredLanguage === AUTO_WEBVIEW_LANGUAGE) {
+    return vscode.env.language || 'en'
+  }
+  return SUPPORTED_WEBVIEW_LANGUAGES.has(configuredLanguage)
+    ? configuredLanguage
+    : vscode.env.language || 'en'
 }
 
 export function getSvelteWebviewLocalResourceRoot(
@@ -58,13 +87,16 @@ export function getSvelteWebviewContent(
   const cspSource = escapeHtmlAttribute(webview.cspSource)
   const scriptNonce = nonce()
   const normalizedBytesPerRow = normalizeBytesPerRow(bytesPerRow)
+  const language = resolveWebviewLanguage()
+  const escapedLanguage = escapeHtmlAttribute(language)
+  const textDirection = textDirectionForLanguage(language)
   const title = escapeHtmlText(vscode.l10n.t('OmegaEdit Data Editor'))
   const loading = escapeHtmlText(
     vscode.l10n.t('Loading OmegaEdit Data Editor...')
   )
 
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="${escapedLanguage}" dir="${textDirection}">
 <head>
   <meta charset="UTF-8">
   <meta
@@ -76,7 +108,7 @@ export function getSvelteWebviewContent(
   <title>${title}</title>
 </head>
 <body>
-  <div id="app" data-bytes-per-row="${normalizedBytesPerRow}">
+  <div id="app" data-bytes-per-row="${normalizedBytesPerRow}" data-locale="${escapedLanguage}">
     <p class="bootstrap-status">${loading}</p>
   </div>
   <script nonce="${scriptNonce}" type="module" src="${scriptUri.toString()}"></script>

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -179,6 +179,19 @@ test('package.json matches shared extension constants', () => {
     'OmegaEdit: Clear External Highlights'
   )
   assert.deepEqual(
+    packageJson.contributes.configuration.properties['omegaEdit.language'].enum,
+    ['auto', 'en', 'es']
+  )
+  assert.equal(
+    packageJson.contributes.configuration.properties['omegaEdit.language']
+      .default,
+    'auto'
+  )
+  assert.equal(
+    packageNls['omegaEdit.configuration.language.description'],
+    "Language for the Svelte data editor UI. Use auto to follow VS Code's display language."
+  )
+  assert.deepEqual(
     packageJson.contributes.configuration.properties[
       'omegaEdit.transformPluginDirectories'
     ].default,
@@ -369,6 +382,10 @@ test('compiled extension entrypoints exist after build', () => {
   )
   const svelteAppSource = fs.readFileSync(
     path.resolve(__dirname, '../webview-ui/src/App.svelte'),
+    'utf8'
+  )
+  const svelteMainSource = fs.readFileSync(
+    path.resolve(__dirname, '../webview-ui/src/main.ts'),
     'utf8'
   )
   const i18nSource = fs.readFileSync(
@@ -595,8 +612,15 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(svelteHostJs, /webview\.js/)
   assert.match(svelteHostJs, /webview\.css/)
   assert.match(svelteHostJs, /vscode\.l10n\.t/)
+  assert.match(svelteHostJs, /getConfiguration\(['"]omegaEdit['"]\)/)
+  assert.match(svelteHostJs, /config\.get\(['"]language['"]/)
+  assert.match(svelteHostJs, /vscode\.env\.language/)
+  assert.match(svelteHostJs, /data-locale/)
   assert.match(svelteHostJs, /escapeHtmlText/)
   assert.match(svelteHostJs, /Loading OmegaEdit Data Editor/)
+  assert.match(svelteMainSource, /setLanguage\(target\.dataset\.locale/)
+  assert.match(svelteMainSource, /document\.documentElement\.lang/)
+  assert.match(svelteMainSource, /document\.documentElement\.dir/)
   assert.match(viteConfigSource, /cssCodeSplit:\s*false/)
   assert.doesNotMatch(svelteHostJs, /Svelte Preview/)
   assert.doesNotMatch(svelteBundleJs, /OmegaEdit Svelte Preview/)
@@ -1013,6 +1037,12 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(previewGridSource, /class:searchHit/)
   assert.match(previewGridSource, /class="text-byte"/)
   assert.match(previewGridSource, /formatAscii\(byte\)/)
+  assert.match(i18nSource, /const englishStrings =/)
+  assert.match(i18nSource, /const localeOverrides/)
+  assert.match(i18nSource, /export function resolveLanguage/)
+  assert.match(i18nSource, /export function setLanguage/)
+  assert.match(i18nSource, /export function formatNumber/)
+  assert.match(i18nSource, /es: \{/)
   assert.match(i18nSource, /byteHoverTitle/)
   assert.match(i18nSource, /HEX Byte/)
   assert.match(
@@ -1289,6 +1319,8 @@ test('compiled extension entrypoints exist after build', () => {
     'utf8'
   )
   assert.match(extensionJs, /transformPluginDirectories/)
+  assert.match(extensionJs, /omegaEdit\.language/)
+  assert.match(extensionJs, /refreshLanguage/)
   assert.match(extensionJs, /OMEGA_EDIT_UNDO_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_REDO_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_TOGGLE_INSERT_DIRECTION_COMMAND/)

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -5,7 +5,7 @@
   import SearchPanel from './components/SearchPanel.svelte'
   import Toolbar from './components/Toolbar.svelte'
   import TransformResultPanel from './components/TransformResultPanel.svelte'
-  import { strings } from './i18n'
+  import { formatNumber, strings } from './i18n'
   import {
     MAX_ANALYSIS_PROFILE_BYTES,
     normalizeBytesPerRow,
@@ -1234,7 +1234,7 @@
 
   function formatSearchOffset(offset: number): string {
     return offsetRadix === 'dec'
-      ? offset.toLocaleString()
+      ? formatNumber(offset)
       : `0x${offset.toString(16).toUpperCase()}`
   }
 
@@ -1395,9 +1395,9 @@
 
     const prefix = message.message || message.phase || strings.transform.completed
     if (typeof message.processedBytes === 'number') {
-      const processed = message.processedBytes.toLocaleString()
+      const processed = formatNumber(message.processedBytes)
       if (typeof message.totalBytes === 'number' && message.totalBytes > 0) {
-        const total = message.totalBytes.toLocaleString()
+        const total = formatNumber(message.totalBytes)
         const percent =
           typeof message.percent === 'number'
             ? ` (${message.percent.toFixed(1)}%)`

--- a/vscode-extension/webview-ui/src/components/ByteInspector.svelte
+++ b/vscode-extension/webview-ui/src/components/ByteInspector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { strings } from '../i18n'
+  import { formatNumber, strings } from '../i18n'
 
   interface InspectorField {
     key: string
@@ -61,10 +61,6 @@
   const selectionLength = $derived(
     hasSelection ? selectionEnd - selectionStart + 1 : 0
   )
-  const toggleLabel = $derived(
-    expanded ? strings.inspector.hide : strings.inspector.show
-  )
-
   function setEndian(useLittleEndian: boolean): void {
     if (littleEndian !== useLittleEndian) {
       onToggleEndian()
@@ -73,7 +69,7 @@
 
   function formatOffset(offset: number): string {
     return offsetRadix === 'dec'
-      ? offset.toLocaleString()
+      ? formatNumber(offset)
       : `0x${offset.toString(16).toUpperCase()}`
   }
 
@@ -540,11 +536,14 @@
       class="inspector-toggle"
       class:inspector-collapsed-toggle={!expanded}
       aria-expanded={expanded}
+      aria-label={
+        expanded ? strings.inspector.collapse : strings.inspector.expand
+      }
       title={expanded ? strings.inspector.collapse : strings.inspector.expand}
       onclick={onToggleExpanded}
     >
       {#if expanded}
-        {toggleLabel}
+        {strings.inspector.collapseSymbol}
       {:else}
         <span>{strings.inspector.show}</span>
         <span class="inspector-collapsed-label">

--- a/vscode-extension/webview-ui/src/components/FileScrollbar.svelte
+++ b/vscode-extension/webview-ui/src/components/FileScrollbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte'
-  import { strings } from '../i18n'
+  import { formatNumber, strings } from '../i18n'
   import type { BytesPerRow } from '../protocol'
 
   const MIN_THUMB_HEIGHT = 24
@@ -70,7 +70,7 @@
         : 100
   )
   const progressLabel = $derived(
-    `${progress.toLocaleString(undefined, {
+    `${formatNumber(progress, {
       maximumFractionDigits: progress >= 99.95 ? 0 : 1,
     })}%`
   )
@@ -88,7 +88,7 @@
 
   function formatOffset(offset: number): string {
     return offsetRadix === 'dec'
-      ? offset.toLocaleString()
+      ? formatNumber(offset)
       : `0x${offset.toString(16).toUpperCase()}`
   }
 

--- a/vscode-extension/webview-ui/src/components/OffsetJump.svelte
+++ b/vscode-extension/webview-ui/src/components/OffsetJump.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { strings } from '../i18n'
+  import { formatNumber, strings } from '../i18n'
 
   interface Props {
     fileSize?: number
@@ -53,7 +53,7 @@
 
   function formatOffset(offset: number): string {
     return offsetRadix === 'dec'
-      ? offset.toLocaleString()
+      ? formatNumber(offset)
       : `0x${offset.toString(16).toUpperCase()}`
   }
 

--- a/vscode-extension/webview-ui/src/components/PreviewGrid.svelte
+++ b/vscode-extension/webview-ui/src/components/PreviewGrid.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte'
-  import { strings } from '../i18n'
+  import { formatNumber, strings } from '../i18n'
   import type { BytesPerRow, WebviewExternalHighlight } from '../protocol'
 
   const FALLBACK_VISIBLE_ROWS = 16
@@ -150,7 +150,7 @@
 
   function formatOffset(offset: number): string {
     return offsetRadix === 'dec'
-      ? offset.toLocaleString()
+      ? formatNumber(offset)
       : `0x${offset.toString(16).toUpperCase().padStart(8, '0')}`
   }
 
@@ -173,7 +173,7 @@
         : strings.grid.textByteTitle,
       formatOffset(byteOffset),
       hex,
-      byte.toLocaleString(),
+      formatNumber(byte),
       formatBinary(byte),
       formatTooltipText(byte),
       byteClassLabel(byte),

--- a/vscode-extension/webview-ui/src/components/ProfilerPanel.svelte
+++ b/vscode-extension/webview-ui/src/components/ProfilerPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { strings } from '../i18n'
+  import { formatNumber, strings } from '../i18n'
   import type {
     HostToWebviewMessage,
     ServerHealthMessage,
@@ -199,7 +199,7 @@
     topProfileBytes.map((entry) => ({
       label: formatByteLabel(entry.byte),
       percent: (entry.count / topProfileMaxCount) * 100,
-      value: `${entry.count.toLocaleString()} | ${formatPercent(
+      value: `${formatNumber(entry.count)} | ${formatPercent(
         byteTotal > 0 ? (entry.count / byteTotal) * 100 : 0
       )}`,
       colorClass: frequencyBarClass(entry.byte, entry.count).trim(),
@@ -207,8 +207,8 @@
   )
   const structureRows = $derived(buildStructureRows())
   const historyRows = $derived([
-    { label: strings.profiler.undo, value: undoCount.toLocaleString() },
-    { label: strings.profiler.redo, value: redoCount.toLocaleString() },
+    { label: strings.profiler.undo, value: formatNumber(undoCount) },
+    { label: strings.profiler.redo, value: formatNumber(redoCount) },
     { label: strings.profiler.canUndo, value: yesNo(canUndo) },
     { label: strings.profiler.canRedo, value: yesNo(canRedo) },
   ])
@@ -441,7 +441,7 @@
     if (value < 100) {
       return `${value.toFixed(1)} ms`
     }
-    return `${Math.round(value).toLocaleString()} ms`
+    return `${formatNumber(Math.round(value))} ms`
   }
 
   function formatByteSize(value: number): string {
@@ -468,7 +468,7 @@
 
   function formatOffset(offset: number): string {
     return offsetRadix === 'dec'
-      ? offset.toLocaleString()
+      ? formatNumber(offset)
       : `0x${offset.toString(16).toUpperCase()}`
   }
 
@@ -497,7 +497,7 @@
     if (!entry || total <= 0) {
       return '-'
     }
-    return `${formatByteLabel(entry.byte)} x ${entry.count.toLocaleString()} (${formatPercent(
+    return `${formatByteLabel(entry.byte)} x ${formatNumber(entry.count)} (${formatPercent(
       (entry.count / total) * 100
     )})`
   }
@@ -579,7 +579,7 @@
       ([label, count]) => ({
         label,
         percent: (count / total) * 100,
-        value: `${count.toLocaleString()} | ${formatPercent(
+        value: `${formatNumber(count)} | ${formatPercent(
           (count / total) * 100
         )}`,
         colorClass: classColorClass(label),
@@ -674,7 +674,7 @@
       { label: strings.profiler.offset, value: formatOffset(visibleOffset) },
       { label: strings.profiler.buffered, value: formatByteSize(viewportLength) },
       { label: strings.profiler.visible, value: formatByteSize(visibleByteCount) },
-      { label: strings.profiler.rows, value: visibleRows.toLocaleString() },
+      { label: strings.profiler.rows, value: formatNumber(visibleRows) },
       {
         label: strings.profiler.capacity,
         value: formatByteSize(viewportProfile?.capacity ?? 0),
@@ -692,7 +692,7 @@
       },
       {
         label: strings.profiler.changes,
-        value: (viewportProfile?.changeCount ?? 0).toLocaleString(),
+        value: formatNumber(viewportProfile?.changeCount ?? 0),
       },
       {
         label: strings.profiler.sync,
@@ -762,15 +762,15 @@
 
     return [
       { label: strings.profiler.scope, value: dataProfile.scopeLabel },
-      { label: strings.profiler.bytes, value: byteTotal.toLocaleString() },
+      { label: strings.profiler.bytes, value: formatNumber(byteTotal) },
       {
         label: strings.profiler.dosEol,
-        value: (dataProfile.byteProfile[256] ?? 0).toLocaleString(),
+        value: formatNumber(dataProfile.byteProfile[256] ?? 0),
       },
       { label: strings.profiler.modeByte, value: formatModeByte(modeByte, byteTotal) },
       {
         label: strings.profiler.ascii,
-        value: `${dataProfile.numAscii.toLocaleString()} / ${formatPercent(
+        value: `${formatNumber(dataProfile.numAscii)} / ${formatPercent(
           asciiPercent
         )}`,
       },
@@ -779,27 +779,27 @@
       { label: strings.profiler.bom, value: characterCount.byteOrderMark || '-' },
       {
         label: strings.profiler.bomBytes,
-        value: characterCount.byteOrderMarkBytes.toLocaleString(),
+        value: formatNumber(characterCount.byteOrderMarkBytes),
       },
       {
         label: strings.profiler.oneByteChars,
-        value: characterCount.singleByteCount.toLocaleString(),
+        value: formatNumber(characterCount.singleByteCount),
       },
       {
         label: strings.profiler.twoByteChars,
-        value: characterCount.doubleByteCount.toLocaleString(),
+        value: formatNumber(characterCount.doubleByteCount),
       },
       {
         label: strings.profiler.threeByteChars,
-        value: characterCount.tripleByteCount.toLocaleString(),
+        value: formatNumber(characterCount.tripleByteCount),
       },
       {
         label: strings.profiler.fourByteChars,
-        value: characterCount.quadByteCount.toLocaleString(),
+        value: formatNumber(characterCount.quadByteCount),
       },
       {
         label: strings.profiler.invalid,
-        value: characterCount.invalidBytes.toLocaleString(),
+        value: formatNumber(characterCount.invalidBytes),
       },
       { label: strings.profiler.profile, value: formatDuration(dataProfile.durationMs) },
     ]
@@ -815,11 +815,11 @@
     return [
       {
         label: strings.profiler.bytes,
-        value: structureAnalysis.count.toLocaleString(),
+        value: formatNumber(structureAnalysis.count),
       },
       {
         label: strings.profiler.unique,
-        value: `${structureAnalysis.unique.toLocaleString()} / 256`,
+        value: `${formatNumber(structureAnalysis.unique)} / 256`,
       },
       { label: strings.profiler.density, value: formatPercent(density) },
       {
@@ -851,7 +851,7 @@
             ? '-'
             : `0x${toHex2(
                 structureAnalysis.longestRunByte
-              )} x ${structureAnalysis.longestRunLength.toLocaleString()}`,
+              )} x ${formatNumber(structureAnalysis.longestRunLength)}`,
       },
     ]
   }
@@ -1037,6 +1037,7 @@
         type="button"
         class="profiler-toggle profiler-collapsed-toggle"
         aria-expanded={expanded}
+        aria-label={strings.profiler.expand}
         title={strings.profiler.expand}
         onclick={onToggleExpanded}
       >
@@ -1048,10 +1049,11 @@
         type="button"
         class="profiler-toggle"
         aria-expanded={expanded}
+        aria-label={strings.profiler.collapse}
         title={strings.profiler.collapse}
         onclick={onToggleExpanded}
       >
-        {strings.profiler.hide}
+        {strings.profiler.collapseSymbol}
       </button>
       <span class="analysis-title">{strings.profiler.title}</span>
       <span class="analysis-tabs" role="tablist" aria-label={strings.profiler.views}>
@@ -1333,7 +1335,7 @@
                         <div>{formatByteLabel(hoveredFrequency.byte)}</div>
                         <div>
                           {strings.profiler.count}
-                          {hoveredFrequency.count.toLocaleString()} |
+                          {formatNumber(hoveredFrequency.count)} |
                           {hoveredFrequency.percent}
                         </div>
                       </div>

--- a/vscode-extension/webview-ui/src/components/TransformPanel.svelte
+++ b/vscode-extension/webview-ui/src/components/TransformPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { tick } from 'svelte'
-  import { strings } from '../i18n'
+  import { formatNumber, strings } from '../i18n'
   import {
     MAX_TRANSFORM_OPTIONS_LENGTH,
     type WebviewTransformPlugin,
@@ -222,7 +222,7 @@
 
   function formatOffset(offset: number): string {
     return offsetRadix === 'dec'
-      ? offset.toLocaleString()
+      ? formatNumber(offset)
       : `0x${offset.toString(16).toUpperCase()}`
   }
 

--- a/vscode-extension/webview-ui/src/i18n.ts
+++ b/vscode-extension/webview-ui/src/i18n.ts
@@ -1,4 +1,25 @@
-export const strings = {
+const DEFAULT_LANGUAGE = 'en'
+const RTL_LANGUAGES = new Set(['ar', 'fa', 'he', 'ps', 'ur'])
+
+let activeLanguage = DEFAULT_LANGUAGE
+
+export function formatNumber(
+  value: number,
+  options?: Intl.NumberFormatOptions
+): string {
+  return value.toLocaleString(activeLanguage, options)
+}
+
+export function textDirectionForLanguage(language: string): 'ltr' | 'rtl' {
+  const [baseLanguage] = normalizeLanguageTag(language).split('-')
+  return RTL_LANGUAGES.has(baseLanguage) ? 'rtl' : 'ltr'
+}
+
+function normalizeLanguageTag(language: string): string {
+  return language.trim().replaceAll('_', '-').toLowerCase()
+}
+
+const englishStrings = {
   app: {
     missingMountPoint: 'Missing Svelte webview mount point',
     failedToStart: (message: string) =>
@@ -90,7 +111,7 @@ export const strings = {
     start: 'Start',
     end: 'End',
     length: 'Length',
-    bytes: (count: number) => `${count.toLocaleString()} byte${count === 1 ? '' : 's'}`,
+    bytes: (count: number) => `${formatNumber(count)} byte${count === 1 ? '' : 's'}`,
     rangeOffsetTitle: 'Enter an offset for this transform range',
     invalidRangeOffset: 'Enter valid start and end offsets',
     noFileRange: 'No file bytes are available to transform',
@@ -146,23 +167,23 @@ export const strings = {
     exportingChangeLog: 'Exporting change log...',
     applyingChangeLog: 'Applying change log...',
     checkpointCreated: (count: number) =>
-      `Checkpoint created (${count.toLocaleString()} total)`,
+      `Checkpoint created (${formatNumber(count)} total)`,
     checkpointRolledBack: (count: number) =>
-      `Checkpoint rolled back (${count.toLocaleString()} remaining)`,
+      `Checkpoint rolled back (${formatNumber(count)} remaining)`,
     changeLogExported: (count: number) =>
-      `Exported ${count.toLocaleString()} change${count === 1 ? '' : 's'}`,
+      `Exported ${formatNumber(count)} change${count === 1 ? '' : 's'}`,
     changeLogApplied: (count: number) =>
-      `Applied ${count.toLocaleString()} change${count === 1 ? '' : 's'}`,
+      `Applied ${formatNumber(count)} change${count === 1 ? '' : 's'}`,
     exportingRange: 'Exporting range...',
     insertingFile: 'Selecting file to insert...',
     replacingWithFile: 'Selecting replacement file...',
     fileActionCancelled: 'File action cancelled',
     exportedRange: (count: number) =>
-      `Exported ${count.toLocaleString()} byte${count === 1 ? '' : 's'}`,
+      `Exported ${formatNumber(count)} byte${count === 1 ? '' : 's'}`,
     insertedFile: (count: number) =>
-      `Inserted ${count.toLocaleString()} byte${count === 1 ? '' : 's'}`,
+      `Inserted ${formatNumber(count)} byte${count === 1 ? '' : 's'}`,
     replacedRangeWithFile: (from: number, to: number) =>
-      `Replaced ${from.toLocaleString()} byte${from === 1 ? '' : 's'} with ${to.toLocaleString()} byte${to === 1 ? '' : 's'}`,
+      `Replaced ${formatNumber(from)} byte${from === 1 ? '' : 's'} with ${formatNumber(to)} byte${to === 1 ? '' : 's'}`,
     resultTitle: 'Transform result',
     resultDefault: 'Result',
     resultAvailable: (label: string) => `${label} available`,
@@ -184,7 +205,7 @@ export const strings = {
     dismissResult: 'Dismiss transform result',
     dismissResultSymbol: 'x',
     transformed: (from: number, to: number) =>
-      `Transformed ${from.toLocaleString()} byte${from === 1 ? '' : 's'} into ${to.toLocaleString()} byte${to === 1 ? '' : 's'}`,
+      `Transformed ${formatNumber(from)} byte${from === 1 ? '' : 's'} into ${formatNumber(to)} byte${to === 1 ? '' : 's'}`,
     completed: 'Transform completed',
     calculationCompleted: 'Calculation completed',
     noContentChange: 'Transform completed without content changes',
@@ -216,13 +237,13 @@ export const strings = {
     searchComplete: 'Search complete',
     noMatch: 'No match',
     largeMatchSummary: (limit: number, offset: string) =>
-      `${limit.toLocaleString()}+ matches @ ${offset}`,
+      `${formatNumber(limit)}+ matches @ ${offset}`,
     boundedMatchSummary: (index: number, total: number, offset: string) =>
       `${index + 1} / ${total} @ ${offset}`,
     replaceSummary: (count: number) =>
       count === 1
         ? 'Replaced 1 match'
-        : `Replaced ${count.toLocaleString()} matches`,
+        : `Replaced ${formatNumber(count)} matches`,
     replacingAll: 'Replacing matches...',
   },
   grid: {
@@ -262,12 +283,12 @@ export const strings = {
     label: 'Selected byte inspector',
     title: 'Inspector',
     show: 'Show',
-    hide: 'Hide',
+    collapseSymbol: 'X',
     expand: 'Expand inspector',
     collapse: 'Collapse inspector',
     selection: 'Selection',
     noSelection: 'No selection',
-    byte: (count: number) => `${count.toLocaleString()} byte${count === 1 ? '' : 's'}`,
+    byte: (count: number) => `${formatNumber(count)} byte${count === 1 ? '' : 's'}`,
     copying: 'Copying...',
     copied: 'Copied',
     cut: 'Cut',
@@ -324,7 +345,7 @@ export const strings = {
     overwroteBytes: (count: number) =>
       count === 1
         ? 'Overwrote 1 byte'
-        : `Overwrote ${count.toLocaleString()} bytes`,
+        : `Overwrote ${formatNumber(count)} bytes`,
     copiedSelection: (count: number, format: 'hex' | 'utf8') =>
       `Copied ${strings.inspector.byte(count)} as ${
         format === 'hex' ? strings.inspector.asHex : strings.inspector.asText
@@ -333,11 +354,11 @@ export const strings = {
     deletedBytes: (count: number) =>
       count === 1
         ? 'Deleted 1 byte'
-        : `Deleted ${count.toLocaleString()} bytes`,
+        : `Deleted ${formatNumber(count)} bytes`,
     pastedBytes: (count: number) =>
       count === 1
         ? 'Pasted 1 byte'
-        : `Pasted ${count.toLocaleString()} bytes`,
+        : `Pasted ${formatNumber(count)} bytes`,
   },
   profiler: {
     label: 'OmegaEdit profiler',
@@ -346,7 +367,7 @@ export const strings = {
     profile: 'Profile',
     structure: 'Structure',
     show: 'Show',
-    hide: 'Hide',
+    collapseSymbol: 'X',
     expand: 'Expand profiler',
     collapse: 'Collapse profiler',
     expandSection: (title: string) => `Expand ${title}`,
@@ -377,7 +398,7 @@ export const strings = {
     profileCapped: (length: string, requestedLength: string) =>
       `Profile capped at ${length} of ${requestedLength}.`,
     frequencyByte: (label: string, count: number) =>
-      `${label} count ${count.toLocaleString()}`,
+      `${label} count ${formatNumber(count)}`,
     count: 'Count',
     linear: 'Linear',
     log: 'Log',
@@ -430,4 +451,253 @@ export const strings = {
   status: {
     hexPending: (label: string) => `Hex edit: ${label}`,
   },
+}
+
+export type WebviewStrings = typeof englishStrings
+type LocaleStringOverrides = {
+  [Section in keyof WebviewStrings]?: Partial<WebviewStrings[Section]>
+}
+
+// Locale overrides may be partial; missing strings fall back to English.
+const localeOverrides: Record<string, LocaleStringOverrides> = {
+  es: {
+    app: {
+      missingMountPoint: 'Falta el punto de montaje de la vista web de Svelte',
+      failedToStart: (message: string) =>
+        `No se pudo iniciar la vista web del editor: ${message}`,
+    },
+    toolbar: {
+      label: 'Barra de herramientas del editor OmegaEdit',
+      bytesPerRow: 'Bytes por fila',
+      bytesPerRowTitle: (count: number) =>
+        `Mostrar ${formatNumber(count)} bytes por fila`,
+      offsetRadix: 'Base del desplazamiento',
+      hexOffsets: 'Hex',
+      decOffsets: 'Dec',
+      hexOffsetsTitle: 'Mostrar desplazamientos en hexadecimal',
+      decOffsetsTitle: 'Mostrar desplazamientos en decimal',
+      insertDirection: 'Direccion de insercion',
+      forwardInsert: 'Adelante',
+      backwardInsert: 'Atras',
+      forwardInsertTitle:
+        'Direccion de insercion: adelante. Haz clic para insertar hacia atras.',
+      backwardInsertTitle:
+        'Direccion de insercion: atras. Haz clic para insertar hacia adelante.',
+      searchPanel: 'Buscar',
+      showSearchPanelTitle: 'Mostrar buscar y reemplazar',
+      hideSearchPanelTitle: 'Ocultar buscar y reemplazar',
+    },
+    navigation: {
+      offsetLabel: 'Desplazamiento',
+      offsetTitleHex: 'Ir al desplazamiento hexadecimal',
+      offsetTitleDec: 'Ir al desplazamiento decimal',
+      go: 'Ir',
+      goTitle: 'Ir al desplazamiento',
+      offsetRequired: 'Introduce un desplazamiento',
+      invalidHexOffset: 'Desplazamiento hexadecimal no valido',
+      invalidDecimalOffset: 'Desplazamiento decimal no valido',
+      noFile: 'No hay archivo cargado',
+      offsetOutOfRange: (maxOffset: string) => `Max ${maxOffset}`,
+      scrollbarLabel: 'Navegacion del archivo',
+      scrollbarDisabled: 'El archivo cabe en la vista',
+      scrollbarValue: (offset: string, progress: string) =>
+        `${offset} (${progress})`,
+    },
+    transform: {
+      label: 'Accion',
+      choose: 'Seleccionar accion...',
+      chooseTitle: 'Elegir una accion para el archivo actual',
+      calculationsGroup: 'Calculos',
+      transformsGroup: 'Transformaciones',
+      fileSplicingGroup: 'Union de archivos',
+      sessionGroup: 'Sesion',
+      createCheckpoint: 'Punto de control',
+      rollbackCheckpoint: 'Revertir',
+      exportChangeLog: 'Exportar registro',
+      applyChangeLog: 'Aplicar registro',
+      loading: 'Cargando transformaciones...',
+      selectRange: 'Selecciona bytes primero',
+      selectRangeFirst: 'Selecciona uno o mas bytes para transformar',
+      options: 'Opciones',
+      apply: 'Aplicar',
+      cancel: 'Cancelar',
+      closeDialog: 'Cerrar opciones de transformacion',
+      resultTitle: 'Resultado de transformacion',
+      resultDefault: 'Resultado',
+      copyResult: 'Copiar',
+      resultCopied: 'Copiado',
+      resultCopyFailed: 'No se pudo copiar',
+      dismissResult: 'Descartar resultado de transformacion',
+      completed: 'Transformacion completada',
+      calculationCompleted: 'Calculo completado',
+      noContentChange:
+        'La transformacion termino sin cambios en el contenido',
+    },
+    search: {
+      label: 'Buscar bytes',
+      placeholder: 'Buscar texto o hexadecimal',
+      replacePlaceholder: 'Reemplazar con texto o hexadecimal',
+      hex: 'Hex',
+      ignoreCase: 'Ignorar mayusculas',
+      forward: 'Adelante',
+      reverse: 'Atras',
+      directionTitle: 'Direccion de busqueda',
+      find: 'Buscar',
+      previous: 'Buscar anterior',
+      next: 'Buscar siguiente',
+      previousTitle: 'Coincidencia anterior',
+      nextTitle: 'Coincidencia siguiente',
+      replace: 'Reemplazar',
+      replaceAll: 'Reemplazar todo',
+      noSearch: 'Sin busqueda',
+      invalidHex: 'Hexadecimal no valido',
+      invalidSearch: 'Busqueda no valida',
+      invalidReplacementHex: 'Reemplazo hexadecimal no valido',
+      ready: 'Listo',
+      searching: 'Buscando...',
+      noMatches: 'Sin coincidencias',
+      searchComplete: 'Busqueda completada',
+      noMatch: 'Sin coincidencia',
+      boundedMatchSummary: (index: number, total: number, offset: string) =>
+        `${formatNumber(index + 1)} / ${formatNumber(total)} @ ${offset}`,
+      replaceSummary: (count: number) =>
+        count === 1
+          ? 'Se reemplazo 1 coincidencia'
+          : `Se reemplazaron ${formatNumber(count)} coincidencias`,
+      replacingAll: 'Reemplazando coincidencias...',
+    },
+    grid: {
+      offset: 'Desplazamiento',
+      waitingForData: 'Esperando datos',
+      preparingFile: 'Preparando archivo...',
+      readOnly: 'Solo lectura',
+      insertTitle: 'Modo insertar',
+      overwriteTitle: 'Modo sobrescribir',
+      notPrintable: 'No imprimible',
+      printableByte: 'ASCII imprimible',
+      controlByte: 'Byte de control',
+      highBitByte: 'Byte de bit alto',
+    },
+    inspector: {
+      label: 'Inspector de byte seleccionado',
+      title: 'Inspector',
+      show: 'Mostrar',
+      expand: 'Expandir inspector',
+      collapse: 'Contraer inspector',
+      selection: 'Seleccion',
+      noSelection: 'Sin seleccion',
+      byte: (count: number) => `${formatNumber(count)} byte${count === 1 ? '' : 's'}`,
+      copying: 'Copiando...',
+      copied: 'Copiado',
+      cut: 'Cortar',
+      insert: 'Insertar',
+      overwrite: 'Sobrescribir',
+      apply: 'Aplicar',
+      asHex: 'hex',
+      asText: 'texto',
+      byteOrder: 'Orden de bytes',
+      emptyValue: 'Introduce un valor',
+      invalidValue: 'Valor no valido',
+      outOfRange: 'Fuera de rango',
+    },
+    profiler: {
+      label: 'Perfilador OmegaEdit',
+      title: 'Analizador',
+      views: 'Vistas de analisis',
+      profile: 'Perfil',
+      structure: 'Estructura',
+      show: 'Mostrar',
+      expand: 'Expandir perfilador',
+      collapse: 'Contraer perfilador',
+      viewport: 'Vista',
+      byteClasses: 'Clases de bytes',
+      dataProfile: 'Perfil de datos',
+      frequency: 'Frecuencia',
+      history: 'Historial',
+      timing: 'Tiempos',
+      server: 'Servidor',
+      details: 'Detalles',
+      status: 'Estado',
+      pending: 'Pendiente',
+      ok: 'OK',
+      warn: 'Aviso',
+      error: 'Error',
+      down: 'Inactivo',
+      selection: 'Seleccion',
+      noBytes: 'No hay bytes en el alcance.',
+      noProfileData: 'No hay datos de perfil en el alcance.',
+      count: 'Conteo',
+      offset: 'Desplazamiento',
+      visible: 'Visible',
+      rows: 'Filas',
+      capacity: 'Capacidad',
+      bytes: 'Bytes',
+      language: 'Idioma',
+      yes: 'Si',
+      no: 'No',
+    },
+    status: {
+      hexPending: (label: string) => `Edicion hex: ${label}`,
+    },
+  },
+} satisfies Record<string, LocaleStringOverrides>
+
+function createStringTable(): WebviewStrings {
+  return {
+    app: { ...englishStrings.app },
+    toolbar: { ...englishStrings.toolbar },
+    navigation: { ...englishStrings.navigation },
+    transform: { ...englishStrings.transform },
+    search: { ...englishStrings.search },
+    grid: { ...englishStrings.grid },
+    inspector: { ...englishStrings.inspector },
+    profiler: { ...englishStrings.profiler },
+    status: { ...englishStrings.status },
+  }
+}
+
+export const strings: WebviewStrings = createStringTable()
+
+function applyLocaleOverrides(overrides?: LocaleStringOverrides): void {
+  Object.assign(strings.app, englishStrings.app, overrides?.app)
+  Object.assign(strings.toolbar, englishStrings.toolbar, overrides?.toolbar)
+  Object.assign(
+    strings.navigation,
+    englishStrings.navigation,
+    overrides?.navigation
+  )
+  Object.assign(strings.transform, englishStrings.transform, overrides?.transform)
+  Object.assign(strings.search, englishStrings.search, overrides?.search)
+  Object.assign(strings.grid, englishStrings.grid, overrides?.grid)
+  Object.assign(strings.inspector, englishStrings.inspector, overrides?.inspector)
+  Object.assign(strings.profiler, englishStrings.profiler, overrides?.profiler)
+  Object.assign(strings.status, englishStrings.status, overrides?.status)
+}
+
+export function resolveLanguage(language: string | undefined): string {
+  const normalized = normalizeLanguageTag(language ?? '')
+  if (!normalized || normalized === DEFAULT_LANGUAGE) {
+    return DEFAULT_LANGUAGE
+  }
+  if (Object.prototype.hasOwnProperty.call(localeOverrides, normalized)) {
+    return normalized
+  }
+  const [baseLanguage] = normalized.split('-')
+  return Object.prototype.hasOwnProperty.call(localeOverrides, baseLanguage)
+    ? baseLanguage
+    : DEFAULT_LANGUAGE
+}
+
+export function setLanguage(language: string | undefined): string {
+  activeLanguage = resolveLanguage(language)
+  applyLocaleOverrides(localeOverrides[activeLanguage])
+  return activeLanguage
+}
+
+export function getLanguage(): string {
+  return activeLanguage
+}
+
+export function getSupportedLanguages(): string[] {
+  return [DEFAULT_LANGUAGE, ...Object.keys(localeOverrides)]
 }

--- a/vscode-extension/webview-ui/src/main.ts
+++ b/vscode-extension/webview-ui/src/main.ts
@@ -1,14 +1,21 @@
 import App from './App.svelte'
 import './styles.css'
 import { mount } from 'svelte'
-import { strings } from './i18n'
+import { setLanguage, strings, textDirectionForLanguage } from './i18n'
 import { normalizeBytesPerRow } from './protocol'
+
+const initialLanguage = document.documentElement.lang || navigator.language
+setLanguage(initialLanguage)
 
 const target = document.getElementById('app')
 
 if (!target) {
   throw new Error(strings.app.missingMountPoint)
 }
+
+const activeLanguage = setLanguage(target.dataset.locale || initialLanguage)
+document.documentElement.lang = activeLanguage
+document.documentElement.dir = textDirectionForLanguage(activeLanguage)
 
 const initialBytesPerRow = normalizeBytesPerRow(
   Number.parseInt(target.dataset.bytesPerRow ?? '', 10)

--- a/vscode-extension/webview-ui/src/styles.css
+++ b/vscode-extension/webview-ui/src/styles.css
@@ -996,6 +996,13 @@ button.dialog-backdrop:focus-visible {
   padding: 2px 7px;
 }
 
+.profiler-toggle:not(.profiler-collapsed-toggle) {
+  inline-size: 30px;
+  padding: 2px 0;
+  font-weight: 600;
+  line-height: 1;
+}
+
 .profiler-panel.collapsed .profiler-header {
   position: relative;
   justify-content: center;
@@ -1739,6 +1746,14 @@ button.dialog-backdrop:focus-visible {
   min-width: 52px;
   min-height: 24px;
   padding: 2px 7px;
+}
+
+.inspector-toggle:not(.inspector-collapsed-toggle) {
+  inline-size: 30px;
+  min-width: 30px;
+  padding: 2px 0;
+  font-weight: 600;
+  line-height: 1;
 }
 
 .inspector-collapsed-toggle {


### PR DESCRIPTION
## Summary

- Replace expanded Inspector and Analyzer "Hide" buttons with compact `X` controls while preserving accessible collapse labels.
- Add webview i18n selection with English fallback, partial Spanish overrides, locale-aware number formatting, and document `lang`/direction setup before Svelte mounts.
- Expose `omegaEdit.language` with `auto`, `en`, and `es` options so localization can be tested without changing VS Code's global display language.
- Document the localization model and guard it with extension tests.

## Why

The Svelte webview had a centralized English string table but no way to choose a language or test localized UI independently. The new setting keeps the default behavior aligned with VS Code while making explicit language selection available for testing and users.

## Validation

- `npm run lint`
- `npx -y -p node@24 node node_modules/typescript/bin/tsc -p ./`
- `npx -y -p node@24 node node_modules/svelte-check/bin/svelte-check --tsconfig ./webview-ui/tsconfig.json`
- `node --test tests/extension.test.js`
