### PR TITLE
fix: demo editor regressions

### DIFF
--- a/plugins/src/endian_swap.cpp
+++ b/plugins/src/endian_swap.cpp
@@ -29,10 +29,12 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
     if (!info_ptr) { return -1; }
     info_ptr->id = "omega.example.endian_swap";
     info_ptr->name = "Endian Swap";
-    info_ptr->description = "Reverse byte order in fixed-width 2, 4, or 8 byte fields.";
+    info_ptr->description = "Reverse byte order in complete fixed-width 2, 4, or 8 byte fields.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
-    info_ptr->help = "Choose a field width of 2, 4, or 8 bytes.";
+    info_ptr->help =
+            "Choose a field width of 2, 4, or 8 bytes. Trailing bytes that do not fill a complete field are left "
+            "unchanged.";
     info_ptr->example = "{\"width\":4}";
     info_ptr->default_args = "{\"width\":2}";
     info_ptr->args_schema = ENDIAN_SWAP_ARGS_SCHEMA;
@@ -49,9 +51,10 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
     std::map<std::string, std::string> options;
     if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
     const int64_t width = omega_edit::plugin::option_int_or(options, "width", 2);
-    if (!(width == 2 || width == 4 || width == 8) || (bytes.size() % static_cast<size_t>(width)) != 0) { return -1; }
+    if (!(width == 2 || width == 4 || width == 8)) { return -1; }
     using difference_type = std::vector<omega_byte_t>::difference_type;
-    for (size_t offset = 0; offset < bytes.size(); offset += static_cast<size_t>(width)) {
+    for (size_t offset = 0; offset + static_cast<size_t>(width) <= bytes.size();
+         offset += static_cast<size_t>(width)) {
         std::reverse(bytes.begin() + static_cast<difference_type>(offset),
                      bytes.begin() + static_cast<difference_type>(offset + static_cast<size_t>(width)));
     }

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -481,6 +481,19 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(helper_session_ptr);
 
+    const auto odd_helper_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(odd_helper_session_ptr);
+    const omega_byte_t odd_endian_bytes[] = {1, 2, 3, 4, 5};
+    REQUIRE(0 < omega_edit_insert_bytes(odd_helper_session_ptr, 0, odd_endian_bytes, 5));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.endian_swap",
+                                                                  odd_helper_session_ptr, 0, 5, "{\"width\":2}",
+                                                                  &response));
+    REQUIRE(std::string({2, 1, 4, 3, 5}) ==
+            omega_session_get_segment_string(odd_helper_session_ptr, 0,
+                                             omega_session_get_computed_file_size(odd_helper_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(odd_helper_session_ptr);
+
     const auto decimal_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(decimal_session_ptr);
     REQUIRE(0 < omega_edit_insert_string(decimal_session_ptr, 0, "123"));

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -127,6 +127,9 @@ interface EditorSession {
   externalHighlights: WebviewExternalHighlight[]
   transformPlugins: WebviewTransformPlugin[]
   transformInFlight: boolean
+  pendingHistoryOperation?: 'undo' | 'redo'
+  pendingHistoryCount?: number
+  historyCommandTask?: Promise<void>
   contentType?: string
   language?: string
 }
@@ -1073,20 +1076,14 @@ export class HexEditorProvider
     if (!this.activeSession) {
       return
     }
-    if (!this.ensureSessionCanMutate(this.activeSession, true)) {
-      return
-    }
-    await vscode.commands.executeCommand('undo')
+    await this.enqueueHistoryCommand(this.activeSession, 'undo', true)
   }
 
   public async redoActive(): Promise<void> {
     if (!this.activeSession) {
       return
     }
-    if (!this.ensureSessionCanMutate(this.activeSession, true)) {
-      return
-    }
-    await vscode.commands.executeCommand('redo')
+    await this.enqueueHistoryCommand(this.activeSession, 'redo', true)
   }
 
   public searchNextActive(): void {
@@ -1532,6 +1529,14 @@ export class HexEditorProvider
         bytesPerRow
       )
       session.capacity = this.getViewportCapacity(bytesPerRow)
+      this.postTransformStatus(
+        session,
+        session.transformInFlight,
+        undefined,
+        session.transformInFlight
+          ? transformMutationBlockedMessage()
+          : undefined
+      )
       this.sendViewportData(session)
       this.postEditState(session)
     }
@@ -1547,6 +1552,14 @@ export class HexEditorProvider
       session.panel.webview.html = this.renderWebviewHtml(
         session.panel.webview,
         session.bytesPerRow
+      )
+      this.postTransformStatus(
+        session,
+        session.transformInFlight,
+        undefined,
+        session.transformInFlight
+          ? transformMutationBlockedMessage()
+          : undefined
       )
       this.sendViewportData(session)
       this.postEditState(session)
@@ -2735,6 +2748,8 @@ export class HexEditorProvider
         this.clearSearchState(session)
       }
 
+      await this.sendViewportData(session)
+
       this.postWebviewMessage(session, {
         type: 'transformComplete',
         pluginId: response.pluginId,
@@ -3434,6 +3449,73 @@ export class HexEditorProvider
     this.postEditState(session)
   }
 
+  private enqueueHistoryCommand(
+    session: EditorSession,
+    operation: 'undo' | 'redo',
+    showWarning = false
+  ): Promise<void> {
+    if (!this.ensureSessionCanMutate(session, showWarning)) {
+      return Promise.resolve()
+    }
+
+    if (session.pendingHistoryOperation !== operation) {
+      session.pendingHistoryOperation = operation
+      session.pendingHistoryCount = 0
+    }
+    session.pendingHistoryCount = (session.pendingHistoryCount ?? 0) + 1
+
+    if (!session.historyCommandTask) {
+      session.historyCommandTask = this.processHistoryCommandQueue(session)
+        .catch((error) => {
+          const message = error instanceof Error ? error.message : String(error)
+          void vscode.window.showErrorMessage(omegaEditErrorMessage(message))
+        })
+        .finally(() => {
+          session.historyCommandTask = undefined
+          session.pendingHistoryOperation = undefined
+          session.pendingHistoryCount = 0
+        })
+    }
+
+    return session.historyCommandTask
+  }
+
+  private async processHistoryCommandQueue(
+    session: EditorSession
+  ): Promise<void> {
+    while (
+      !session.scope.isDisposed &&
+      !session.disposed &&
+      session.pendingHistoryOperation &&
+      (session.pendingHistoryCount ?? 0) > 0
+    ) {
+      if (this.activeSession !== session) {
+        session.pendingHistoryOperation = undefined
+        session.pendingHistoryCount = 0
+        return
+      }
+
+      const operation = session.pendingHistoryOperation
+      session.pendingHistoryCount = Math.max(
+        0,
+        (session.pendingHistoryCount ?? 0) - 1
+      )
+
+      const editState = session.history.getEditState()
+      if (operation === 'undo') {
+        if (!editState.canUndo) {
+          continue
+        }
+        await vscode.commands.executeCommand('undo')
+      } else {
+        if (!editState.canRedo) {
+          continue
+        }
+        await vscode.commands.executeCommand('redo')
+      }
+    }
+  }
+
   private notifyDocumentChanged(session: EditorSession): void {
     this._onDidChangeCustomDocument.fire({
       document: session.document,
@@ -3800,6 +3882,14 @@ export class HexEditorProvider
 
         case 'setViewportMetrics': {
           const visibleRows = Math.max(1, Math.floor(msg.visibleRows))
+          if (session.transformInFlight) {
+            this.postTransformStatus(
+              session,
+              true,
+              undefined,
+              transformMutationBlockedMessage()
+            )
+          }
           if (visibleRows !== session.visibleRows) {
             session.visibleRows = visibleRows
             await this.scrollTo(session, session.offset)
@@ -4054,12 +4144,12 @@ export class HexEditorProvider
           // stack; VS Code then calls our registered undo() callback, which
           // calls session.history.undo() and keeps VS Code's dirty state in
           // sync (including clearing dirty when back at the saved baseline).
-          await vscode.commands.executeCommand('undo')
+          await this.enqueueHistoryCommand(session, 'undo')
           break
         }
 
         case 'redo': {
-          await vscode.commands.executeCommand('redo')
+          await this.enqueueHistoryCommand(session, 'redo')
           break
         }
 

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -17,7 +17,12 @@
     type WebviewExternalHighlight,
     type WebviewTransformPlugin,
   } from './protocol'
-  import { getPreviewState, postToHost, setPreviewState } from './vscodeApi'
+  import {
+    getPreviewState,
+    postToHost,
+    setPreviewState,
+    type PersistedViewportSnapshot,
+  } from './vscodeApi'
 
   const DEFAULT_VISIBLE_ROWS = 16
   const INTERNAL_HEX_CLIPBOARD_FORMAT = 'application/x-omega-edit-hex'
@@ -70,11 +75,17 @@
     label: string
     value: string
     mimeType: string
+    offset: number
+    rangeEndOffset: number
+    byteLength: number
+    createdAtLabel: string
+    historyLabel: string
+  }
+
+  interface DisplayTransformResultState extends TransformResultState {
     rangeStart: string
     rangeEnd: string
     length: string
-    createdAtLabel: string
-    historyLabel: string
   }
 
   const DEFAULT_ANALYSIS_SECTION_ORDER: AnalysisSectionOrder = {
@@ -98,16 +109,21 @@
   let { initialBytesPerRow = 16 }: Props = $props()
 
   const restoredState = getPreviewState()
+  const restoredViewportSnapshot = normalizeViewportSnapshot(
+    restoredState?.viewportSnapshot
+  )
 
   let bytesPerRow = $state<BytesPerRow>(
     normalizeBytesPerRow(
       restoredState?.bytesPerRow ?? untrack(() => initialBytesPerRow)
     )
   )
-  let fileSize = $state(0)
-  let visibleOffset = $state(0)
-  let viewportOffset = $state(0)
-  let viewportData = $state<number[]>([])
+  let fileSize = $state(restoredViewportSnapshot?.fileSize ?? 0)
+  let visibleOffset = $state(restoredViewportSnapshot?.visibleOffset ?? 0)
+  let viewportOffset = $state(restoredViewportSnapshot?.viewportOffset ?? 0)
+  let viewportData = $state<number[]>(
+    restoredViewportSnapshot?.viewportData ?? []
+  )
   let visibleRows = $state(DEFAULT_VISIBLE_ROWS)
   let pendingVisibleOffset = $state<number | undefined>(undefined)
   let pendingSearchReveal = $state<PendingSearchReveal | undefined>(undefined)
@@ -140,8 +156,13 @@
   let transformResult = $state<TransformResultState | undefined>(undefined)
   let transformResultHistory = $state<TransformResultState[]>([])
   let transformResultSequence = $state(0)
-  let externalHighlights = $state<WebviewExternalHighlight[]>([])
-  let preparingFile = $state(true)
+  let externalHighlights = $state<WebviewExternalHighlight[]>(
+    restoredViewportSnapshot?.externalHighlights ?? []
+  )
+  let viewportSnapshot = $state<PersistedViewportSnapshot | undefined>(
+    restoredViewportSnapshot
+  )
+  let preparingFile = $state(!restoredViewportSnapshot)
   let canUndo = $state(false)
   let canRedo = $state(false)
   let undoCount = $state(0)
@@ -284,6 +305,12 @@
   const profilerSelectedBytes = $derived(
     selectedVisibleBytes.length === selectionLength ? selectedVisibleBytes : []
   )
+  const displayTransformResult = $derived(
+    transformResult ? formatTransformResult(transformResult) : undefined
+  )
+  const displayTransformResultHistory = $derived(
+    transformResultHistory.map(formatTransformResult)
+  )
 
   let analysisProfileRequestTimer: ReturnType<typeof setTimeout> | undefined
 
@@ -327,6 +354,7 @@
       searchPanelVisible: boolean
       profilerExpanded: boolean
       analysisSectionOrder: AnalysisSectionOrder
+      viewportSnapshot: PersistedViewportSnapshot | undefined
     }> = {}
   ): void {
     setPreviewState({
@@ -336,8 +364,83 @@
       searchPanelVisible,
       profilerExpanded,
       analysisSectionOrder,
+      viewportSnapshot,
       ...overrides,
     })
+  }
+
+  function normalizeViewportSnapshot(
+    rawSnapshot: unknown
+  ): PersistedViewportSnapshot | undefined {
+    if (!rawSnapshot || typeof rawSnapshot !== 'object') {
+      return undefined
+    }
+
+    const snapshot = rawSnapshot as Record<string, unknown>
+    const nextFileSize = safeInteger(snapshot.fileSize)
+    const nextVisibleOffset = safeInteger(snapshot.visibleOffset)
+    const nextViewportOffset = safeInteger(snapshot.viewportOffset)
+    const nextViewportData = normalizeByteArray(snapshot.viewportData)
+
+    if (
+      nextFileSize === undefined ||
+      nextVisibleOffset === undefined ||
+      nextViewportOffset === undefined ||
+      !nextViewportData
+    ) {
+      return undefined
+    }
+
+    return {
+      fileSize: nextFileSize,
+      visibleOffset: Math.min(nextVisibleOffset, Math.max(0, nextFileSize)),
+      viewportOffset: Math.min(nextViewportOffset, Math.max(0, nextFileSize)),
+      viewportData: nextViewportData,
+      externalHighlights: normalizeExternalHighlights(
+        snapshot.externalHighlights
+      ),
+    }
+  }
+
+  function safeInteger(value: unknown): number | undefined {
+    return typeof value === 'number' &&
+      Number.isSafeInteger(value) &&
+      value >= 0
+      ? value
+      : undefined
+  }
+
+  function normalizeByteArray(value: unknown): number[] | undefined {
+    if (!Array.isArray(value)) {
+      return undefined
+    }
+
+    const bytes: number[] = []
+    for (const byte of value) {
+      if (
+        typeof byte !== 'number' ||
+        !Number.isInteger(byte) ||
+        byte < 0 ||
+        byte > 0xff
+      ) {
+        return undefined
+      }
+      bytes.push(byte)
+    }
+    return bytes
+  }
+
+  function normalizeExternalHighlights(
+    value: unknown
+  ): WebviewExternalHighlight[] {
+    if (!Array.isArray(value)) {
+      return []
+    }
+
+    return value.filter(
+      (highlight): highlight is WebviewExternalHighlight =>
+        Boolean(highlight) && typeof highlight === 'object'
+    ) as WebviewExternalHighlight[]
   }
 
   function normalizeAnalysisSectionOrder(
@@ -1467,8 +1570,6 @@
     const timestamp = Date.now()
     const title = transformPluginTitle(message.pluginId)
     const label = message.resultLabel || strings.transform.resultDefault
-    const rangeStart = formatSearchOffset(message.offset)
-    const rangeEndLabel = formatSearchOffset(rangeEnd)
     const createdAtLabel = formatTransformResultTime(timestamp)
     transformResultSequence += 1
 
@@ -1479,15 +1580,29 @@
       label,
       value: message.resultText,
       mimeType: message.resultMimeType,
-      rangeStart,
-      rangeEnd: rangeEndLabel,
-      length: strings.transform.bytes(displayLength),
+      offset: message.offset,
+      rangeEndOffset: rangeEnd,
+      byteLength: displayLength,
       createdAtLabel,
+      historyLabel: '',
+    }
+  }
+
+  function formatTransformResult(
+    result: TransformResultState
+  ): DisplayTransformResultState {
+    const rangeStart = formatSearchOffset(result.offset)
+    const rangeEnd = formatSearchOffset(result.rangeEndOffset)
+    return {
+      ...result,
+      rangeStart,
+      rangeEnd,
+      length: strings.transform.bytes(result.byteLength),
       historyLabel: strings.transform.resultHistoryItem(
-        label,
+        result.label,
         rangeStart,
-        rangeEndLabel,
-        createdAtLabel
+        rangeEnd,
+        result.createdAtLabel
       ),
     }
   }
@@ -1534,6 +1649,21 @@
       target instanceof HTMLTextAreaElement ||
       target instanceof HTMLSelectElement
     )
+  }
+
+  function historyShortcut(event: KeyboardEvent): 'undo' | 'redo' | undefined {
+    if ((!event.ctrlKey && !event.metaKey) || event.altKey) {
+      return undefined
+    }
+
+    const key = event.key.toLowerCase()
+    if (key === 'z') {
+      return event.shiftKey ? 'redo' : 'undo'
+    }
+    if (key === 'y' && !event.shiftKey) {
+      return 'redo'
+    }
+    return undefined
   }
 
   function normalizeHexInput(
@@ -1972,6 +2102,14 @@
           selectionAnchor = -1
           selectedOffset = nextOffset
         }
+        viewportSnapshot = {
+          fileSize: message.fileSize,
+          visibleOffset,
+          viewportOffset: message.offset,
+          viewportData: message.data,
+          externalHighlights: message.externalHighlights,
+        }
+        savePreviewState()
         applyPendingSearchReveal()
         break
       }
@@ -2133,6 +2271,13 @@
         break
       case 'externalHighlights':
         externalHighlights = message.highlights
+        if (viewportSnapshot) {
+          viewportSnapshot = {
+            ...viewportSnapshot,
+            externalHighlights: message.highlights,
+          }
+          savePreviewState()
+        }
         break
       case 'editMode':
         setInspectorEditMode(message.editMode)
@@ -2163,6 +2308,17 @@
       handleHostMessage(event.data)
     }
     const keyListener = (event: KeyboardEvent) => {
+      const historyAction = historyShortcut(event)
+      if (historyAction && !isEditableTarget(event.target)) {
+        event.preventDefault()
+        if (transformInFlight) {
+          clipboardMessage = strings.transform.inFlight
+          replaceMessage = strings.transform.inFlight
+          return
+        }
+        postToHost({ type: historyAction })
+        return
+      }
       if (
         event.defaultPrevented ||
         event.key !== 'Insert' ||
@@ -2215,8 +2371,8 @@
     {transformInFlight}
     {transformPluginError}
     {transformFeedback}
-    transformResults={transformResultHistory}
-    activeTransformResultId={transformResult?.id}
+    transformResults={displayTransformResultHistory}
+    activeTransformResultId={displayTransformResult?.id}
     {searchPanelVisible}
     {selectedOffset}
     {selectionStart}
@@ -2265,16 +2421,16 @@
       />
     {/if}
 
-    {#if transformResult}
+    {#if displayTransformResult}
       <TransformResultPanel
-        title={transformResult.title}
-        summary={transformResult.summary}
-        label={transformResult.label}
-        value={transformResult.value}
-        mimeType={transformResult.mimeType}
-        rangeStart={transformResult.rangeStart}
-        rangeEnd={transformResult.rangeEnd}
-        length={transformResult.length}
+        title={displayTransformResult.title}
+        summary={displayTransformResult.summary}
+        label={displayTransformResult.label}
+        value={displayTransformResult.value}
+        mimeType={displayTransformResult.mimeType}
+        rangeStart={displayTransformResult.rangeStart}
+        rangeEnd={displayTransformResult.rangeEnd}
+        length={displayTransformResult.length}
         onDismiss={dismissTransformResult}
       />
     {/if}

--- a/vscode-extension/webview-ui/src/vscodeApi.ts
+++ b/vscode-extension/webview-ui/src/vscodeApi.ts
@@ -1,4 +1,12 @@
-import type { WebviewToHostMessage } from './protocol'
+import type { WebviewExternalHighlight, WebviewToHostMessage } from './protocol'
+
+export interface PersistedViewportSnapshot {
+  fileSize: number
+  visibleOffset: number
+  viewportOffset: number
+  viewportData: number[]
+  externalHighlights?: WebviewExternalHighlight[]
+}
 
 export interface PersistedPreviewState {
   bytesPerRow?: number
@@ -7,6 +15,7 @@ export interface PersistedPreviewState {
   searchPanelVisible?: boolean
   profilerExpanded?: boolean
   analysisSectionOrder?: Record<string, string[]>
+  viewportSnapshot?: PersistedViewportSnapshot
 }
 
 const vscode = acquireVsCodeApi<PersistedPreviewState>()


### PR DESCRIPTION
## Summary

Fixes the demo regressions found while exercising transform plugins and the VS Code data editor:

- Let endian swap transform arbitrary selections by swapping complete fields and leaving trailing partial fields unchanged.
- Refresh viewport data after transform completion so Base64 encode/decode updates the visible bytes immediately.
- Queue rapid undo/redo commands per session so repeated Ctrl/Cmd-Z requests do not overlap VS Code undo operations.
- Preserve a validated viewport snapshot across webview reloads so changing bytes-per-row during long read-only transforms keeps visible data instead of showing the preparing spinner.
- Format transform result offsets from stored numeric ranges so Dec/Hex changes update existing calculation results.

## Validation

- `npm run compile:extension`
- `npm run check:webview` with WSL `nvm use 24.17.0`
- `npm run compile:webview` with WSL `nvm use 24.17.0`
- `ctest --test-dir .codex-tmp/demo-fixes-build/plugins --output-on-failure -R omega_transform_plugin_tests`
