### PR TITLE
fix: transform changelog atomicity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ package-lock.json
 # IDE files
 .idea/
 
+# Agent scratch files
+.claude/
+.codex-tmp/
+
 # Ignore addon files
 **/*.node
 

--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -55,13 +55,16 @@ This is the reported bug. Root causes are spread across all three layers.
    `vscode-extension/src/hexEditorProvider.ts:2324-2333` records the transform result as a
    `REPLACE` change record with raw replacement bytes. The plugin id and options are dropped.
    See gap G1 below (first-class Transform change kind).
+   **Status: Fixed.** Direct VS Code transform application now records a lightweight
+   `TRANSFORM` history entry with plugin id, options, replacement length, and size metadata
+   instead of materializing replacement bytes as a generic `REPLACE`.
 
 5. **Whole-replacement is buffered in memory as hex.**
    The extension reads the entire replacement back via `getSegment` and stores it hex-encoded
    in the in-memory change log (2× the byte size). For large transforms this is a latent OOM
    and conflicts with the large-file promise. (Same hex-doubling appears in the AI change log.)
-   **Status: Partially fixed.** Large transform replacements are no longer read back into
-   local VS Code history above the splice cap; general hex/in-memory change-log storage remains.
+   **Status: Partially fixed.** Direct VS Code transforms no longer read replacements back into
+   local history at all; general hex/in-memory change-log storage remains.
 
 6. **No surfaced reason when a transform genuinely does nothing.**
    When `content_changed` is false there is no message explaining *why* (schema mismatch vs.
@@ -89,21 +92,27 @@ This is the reported bug. Root causes are spread across all three layers.
    and no record of how far it got. Should wrap in a begin/end transaction (core supports
    transaction state — see `omega_session_get_transaction_state` usage in the server) or, at
    minimum, checkpoint before and restore on failure.
-   **Status: Partially fixed.** AI change-log apply now runs non-empty logs inside a server
-   transaction; explicit checkpoint rollback / applied-count reporting on failure is still open.
+   **Status: Partially fixed.** AI change-log apply now runs normal edit batches inside server
+   transactions and rolls back to the starting change count if a later entry fails. A dedicated
+   discard-redo rollback primitive / applied-count reporting on failure is still open.
 
 9. **`applyChangeLog` is not atomic (extension).**
    `vscode-extension/src/hexEditorProvider.ts` `applyChangeLogEntries` has the same
    sequential, non-transactional shape.
-   **Status: Partially fixed.** Extension import now applies non-empty logs inside one server
-   transaction and records the applied entries as one local undo/redo transaction; explicit
-   rollback on mid-apply failure is still open.
+   **Status: Partially fixed.** Extension import now applies normal edit batches inside server
+   transactions, records successful imports as one local undo/redo transaction, and rolls back
+   to the starting change count on mid-apply failure. A dedicated discard-redo rollback
+   primitive remains open.
 
 10. **Transforms are not atomic/first-class.** (User-requested flag — see G1.)
     A transform that internally expands/shrinks/replaces is recorded as one opaque `REPLACE`
     instead of a reversible, replayable `Transform` operation. Undo works by byte-replacement,
     not by re-running/inverting the transform, so the change log cannot reproduce the transform
     on a *different* file (the whole point of a portable change log).
+    **Status: Partially fixed.** Core/proto/server/client/export/import paths now carry
+    `TRANSFORM` metadata, and direct VS Code transforms now record that metadata locally.
+    Transform replay still depends on the target having the same plugin semantics and rollback
+    still uses undo-to-start-count compensation rather than a dedicated atomic import primitive.
 
 11. **Checkpoint rollback names must not promise snapshot restore semantics.**
     The checkpoint operation calls `destroyLastCheckpoint`; there is no snapshot/restore
@@ -231,8 +240,8 @@ This is the reported bug. Root causes are spread across all three layers.
 27. **`applyChangeLog` round-trip test only covers the happy path.**
     `packages/ai/tests/specs/toolkit.spec.ts` exercises a single OVERWRITE. No test for
     multi-entry logs, REPLACE entries, partial-failure/atomicity, or the entry/byte caps.
-    **Status: Partially fixed.** Added malformed wrapped-change-log import coverage; multi-entry,
-    REPLACE, partial-failure, and cap tests remain open.
+    **Status: Partially fixed.** Added malformed wrapped-change-log import coverage and a
+    partial-failure rollback regression; multi-entry, REPLACE, and cap tests remain open.
 
 ---
 
@@ -266,7 +275,9 @@ This is the reported bug. Root causes are spread across all three layers.
     plus subscribe/unsubscribe can therefore park each thread on the other's lock. The session
     event path needs one consistent lock order, or the core event-interest update needs to be
     split so subscription bookkeeping is never held while acquiring `core_mutex`.
-    **Status: New.**
+    **Status: Fixed.** Session event callbacks now copy matching subscriber queues while holding
+    only the subscription mutex and push after releasing it; subscription management releases
+    the subscription mutex before taking `core_mutex`.
 
 29. **Transform progress publishing relies on an implicit core lock.**
     `server/cpp/src/session_manager.cpp:777-816` reads `omega_session_get_computed_file_size`,
@@ -276,7 +287,9 @@ This is the reported bug. Root causes are spread across all three layers.
     `SessionManager` with no contract enforcing that precondition. A future caller could race
     session mutation or destruction and make progress reporting touch the non-thread-safe core
     session outside its guard.
-    **Status: New.**
+    **Status: Fixed.** Transform progress publishing no longer reads core session state; progress
+    events carry lifecycle/progress payloads only, while normal core session events provide
+    authoritative size/change counters.
 
 ---
 

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -449,6 +449,50 @@ async function collectChangeLogEntries(
   return changes
 }
 
+async function rollbackSessionToChangeCount(
+  sessionId: string,
+  targetChangeCount: number
+): Promise<boolean> {
+  let currentChangeCount = await getChangeCount(sessionId)
+  let rolledBack = false
+  while (currentChangeCount > targetChangeCount) {
+    await undo(sessionId)
+    rolledBack = true
+    const nextChangeCount = await getChangeCount(sessionId)
+    if (nextChangeCount >= currentChangeCount) {
+      throw new Error(
+        `Rollback did not reduce change count from ${currentChangeCount}`
+      )
+    }
+    currentChangeCount = nextChangeCount
+  }
+
+  if (currentChangeCount !== targetChangeCount) {
+    throw new Error(
+      `Rollback ended at change count ${currentChangeCount}, expected ${targetChangeCount}`
+    )
+  }
+
+  return rolledBack
+}
+
+function changeLogApplyErrorWithRollbackFailure(
+  applyError: unknown,
+  rollbackError: unknown
+): Error {
+  const applyMessage =
+    applyError instanceof Error ? applyError.message : String(applyError)
+  const rollbackMessage =
+    rollbackError instanceof Error
+      ? rollbackError.message
+      : String(rollbackError)
+  const error = new Error(
+    `Failed to apply change log and rollback failed: ${applyMessage}; rollback error: ${rollbackMessage}`
+  )
+  ;(error as Error & { cause?: unknown }).cause = applyError
+  return error
+}
+
 function createChangeLogDocument(
   changes: ChangeLogEntry[],
   sourceChangeCount: number
@@ -719,6 +763,7 @@ export class OmegaEditToolkit {
     await this.ensureServerRunning()
 
     if (changes.length > 0) {
+      const startChangeCount = await getChangeCount(request.sessionId)
       const applyChange = async (change: ChangeLogEntry) => {
         const data = Buffer.from(change.data, 'hex')
         switch (change.kind) {
@@ -748,30 +793,42 @@ export class OmegaEditToolkit {
             break
         }
       }
-      let pendingBatch: ChangeLogEntry[] = []
-      const flushBatch = async () => {
-        if (pendingBatch.length === 0) {
-          return
-        }
-
-        const batch = pendingBatch
-        pendingBatch = []
-        await runSessionTransaction(request.sessionId, async () => {
-          for (const change of batch) {
-            await applyChange(change)
+      try {
+        let pendingBatch: ChangeLogEntry[] = []
+        const flushBatch = async () => {
+          if (pendingBatch.length === 0) {
+            return
           }
-        })
-      }
 
-      for (const change of changes) {
-        if (change.kind === 'TRANSFORM') {
-          await flushBatch()
-          await applyChange(change)
-        } else {
-          pendingBatch.push(change)
+          const batch = pendingBatch
+          pendingBatch = []
+          await runSessionTransaction(request.sessionId, async () => {
+            for (const change of batch) {
+              await applyChange(change)
+            }
+          })
         }
+
+        for (const change of changes) {
+          if (change.kind === 'TRANSFORM') {
+            await flushBatch()
+            await applyChange(change)
+          } else {
+            pendingBatch.push(change)
+          }
+        }
+        await flushBatch()
+      } catch (error) {
+        try {
+          await rollbackSessionToChangeCount(
+            request.sessionId,
+            startChangeCount
+          )
+        } catch (rollbackError) {
+          throw changeLogApplyErrorWithRollbackFailure(error, rollbackError)
+        }
+        throw error
       }
-      await flushBatch()
     }
 
     return {

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -342,6 +342,56 @@ describe('@omega-edit/ai toolkit', () => {
     }
   })
 
+  it('rolls back a partially applied change log when a later entry fails', async function () {
+    const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
+    assert.ok(port, 'expected an available port for OmegaEdit')
+
+    const toolkit = new OmegaEditToolkit({ port: port!, autoStart: true })
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
+    const inputPath = path.join(tempDir, 'input.bin')
+    fs.writeFileSync(inputPath, Buffer.from('abcdef', 'utf8'))
+
+    let createdSessionId = ''
+
+    try {
+      const created = await toolkit.createSession(inputPath)
+      createdSessionId = created.sessionId
+
+      await assert.rejects(
+        () =>
+          toolkit.applyChangeLog({
+            sessionId: createdSessionId,
+            changes: [
+              {
+                kind: 'INSERT',
+                offset: 1,
+                length: 0,
+                data: Buffer.from('ZZ', 'utf8').toString('hex'),
+              },
+              {
+                kind: 'DELETE',
+                offset: 1000,
+                length: 1,
+                data: '',
+              },
+            ],
+          }),
+        /delete failed|change operation failed|invalid change arguments/i
+      )
+
+      const range = await toolkit.readRange(createdSessionId, 0, 6)
+      assert.equal(range.data.utf8, 'abcdef')
+      const status = await toolkit.sessionStatus(createdSessionId)
+      assert.equal(status.changeCount, 0)
+    } finally {
+      if (createdSessionId) {
+        await toolkit.destroySession(createdSessionId).catch(() => undefined)
+      }
+      await toolkit.stopServer().catch(() => undefined)
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   it('reports server-detected content types through profileRange', async function () {
     const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
     assert.ok(port, 'expected an available port for OmegaEdit')

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -742,9 +742,13 @@ bool SessionManager::publish_transform_progress(const std::string &session_id, i
     SessionEventData evt;
     evt.session_id = info->session_id;
     evt.session_event_kind = event_kind;
-    evt.computed_file_size = omega_session_get_computed_file_size(info->session);
-    evt.change_count = omega_session_get_num_changes(info->session);
-    evt.undo_count = omega_session_get_num_undone_changes(info->session);
+    // Transform progress callbacks run while the non-thread-safe core session is
+    // usually already locked by the mutating RPC. Progress events are lifecycle
+    // notifications; authoritative session size/change counters are delivered by
+    // normal core session events.
+    evt.computed_file_size = 0;
+    evt.change_count = 0;
+    evt.undo_count = 0;
     evt.serial = 0;
     evt.transform_progress = progress;
     evt.has_transform_progress = true;

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -756,6 +756,50 @@ async function collectChangeLogRecords(
   return changes
 }
 
+async function rollbackSessionToChangeCount(
+  sessionId: string,
+  targetChangeCount: number
+): Promise<boolean> {
+  let currentChangeCount = await getChangeCount(sessionId)
+  let rolledBack = false
+  while (currentChangeCount > targetChangeCount) {
+    await undo(sessionId)
+    rolledBack = true
+    const nextChangeCount = await getChangeCount(sessionId)
+    if (nextChangeCount >= currentChangeCount) {
+      throw new Error(
+        `Rollback did not reduce change count from ${currentChangeCount}`
+      )
+    }
+    currentChangeCount = nextChangeCount
+  }
+
+  if (currentChangeCount !== targetChangeCount) {
+    throw new Error(
+      `Rollback ended at change count ${currentChangeCount}, expected ${targetChangeCount}`
+    )
+  }
+
+  return rolledBack
+}
+
+function changeLogApplyErrorWithRollbackFailure(
+  applyError: unknown,
+  rollbackError: unknown
+): Error {
+  const applyMessage =
+    applyError instanceof Error ? applyError.message : String(applyError)
+  const rollbackMessage =
+    rollbackError instanceof Error
+      ? rollbackError.message
+      : String(rollbackError)
+  const error = new Error(
+    `Failed to apply change log and rollback failed: ${applyMessage}; rollback error: ${rollbackMessage}`
+  )
+  ;(error as Error & { cause?: unknown }).cause = applyError
+  return error
+}
+
 function safeChangeRecord(value: unknown): ChangeRecord | undefined {
   if (!isRecord(value)) {
     return undefined
@@ -2817,6 +2861,7 @@ export class HexEditorProvider
       const originalLength =
         length === 0 ? remainingLength : Math.min(length, remainingLength)
       const sessionSyncVersion = session.sessionSyncVersion
+      const computedFileSizeBefore = session.fileSize
       const response = await applyTransformPlugin(
         session.sessionId,
         pluginId,
@@ -2826,33 +2871,21 @@ export class HexEditorProvider
       )
 
       if (response.contentChanged) {
-        const replacement =
-          response.replacementLength > 0 &&
-          response.replacementLength <= MAX_FILE_SPLICE_BYTES
-            ? await getSegment(
-                session.sessionId,
-                response.offset,
-                response.replacementLength
-              )
-            : new Uint8Array()
-
-        if (
-          response.replacementLength > MAX_FILE_SPLICE_BYTES &&
-          replacement.byteLength === 0
-        ) {
-          session.history.recordLocalMutation()
-        } else {
-          session.history.recordLocalChange({
-            serial: session.history.getChangeLog().length + 1,
-            kind: 'REPLACE',
-            offset: response.offset,
-            length: response.length,
-            data:
-              replacement.byteLength > 0
-                ? Buffer.from(replacement).toString('hex')
-                : '',
-          })
+        if (response.serial === undefined) {
+          throw new Error('Transform did not return a change serial')
         }
+        session.history.recordLocalChange({
+          serial: response.serial,
+          kind: 'TRANSFORM',
+          offset: response.offset,
+          length: response.length,
+          data: '',
+          transformId: response.pluginId,
+          ...(optionsJson !== undefined ? { optionsJson } : {}),
+          replacementLength: response.replacementLength,
+          computedFileSizeBefore,
+          computedFileSizeAfter: response.computedFileSize,
+        })
         this.postEditState(session)
         this.notifyDocumentChanged(session)
         await this.waitForSessionSync(session, sessionSyncVersion)
@@ -3646,6 +3679,7 @@ export class HexEditorProvider
       return 0
     }
 
+    const startChangeCount = await getChangeCount(session.sessionId)
     const sessionSyncVersion = session.sessionSyncVersion
     const appliedChanges: ChangeRecord[] = []
     const recordAppliedChanges = async () => {
@@ -3692,7 +3726,20 @@ export class HexEditorProvider
       }
       await flushBatch()
     } catch (error) {
-      await recordAppliedChanges()
+      try {
+        const rolledBack = await rollbackSessionToChangeCount(
+          session.sessionId,
+          startChangeCount
+        )
+        if (rolledBack) {
+          await this.waitForSessionSync(session, sessionSyncVersion)
+          await this.sendViewportData(session)
+          this.clearSearchState(session)
+          this.postEditState(session)
+        }
+      } catch (rollbackError) {
+        throw changeLogApplyErrorWithRollbackFailure(error, rollbackError)
+      }
       throw error
     }
 

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -492,6 +492,8 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerJs, /countCharacters/)
   assert.match(providerJs, /listTransformPlugins/)
   assert.match(providerJs, /applyTransformPlugin/)
+  assert.match(providerJs, /kind:\s*['"]TRANSFORM['"]/)
+  assert.match(providerJs, /transformId:\s*response\.pluginId/)
   assert.match(providerJs, /formatTransformCompletionMessage/)
   assert.match(providerJs, /omegaEdit\.hexEditorActive/)
   assert.match(providerJs, /omegaEdit\.canUndo/)


### PR DESCRIPTION
## Summary

This PR fixes the first transform/change-log atomicity batch from `SHORTCOMINGS.md`.

- Roll back AI `applyChangeLog` to the starting change count when a later entry fails.
- Apply the same rollback behavior to VS Code change-log imports and keep failed partial imports out of local history.
- Record direct VS Code transforms as lightweight `TRANSFORM` history entries with plugin/options/size metadata instead of materializing replacement bytes as generic `REPLACE` entries.
- Avoid reading unlocked core session state from transform progress publishing; progress events now carry lifecycle/progress payloads only.
- Update `SHORTCOMINGS.md` and add regression/static coverage for the changed behavior.

## Why

Partial change-log imports could leave sessions mutated without a clear recovery path, and direct VS Code transforms were losing transform identity in local history. Transform progress publishing also depended on an implicit core-lock precondition that was easy to violate later.

## Validation

Passed locally on Node 24:

- `yarn workspace @omega-edit/ai lint`
- `yarn workspace @omega-edit/ai build`
- `npm --prefix vscode-extension run compile:extension`
- `npm --prefix vscode-extension run lint`
- `npm --prefix vscode-extension run test:unit`
- `git diff --check`

Native WSL/Linux validation:

- Built core with Ninja Debug into `.codex-tmp/native-core-build`.
- Installed core to `.codex-tmp/native-core-install`.
- `ctest -C Debug --test-dir .codex-tmp/native-core-build/plugins --output-on-failure`: passed 1/1.
- `ctest -C Debug --test-dir .codex-tmp/native-core-build/core --output-on-failure`: 98/99 passed; `File Copy` failed on `/mnt/d` file mode/mtime metadata expectations.
- Installed Conan in `.codex-tmp/conan-venv`; Conan packages are cached in `~/.conan2` and generated files are in `.codex-tmp/native-server-conan` for reuse.
- `conan install server/cpp --output-folder=.codex-tmp/native-server-conan --build=missing ...`: passed, including source builds for gRPC and libmagic.
- `cmake -G Ninja -S server/cpp -B .codex-tmp/native-server-build ...`: passed.
- `cmake --build .codex-tmp/native-server-build --target omega-edit-grpc-server`: passed.
- `.codex-tmp/native-server-build/omega-edit-grpc-server --help`: passed.
- `CPP_SERVER_BINARY=.codex-tmp/native-server-build/omega-edit-grpc-server yarn workspace @omega-edit/ai exec vitest run --config vitest.config.ts`: passed 2 files, 11 tests.
