### PR TITLE
feat: enforce atomic fingerprinted change logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,6 +527,7 @@ jobs:
         run: yarn workspace @omega-edit/server package
         env:
           CPP_SERVER_BINARIES_DIR: ${{ github.workspace }}/_server_binaries
+          OMEGA_EDIT_TRANSFORM_PLUGINS_DIR: ${{ github.workspace }}/_transform_plugins
 
       - name: Build local client release tarball
         run: yarn workspace @omega-edit/client package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,6 +247,7 @@ jobs:
         run: yarn workspace @omega-edit/server package
         env:
           CPP_SERVER_BINARIES_DIR: ${{ github.workspace }}/_server_binaries
+          OMEGA_EDIT_TRANSFORM_PLUGINS_DIR: ${{ github.workspace }}/_transform_plugins
 
       - name: Build local client release tarball
         run: yarn workspace @omega-edit/client package

--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -92,17 +92,16 @@ This is the reported bug. Root causes are spread across all three layers.
    and no record of how far it got. Should wrap in a begin/end transaction (core supports
    transaction state — see `omega_session_get_transaction_state` usage in the server) or, at
    minimum, checkpoint before and restore on failure.
-   **Status: Partially fixed.** AI change-log apply now runs normal edit batches inside server
-   transactions and rolls back to the starting change count if a later entry fails. A dedicated
-   discard-redo rollback primitive / applied-count reporting on failure is still open.
+   **Status: Fixed.** AI change-log apply now verifies the before fingerprint, applies normal
+   edit batches inside server transactions, verifies the after fingerprint before reporting
+   success, and rolls back to the starting change count on any apply/postcondition failure.
 
 9. **`applyChangeLog` is not atomic (extension).**
    `vscode-extension/src/hexEditorProvider.ts` `applyChangeLogEntries` has the same
    sequential, non-transactional shape.
-   **Status: Partially fixed.** Extension import now applies normal edit batches inside server
-   transactions, records successful imports as one local undo/redo transaction, and rolls back
-   to the starting change count on mid-apply failure. A dedicated discard-redo rollback
-   primitive remains open.
+   **Status: Fixed.** Extension import now verifies the before fingerprint, applies normal edit
+   batches inside server transactions, verifies the after fingerprint before recording local
+   history, and rolls back to the starting change count on any apply/postcondition failure.
 
 10. **Transforms are not atomic/first-class.** (User-requested flag — see G1.)
     A transform that internally expands/shrinks/replaces is recorded as one opaque `REPLACE`
@@ -176,9 +175,9 @@ This is the reported bug. Root causes are spread across all three layers.
 18. **Change-log entry/byte caps.**
     AI: `MAX_CHANGE_LOG_ENTRIES = 100_000`, `MAX_CHANGE_LOG_ENTRY_BYTES = 32 MiB`,
     `MAX_CHANGE_LOG_BYTES = 96 MiB` (`packages/ai/src/service.ts`). Extension mirrors these
-    (`hexEditorProvider.ts:146-148`). A session with >100k changes simply cannot export a log,
-    and `foldedChangeCount` silently hides the dropped ones (see E20). For a tool whose pitch is
-    massive files, a 100k-change ceiling is low.
+    (`hexEditorProvider.ts:146-148`). A session with >100k changes still cannot export a
+    non-streaming log. Export now fails loudly instead of hiding dropped changes, but for a tool
+    whose pitch is massive files, a 100k-change ceiling is low.
 
 19. **In-memory hex doubling everywhere.**
     Change-log data is stored/transported as hex strings (2× bytes) in both AI and extension,
@@ -195,13 +194,17 @@ This is the reported bug. Root causes are spread across all three layers.
     baseline are dropped and only counted in `foldedChangeCount`. The exported log therefore
     cannot faithfully reproduce a session that used checkpoints or transforms. This is presented
     in the README as a feature ("portable…apply to a fleet of files"), which overstates fidelity.
+    **Status: Fixed.** Export now checks the core model first, rejects unavailable serials /
+    missing details instead of emitting an incomplete log, writes explicit completeness metadata,
+    and includes server-computed before/after size+digest fingerprints for non-streaming logs.
+    The old folded-count path has been removed.
 
 21. **No schema validation / versioning enforcement on import.**
     `normalizeChangeLogEntries` accepts an array *or* `{changes:[...]}` but does not check
     `format`/`version` fields it itself writes. A v2 document or a foreign JSON array would be
     applied (or partially applied) without a compatibility gate.
-    **Status: Fixed.** Wrapped imports must now match the OmegaEdit change-log format and
-    version; the legacy bare-array form is still accepted.
+    **Status: Fixed.** Imports must now match the OmegaEdit change-log format and version;
+    bare JSON arrays are rejected.
 
 22. **`groupId` and `serial` are carried but not honored.**
     Import preserves `serial`/`groupId` (`service.ts` normalize) but apply ignores them — no
@@ -220,6 +223,8 @@ This is the reported bug. Root causes are spread across all three layers.
     `packages/client/src/protobuf_ts/change.ts` fills `sessionEventKind`, `computedFileSize`,
     `changeCount`, `undoCount` with zeros just to satisfy the shared request message. Harmless
     now but couples a read to an event-shaped message; a stricter server could reject it.
+    **Status: Fixed.** `GetChangeDetailsRequest` now carries only `session_id` and optional
+    `serial`.
 
 ---
 
@@ -257,6 +262,9 @@ This is the reported bug. Root causes are spread across all three layers.
 - **G3 — Streaming / file-backed change logs** to drop the in-memory and entry-count caps.
 - **G4 — BigInt offsets/lengths** at the TS boundary to lift the 2^53 ceiling.
 - **G5 — Transactional `applyChangeLog`** (begin/end transaction or checkpoint-guarded) for atomicity.
+  **Status: Fixed for change-log import.** Normal edit batches are transactional and the whole
+  import rolls back on failure; a future native "restore to starting serial and discard redo"
+  primitive would still make rollback cheaper and more direct.
 - **G6 — gRPC status-code based error handling.** **Status: Fixed.** Missing change-detail
   handling now follows preserved gRPC status codes instead of message text.
 

--- a/core/src/include/omega_edit/session.h
+++ b/core/src/include/omega_edit/session.h
@@ -103,6 +103,16 @@ void *omega_session_get_user_data_ptr(const omega_session_t *session_ptr);
 int omega_session_get_segment(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr, int64_t offset);
 
 /**
+ * Given a session, populate a segment from the immutable original session content.
+ * @param session_ptr session whose original content should be read
+ * @param data_segment_ptr data segment to populate
+ * @param offset original-content byte offset to read from
+ * @return 0 if the segment is populated successfully and non-zero otherwise
+ */
+int omega_session_get_original_segment(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr,
+                                       int64_t offset);
+
+/**
  * Given a session, return the number of active viewports
  * @param session_ptr session to get the number of active viewports for
  * @return number of active viewports
@@ -136,6 +146,13 @@ int64_t omega_session_get_num_undone_changes(const omega_session_t *session_ptr)
  * @return computed file size in bytes, or -1 on failure
  */
 int64_t omega_session_get_computed_file_size(const omega_session_t *session_ptr);
+
+/**
+ * Given a session, return the original file size in bytes
+ * @param session_ptr session to inspect
+ * @return original file size in bytes, or -1 on failure
+ */
+int64_t omega_session_get_original_file_size(const omega_session_t *session_ptr);
 
 /**
  * Given a session, get the last change (if any)

--- a/core/src/include/omega_edit/transform.h
+++ b/core/src/include/omega_edit/transform.h
@@ -175,6 +175,15 @@ int omega_transform_plugin_registry_apply_to_session_with_progress_and_serial(
         int64_t offset, int64_t length, const char *options_json, omega_transform_plugin_progress_cbk_t progress,
         void *progress_user_data_ptr, omega_transform_plugin_response_t *response_ptr, int64_t *change_serial_out);
 
+int omega_transform_plugin_registry_inspect_reader(omega_transform_plugin_registry_t *registry_ptr,
+                                                   const char *plugin_id, int64_t session_offset,
+                                                   int64_t session_length, const char *options_json,
+                                                   const char *checkpoint_directory, omega_transform_plugin_read_t read,
+                                                   void *reader_user_data_ptr, int64_t preferred_chunk_size,
+                                                   omega_transform_plugin_progress_cbk_t progress,
+                                                   void *progress_user_data_ptr,
+                                                   omega_transform_plugin_response_t *response_ptr);
+
 /**
  * Release response-owned replacement/result buffers and reset all fields to zero/null.
  */

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -69,7 +69,7 @@ int omega_session_get_original_segment(const omega_session_t *session_ptr, omega
     if (original_file_size < 0 || offset > original_file_size) { return -1; }
     if (data_segment_ptr->capacity == 0 || offset == original_file_size) { return 0; }
 
-    const auto read_length = std::min(data_segment_ptr->capacity, original_file_size - offset);
+    const auto read_length = (std::min)(data_segment_ptr->capacity, original_file_size - offset);
     auto *file_ptr = session_ptr->models_.front()->file_ptr;
     if (file_ptr == nullptr) { return read_length == 0 ? 0 : -1; }
     if (0 != FSEEK(file_ptr, offset, SEEK_SET)) { return -1; }
@@ -368,7 +368,7 @@ int omega_session_byte_frequency_profile(const omega_session_t *session_ptr,
     }
     memset(profile_ptr, 0, sizeof(omega_byte_frequency_profile_t));
     if (0 < length) {
-        const auto segment_ptr = omega_segment_create(std::min(length, static_cast<int64_t>(BUFSIZ)));
+        const auto segment_ptr = omega_segment_create((std::min)(length, static_cast<int64_t>(BUFSIZ)));
         omega_byte_t last_profiled_byte = 0;
         int64_t dos_eol_count = 0;
         while (length) {
@@ -377,7 +377,7 @@ int omega_session_byte_frequency_profile(const omega_session_t *session_ptr,
                 omega_segment_destroy(segment_ptr);
                 return rc;
             }
-            const auto profile_length = std::min(length, omega_segment_get_length(segment_ptr));
+            const auto profile_length = (std::min)(length, omega_segment_get_length(segment_ptr));
             const auto segment_data = omega_segment_get_data(segment_ptr);
             for (auto i = 0; i < profile_length; ++i) {
                 if (last_profiled_byte == '\r' && segment_data[i] == '\n') { ++dos_eol_count; }
@@ -405,7 +405,7 @@ int omega_session_character_counts(const omega_session_t *session_ptr, omega_cha
         return -1;
     }
     omega_character_counts_set_BOM(omega_character_counts_reset(counts_ptr), bom);
-    const auto segment_ptr = omega_segment_create(std::min(length, static_cast<int64_t>(BUFSIZ)));
+    const auto segment_ptr = omega_segment_create((std::min)(length, static_cast<int64_t>(BUFSIZ)));
     while (length) {
         const auto rc = omega_session_get_segment(session_ptr, segment_ptr, offset);
         if (rc != 0) {
@@ -413,7 +413,7 @@ int omega_session_character_counts(const omega_session_t *session_ptr, omega_cha
             return rc;
         }
         const auto segment_data = omega_segment_get_data(segment_ptr);
-        const auto count_length = std::min(length, omega_segment_get_length(segment_ptr));
+        const auto count_length = (std::min)(length, omega_segment_get_length(segment_ptr));
         omega_util_count_characters(segment_data, count_length, counts_ptr);
         if (!safe_add_int64_(offset, count_length, offset)) {
             omega_segment_destroy(segment_ptr);

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -16,6 +16,7 @@
 #include "impl_/change_def.hpp"
 #include "impl_/character_counts_def.h"
 #include "impl_/internal_fun.hpp"
+#include "impl_/macros.h"
 #include "impl_/model_def.hpp"
 #include "impl_/safe_math.hpp"
 #include "impl_/segment_def.hpp"
@@ -24,10 +25,12 @@
 #include "omega_edit/fwd_defs.h"
 #include "omega_edit/segment.h"
 #include "omega_edit/viewport.h"
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 
 using omega_edit::internal::omega_change_get_transaction_bit_;
+using omega_edit::internal::omega_data_get_data_;
 using omega_edit::internal::omega_session_end_event_batch_;
 using omega_edit::internal::populate_data_segment_;
 using omega_edit::internal::safe_add_int64_;
@@ -45,6 +48,38 @@ int omega_session_get_segment(const omega_session_t *session_ptr, omega_segment_
     if (!session_ptr || !data_segment_ptr || offset < 0 || data_segment_ptr->capacity < 0) { return -1; }
     data_segment_ptr->offset = offset;
     return populate_data_segment_(session_ptr, data_segment_ptr);
+}
+
+int64_t omega_session_get_original_file_size(const omega_session_t *session_ptr) {
+    if (!session_ptr || session_ptr->models_.empty() || !session_ptr->models_.front()) { return -1; }
+    auto *file_ptr = session_ptr->models_.front()->file_ptr;
+    if (file_ptr == nullptr) { return 0; }
+    if (0 != FSEEK(file_ptr, 0L, SEEK_END)) { return -1; }
+    const auto file_size = FTELL(file_ptr);
+    return file_size < 0 ? -1 : file_size;
+}
+
+int omega_session_get_original_segment(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr,
+                                       int64_t offset) {
+    if (!session_ptr || !data_segment_ptr || offset < 0 || data_segment_ptr->capacity < 0) { return -1; }
+    data_segment_ptr->offset = offset;
+    data_segment_ptr->length = 0;
+
+    const auto original_file_size = omega_session_get_original_file_size(session_ptr);
+    if (original_file_size < 0 || offset > original_file_size) { return -1; }
+    if (data_segment_ptr->capacity == 0 || offset == original_file_size) { return 0; }
+
+    const auto read_length = std::min(data_segment_ptr->capacity, original_file_size - offset);
+    auto *file_ptr = session_ptr->models_.front()->file_ptr;
+    if (file_ptr == nullptr) { return read_length == 0 ? 0 : -1; }
+    if (0 != FSEEK(file_ptr, offset, SEEK_SET)) { return -1; }
+
+    auto *data = omega_data_get_data_(&data_segment_ptr->data, data_segment_ptr->capacity);
+    const auto actual = static_cast<int64_t>(fread(data, sizeof(omega_byte_t), read_length, file_ptr));
+    if (actual != read_length) { return -1; }
+    data_segment_ptr->length = actual;
+    data[data_segment_ptr->length] = '\0';
+    return 0;
 }
 
 int64_t omega_session_get_num_viewports(const omega_session_t *session_ptr) {

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -1053,6 +1053,60 @@ int omega_transform_plugin_registry_apply_to_session_with_progress_and_serial(
     return 0;
 }
 
+int omega_transform_plugin_registry_inspect_reader(omega_transform_plugin_registry_t *registry_ptr,
+                                                   const char *plugin_id, int64_t session_offset,
+                                                   int64_t session_length, const char *options_json,
+                                                   const char *checkpoint_directory, omega_transform_plugin_read_t read,
+                                                   void *reader_user_data_ptr, int64_t preferred_chunk_size,
+                                                   omega_transform_plugin_progress_cbk_t progress,
+                                                   void *progress_user_data_ptr,
+                                                   omega_transform_plugin_response_t *response_ptr) {
+    if (response_ptr) { omega_transform_plugin_response_clear(response_ptr); }
+    if (!registry_ptr || !plugin_id || !*plugin_id || session_offset < 0 || session_length < 0 || !read) { return -1; }
+
+    auto iter = std::find_if(registry_ptr->plugins.begin(), registry_ptr->plugins.end(),
+                             [plugin_id](const auto &plugin) { return plugin->info.id == std::string(plugin_id); });
+    if (iter == registry_ptr->plugins.end()) { return -1; }
+    if ((*iter)->info.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT) { return -1; }
+    if (((*iter)->info.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) { return -1; }
+    if (0 != omega_transform_plugin_options_match_args_schema(options_json, (*iter)->info.args_schema)) { return -1; }
+
+    plugin_allocator_state_t allocator_state{checkpoint_directory, {}};
+
+    omega_transform_plugin_request_t request{};
+    request.input_length = 0;
+    request.session_offset = session_offset;
+    request.session_length = session_length;
+    request.options_json = options_json;
+    request.alloc = plugin_alloc_;
+    request.allocator_user_data_ptr = &allocator_state;
+    request.read = read;
+    request.reader_user_data_ptr = reader_user_data_ptr;
+    request.preferred_chunk_size = preferred_chunk_size > 0
+                                           ? std::min(preferred_chunk_size, TRANSFORM_PLUGIN_STREAM_CHUNK_BYTES)
+                                           : TRANSFORM_PLUGIN_STREAM_CHUNK_BYTES;
+    request.progress = progress;
+    request.progress_user_data_ptr = progress_user_data_ptr;
+
+    omega_transform_plugin_response_t plugin_response{};
+    if (0 != (*iter)->apply(&request, &plugin_response)) {
+        release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
+        omega_transform_plugin_response_clear(&plugin_response);
+        return -1;
+    }
+    if (!plugin_buffer_is_valid_(plugin_response.replacement_bytes, plugin_response.replacement_length) ||
+        !plugin_buffer_is_valid_(plugin_response.result_bytes, plugin_response.result_length) ||
+        plugin_response.replacement_bytes != nullptr || plugin_response.replacement_length != 0) {
+        release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
+        omega_transform_plugin_response_clear(&plugin_response);
+        return -1;
+    }
+
+    release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
+    move_plugin_response_(response_ptr, plugin_response);
+    return 0;
+}
+
 void omega_transform_plugin_response_clear(omega_transform_plugin_response_t *response_ptr) {
     if (!response_ptr) { return; }
     release_plugin_allocation_(response_ptr->replacement_bytes);

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -79,9 +79,9 @@ codecs, transcodes, record/message helpers, and digest/checksum inspectors.
 All CLI commands emit JSON to stdout and return non-zero exit codes on failure.
 Exported change logs are portable `omega-edit.change-log` documents containing
 the byte operations needed to apply the same edits to another session, another
-file, or a fleet of compatible files. `foldedChangeCount` is non-zero when
-earlier edits have been absorbed into an OmegaEdit checkpoint baseline rather
-than exported as replayable byte operations.
+file, or a fleet of compatible files. Non-streaming change logs include
+before/after content fingerprints, and export fails instead of writing an
+incomplete replay log when any change details are unavailable.
 
 ## MCP Quick Start
 

--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -11,7 +11,7 @@ import {
 } from './constants'
 import { OmegaEditToolkit } from './service'
 import { parseInputData } from './codec'
-import { ChangeLogEntry, InputEncoding, PatchKind } from './types'
+import { ChangeLogDocument, InputEncoding, PatchKind } from './types'
 
 type JsonObject = Record<string, unknown>
 
@@ -112,16 +112,16 @@ function getNumber(
   return value
 }
 
-function getChangeLogEntries(
+function getChangeLogDocument(
   object: JsonObject,
   key: string
-): ChangeLogEntry[] | undefined {
+): ChangeLogDocument | undefined {
   const value = object[key]
   if (value === undefined) return undefined
-  if (!Array.isArray(value)) {
-    throw new Error(`${key} must be an array`)
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${key} must be an object`)
   }
-  return value as ChangeLogEntry[]
+  return value as ChangeLogDocument
 }
 
 function getInputValue(argumentsObject: JsonObject): {
@@ -328,13 +328,13 @@ function buildTools(toolkit: OmegaEditToolkit): ToolDefinition[] {
     {
       name: 'omega_edit_apply_change_log',
       description:
-        'Apply an OmegaEdit change log to a session from an inputPath or inline changeLog array.',
+        'Apply a versioned OmegaEdit change-log document to a session from an inputPath or inline changeLog object.',
       inputSchema: {
         type: 'object',
         properties: {
           sessionId: { type: 'string' },
           inputPath: { type: 'string' },
-          changeLog: { type: 'array', items: { type: 'object' } },
+          changeLog: { type: 'object' },
           dryRun: { type: 'boolean' },
         },
         required: ['sessionId'],
@@ -343,7 +343,7 @@ function buildTools(toolkit: OmegaEditToolkit): ToolDefinition[] {
         return await toolkit.applyChangeLog({
           sessionId: getString(argumentsObject, 'sessionId', true)!,
           inputPath: getString(argumentsObject, 'inputPath'),
-          changes: getChangeLogEntries(argumentsObject, 'changeLog'),
+          changes: getChangeLogDocument(argumentsObject, 'changeLog'),
           dryRun: getBoolean(argumentsObject, 'dryRun') || false,
         })
       },

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -4,8 +4,10 @@ import {
   delay,
   type IServerControlResult,
   IOFlags,
+  SessionFingerprintContent,
   TransformPluginOperation,
   applyTransformPlugin as applyClientTransformPlugin,
+  checkSessionModel,
   createCheckpoint as createClientCheckpoint,
   createSession,
   del,
@@ -20,6 +22,7 @@ import {
   getLastChange,
   getServerInfo,
   getSegment,
+  getSessionFingerprint,
   isPortAvailable,
   getUndoCount,
   getViewportCount,
@@ -57,6 +60,7 @@ import {
   ApplyChangeLogResult,
   ChangeLogDocument,
   ChangeLogEntry,
+  ChangeLogFingerprint,
   ChangeLogResult,
   CheckpointResult,
   PatchPreview,
@@ -79,8 +83,20 @@ const MAX_CHANGE_LOG_ENTRY_BYTES = 32 * 1024 * 1024
 const MAX_CHANGE_LOG_BYTES = MAX_CHANGE_LOG_ENTRY_BYTES * 3
 const MAX_CHANGE_LOG_JSON_NESTING = 256
 const CHANGE_LOG_FORMAT = 'omega-edit.change-log'
-const CHANGE_LOG_VERSION = 1
+const CHANGE_LOG_VERSION = 2
+const DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM = 'sha256'
 const GRPC_NOT_FOUND = 5
+
+interface CollectedChangeLogEntries {
+  changes: ChangeLogEntry[]
+  unavailableChangeSerials: number[]
+}
+
+interface ParsedChangeLog {
+  changes: ChangeLogEntry[]
+  before?: ChangeLogFingerprint
+  after?: ChangeLogFingerprint
+}
 
 const changeKindNames = new Map<number, string>(
   Object.entries(ChangeKind)
@@ -140,22 +156,24 @@ function assertJsonNestingLimit(text: string): void {
   }
 }
 
-function normalizeChangeLogEntries(value: unknown): ChangeLogEntry[] {
+function normalizeChangeLogEntries(value: unknown): ParsedChangeLog {
   let entries: unknown[] | undefined
-  if (Array.isArray(value)) {
-    entries = value
-  } else if (isRecord(value)) {
+  let document: Record<string, unknown> | undefined
+  if (isRecord(value)) {
     if (value.format !== CHANGE_LOG_FORMAT) {
       throw new Error('Unsupported change log format')
     }
     if (value.version !== CHANGE_LOG_VERSION) {
       throw new Error('Unsupported change log version')
     }
+    document = value
     entries = Array.isArray(value.changes) ? value.changes : undefined
   }
 
   if (!entries) {
-    throw new Error('Change log must be a JSON array or an object with changes')
+    throw new Error(
+      'Change log must be a versioned omega-edit.change-log document'
+    )
   }
   if (entries.length > MAX_CHANGE_LOG_ENTRIES) {
     throw new Error(
@@ -167,7 +185,180 @@ function normalizeChangeLogEntries(value: unknown): ChangeLogEntry[] {
     normalizeChangeLogEntry(entry, index)
   )
   validateChangeLogMetadata(normalized)
-  return normalized
+  if (document) {
+    validateChangeLogDocumentMetadata(document, normalized)
+    return {
+      changes: normalized,
+      before: normalizeChangeLogFingerprint(document.before, 'before'),
+      after: normalizeChangeLogFingerprint(document.after, 'after'),
+    }
+  }
+  return { changes: normalized }
+}
+
+function readDocumentCount(
+  document: Record<string, unknown>,
+  key: string
+): number {
+  const value = document[key]
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Change log ${key} must be a non-negative safe integer`)
+  }
+  return value
+}
+
+function normalizeUnavailableChangeSerials(
+  value: unknown,
+  sourceChangeCount: number
+): number[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Change log unavailableChangeSerials must be an array')
+  }
+
+  const seen = new Set<number>()
+  return value.map((serial, index) => {
+    if (
+      typeof serial !== 'number' ||
+      !Number.isSafeInteger(serial) ||
+      serial <= 0
+    ) {
+      throw new Error(
+        `Change log unavailableChangeSerials[${index}] must be a positive safe integer`
+      )
+    }
+    if (serial > sourceChangeCount) {
+      throw new Error(
+        `Change log unavailableChangeSerials[${index}] exceeds sourceChangeCount`
+      )
+    }
+    if (seen.has(serial)) {
+      throw new Error(
+        `Change log unavailableChangeSerials[${index}] duplicates serial ${serial}`
+      )
+    }
+    seen.add(serial)
+    return serial
+  })
+}
+
+function normalizeChangeLogFingerprint(
+  value: unknown,
+  key: 'before' | 'after'
+): ChangeLogFingerprint {
+  if (!isRecord(value)) {
+    throw new Error(`Change log ${key} fingerprint must be an object`)
+  }
+
+  const byteLength = value.byteLength
+  if (
+    typeof byteLength !== 'number' ||
+    !Number.isSafeInteger(byteLength) ||
+    byteLength < 0
+  ) {
+    throw new Error(
+      `Change log ${key}.byteLength must be a non-negative safe integer`
+    )
+  }
+
+  if (!isRecord(value.digest)) {
+    throw new Error(`Change log ${key}.digest must be an object`)
+  }
+
+  const algorithm = value.digest.algorithm
+  if (typeof algorithm !== 'string' || !algorithm.trim()) {
+    throw new Error(`Change log ${key}.digest.algorithm must be a string`)
+  }
+
+  const digestValue = value.digest.value
+  if (typeof digestValue !== 'string' || !digestValue.trim()) {
+    throw new Error(`Change log ${key}.digest.value must be a string`)
+  }
+
+  return {
+    byteLength,
+    digest: {
+      algorithm: algorithm.trim().toLowerCase(),
+      value: digestValue.trim().toLowerCase(),
+    },
+  }
+}
+
+function describeUnavailableSerials(serials: number[]): string {
+  const preview = serials.slice(0, 10).join(', ')
+  const suffix = serials.length > 10 ? ', ...' : ''
+  return preview ? ` (serials: ${preview}${suffix})` : ''
+}
+
+function incompleteChangeLogMessage(action: 'export' | 'apply'): string {
+  return action === 'export'
+    ? 'Change log export is incomplete: the server no longer has details for every reported change'
+    : 'Change log is incomplete: unavailable change details cannot be replayed safely'
+}
+
+function assertCompleteChangeLog(
+  action: 'export' | 'apply',
+  unavailableChangeSerials: number[]
+): void {
+  if (unavailableChangeSerials.length === 0) {
+    return
+  }
+  throw new Error(
+    `${incompleteChangeLogMessage(action)}${describeUnavailableSerials(
+      unavailableChangeSerials
+    )}`
+  )
+}
+
+async function assertSessionModelValidForChangeLogExport(
+  sessionId: string
+): Promise<void> {
+  const check = await checkSessionModel(sessionId)
+  if (check.valid) {
+    return
+  }
+
+  throw new Error(
+    `Change log export refused: OmegaEdit model integrity check failed with status ${check.status}`
+  )
+}
+
+function validateChangeLogDocumentMetadata(
+  document: Record<string, unknown>,
+  changes: ChangeLogEntry[]
+): void {
+  if (typeof document.complete !== 'boolean') {
+    throw new Error('Change log complete must be a boolean')
+  }
+
+  const changeCount = readDocumentCount(document, 'changeCount')
+  const sourceChangeCount = readDocumentCount(document, 'sourceChangeCount')
+  const unavailableChangeCount = readDocumentCount(
+    document,
+    'unavailableChangeCount'
+  )
+  if (changeCount !== changes.length) {
+    throw new Error('Change log changeCount must match changes length')
+  }
+  if (sourceChangeCount < changeCount) {
+    throw new Error('Change log sourceChangeCount must cover changeCount')
+  }
+
+  const unavailableChangeSerials = normalizeUnavailableChangeSerials(
+    document.unavailableChangeSerials,
+    sourceChangeCount
+  )
+  if (unavailableChangeCount !== unavailableChangeSerials.length) {
+    throw new Error(
+      'Change log unavailableChangeCount must match unavailableChangeSerials length'
+    )
+  }
+  if (document.complete !== (unavailableChangeCount === 0)) {
+    throw new Error(
+      'Change log complete must match unavailable change metadata'
+    )
+  }
+
+  assertCompleteChangeLog('apply', unavailableChangeSerials)
 }
 
 function normalizeChangeLogEntry(
@@ -349,7 +540,7 @@ function validateChangeLogMetadata(entries: ChangeLogEntry[]): void {
   }
 }
 
-async function readChangeLogFile(inputPath: string): Promise<ChangeLogEntry[]> {
+async function readChangeLogFile(inputPath: string): Promise<ParsedChangeLog> {
   const stat = await fs.stat(inputPath)
   if (stat.size > MAX_CHANGE_LOG_BYTES) {
     throw new Error(
@@ -433,8 +624,9 @@ function hasGrpcStatusCode(error: unknown, code: number): boolean {
 async function collectChangeLogEntries(
   sessionId: string,
   sourceChangeCount: number
-): Promise<ChangeLogEntry[]> {
+): Promise<CollectedChangeLogEntries> {
   const changes: ChangeLogEntry[] = []
+  const unavailableChangeSerials: number[] = []
   for (let serial = 1; serial <= sourceChangeCount; serial += 1) {
     try {
       changes.push(
@@ -444,9 +636,10 @@ async function collectChangeLogEntries(
       if (!isMissingChangeDetailsError(error)) {
         throw error
       }
+      unavailableChangeSerials.push(serial)
     }
   }
-  return changes
+  return { changes, unavailableChangeSerials }
 }
 
 async function rollbackSessionToChangeCount(
@@ -493,16 +686,79 @@ function changeLogApplyErrorWithRollbackFailure(
   return error
 }
 
+async function getChangeLogFingerprint(
+  sessionId: string,
+  content: SessionFingerprintContent,
+  algorithm = DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM
+): Promise<ChangeLogFingerprint> {
+  const response = await getSessionFingerprint(sessionId, content, algorithm)
+  if (!response.fingerprint?.digest) {
+    throw new Error('Server fingerprint response is missing digest metadata')
+  }
+
+  return {
+    byteLength: response.fingerprint.byteLength,
+    digest: {
+      algorithm: response.fingerprint.digest.algorithm.toLowerCase(),
+      value: response.fingerprint.digest.value.toLowerCase(),
+    },
+  }
+}
+
+function fingerprintLabel(fingerprint: ChangeLogFingerprint): string {
+  return `${fingerprint.byteLength} bytes ${fingerprint.digest.algorithm}:${fingerprint.digest.value}`
+}
+
+function fingerprintsMatch(
+  actual: ChangeLogFingerprint,
+  expected: ChangeLogFingerprint
+): boolean {
+  return (
+    actual.byteLength === expected.byteLength &&
+    actual.digest.algorithm === expected.digest.algorithm &&
+    actual.digest.value === expected.digest.value
+  )
+}
+
+async function assertCurrentSessionFingerprint(
+  sessionId: string,
+  expected: ChangeLogFingerprint,
+  phase: 'before' | 'after'
+): Promise<void> {
+  const actual = await getChangeLogFingerprint(
+    sessionId,
+    SessionFingerprintContent.COMPUTED,
+    expected.digest.algorithm
+  )
+  if (fingerprintsMatch(actual, expected)) {
+    return
+  }
+
+  const preposition = phase === 'before' ? 'before applying' : 'after applying'
+  throw new Error(
+    `Change log ${phase} fingerprint mismatch ${preposition}: expected ${fingerprintLabel(
+      expected
+    )}, actual ${fingerprintLabel(actual)}`
+  )
+}
+
 function createChangeLogDocument(
   changes: ChangeLogEntry[],
-  sourceChangeCount: number
+  sourceChangeCount: number,
+  unavailableChangeSerials: number[],
+  before: ChangeLogFingerprint,
+  after: ChangeLogFingerprint
 ): ChangeLogDocument {
   return {
     format: CHANGE_LOG_FORMAT,
     version: CHANGE_LOG_VERSION,
+    complete: unavailableChangeSerials.length === 0,
+    before,
+    after,
     changeCount: changes.length,
     sourceChangeCount,
-    foldedChangeCount: sourceChangeCount - changes.length,
+    unavailableChangeCount: unavailableChangeSerials.length,
+    unavailableChangeSerials,
     changes,
   }
 }
@@ -716,6 +972,11 @@ export class OmegaEditToolkit {
   ): Promise<ChangeLogResult> {
     await this.ensureServerRunning()
 
+    await assertSessionModelValidForChangeLogExport(sessionId)
+    const before = await getChangeLogFingerprint(
+      sessionId,
+      SessionFingerprintContent.ORIGINAL
+    )
     const sourceChangeCount = await getChangeCount(sessionId)
     if (sourceChangeCount > MAX_CHANGE_LOG_ENTRIES) {
       throw new Error(
@@ -723,8 +984,23 @@ export class OmegaEditToolkit {
       )
     }
 
-    const changes = await collectChangeLogEntries(sessionId, sourceChangeCount)
-    const document = createChangeLogDocument(changes, sourceChangeCount)
+    const collected = await collectChangeLogEntries(
+      sessionId,
+      sourceChangeCount
+    )
+    assertCompleteChangeLog('export', collected.unavailableChangeSerials)
+    const after = await getChangeLogFingerprint(
+      sessionId,
+      SessionFingerprintContent.COMPUTED,
+      before.digest.algorithm
+    )
+    const document = createChangeLogDocument(
+      collected.changes,
+      sourceChangeCount,
+      collected.unavailableChangeSerials,
+      before,
+      after
+    )
 
     if (outputPath) {
       await fs.writeFile(outputPath, `${JSON.stringify(document, null, 2)}\n`, {
@@ -736,10 +1012,14 @@ export class OmegaEditToolkit {
       sessionId,
       format: document.format,
       version: document.version,
-      changeCount: changes.length,
+      complete: document.complete,
+      before: document.before,
+      after: document.after,
+      changeCount: document.changeCount,
       sourceChangeCount: document.sourceChangeCount,
-      foldedChangeCount: document.foldedChangeCount,
-      changes,
+      unavailableChangeCount: document.unavailableChangeCount,
+      unavailableChangeSerials: document.unavailableChangeSerials,
+      changes: document.changes,
       outputPath,
     }
   }
@@ -747,53 +1027,70 @@ export class OmegaEditToolkit {
   async applyChangeLog(
     request: ApplyChangeLogRequest
   ): Promise<ApplyChangeLogResult> {
-    const changes = request.inputPath
+    const parsed = request.inputPath
       ? await readChangeLogFile(request.inputPath)
       : normalizeChangeLogEntries(request.changes)
+    const { changes } = parsed
 
     if (request.dryRun) {
       return {
         sessionId: request.sessionId,
         applied: false,
-        changeCount: changes.length,
+        changeCount: 0,
+        inputChangeCount: changes.length,
         inputPath: request.inputPath,
       }
     }
 
     await this.ensureServerRunning()
 
-    if (changes.length > 0) {
-      const startChangeCount = await getChangeCount(request.sessionId)
+    if (parsed.before) {
+      await assertCurrentSessionFingerprint(
+        request.sessionId,
+        parsed.before,
+        'before'
+      )
+    }
+
+    let appliedChangeCount = 0
+    const startChangeCount = await getChangeCount(request.sessionId)
+    try {
       const applyChange = async (change: ChangeLogEntry) => {
         const data = Buffer.from(change.data, 'hex')
         switch (change.kind) {
           case 'INSERT':
             await insert(request.sessionId, change.offset, data)
-            break
+            return true
           case 'DELETE':
             await del(request.sessionId, change.offset, change.length)
-            break
+            return true
           case 'OVERWRITE':
             await overwrite(request.sessionId, change.offset, data)
-            break
+            return true
           case 'REPLACE':
             await replace(request.sessionId, change.offset, change.length, data)
-            break
+            return true
           case 'TRANSFORM':
             if (!change.transformId) {
               throw new Error('TRANSFORM change requires transformId')
             }
-            await applyClientTransformPlugin(
-              request.sessionId,
-              change.transformId,
-              change.offset,
-              change.length,
-              change.optionsJson
-            )
-            break
+            return (
+              await applyClientTransformPlugin(
+                request.sessionId,
+                change.transformId,
+                change.offset,
+                change.length,
+                change.optionsJson
+              )
+            ).contentChanged
         }
       }
-      try {
+      const applyAndCountChange = async (change: ChangeLogEntry) => {
+        if (await applyChange(change)) {
+          appliedChangeCount += 1
+        }
+      }
+      if (changes.length > 0) {
         let pendingBatch: ChangeLogEntry[] = []
         const flushBatch = async () => {
           if (pendingBatch.length === 0) {
@@ -804,7 +1101,7 @@ export class OmegaEditToolkit {
           pendingBatch = []
           await runSessionTransaction(request.sessionId, async () => {
             for (const change of batch) {
-              await applyChange(change)
+              await applyAndCountChange(change)
             }
           })
         }
@@ -812,29 +1109,35 @@ export class OmegaEditToolkit {
         for (const change of changes) {
           if (change.kind === 'TRANSFORM') {
             await flushBatch()
-            await applyChange(change)
+            await applyAndCountChange(change)
           } else {
             pendingBatch.push(change)
           }
         }
         await flushBatch()
-      } catch (error) {
-        try {
-          await rollbackSessionToChangeCount(
-            request.sessionId,
-            startChangeCount
-          )
-        } catch (rollbackError) {
-          throw changeLogApplyErrorWithRollbackFailure(error, rollbackError)
-        }
-        throw error
       }
+
+      if (parsed.after) {
+        await assertCurrentSessionFingerprint(
+          request.sessionId,
+          parsed.after,
+          'after'
+        )
+      }
+    } catch (error) {
+      try {
+        await rollbackSessionToChangeCount(request.sessionId, startChangeCount)
+      } catch (rollbackError) {
+        throw changeLogApplyErrorWithRollbackFailure(error, rollbackError)
+      }
+      throw error
     }
 
     return {
       sessionId: request.sessionId,
       applied: true,
-      changeCount: changes.length,
+      changeCount: appliedChangeCount,
+      inputChangeCount: changes.length,
       inputPath: request.inputPath,
     }
   }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -53,29 +53,47 @@ export interface ChangeLogEntry {
   groupId?: string
 }
 
+export interface ChangeLogDigest {
+  algorithm: string
+  value: string
+}
+
+export interface ChangeLogFingerprint {
+  byteLength: number
+  digest: ChangeLogDigest
+}
+
 export interface ChangeLogDocument {
   format: 'omega-edit.change-log'
-  version: 1
+  version: 2
+  complete: boolean
+  before: ChangeLogFingerprint
+  after: ChangeLogFingerprint
   changeCount: number
   sourceChangeCount: number
-  foldedChangeCount: number
+  unavailableChangeCount: number
+  unavailableChangeSerials: number[]
   changes: ChangeLogEntry[]
 }
 
 export interface ChangeLogResult {
   sessionId: string
   format: 'omega-edit.change-log'
-  version: 1
+  version: 2
+  complete: boolean
+  before: ChangeLogFingerprint
+  after: ChangeLogFingerprint
   changeCount: number
   sourceChangeCount: number
-  foldedChangeCount: number
+  unavailableChangeCount: number
+  unavailableChangeSerials: number[]
   changes: ChangeLogEntry[]
   outputPath?: string
 }
 
 export interface ApplyChangeLogRequest {
   sessionId: string
-  changes?: ChangeLogEntry[] | ChangeLogDocument
+  changes?: ChangeLogDocument
   inputPath?: string
   dryRun?: boolean
 }
@@ -84,6 +102,7 @@ export interface ApplyChangeLogResult {
   sessionId: string
   applied: boolean
   changeCount: number
+  inputChangeCount: number
   inputPath?: string
 }
 

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -6,6 +6,42 @@ import * as path from 'path'
 import * as omegaEditClient from '@omega-edit/client'
 import { OmegaEditToolkit } from '../../src/service'
 import { parseInputData } from '../../src/codec'
+import type { ChangeLogDocument, ChangeLogEntry } from '../../src/types'
+
+const EMPTY_SHA256_FINGERPRINT = {
+  byteLength: 0,
+  digest: {
+    algorithm: 'sha256',
+    value: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+  },
+}
+
+const ABCDEF_SHA256_FINGERPRINT = {
+  byteLength: 6,
+  digest: {
+    algorithm: 'sha256',
+    value: 'bef57ec7f53a6d40beb640a780a639c83bc29ac8a9816f1fc6c5c6dcd93c4721',
+  },
+}
+
+function makeChangeLogDocument(
+  changes: ChangeLogEntry[],
+  overrides: Partial<ChangeLogDocument> = {}
+): ChangeLogDocument {
+  const document: ChangeLogDocument = {
+    format: 'omega-edit.change-log',
+    version: 2,
+    complete: true,
+    before: EMPTY_SHA256_FINGERPRINT,
+    after: EMPTY_SHA256_FINGERPRINT,
+    changeCount: changes.length,
+    sourceChangeCount: changes.length,
+    unavailableChangeCount: 0,
+    unavailableChangeSerials: [],
+    changes,
+  }
+  return { ...document, ...overrides }
+}
 
 describe('@omega-edit/ai toolkit', () => {
   it('preserves the original connection failure as the cause', async function () {
@@ -47,7 +83,7 @@ describe('@omega-edit/ai toolkit', () => {
         invalidVersionPath,
         JSON.stringify({
           format: 'omega-edit.change-log',
-          version: 2,
+          version: 1,
           changes: [],
         })
       )
@@ -92,25 +128,36 @@ describe('@omega-edit/ai toolkit', () => {
     const wrappedDocument = await toolkit.applyChangeLog({
       sessionId: 'session',
       dryRun: true,
-      changes: {
-        format: 'omega-edit.change-log',
-        version: 1,
-        changeCount: 0,
-        sourceChangeCount: 0,
-        foldedChangeCount: 0,
-        changes: [],
-      },
+      changes: makeChangeLogDocument([]),
     })
     assert.equal(wrappedDocument.applied, false)
     assert.equal(wrappedDocument.changeCount, 0)
+    assert.equal(wrappedDocument.inputChangeCount, 0)
 
-    const legacyArray = await toolkit.applyChangeLog({
-      sessionId: 'session',
-      dryRun: true,
-      changes: [],
-    })
-    assert.equal(legacyArray.applied, false)
-    assert.equal(legacyArray.changeCount, 0)
+    await assert.rejects(
+      () =>
+        toolkit.applyChangeLog({
+          sessionId: 'session',
+          dryRun: true,
+          changes: makeChangeLogDocument([], {
+            complete: false,
+            sourceChangeCount: 1,
+            unavailableChangeCount: 1,
+            unavailableChangeSerials: [1],
+          }),
+        }),
+      /Change log is incomplete/
+    )
+
+    await assert.rejects(
+      () =>
+        (toolkit.applyChangeLog as any)({
+          sessionId: 'session',
+          dryRun: true,
+          changes: [],
+        }),
+      /versioned omega-edit\.change-log document/
+    )
   })
 
   it('rejects inconsistent change-log serial and group metadata', async function () {
@@ -121,7 +168,7 @@ describe('@omega-edit/ai toolkit', () => {
         toolkit.applyChangeLog({
           sessionId: 'session',
           dryRun: true,
-          changes: [
+          changes: makeChangeLogDocument([
             {
               serial: 1,
               kind: 'INSERT',
@@ -136,7 +183,7 @@ describe('@omega-edit/ai toolkit', () => {
               length: 0,
               data: '42',
             },
-          ],
+          ]),
         }),
       /serial metadata must be contiguous/
     )
@@ -146,7 +193,7 @@ describe('@omega-edit/ai toolkit', () => {
         toolkit.applyChangeLog({
           sessionId: 'session',
           dryRun: true,
-          changes: [
+          changes: makeChangeLogDocument([
             {
               kind: 'INSERT',
               offset: 0,
@@ -168,7 +215,7 @@ describe('@omega-edit/ai toolkit', () => {
               data: '43',
               groupId: 'batch-a',
             },
-          ],
+          ]),
         }),
       /groupId "batch-a" is not contiguous/
     )
@@ -277,20 +324,36 @@ describe('@omega-edit/ai toolkit', () => {
         true
       )
       assert.equal(exportedLog.format, 'omega-edit.change-log')
-      assert.equal(exportedLog.version, 1)
+      assert.equal(exportedLog.version, 2)
+      assert.equal(exportedLog.complete, true)
+      assert.equal(exportedLog.before.byteLength, 6)
+      assert.equal(exportedLog.before.digest.algorithm, 'sha256')
+      assert.match(exportedLog.before.digest.value, /^[0-9a-f]+$/)
+      assert.equal(exportedLog.after.byteLength, 6)
+      assert.equal(exportedLog.after.digest.algorithm, 'sha256')
+      assert.match(exportedLog.after.digest.value, /^[0-9a-f]+$/)
+      assert.notEqual(
+        exportedLog.before.digest.value,
+        exportedLog.after.digest.value
+      )
       assert.equal(exportedLog.changeCount, 1)
       assert.equal(exportedLog.sourceChangeCount, 1)
-      assert.equal(exportedLog.foldedChangeCount, 0)
+      assert.equal(exportedLog.unavailableChangeCount, 0)
+      assert.deepEqual(exportedLog.unavailableChangeSerials, [])
       assert.equal(exportedLog.changes[0].kind, 'OVERWRITE')
       assert.equal(fs.existsSync(changeLogPath), true)
       const changeLogDocument = JSON.parse(
         await fs.promises.readFile(changeLogPath, 'utf8')
       )
       assert.equal(changeLogDocument.format, 'omega-edit.change-log')
-      assert.equal(changeLogDocument.version, 1)
+      assert.equal(changeLogDocument.version, 2)
+      assert.equal(changeLogDocument.complete, true)
+      assert.deepEqual(changeLogDocument.before, exportedLog.before)
+      assert.deepEqual(changeLogDocument.after, exportedLog.after)
       assert.equal(changeLogDocument.changeCount, 1)
       assert.equal(changeLogDocument.sourceChangeCount, 1)
-      assert.equal(changeLogDocument.foldedChangeCount, 0)
+      assert.equal(changeLogDocument.unavailableChangeCount, 0)
+      assert.deepEqual(changeLogDocument.unavailableChangeSerials, [])
       assert.equal(changeLogDocument.changes[0].kind, 'OVERWRITE')
 
       await fs.promises.writeFile(replayPath, Buffer.from('abcdef', 'utf8'))
@@ -302,6 +365,7 @@ describe('@omega-edit/ai toolkit', () => {
         })
         assert.equal(appliedLog.applied, true)
         assert.equal(appliedLog.changeCount, 1)
+        assert.equal(appliedLog.inputChangeCount, 1)
         const replayedRange = await toolkit.readRange(
           replaySession.sessionId,
           0,
@@ -361,20 +425,25 @@ describe('@omega-edit/ai toolkit', () => {
         () =>
           toolkit.applyChangeLog({
             sessionId: createdSessionId,
-            changes: [
+            changes: makeChangeLogDocument(
+              [
+                {
+                  kind: 'INSERT',
+                  offset: 1,
+                  length: 0,
+                  data: Buffer.from('ZZ', 'utf8').toString('hex'),
+                },
+                {
+                  kind: 'DELETE',
+                  offset: 1000,
+                  length: 1,
+                  data: '',
+                },
+              ],
               {
-                kind: 'INSERT',
-                offset: 1,
-                length: 0,
-                data: Buffer.from('ZZ', 'utf8').toString('hex'),
-              },
-              {
-                kind: 'DELETE',
-                offset: 1000,
-                length: 1,
-                data: '',
-              },
-            ],
+                before: ABCDEF_SHA256_FINGERPRINT,
+              }
+            ),
           }),
         /delete failed|change operation failed|invalid change arguments/i
       )

--- a/packages/client/src/protobuf_ts/change.ts
+++ b/packages/client/src/protobuf_ts/change.ts
@@ -20,7 +20,6 @@
 import {
   ChangeKind as ProtoChangeKind,
   CountKind,
-  SessionEventKind,
   type GetCountResponse,
   type GetChangeDetailsResponse,
   type GetLastChangeResponse,
@@ -354,10 +353,6 @@ export async function getChangeDetails(
   const log = getLogger()
   const request = {
     sessionId,
-    sessionEventKind: SessionEventKind.UNSPECIFIED,
-    computedFileSize: 0,
-    changeCount: 0,
-    undoCount: 0,
     serial,
   }
   debugLog(log, () => ({ fn: 'protobufTs.getChangeDetails', rqst: request }))

--- a/packages/client/src/protobuf_ts/change.ts
+++ b/packages/client/src/protobuf_ts/change.ts
@@ -353,6 +353,10 @@ export async function getChangeDetails(
   const log = getLogger()
   const request = {
     sessionId,
+    sessionEventKind: 0,
+    computedFileSize: 0,
+    changeCount: 0,
+    undoCount: 0,
     serial,
   }
   debugLog(log, () => ({ fn: 'protobufTs.getChangeDetails', rqst: request }))

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -53,6 +53,10 @@ import type { GetSegmentResponse } from './omega_edit'
 import type { GetSegmentRequest } from './omega_edit'
 import type { GetSessionCountResponse } from './omega_edit'
 import type { GetSessionCountRequest } from './omega_edit'
+import type { GetSessionFingerprintResponse } from './omega_edit'
+import type { GetSessionFingerprintRequest } from './omega_edit'
+import type { CheckSessionModelResponse } from './omega_edit'
+import type { CheckSessionModelRequest } from './omega_edit'
 import type { GetCountResponse } from './omega_edit'
 import type { GetCountRequest } from './omega_edit'
 import type { GetLanguageResponse } from './omega_edit'
@@ -1205,6 +1209,80 @@ export interface IEditorServiceClient {
   getCount(
     input: GetCountRequest,
     callback: (err: grpc.ServiceError | null, value?: GetCountResponse) => void
+  ): grpc.ClientUnaryCall
+  /**
+   * Check the native session model for internal consistency.
+   *
+   * @generated from protobuf rpc: CheckSessionModel
+   */
+  checkSessionModel(
+    input: CheckSessionModelRequest,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: CheckSessionModelResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  checkSessionModel(
+    input: CheckSessionModelRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: CheckSessionModelResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  checkSessionModel(
+    input: CheckSessionModelRequest,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: CheckSessionModelResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  checkSessionModel(
+    input: CheckSessionModelRequest,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: CheckSessionModelResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  /**
+   * Compute a server-side fingerprint for original or computed session content.
+   *
+   * @generated from protobuf rpc: GetSessionFingerprint
+   */
+  getSessionFingerprint(
+    input: GetSessionFingerprintRequest,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: GetSessionFingerprintResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  getSessionFingerprint(
+    input: GetSessionFingerprintRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: GetSessionFingerprintResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  getSessionFingerprint(
+    input: GetSessionFingerprintRequest,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: GetSessionFingerprintResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  getSessionFingerprint(
+    input: GetSessionFingerprintRequest,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: GetSessionFingerprintResponse
+    ) => void
   ): grpc.ClientUnaryCall
   /**
    * Return the total number of active sessions on the server.
@@ -2961,6 +3039,88 @@ export class EditorServiceClient
     )
   }
   /**
+   * Check the native session model for internal consistency.
+   *
+   * @generated from protobuf rpc: CheckSessionModel
+   */
+  checkSessionModel(
+    input: CheckSessionModelRequest,
+    metadata:
+      | grpc.Metadata
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: CheckSessionModelResponse
+        ) => void),
+    options?:
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: CheckSessionModelResponse
+        ) => void),
+    callback?: (
+      err: grpc.ServiceError | null,
+      value?: CheckSessionModelResponse
+    ) => void
+  ): grpc.ClientUnaryCall {
+    const method = EditorService.methods[28]
+    return this.makeUnaryRequest<
+      CheckSessionModelRequest,
+      CheckSessionModelResponse
+    >(
+      `/${EditorService.typeName}/${method.name}`,
+      (value: CheckSessionModelRequest): Buffer =>
+        Buffer.from(method.I.toBinary(value, this._binaryOptions)),
+      (value: Buffer): CheckSessionModelResponse =>
+        method.O.fromBinary(value, this._binaryOptions),
+      input,
+      metadata as any,
+      options as any,
+      callback as any
+    )
+  }
+  /**
+   * Compute a server-side fingerprint for original or computed session content.
+   *
+   * @generated from protobuf rpc: GetSessionFingerprint
+   */
+  getSessionFingerprint(
+    input: GetSessionFingerprintRequest,
+    metadata:
+      | grpc.Metadata
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: GetSessionFingerprintResponse
+        ) => void),
+    options?:
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: GetSessionFingerprintResponse
+        ) => void),
+    callback?: (
+      err: grpc.ServiceError | null,
+      value?: GetSessionFingerprintResponse
+    ) => void
+  ): grpc.ClientUnaryCall {
+    const method = EditorService.methods[29]
+    return this.makeUnaryRequest<
+      GetSessionFingerprintRequest,
+      GetSessionFingerprintResponse
+    >(
+      `/${EditorService.typeName}/${method.name}`,
+      (value: GetSessionFingerprintRequest): Buffer =>
+        Buffer.from(method.I.toBinary(value, this._binaryOptions)),
+      (value: Buffer): GetSessionFingerprintResponse =>
+        method.O.fromBinary(value, this._binaryOptions),
+      input,
+      metadata as any,
+      options as any,
+      callback as any
+    )
+  }
+  /**
    * Return the total number of active sessions on the server.
    *
    * @generated from protobuf rpc: GetSessionCount
@@ -2985,7 +3145,7 @@ export class EditorServiceClient
       value?: GetSessionCountResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[28]
+    const method = EditorService.methods[30]
     return this.makeUnaryRequest<
       GetSessionCountRequest,
       GetSessionCountResponse
@@ -3020,7 +3180,7 @@ export class EditorServiceClient
       value?: GetSegmentResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[29]
+    const method = EditorService.methods[31]
     return this.makeUnaryRequest<GetSegmentRequest, GetSegmentResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetSegmentRequest): Buffer =>
@@ -3063,7 +3223,7 @@ export class EditorServiceClient
       value?: SearchSessionResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[30]
+    const method = EditorService.methods[32]
     return this.makeUnaryRequest<SearchSessionRequest, SearchSessionResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: SearchSessionRequest): Buffer =>
@@ -3103,7 +3263,7 @@ export class EditorServiceClient
       value?: ReplaceSessionResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[31]
+    const method = EditorService.methods[33]
     return this.makeUnaryRequest<ReplaceSessionRequest, ReplaceSessionResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: ReplaceSessionRequest): Buffer =>
@@ -3143,7 +3303,7 @@ export class EditorServiceClient
       value?: ReplaceSessionCheckpointedResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[32]
+    const method = EditorService.methods[34]
     return this.makeUnaryRequest<
       ReplaceSessionCheckpointedRequest,
       ReplaceSessionCheckpointedResponse
@@ -3184,7 +3344,7 @@ export class EditorServiceClient
       value?: CreateCheckpointResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[33]
+    const method = EditorService.methods[35]
     return this.makeUnaryRequest<
       CreateCheckpointRequest,
       CreateCheckpointResponse
@@ -3226,7 +3386,7 @@ export class EditorServiceClient
       value?: DestroyLastCheckpointResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[34]
+    const method = EditorService.methods[36]
     return this.makeUnaryRequest<
       DestroyLastCheckpointRequest,
       DestroyLastCheckpointResponse
@@ -3267,7 +3427,7 @@ export class EditorServiceClient
       value?: ListTransformPluginsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[35]
+    const method = EditorService.methods[37]
     return this.makeUnaryRequest<
       ListTransformPluginsRequest,
       ListTransformPluginsResponse
@@ -3309,7 +3469,7 @@ export class EditorServiceClient
       value?: ApplyTransformPluginResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[36]
+    const method = EditorService.methods[38]
     return this.makeUnaryRequest<
       ApplyTransformPluginRequest,
       ApplyTransformPluginResponse
@@ -3351,7 +3511,7 @@ export class EditorServiceClient
       value?: GetByteFrequencyProfileResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[37]
+    const method = EditorService.methods[39]
     return this.makeUnaryRequest<
       GetByteFrequencyProfileRequest,
       GetByteFrequencyProfileResponse
@@ -3393,7 +3553,7 @@ export class EditorServiceClient
       value?: GetCharacterCountsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[38]
+    const method = EditorService.methods[40]
     return this.makeUnaryRequest<
       GetCharacterCountsRequest,
       GetCharacterCountsResponse
@@ -3438,7 +3598,7 @@ export class EditorServiceClient
       value?: ServerControlResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[39]
+    const method = EditorService.methods[41]
     return this.makeUnaryRequest<ServerControlRequest, ServerControlResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: ServerControlRequest): Buffer =>
@@ -3471,7 +3631,7 @@ export class EditorServiceClient
       value?: GetHeartbeatResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[40]
+    const method = EditorService.methods[42]
     return this.makeUnaryRequest<GetHeartbeatRequest, GetHeartbeatResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetHeartbeatRequest): Buffer =>
@@ -3500,7 +3660,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToSessionEventsResponse> {
-    const method = EditorService.methods[41]
+    const method = EditorService.methods[43]
     return this.makeServerStreamRequest<
       SubscribeToSessionEventsRequest,
       SubscribeToSessionEventsResponse
@@ -3526,7 +3686,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToViewportEventsResponse> {
-    const method = EditorService.methods[42]
+    const method = EditorService.methods[44]
     return this.makeServerStreamRequest<
       SubscribeToViewportEventsRequest,
       SubscribeToViewportEventsResponse
@@ -3566,7 +3726,7 @@ export class EditorServiceClient
       value?: UnsubscribeToSessionEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[43]
+    const method = EditorService.methods[45]
     return this.makeUnaryRequest<
       UnsubscribeToSessionEventsRequest,
       UnsubscribeToSessionEventsResponse
@@ -3607,7 +3767,7 @@ export class EditorServiceClient
       value?: UnsubscribeToViewportEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[44]
+    const method = EditorService.methods[46]
     return this.makeUnaryRequest<
       UnsubscribeToViewportEventsRequest,
       UnsubscribeToViewportEventsResponse

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -813,23 +813,7 @@ export interface GetChangeDetailsRequest {
    */
   sessionId: string // Session ID.
   /**
-   * @generated from protobuf field: omega_edit.v1.SessionEventKind session_event_kind = 2
-   */
-  sessionEventKind: SessionEventKind // Event kind.
-  /**
-   * @generated from protobuf field: int64 computed_file_size = 3
-   */
-  computedFileSize: number // Computed file size after the event.
-  /**
-   * @generated from protobuf field: int64 change_count = 4
-   */
-  changeCount: number // Change count after the event.
-  /**
-   * @generated from protobuf field: int64 undo_count = 5
-   */
-  undoCount: number // Undo count after the event.
-  /**
-   * @generated from protobuf field: optional int64 serial = 6
+   * @generated from protobuf field: optional int64 serial = 2
    */
   serial?: number // Serial number of the change.
 }
@@ -1193,6 +1177,104 @@ export interface GetCountResponse {
    * @generated from protobuf field: repeated omega_edit.v1.SingleCount counts = 2
    */
   counts: SingleCount[]
+}
+/**
+ * Request to run the native model-integrity check for a session.
+ *
+ * @generated from protobuf message omega_edit.v1.CheckSessionModelRequest
+ */
+export interface CheckSessionModelRequest {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session to check.
+}
+/**
+ * Result of the native model-integrity check.
+ *
+ * @generated from protobuf message omega_edit.v1.CheckSessionModelResponse
+ */
+export interface CheckSessionModelResponse {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session that was checked.
+  /**
+   * @generated from protobuf field: bool valid = 2
+   */
+  valid: boolean // True when omega_check_model returned 0.
+  /**
+   * @generated from protobuf field: int32 status = 3
+   */
+  status: number // Raw omega_check_model return code.
+}
+/**
+ * Digest metadata for a content fingerprint.
+ *
+ * @generated from protobuf message omega_edit.v1.ContentDigest
+ */
+export interface ContentDigest {
+  /**
+   * @generated from protobuf field: string algorithm = 1
+   */
+  algorithm: string // Digest algorithm identifier, e.g. "sha256".
+  /**
+   * @generated from protobuf field: string value = 2
+   */
+  value: string // Lowercase hexadecimal digest value.
+}
+/**
+ * Size and digest for a session content snapshot.
+ *
+ * @generated from protobuf message omega_edit.v1.SessionContentFingerprint
+ */
+export interface SessionContentFingerprint {
+  /**
+   * @generated from protobuf field: int64 byte_length = 1
+   */
+  byteLength: number // Content size in bytes.
+  /**
+   * @generated from protobuf field: omega_edit.v1.ContentDigest digest = 2
+   */
+  digest?: ContentDigest // Digest of the content bytes.
+}
+/**
+ * Request a server-side fingerprint for original or computed session content.
+ *
+ * @generated from protobuf message omega_edit.v1.GetSessionFingerprintRequest
+ */
+export interface GetSessionFingerprintRequest {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session to fingerprint.
+  /**
+   * @generated from protobuf field: omega_edit.v1.SessionFingerprintContent content = 2
+   */
+  content: SessionFingerprintContent // Original or computed content.
+  /**
+   * @generated from protobuf field: optional string algorithm = 3
+   */
+  algorithm?: string // Digest algorithm; defaults to "sha256".
+}
+/**
+ * Server-side content fingerprint result.
+ *
+ * @generated from protobuf message omega_edit.v1.GetSessionFingerprintResponse
+ */
+export interface GetSessionFingerprintResponse {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session that was fingerprinted.
+  /**
+   * @generated from protobuf field: omega_edit.v1.SessionFingerprintContent content = 2
+   */
+  content: SessionFingerprintContent // Content that was fingerprinted.
+  /**
+   * @generated from protobuf field: omega_edit.v1.SessionContentFingerprint fingerprint = 3
+   */
+  fingerprint?: SessionContentFingerprint // Size and digest.
 }
 /**
  * Request the total number of active sessions.
@@ -2354,6 +2436,29 @@ export enum ServerControlStatus {
    * @generated from protobuf enum value: SERVER_CONTROL_STATUS_DRAINING = 2;
    */
   DRAINING = 2,
+}
+/**
+ * Which session content should be fingerprinted.
+ *
+ * @generated from protobuf enum omega_edit.v1.SessionFingerprintContent
+ */
+export enum SessionFingerprintContent {
+  /**
+   * @generated from protobuf enum value: SESSION_FINGERPRINT_CONTENT_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+  /**
+   * Content captured when the session was created.
+   *
+   * @generated from protobuf enum value: SESSION_FINGERPRINT_CONTENT_ORIGINAL = 1;
+   */
+  ORIGINAL = 1,
+  /**
+   * Current logical content after edits.
+   *
+   * @generated from protobuf enum value: SESSION_FINGERPRINT_CONTENT_COMPUTED = 2;
+   */
+  COMPUTED = 2,
 }
 /**
  * Transform plugin operation mode.
@@ -6328,37 +6433,6 @@ class GetChangeDetailsRequest$Type extends MessageType<GetChangeDetailsRequest> 
       { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
       {
         no: 2,
-        name: 'session_event_kind',
-        kind: 'enum',
-        T: () => [
-          'omega_edit.v1.SessionEventKind',
-          SessionEventKind,
-          'SESSION_EVENT_KIND_',
-        ],
-      },
-      {
-        no: 3,
-        name: 'computed_file_size',
-        kind: 'scalar',
-        T: 3 /*ScalarType.INT64*/,
-        L: 2 /*LongType.NUMBER*/,
-      },
-      {
-        no: 4,
-        name: 'change_count',
-        kind: 'scalar',
-        T: 3 /*ScalarType.INT64*/,
-        L: 2 /*LongType.NUMBER*/,
-      },
-      {
-        no: 5,
-        name: 'undo_count',
-        kind: 'scalar',
-        T: 3 /*ScalarType.INT64*/,
-        L: 2 /*LongType.NUMBER*/,
-      },
-      {
-        no: 6,
         name: 'serial',
         kind: 'scalar',
         opt: true,
@@ -6372,10 +6446,6 @@ class GetChangeDetailsRequest$Type extends MessageType<GetChangeDetailsRequest> 
   ): GetChangeDetailsRequest {
     const message = globalThis.Object.create(this.messagePrototype!)
     message.sessionId = ''
-    message.sessionEventKind = 0
-    message.computedFileSize = 0
-    message.changeCount = 0
-    message.undoCount = 0
     if (value !== undefined)
       reflectionMergePartial<GetChangeDetailsRequest>(this, message, value)
     return message
@@ -6394,19 +6464,7 @@ class GetChangeDetailsRequest$Type extends MessageType<GetChangeDetailsRequest> 
         case /* string session_id */ 1:
           message.sessionId = reader.string()
           break
-        case /* omega_edit.v1.SessionEventKind session_event_kind */ 2:
-          message.sessionEventKind = reader.int32()
-          break
-        case /* int64 computed_file_size */ 3:
-          message.computedFileSize = reader.int64().toNumber()
-          break
-        case /* int64 change_count */ 4:
-          message.changeCount = reader.int64().toNumber()
-          break
-        case /* int64 undo_count */ 5:
-          message.undoCount = reader.int64().toNumber()
-          break
-        case /* optional int64 serial */ 6:
+        case /* optional int64 serial */ 2:
           message.serial = reader.int64().toNumber()
           break
         default:
@@ -6436,21 +6494,9 @@ class GetChangeDetailsRequest$Type extends MessageType<GetChangeDetailsRequest> 
     /* string session_id = 1; */
     if (message.sessionId !== '')
       writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
-    /* omega_edit.v1.SessionEventKind session_event_kind = 2; */
-    if (message.sessionEventKind !== 0)
-      writer.tag(2, WireType.Varint).int32(message.sessionEventKind)
-    /* int64 computed_file_size = 3; */
-    if (message.computedFileSize !== 0)
-      writer.tag(3, WireType.Varint).int64(message.computedFileSize)
-    /* int64 change_count = 4; */
-    if (message.changeCount !== 0)
-      writer.tag(4, WireType.Varint).int64(message.changeCount)
-    /* int64 undo_count = 5; */
-    if (message.undoCount !== 0)
-      writer.tag(5, WireType.Varint).int64(message.undoCount)
-    /* optional int64 serial = 6; */
+    /* optional int64 serial = 2; */
     if (message.serial !== undefined)
-      writer.tag(6, WireType.Varint).int64(message.serial)
+      writer.tag(2, WireType.Varint).int64(message.serial)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -8264,6 +8310,550 @@ class GetCountResponse$Type extends MessageType<GetCountResponse> {
  * @generated MessageType for protobuf message omega_edit.v1.GetCountResponse
  */
 export const GetCountResponse = new GetCountResponse$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class CheckSessionModelRequest$Type extends MessageType<CheckSessionModelRequest> {
+  constructor() {
+    super('omega_edit.v1.CheckSessionModelRequest', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+    ])
+  }
+  create(
+    value?: PartialMessage<CheckSessionModelRequest>
+  ): CheckSessionModelRequest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    if (value !== undefined)
+      reflectionMergePartial<CheckSessionModelRequest>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: CheckSessionModelRequest
+  ): CheckSessionModelRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: CheckSessionModelRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.CheckSessionModelRequest
+ */
+export const CheckSessionModelRequest = new CheckSessionModelRequest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class CheckSessionModelResponse$Type extends MessageType<CheckSessionModelResponse> {
+  constructor() {
+    super('omega_edit.v1.CheckSessionModelResponse', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 2, name: 'valid', kind: 'scalar', T: 8 /*ScalarType.BOOL*/ },
+      { no: 3, name: 'status', kind: 'scalar', T: 5 /*ScalarType.INT32*/ },
+    ])
+  }
+  create(
+    value?: PartialMessage<CheckSessionModelResponse>
+  ): CheckSessionModelResponse {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.valid = false
+    message.status = 0
+    if (value !== undefined)
+      reflectionMergePartial<CheckSessionModelResponse>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: CheckSessionModelResponse
+  ): CheckSessionModelResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* bool valid */ 2:
+          message.valid = reader.bool()
+          break
+        case /* int32 status */ 3:
+          message.status = reader.int32()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: CheckSessionModelResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* bool valid = 2; */
+    if (message.valid !== false)
+      writer.tag(2, WireType.Varint).bool(message.valid)
+    /* int32 status = 3; */
+    if (message.status !== 0)
+      writer.tag(3, WireType.Varint).int32(message.status)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.CheckSessionModelResponse
+ */
+export const CheckSessionModelResponse = new CheckSessionModelResponse$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class ContentDigest$Type extends MessageType<ContentDigest> {
+  constructor() {
+    super('omega_edit.v1.ContentDigest', [
+      { no: 1, name: 'algorithm', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      { no: 2, name: 'value', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+    ])
+  }
+  create(value?: PartialMessage<ContentDigest>): ContentDigest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.algorithm = ''
+    message.value = ''
+    if (value !== undefined)
+      reflectionMergePartial<ContentDigest>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: ContentDigest
+  ): ContentDigest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string algorithm */ 1:
+          message.algorithm = reader.string()
+          break
+        case /* string value */ 2:
+          message.value = reader.string()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: ContentDigest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string algorithm = 1; */
+    if (message.algorithm !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.algorithm)
+    /* string value = 2; */
+    if (message.value !== '')
+      writer.tag(2, WireType.LengthDelimited).string(message.value)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.ContentDigest
+ */
+export const ContentDigest = new ContentDigest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class SessionContentFingerprint$Type extends MessageType<SessionContentFingerprint> {
+  constructor() {
+    super('omega_edit.v1.SessionContentFingerprint', [
+      {
+        no: 1,
+        name: 'byte_length',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      { no: 2, name: 'digest', kind: 'message', T: () => ContentDigest },
+    ])
+  }
+  create(
+    value?: PartialMessage<SessionContentFingerprint>
+  ): SessionContentFingerprint {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.byteLength = 0
+    if (value !== undefined)
+      reflectionMergePartial<SessionContentFingerprint>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: SessionContentFingerprint
+  ): SessionContentFingerprint {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* int64 byte_length */ 1:
+          message.byteLength = reader.int64().toNumber()
+          break
+        case /* omega_edit.v1.ContentDigest digest */ 2:
+          message.digest = ContentDigest.internalBinaryRead(
+            reader,
+            reader.uint32(),
+            options,
+            message.digest
+          )
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: SessionContentFingerprint,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* int64 byte_length = 1; */
+    if (message.byteLength !== 0)
+      writer.tag(1, WireType.Varint).int64(message.byteLength)
+    /* omega_edit.v1.ContentDigest digest = 2; */
+    if (message.digest)
+      ContentDigest.internalBinaryWrite(
+        message.digest,
+        writer.tag(2, WireType.LengthDelimited).fork(),
+        options
+      ).join()
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.SessionContentFingerprint
+ */
+export const SessionContentFingerprint = new SessionContentFingerprint$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class GetSessionFingerprintRequest$Type extends MessageType<GetSessionFingerprintRequest> {
+  constructor() {
+    super('omega_edit.v1.GetSessionFingerprintRequest', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'content',
+        kind: 'enum',
+        T: () => [
+          'omega_edit.v1.SessionFingerprintContent',
+          SessionFingerprintContent,
+          'SESSION_FINGERPRINT_CONTENT_',
+        ],
+      },
+      {
+        no: 3,
+        name: 'algorithm',
+        kind: 'scalar',
+        opt: true,
+        T: 9 /*ScalarType.STRING*/,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<GetSessionFingerprintRequest>
+  ): GetSessionFingerprintRequest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.content = 0
+    if (value !== undefined)
+      reflectionMergePartial<GetSessionFingerprintRequest>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: GetSessionFingerprintRequest
+  ): GetSessionFingerprintRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* omega_edit.v1.SessionFingerprintContent content */ 2:
+          message.content = reader.int32()
+          break
+        case /* optional string algorithm */ 3:
+          message.algorithm = reader.string()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: GetSessionFingerprintRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* omega_edit.v1.SessionFingerprintContent content = 2; */
+    if (message.content !== 0)
+      writer.tag(2, WireType.Varint).int32(message.content)
+    /* optional string algorithm = 3; */
+    if (message.algorithm !== undefined)
+      writer.tag(3, WireType.LengthDelimited).string(message.algorithm)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.GetSessionFingerprintRequest
+ */
+export const GetSessionFingerprintRequest =
+  new GetSessionFingerprintRequest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class GetSessionFingerprintResponse$Type extends MessageType<GetSessionFingerprintResponse> {
+  constructor() {
+    super('omega_edit.v1.GetSessionFingerprintResponse', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'content',
+        kind: 'enum',
+        T: () => [
+          'omega_edit.v1.SessionFingerprintContent',
+          SessionFingerprintContent,
+          'SESSION_FINGERPRINT_CONTENT_',
+        ],
+      },
+      {
+        no: 3,
+        name: 'fingerprint',
+        kind: 'message',
+        T: () => SessionContentFingerprint,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<GetSessionFingerprintResponse>
+  ): GetSessionFingerprintResponse {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.content = 0
+    if (value !== undefined)
+      reflectionMergePartial<GetSessionFingerprintResponse>(
+        this,
+        message,
+        value
+      )
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: GetSessionFingerprintResponse
+  ): GetSessionFingerprintResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* omega_edit.v1.SessionFingerprintContent content */ 2:
+          message.content = reader.int32()
+          break
+        case /* omega_edit.v1.SessionContentFingerprint fingerprint */ 3:
+          message.fingerprint = SessionContentFingerprint.internalBinaryRead(
+            reader,
+            reader.uint32(),
+            options,
+            message.fingerprint
+          )
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: GetSessionFingerprintResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* omega_edit.v1.SessionFingerprintContent content = 2; */
+    if (message.content !== 0)
+      writer.tag(2, WireType.Varint).int32(message.content)
+    /* omega_edit.v1.SessionContentFingerprint fingerprint = 3; */
+    if (message.fingerprint)
+      SessionContentFingerprint.internalBinaryWrite(
+        message.fingerprint,
+        writer.tag(3, WireType.LengthDelimited).fork(),
+        options
+      ).join()
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.GetSessionFingerprintResponse
+ */
+export const GetSessionFingerprintResponse =
+  new GetSessionFingerprintResponse$Type()
 // @generated message type with reflection information, may provide speed optimized methods
 class GetSessionCountRequest$Type extends MessageType<GetSessionCountRequest> {
   constructor() {
@@ -12251,6 +12841,18 @@ export const EditorService = new ServiceType('omega_edit.v1.EditorService', [
     O: GetLanguageResponse,
   },
   { name: 'GetCount', options: {}, I: GetCountRequest, O: GetCountResponse },
+  {
+    name: 'CheckSessionModel',
+    options: {},
+    I: CheckSessionModelRequest,
+    O: CheckSessionModelResponse,
+  },
+  {
+    name: 'GetSessionFingerprint',
+    options: {},
+    I: GetSessionFingerprintRequest,
+    O: GetSessionFingerprintResponse,
+  },
   {
     name: 'GetSessionCount',
     options: {},

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -813,7 +813,23 @@ export interface GetChangeDetailsRequest {
    */
   sessionId: string // Session ID.
   /**
-   * @generated from protobuf field: optional int64 serial = 2
+   * @generated from protobuf field: omega_edit.v1.SessionEventKind session_event_kind = 2
+   */
+  sessionEventKind: SessionEventKind // Compatibility field; ignored by the server.
+  /**
+   * @generated from protobuf field: int64 computed_file_size = 3
+   */
+  computedFileSize: number // Compatibility field; ignored by the server.
+  /**
+   * @generated from protobuf field: int64 change_count = 4
+   */
+  changeCount: number // Compatibility field; ignored by the server.
+  /**
+   * @generated from protobuf field: int64 undo_count = 5
+   */
+  undoCount: number // Compatibility field; ignored by the server.
+  /**
+   * @generated from protobuf field: optional int64 serial = 6
    */
   serial?: number // Serial number of the change.
 }
@@ -6433,6 +6449,37 @@ class GetChangeDetailsRequest$Type extends MessageType<GetChangeDetailsRequest> 
       { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
       {
         no: 2,
+        name: 'session_event_kind',
+        kind: 'enum',
+        T: () => [
+          'omega_edit.v1.SessionEventKind',
+          SessionEventKind,
+          'SESSION_EVENT_KIND_',
+        ],
+      },
+      {
+        no: 3,
+        name: 'computed_file_size',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 4,
+        name: 'change_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 5,
+        name: 'undo_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 6,
         name: 'serial',
         kind: 'scalar',
         opt: true,
@@ -6446,6 +6493,10 @@ class GetChangeDetailsRequest$Type extends MessageType<GetChangeDetailsRequest> 
   ): GetChangeDetailsRequest {
     const message = globalThis.Object.create(this.messagePrototype!)
     message.sessionId = ''
+    message.sessionEventKind = 0
+    message.computedFileSize = 0
+    message.changeCount = 0
+    message.undoCount = 0
     if (value !== undefined)
       reflectionMergePartial<GetChangeDetailsRequest>(this, message, value)
     return message
@@ -6464,7 +6515,19 @@ class GetChangeDetailsRequest$Type extends MessageType<GetChangeDetailsRequest> 
         case /* string session_id */ 1:
           message.sessionId = reader.string()
           break
-        case /* optional int64 serial */ 2:
+        case /* omega_edit.v1.SessionEventKind session_event_kind */ 2:
+          message.sessionEventKind = reader.int32()
+          break
+        case /* int64 computed_file_size */ 3:
+          message.computedFileSize = reader.int64().toNumber()
+          break
+        case /* int64 change_count */ 4:
+          message.changeCount = reader.int64().toNumber()
+          break
+        case /* int64 undo_count */ 5:
+          message.undoCount = reader.int64().toNumber()
+          break
+        case /* optional int64 serial */ 6:
           message.serial = reader.int64().toNumber()
           break
         default:
@@ -6494,9 +6557,21 @@ class GetChangeDetailsRequest$Type extends MessageType<GetChangeDetailsRequest> 
     /* string session_id = 1; */
     if (message.sessionId !== '')
       writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
-    /* optional int64 serial = 2; */
+    /* omega_edit.v1.SessionEventKind session_event_kind = 2; */
+    if (message.sessionEventKind !== 0)
+      writer.tag(2, WireType.Varint).int32(message.sessionEventKind)
+    /* int64 computed_file_size = 3; */
+    if (message.computedFileSize !== 0)
+      writer.tag(3, WireType.Varint).int64(message.computedFileSize)
+    /* int64 change_count = 4; */
+    if (message.changeCount !== 0)
+      writer.tag(4, WireType.Varint).int64(message.changeCount)
+    /* int64 undo_count = 5; */
+    if (message.undoCount !== 0)
+      writer.tag(5, WireType.Varint).int64(message.undoCount)
+    /* optional int64 serial = 6; */
     if (message.serial !== undefined)
-      writer.tag(2, WireType.Varint).int64(message.serial)
+      writer.tag(6, WireType.Varint).int64(message.serial)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -19,7 +19,9 @@
 
 import {
   CountKind,
+  SessionFingerprintContent,
   type ApplyTransformPluginResponse,
+  type CheckSessionModelResponse,
   type CreateCheckpointResponse,
   type CreateSessionRequest,
   type CreateSessionResponse,
@@ -31,6 +33,7 @@ import {
   type GetCountResponse,
   type GetLanguageResponse,
   type GetSegmentResponse,
+  type GetSessionFingerprintResponse,
   type GetSessionCountResponse,
   type ListTransformPluginsResponse,
   type NotifyChangedViewportsResponse,
@@ -138,6 +141,101 @@ export async function destroySession(sessionId: string): Promise<string> {
         return reject(makeWrappedError('destroySession', error))
       }
     })
+  })
+}
+
+export async function checkSessionModel(
+  sessionId: string
+): Promise<CheckSessionModelResponse> {
+  const log = getLogger()
+  const request = { sessionId }
+  debugLog(log, () => ({ fn: 'protobufTs.checkSessionModel', rqst: request }))
+  const client = await getClient()
+
+  return new Promise<CheckSessionModelResponse>((resolve, reject) => {
+    callUnary(client, client.checkSessionModel, request, (err, response) => {
+      if (err) {
+        log.error({
+          fn: 'protobufTs.checkSessionModel',
+          rqst: request,
+          err: {
+            msg: err.message,
+            details: err.details,
+            code: err.code,
+            stack: err.stack,
+          },
+        })
+        return reject(makeWrappedError('checkSessionModel', err))
+      }
+
+      try {
+        const required = requireResponse(
+          response as CheckSessionModelResponse | undefined,
+          'checkSessionModel'
+        )
+        debugLog(log, () => ({
+          fn: 'protobufTs.checkSessionModel',
+          resp: required,
+        }))
+        return resolve(required)
+      } catch (error) {
+        return reject(makeWrappedError('checkSessionModel', error))
+      }
+    })
+  })
+}
+
+export async function getSessionFingerprint(
+  sessionId: string,
+  content: SessionFingerprintContent,
+  algorithm = ''
+): Promise<GetSessionFingerprintResponse> {
+  const log = getLogger()
+  const request =
+    algorithm.length > 0
+      ? { sessionId, content, algorithm }
+      : { sessionId, content }
+  debugLog(log, () => ({
+    fn: 'protobufTs.getSessionFingerprint',
+    rqst: request,
+  }))
+  const client = await getClient()
+
+  return new Promise<GetSessionFingerprintResponse>((resolve, reject) => {
+    callUnary(
+      client,
+      client.getSessionFingerprint,
+      request,
+      (err, response) => {
+        if (err) {
+          log.error({
+            fn: 'protobufTs.getSessionFingerprint',
+            rqst: request,
+            err: {
+              msg: err.message,
+              details: err.details,
+              code: err.code,
+              stack: err.stack,
+            },
+          })
+          return reject(makeWrappedError('getSessionFingerprint', err))
+        }
+
+        try {
+          const required = requireResponse(
+            response as GetSessionFingerprintResponse | undefined,
+            'getSessionFingerprint'
+          )
+          debugLog(log, () => ({
+            fn: 'protobufTs.getSessionFingerprint',
+            resp: required,
+          }))
+          return resolve(required)
+        } catch (error) {
+          return reject(makeWrappedError('getSessionFingerprint', error))
+        }
+      }
+    )
   })
 }
 

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -20,15 +20,20 @@
 import {
   TransformPluginOperation as RawProtoTransformPluginOperation,
   IOFlags as ProtoIOFlags,
+  SessionFingerprintContent as RawProtoSessionFingerprintContent,
   SessionEventKind as RawProtoSessionEventKind,
   ViewportEventKind as RawProtoViewportEventKind,
   type ApplyTransformPluginResponse as RawApplyTransformPluginResponse,
+  type CheckSessionModelResponse as RawCheckSessionModelResponse,
+  type GetSessionFingerprintResponse as RawGetSessionFingerprintResponse,
+  type SessionContentFingerprint as RawSessionContentFingerprint,
   type TransformProgress,
   type TransformPluginInfo as RawTransformPluginInfo,
 } from './protobuf_ts/generated/omega_edit/v1/omega_edit'
 import {
   applyTransformPlugin as rawApplyTransformPlugin,
   beginSessionTransaction as rawBeginSessionTransaction,
+  checkSessionModel as rawCheckSessionModel,
   countCharacters as rawCountCharacters,
   createCheckpoint as rawCreateCheckpoint,
   createSession as rawCreateSession,
@@ -40,6 +45,7 @@ import {
   getCounts as rawGetCounts,
   getLanguage as rawGetLanguage,
   getSegment as rawGetSegment,
+  getSessionFingerprint as rawGetSessionFingerprint,
   getSessionCount as rawGetSessionCount,
   listTransformPlugins as rawListTransformPlugins,
   notifyChangedViewports as rawNotifyChangedViewports,
@@ -127,6 +133,14 @@ export const ViewportEventKind = {
 export type ViewportEventKind =
   (typeof ViewportEventKind)[keyof typeof ViewportEventKind]
 
+export const SessionFingerprintContent = {
+  UNSPECIFIED: RawProtoSessionFingerprintContent.UNSPECIFIED,
+  ORIGINAL: RawProtoSessionFingerprintContent.ORIGINAL,
+  COMPUTED: RawProtoSessionFingerprintContent.COMPUTED,
+} as const
+export type SessionFingerprintContent =
+  (typeof SessionFingerprintContent)[keyof typeof SessionFingerprintContent]
+
 export const TransformPluginOperation = {
   UNSPECIFIED: RawProtoTransformPluginOperation.UNSPECIFIED,
   REPLACE: RawProtoTransformPluginOperation.REPLACE,
@@ -138,6 +152,9 @@ export type TransformPluginOperation =
 
 export type TransformPluginInfo = RawTransformPluginInfo
 export type ApplyTransformPluginResponse = RawApplyTransformPluginResponse
+export type CheckSessionModelResponse = RawCheckSessionModelResponse
+export type SessionContentFingerprint = RawSessionContentFingerprint
+export type GetSessionFingerprintResponse = RawGetSessionFingerprintResponse
 export type { TransformProgress }
 
 export const PROFILE_DOS_EOL = 256
@@ -169,6 +186,50 @@ export async function createSessionFromBytes(
 
 export function destroySession(session_id: string): Promise<string> {
   return rawDestroySession(session_id)
+}
+
+export async function checkSessionModel(
+  session_id: string
+): Promise<CheckSessionModelResponse> {
+  const response = await rawCheckSessionModel(session_id)
+  return {
+    sessionId: response.sessionId,
+    valid: response.valid,
+    status: requireSafeIntegerOutput(
+      'checkSessionModel status',
+      response.status
+    ),
+  }
+}
+
+export async function getSessionFingerprint(
+  session_id: string,
+  content: SessionFingerprintContent,
+  algorithm = 'sha256'
+): Promise<GetSessionFingerprintResponse> {
+  const response = await rawGetSessionFingerprint(
+    session_id,
+    content,
+    algorithm
+  )
+  if (!response.fingerprint?.digest) {
+    throw new Error('getSessionFingerprint response missing fingerprint digest')
+  }
+
+  return {
+    sessionId: response.sessionId,
+    content: response.content,
+    fingerprint: {
+      byteLength: requireSafeIntegerOutput(
+        'session fingerprint byte length',
+        response.fingerprint.byteLength
+      ),
+      digest: {
+        algorithm: response.fingerprint.digest.algorithm,
+        value: response.fingerprint.digest.value,
+      },
+    },
+  }
 }
 
 export async function createCheckpoint(session_id: string): Promise<number> {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -148,7 +148,11 @@ The native binary supports:
 | `--log-config` | Read log file/level from a logback-style XML config |
 | `--transform-plugin-dir` | Register transform plugins from a directory; repeat for multiple directories |
 
-Transform plugin directories can also be supplied with `OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS`.
+The package includes the first-party transform plugins for the current platform and
+registers them automatically when no explicit transform plugin directories are supplied.
+Custom transform plugin directories can also be supplied with `transformPluginDirectories`,
+`--transform-plugin-dir`, `OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS`, or
+`OMEGA_EDIT_TRANSFORM_PLUGINS_DIR`.
 Use the platform path-list separator (`:` on Unix-like systems, `;` on Windows).
 See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the native ABI,
 SDK helpers, plugin package layout, and exemplar plugins, including base64

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -123,6 +123,141 @@ function getPlatformBinaryName(): string {
   return `omega-edit-grpc-server-${platformStr}${ext}`
 }
 
+function getTransformPluginPlatformId(): string | undefined {
+  const platform = os.platform()
+  const arch = os.arch()
+
+  if (platform === 'linux' && (arch === 'x64' || arch === 'arm64')) {
+    return `linux-${arch}`
+  }
+  if (platform === 'darwin' && (arch === 'x64' || arch === 'arm64')) {
+    return `macos-${arch}`
+  }
+  if (platform === 'win32' && arch === 'x64') {
+    return 'windows-x64'
+  }
+  return undefined
+}
+
+function getTransformPluginExtensions(): string[] {
+  if (os.platform() === 'win32') return ['.dll']
+  if (os.platform() === 'darwin') return ['.dylib', '.so']
+  return ['.so']
+}
+
+function directoryExists(directory: string): boolean {
+  try {
+    return fs.statSync(directory).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function directoryHasTransformPlugin(directory: string): boolean {
+  if (!directoryExists(directory)) return false
+
+  const extensions = getTransformPluginExtensions()
+  return fs.readdirSync(directory).some((file) => {
+    return (
+      file.startsWith('omega_transform_') &&
+      extensions.some((extension) => file.endsWith(extension))
+    )
+  })
+}
+
+function normalizeWindowsPath(directory: string): string {
+  if (os.platform() !== 'win32') return directory
+
+  const msysPath = directory.match(/^\/([a-zA-Z])\/(.*)$/)
+  return msysPath
+    ? `${msysPath[1]}:\\${msysPath[2].replace(/\//g, '\\')}`
+    : directory
+}
+
+function splitPathList(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(path.delimiter)
+    .map((directory) => normalizeWindowsPath(directory.trim()))
+    .filter(Boolean)
+}
+
+function findRepositoryRoot(startDir: string): string {
+  const candidates = [
+    path.resolve(startDir, '..'),
+    path.resolve(startDir, '..', '..'),
+    path.resolve(startDir, '..', '..', '..'),
+  ]
+
+  return (
+    candidates.find(
+      (candidate) =>
+        directoryExists(path.join(candidate, 'packages', 'server')) &&
+        directoryExists(path.join(candidate, 'server', 'cpp'))
+    ) ?? path.resolve(startDir, '..')
+  )
+}
+
+function getDefaultTransformPluginDirectories(binDir: string): string[] {
+  const platformId = getTransformPluginPlatformId()
+  const outDir = path.dirname(binDir)
+  const repoRoot = findRepositoryRoot(outDir)
+  const envCandidates = [
+    ...splitPathList(process.env.OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS),
+    ...splitPathList(process.env.OMEGA_EDIT_TRANSFORM_PLUGINS_DIR),
+    ...splitPathList(process.env.OMEGA_EDIT_TEST_PLUGIN_DIR),
+  ]
+  const candidates = [
+    ...envCandidates,
+    platformId ? path.join(outDir, 'transform-plugins', platformId) : '',
+    path.join(
+      repoRoot,
+      '.codex-tmp',
+      'native-core-build',
+      'core',
+      'src',
+      'tests',
+      'plugins'
+    ),
+    path.join(repoRoot, '_build_core', 'plugins', 'plugins'),
+    path.join(repoRoot, '_build_core', 'core', 'src', 'tests', 'plugins'),
+    path.join(repoRoot, '_build', 'plugins', 'plugins'),
+    path.join(repoRoot, 'build', 'core', 'src', 'tests', 'plugins'),
+    path.join(repoRoot, 'build-coverage', 'core', 'src', 'tests', 'plugins'),
+    path.join(
+      repoRoot,
+      'build-shared-Debug',
+      'core',
+      'src',
+      'tests',
+      'plugins'
+    ),
+    path.join(
+      repoRoot,
+      'build-shared-Release',
+      'core',
+      'src',
+      'tests',
+      'plugins'
+    ),
+    path.join(
+      repoRoot,
+      'build-shared-RelWithDebInfo',
+      'core',
+      'src',
+      'tests',
+      'plugins'
+    ),
+  ].filter(Boolean)
+
+  const expandedCandidates = candidates.flatMap((candidate) =>
+    platformId ? [path.join(candidate, platformId), candidate] : [candidate]
+  )
+
+  return Array.from(new Set(expandedCandidates)).filter(
+    directoryHasTransformPlugin
+  )
+}
+
 /**
  * Find the C++ server binary path.
  * First checks the CPP_SERVER_BINARY environment variable for a local dev override.
@@ -200,44 +335,56 @@ function findServerBinary(binDir: string): string {
 /**
  * Convert HeartbeatOptions to native CLI flags understood by the C++ server.
  */
-function heartbeatToArgs(opts?: HeartbeatOptions): string[] {
-  if (!opts) return []
+function heartbeatToArgs(
+  opts?: HeartbeatOptions,
+  defaultTransformPluginDirectories: string[] = []
+): string[] {
+  if (!opts && defaultTransformPluginDirectories.length === 0) return []
   const args: string[] = []
-  if (opts.sessionTimeoutMs !== undefined) {
+  if (opts?.sessionTimeoutMs !== undefined) {
     args.push(`--session-timeout=${opts.sessionTimeoutMs}`)
   }
-  if (opts.cleanupIntervalMs !== undefined) {
+  if (opts?.cleanupIntervalMs !== undefined) {
     args.push(`--cleanup-interval=${opts.cleanupIntervalMs}`)
   }
-  if (opts.shutdownWhenNoSessions) {
+  if (opts?.shutdownWhenNoSessions) {
     args.push('--shutdown-when-no-sessions')
   }
-  if (opts.sessionEventQueueCapacity !== undefined) {
+  if (opts?.sessionEventQueueCapacity !== undefined) {
     args.push(
       `--session-event-queue-capacity=${opts.sessionEventQueueCapacity}`
     )
   }
-  if (opts.viewportEventQueueCapacity !== undefined) {
+  if (opts?.viewportEventQueueCapacity !== undefined) {
     args.push(
       `--viewport-event-queue-capacity=${opts.viewportEventQueueCapacity}`
     )
   }
-  if (opts.maxChangeBytes !== undefined) {
+  if (opts?.maxChangeBytes !== undefined) {
     args.push(`--max-change-bytes=${opts.maxChangeBytes}`)
   }
-  if (opts.maxViewportsPerSession !== undefined) {
+  if (opts?.maxViewportsPerSession !== undefined) {
     args.push(`--max-viewports-per-session=${opts.maxViewportsPerSession}`)
   }
-  if (opts.logConfigFile !== undefined) {
+  if (opts?.logConfigFile !== undefined) {
     args.push(`--log-config=${opts.logConfigFile}`)
   }
-  if (opts.logFile !== undefined) {
+  if (opts?.logFile !== undefined) {
     args.push(`--log-file=${opts.logFile}`)
   }
-  if (opts.logLevel !== undefined) {
+  if (opts?.logLevel !== undefined) {
     args.push(`--log-level=${opts.logLevel}`)
   }
-  for (const directory of opts.transformPluginDirectories ?? []) {
+  const configuredTransformPluginDirectories =
+    opts?.transformPluginDirectories?.filter(
+      (directory) =>
+        typeof directory === 'string' && directory.trim().length > 0
+    ) ?? []
+  const transformPluginDirectories =
+    configuredTransformPluginDirectories.length > 0
+      ? configuredTransformPluginDirectories
+      : defaultTransformPluginDirectories
+  for (const directory of transformPluginDirectories) {
     args.push(`--transform-plugin-dir=${directory}`)
   }
   return args
@@ -255,8 +402,13 @@ async function executeServer(
 ): Promise<ChildProcess> {
   const binDir = getBinFolderPath(path.resolve(__dirname))
   const serverBinary = findServerBinary(binDir)
+  const defaultTransformPluginDirectories =
+    getDefaultTransformPluginDirectories(binDir)
 
-  const serverArgs = [...args, ...heartbeatToArgs(heartbeat)]
+  const serverArgs = [
+    ...args,
+    ...heartbeatToArgs(heartbeat, defaultTransformPluginDirectories),
+  ]
 
   if (!serverBinary.endsWith('.exe')) {
     fs.chmodSync(serverBinary, 0o755)

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -104,7 +104,7 @@ function findTransformPluginDirectory(platformId) {
   ].filter(Boolean)
 
   for (const candidate of candidates) {
-    const platformCandidate = platformId ? path.join(candidate, platformId) : ''
+    const platformCandidate = path.join(candidate, platformId)
     if (directoryHasTransformPlugin(platformCandidate)) {
       return platformCandidate
     }

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -27,6 +27,47 @@ const serverBinaryName = isWin
   ? 'omega-edit-grpc-server.exe'
   : 'omega-edit-grpc-server'
 
+function getTransformPluginPlatformId() {
+  const arch = process.arch
+  if (process.platform === 'linux' && (arch === 'x64' || arch === 'arm64')) {
+    return `linux-${arch}`
+  }
+  if (process.platform === 'darwin' && (arch === 'x64' || arch === 'arm64')) {
+    return `macos-${arch}`
+  }
+  if (process.platform === 'win32' && arch === 'x64') {
+    return 'windows-x64'
+  }
+  return null
+}
+
+function getTransformPluginExtensions() {
+  if (process.platform === 'win32') return ['.dll']
+  if (process.platform === 'darwin') return ['.dylib', '.so']
+  return ['.so']
+}
+
+function directoryHasTransformPlugin(directory) {
+  if (!directory || !fs.existsSync(directory)) return false
+  if (!fs.statSync(directory).isDirectory()) return false
+
+  const extensions = getTransformPluginExtensions()
+  return fs
+    .readdirSync(directory)
+    .some(
+      (file) =>
+        file.startsWith('omega_transform_') &&
+        extensions.some((extension) => file.endsWith(extension))
+    )
+}
+
+function splitPathList(value) {
+  return (value || '')
+    .split(path.delimiter)
+    .map((directory) => directory.trim())
+    .filter(Boolean)
+}
+
 // Look for the C++ server binary in several possible locations
 function findServerBinary() {
   const searchPaths = [
@@ -44,6 +85,76 @@ function findServerBinary() {
     if (fs.existsSync(p)) return p
   }
   return null
+}
+
+function findTransformPluginDirectory(platformId) {
+  const candidates = [
+    ...splitPathList(process.env.OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS),
+    ...splitPathList(process.env.OMEGA_EDIT_TRANSFORM_PLUGINS_DIR),
+    ...splitPathList(process.env.OMEGA_EDIT_TEST_PLUGIN_DIR),
+    path.resolve('../../.codex-tmp/native-core-build/core/src/tests/plugins'),
+    path.resolve('../../_build_core/plugins/plugins'),
+    path.resolve('../../_build_core/core/src/tests/plugins'),
+    path.resolve('../../_build/plugins/plugins'),
+    path.resolve('../../build/core/src/tests/plugins'),
+    path.resolve('../../build-coverage/core/src/tests/plugins'),
+    path.resolve('../../build-shared-Debug/core/src/tests/plugins'),
+    path.resolve('../../build-shared-Release/core/src/tests/plugins'),
+    path.resolve('../../build-shared-RelWithDebInfo/core/src/tests/plugins'),
+  ].filter(Boolean)
+
+  for (const candidate of candidates) {
+    const platformCandidate = platformId ? path.join(candidate, platformId) : ''
+    if (directoryHasTransformPlugin(platformCandidate)) {
+      return platformCandidate
+    }
+    if (directoryHasTransformPlugin(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+function copyTransformPlugins(outputPath) {
+  const platformId = getTransformPluginPlatformId()
+  if (!platformId) return
+
+  const sourceDir = findTransformPluginDirectory(platformId)
+  if (!sourceDir) {
+    const message =
+      'Transform plugin binaries not found. Set OMEGA_EDIT_TRANSFORM_PLUGINS_DIR or build the plugins first.'
+    if (process.env.CI) {
+      throw new Error(message)
+    }
+    console.warn(`WARNING: ${message}`)
+    return
+  }
+
+  const extensions = getTransformPluginExtensions()
+  const destDir = path.resolve(outputPath, 'transform-plugins', platformId)
+  fs.rmSync(destDir, { recursive: true, force: true })
+  fs.mkdirSync(destDir, { recursive: true })
+
+  const plugins = fs
+    .readdirSync(sourceDir)
+    .filter(
+      (file) =>
+        file.startsWith('omega_transform_') &&
+        extensions.some((extension) => file.endsWith(extension))
+    )
+    .sort()
+
+  for (const plugin of plugins) {
+    const src = path.join(sourceDir, plugin)
+    const dest = path.join(destDir, plugin)
+    fs.copyFileSync(src, dest)
+    if (!plugin.endsWith('.dll')) {
+      fs.chmodSync(dest, 0o755)
+    }
+  }
+  console.log(
+    `Copied ${plugins.length} transform plugin(s): ${sourceDir} -> ${destDir}`
+  )
 }
 
 // Find the omega_edit shared library
@@ -196,6 +307,7 @@ module.exports = {
           }
           // NOTE: shared library is optional; when the C++ server is statically
           // linked against the core library, no shared lib is needed at runtime.
+          copyTransformPlugins(compiler.options.output.path)
         })
       },
     },

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -170,6 +170,12 @@ service EditorService {
   // viewports, checkpoints, etc.) in a single round-trip.
   rpc GetCount(GetCountRequest) returns (GetCountResponse);
 
+  // Check the native session model for internal consistency.
+  rpc CheckSessionModel(CheckSessionModelRequest) returns (CheckSessionModelResponse);
+
+  // Compute a server-side fingerprint for original or computed session content.
+  rpc GetSessionFingerprint(GetSessionFingerprintRequest) returns (GetSessionFingerprintResponse);
+
   // Return the total number of active sessions on the server.
   rpc GetSessionCount(GetSessionCountRequest) returns (GetSessionCountResponse);
 
@@ -696,12 +702,8 @@ message NotifyChangedViewportsResponse {
 
 // Request to retrieve details of a specific change by serial number.
 message GetChangeDetailsRequest {
-  string session_id = 1;                       // Session ID.
-  SessionEventKind session_event_kind = 2;     // Event kind.
-  int64 computed_file_size = 3;                // Computed file size after the event.
-  int64 change_count = 4;                      // Change count after the event.
-  int64 undo_count = 5;                        // Undo count after the event.
-  optional int64 serial = 6;                   // Serial number of the change.
+  string session_id = 1;     // Session ID.
+  optional int64 serial = 2; // Serial number of the change.
 }
 
 // Response with full details of a single change.
@@ -834,6 +836,51 @@ message SingleCount {
 message GetCountResponse {
   string session_id = 1;
   repeated SingleCount counts = 2;
+}
+
+// Request to run the native model-integrity check for a session.
+message CheckSessionModelRequest {
+  string session_id = 1; // Session to check.
+}
+
+// Result of the native model-integrity check.
+message CheckSessionModelResponse {
+  string session_id = 1; // Session that was checked.
+  bool valid = 2;        // True when omega_check_model returned 0.
+  int32 status = 3;      // Raw omega_check_model return code.
+}
+
+// Which session content should be fingerprinted.
+enum SessionFingerprintContent {
+  SESSION_FINGERPRINT_CONTENT_UNSPECIFIED = 0;
+  SESSION_FINGERPRINT_CONTENT_ORIGINAL = 1; // Content captured when the session was created.
+  SESSION_FINGERPRINT_CONTENT_COMPUTED = 2; // Current logical content after edits.
+}
+
+// Digest metadata for a content fingerprint.
+message ContentDigest {
+  string algorithm = 1; // Digest algorithm identifier, e.g. "sha256".
+  string value = 2;     // Lowercase hexadecimal digest value.
+}
+
+// Size and digest for a session content snapshot.
+message SessionContentFingerprint {
+  int64 byte_length = 1;    // Content size in bytes.
+  ContentDigest digest = 2; // Digest of the content bytes.
+}
+
+// Request a server-side fingerprint for original or computed session content.
+message GetSessionFingerprintRequest {
+  string session_id = 1;                    // Session to fingerprint.
+  SessionFingerprintContent content = 2;    // Original or computed content.
+  optional string algorithm = 3;            // Digest algorithm; defaults to "sha256".
+}
+
+// Server-side content fingerprint result.
+message GetSessionFingerprintResponse {
+  string session_id = 1;                         // Session that was fingerprinted.
+  SessionFingerprintContent content = 2;         // Content that was fingerprinted.
+  SessionContentFingerprint fingerprint = 3;     // Size and digest.
 }
 
 // Request the total number of active sessions.

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -702,8 +702,12 @@ message NotifyChangedViewportsResponse {
 
 // Request to retrieve details of a specific change by serial number.
 message GetChangeDetailsRequest {
-  string session_id = 1;     // Session ID.
-  optional int64 serial = 2; // Serial number of the change.
+  string session_id = 1;                   // Session ID.
+  SessionEventKind session_event_kind = 2; // Compatibility field; ignored by the server.
+  int64 computed_file_size = 3;            // Compatibility field; ignored by the server.
+  int64 change_count = 4;                  // Compatibility field; ignored by the server.
+  int64 undo_count = 5;                    // Compatibility field; ignored by the server.
+  optional int64 serial = 6;               // Serial number of the change.
 }
 
 // Response with full details of a single change.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -16,12 +16,14 @@
 
 #include <omega_edit.h>
 #include <omega_edit/character_counts.h>
+#include <omega_edit/check.h>
 #include <omega_edit/utility.h>
 #include <omega_edit/version.h>
 
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cctype>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -72,6 +74,89 @@ static int get_pid() {
 static int get_cpu_count() {
     auto n = std::thread::hardware_concurrency();
     return n > 0 ? static_cast<int>(n) : 1;
+}
+
+static constexpr char SESSION_FINGERPRINT_DIGEST_PLUGIN_ID[] = "omega.example.openssl_digests";
+static constexpr char DEFAULT_SESSION_FINGERPRINT_ALGORITHM[] = "sha256";
+static constexpr int64_t SESSION_FINGERPRINT_CHUNK_SIZE = 1024 * 1024;
+
+static std::string normalize_digest_algorithm(std::string algorithm) {
+    if (algorithm.empty()) { return DEFAULT_SESSION_FINGERPRINT_ALGORITHM; }
+    std::transform(algorithm.begin(), algorithm.end(), algorithm.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return algorithm;
+}
+
+static bool digest_algorithm_is_json_safe(const std::string &algorithm) {
+    return !algorithm.empty() &&
+           std::all_of(algorithm.begin(), algorithm.end(),
+                       [](unsigned char c) { return std::isalnum(c) != 0 || c == '-'; });
+}
+
+static std::string make_digest_options_json(const std::string &algorithm) {
+    return "{\"algorithm\":\"" + algorithm + "\"}";
+}
+
+using session_fingerprint_content = ::omega_edit::v1::SessionFingerprintContent;
+
+static int64_t get_session_fingerprint_byte_length(omega_session_t *session, session_fingerprint_content content) {
+    switch (content) {
+    case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL:
+        return omega_session_get_original_file_size(session);
+    case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED:
+        return omega_session_get_computed_file_size(session);
+    default:
+        return -1;
+    }
+}
+
+static int read_session_fingerprint_segment(const omega_session_t *session, session_fingerprint_content content,
+                                            omega_segment_t *segment, int64_t offset) {
+    switch (content) {
+    case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL:
+        return omega_session_get_original_segment(session, segment, offset);
+    case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED:
+        return omega_session_get_segment(session, segment, offset);
+    default:
+        return -1;
+    }
+}
+
+struct session_fingerprint_reader {
+    const omega_session_t *session{};
+    session_fingerprint_content content{};
+    int64_t byte_length{};
+};
+
+static int64_t read_session_fingerprint_chunk(int64_t relative_offset, omega_byte_t *buffer, int64_t length,
+                                              void *user_data_ptr) {
+    auto *reader = static_cast<session_fingerprint_reader *>(user_data_ptr);
+    if (!reader || !reader->session || !buffer || relative_offset < 0 || length < 0 ||
+        relative_offset > reader->byte_length) {
+        return -1;
+    }
+
+    const auto remaining = reader->byte_length - relative_offset;
+    const auto read_length = std::min(std::min(length, remaining), SESSION_FINGERPRINT_CHUNK_SIZE);
+    if (read_length == 0) { return 0; }
+
+    auto *segment = omega_segment_create(read_length);
+    if (!segment) { return -1; }
+    const auto rc = read_session_fingerprint_segment(reader->session, reader->content, segment, relative_offset);
+    if (rc != 0) {
+        omega_segment_destroy(segment);
+        return -1;
+    }
+
+    const auto segment_length = std::min(read_length, omega_segment_get_length(segment));
+    auto *data = omega_segment_get_data(segment);
+    if (segment_length <= 0 || !data) {
+        omega_segment_destroy(segment);
+        return -1;
+    }
+    std::memcpy(buffer, data, static_cast<size_t>(segment_length));
+    omega_segment_destroy(segment);
+    return segment_length;
 }
 
 struct process_memory_metrics {
@@ -1269,6 +1354,101 @@ grpc::Status EditorServiceImpl::GetCount(grpc::ServerContext * /*context*/,
         single->set_count(count_value);
     }
 
+    return grpc::Status::OK;
+}
+
+grpc::Status EditorServiceImpl::CheckSessionModel(grpc::ServerContext * /*context*/,
+                                                  const ::omega_edit::v1::CheckSessionModelRequest *request,
+                                                  ::omega_edit::v1::CheckSessionModelResponse *response) {
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
+        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    }
+
+    const auto status = omega_check_model(locked_session.session());
+    response->set_session_id(request->session_id());
+    response->set_valid(status == 0);
+    response->set_status(status);
+    return grpc::Status::OK;
+}
+
+grpc::Status EditorServiceImpl::GetSessionFingerprint(
+        grpc::ServerContext * /*context*/, const ::omega_edit::v1::GetSessionFingerprintRequest *request,
+        ::omega_edit::v1::GetSessionFingerprintResponse *response) {
+    const auto content = request->content();
+    if (content != ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL &&
+        content != ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "fingerprint content must be original or computed");
+    }
+
+    auto algorithm = normalize_digest_algorithm(request->has_algorithm() ? request->algorithm() : "");
+    if (!digest_algorithm_is_json_safe(algorithm)) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                            "unsupported fingerprint digest algorithm: " + algorithm);
+    }
+    const auto options_json = make_digest_options_json(algorithm);
+
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
+        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    }
+    auto *session = locked_session.session();
+
+    const auto byte_length = get_session_fingerprint_byte_length(session, content);
+    if (byte_length < 0) {
+        return grpc::Status(grpc::StatusCode::INTERNAL, "session content length unavailable for fingerprint");
+    }
+
+    transform_plugin_response_guard plugin_response;
+    {
+        std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
+        const auto *plugin_info = omega_transform_plugin_registry_find_info(transform_plugin_registry_,
+                                                                           SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
+        if (!plugin_info) {
+            return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                "session fingerprint digest plugin is not registered: " +
+                                        std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
+        }
+        if (plugin_info->operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
+            (plugin_info->flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
+            return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                "session fingerprint digest plugin must be a streaming inspect plugin");
+        }
+        if (0 != omega_transform_plugin_options_match_args_schema(options_json.c_str(), plugin_info->args_schema)) {
+            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                "unsupported fingerprint digest algorithm: " + algorithm);
+        }
+
+        session_fingerprint_reader reader{session, content, byte_length};
+        if (0 != omega_transform_plugin_registry_inspect_reader(
+                         transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
+                         options_json.c_str(), omega_session_get_checkpoint_directory(session),
+                         read_session_fingerprint_chunk, &reader, SESSION_FINGERPRINT_CHUNK_SIZE, nullptr, nullptr,
+                         &plugin_response.response)) {
+            return grpc::Status(grpc::StatusCode::INTERNAL,
+                                "session fingerprint digest plugin failed: " +
+                                        std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
+        }
+    }
+
+    if (plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
+        return grpc::Status(grpc::StatusCode::INTERNAL,
+                            "session fingerprint digest plugin returned an empty digest");
+    }
+
+    std::string digest_value(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
+                             static_cast<size_t>(plugin_response.response.result_length));
+    if (plugin_response.response.result_label && *plugin_response.response.result_label) {
+        algorithm = normalize_digest_algorithm(plugin_response.response.result_label);
+    }
+
+    response->set_session_id(request->session_id());
+    response->set_content(content);
+    auto *fingerprint = response->mutable_fingerprint();
+    fingerprint->set_byte_length(byte_length);
+    auto *digest_response = fingerprint->mutable_digest();
+    digest_response->set_algorithm(algorithm);
+    digest_response->set_value(digest_value);
     return grpc::Status::OK;
 }
 

--- a/server/cpp/src/editor_service.h
+++ b/server/cpp/src/editor_service.h
@@ -149,6 +149,14 @@ public:
     grpc::Status GetCount(grpc::ServerContext *context, const ::omega_edit::v1::GetCountRequest *request,
                           ::omega_edit::v1::GetCountResponse *response) override;
 
+    grpc::Status CheckSessionModel(grpc::ServerContext *context,
+                                   const ::omega_edit::v1::CheckSessionModelRequest *request,
+                                   ::omega_edit::v1::CheckSessionModelResponse *response) override;
+
+    grpc::Status GetSessionFingerprint(grpc::ServerContext *context,
+                                       const ::omega_edit::v1::GetSessionFingerprintRequest *request,
+                                       ::omega_edit::v1::GetSessionFingerprintResponse *response) override;
+
     grpc::Status GetSessionCount(grpc::ServerContext *context,
                                  const ::omega_edit::v1::GetSessionCountRequest *request,
                                  ::omega_edit::v1::GetSessionCountResponse *response) override;

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -28,9 +28,9 @@ A standalone VS Code extension that uses [Ωedit™](https://github.com/ctc-oss/
 
 Change log exports are portable `omega-edit.change-log` documents containing
 the byte operations needed to apply the same edits to another session, another
-file, or a fleet of compatible files. `foldedChangeCount` is non-zero when
-earlier edits have been absorbed into an OmegaEdit checkpoint baseline rather
-than exported as replayable byte operations.
+file, or a fleet of compatible files. Exports include before/after content
+fingerprints, and OmegaEdit refuses to write or apply incomplete change logs
+when required change details are unavailable.
 
 ## Client Helpers Used Here
 

--- a/vscode-extension/src/api.ts
+++ b/vscode-extension/src/api.ts
@@ -63,12 +63,26 @@ export interface OmegaEditRollbackCheckpointResult {
   checkpointCount: number
 }
 
+export interface OmegaEditChangeLogDigest {
+  algorithm: string
+  value: string
+}
+
+export interface OmegaEditChangeLogFingerprint {
+  byteLength: number
+  digest: OmegaEditChangeLogDigest
+}
+
 export interface OmegaEditChangeLogResult {
   state?: OmegaEditEditorState
   uri?: vscode.Uri
   changeCount: number
   sourceChangeCount?: number
-  foldedChangeCount?: number
+  complete?: boolean
+  before?: OmegaEditChangeLogFingerprint
+  after?: OmegaEditChangeLogFingerprint
+  unavailableChangeCount?: number
+  unavailableChangeSerials?: number[]
   cancelled?: boolean
 }
 

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -31,6 +31,7 @@ import {
   ALL_EVENTS,
   applyTransformPlugin,
   ChangeKind,
+  checkSessionModel,
   clear,
   countCharacters,
   CountKind,
@@ -52,6 +53,7 @@ import {
   getLanguage,
   getSegment,
   getServerInfo,
+  getSessionFingerprint,
   getViewportData,
   IOFlags,
   SaveStatus,
@@ -66,6 +68,7 @@ import {
   redo,
   runSessionTransaction,
   saveSession,
+  SessionFingerprintContent,
   SessionEventKind,
   startServerHeartbeatLoop,
   type TransformProgress,
@@ -144,6 +147,27 @@ interface AnalysisProfileRequest {
   isCapped: boolean
 }
 
+interface CollectedChangeLogRecords {
+  changes: ChangeRecord[]
+  unavailableChangeSerials: number[]
+}
+
+interface ChangeLogDigest {
+  algorithm: string
+  value: string
+}
+
+interface ChangeLogFingerprint {
+  byteLength: number
+  digest: ChangeLogDigest
+}
+
+interface ParsedChangeLog {
+  changes: ChangeRecord[]
+  before?: ChangeLogFingerprint
+  after?: ChangeLogFingerprint
+}
+
 const SESSION_SYNC_TIMEOUT_MS = 2000
 const VIEWPORT_BUFFER_BYTES = 8 * 1024
 const SERVER_HEALTH_WARN_LATENCY_MS = 75
@@ -154,7 +178,8 @@ const MAX_FILE_SPLICE_BYTES = 32 * 1024 * 1024
 const MAX_CHANGE_LOG_BYTES = MAX_FILE_SPLICE_BYTES * 3
 const MAX_CHANGE_LOG_ENTRIES = 100_000
 const CHANGE_LOG_FORMAT = 'omega-edit.change-log'
-const CHANGE_LOG_VERSION = 1
+const CHANGE_LOG_VERSION = 2
+const DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM = 'sha256'
 const GRPC_NOT_FOUND = 5
 const CONTEXT_HEX_EDITOR_ACTIVE = 'omegaEdit.hexEditorActive'
 const CONTEXT_CAN_UNDO = 'omegaEdit.canUndo'
@@ -738,8 +763,9 @@ async function collectChangeLogRecords(
   sessionId: string,
   sourceChangeCount: number,
   onProgress?: (processedSerial: number) => void
-): Promise<ChangeRecord[]> {
+): Promise<CollectedChangeLogRecords> {
   const changes: ChangeRecord[] = []
+  const unavailableChangeSerials: number[] = []
   for (let serial = 1; serial <= sourceChangeCount; serial += 1) {
     try {
       changes.push(
@@ -749,11 +775,12 @@ async function collectChangeLogRecords(
       if (!isMissingChangeDetailsError(error)) {
         throw error
       }
+      unavailableChangeSerials.push(serial)
     } finally {
       onProgress?.(serial)
     }
   }
-  return changes
+  return { changes, unavailableChangeSerials }
 }
 
 async function rollbackSessionToChangeCount(
@@ -980,7 +1007,208 @@ function validateChangeRecordMetadata(
   }
 }
 
-function parseChangeLog(content: Uint8Array): ChangeRecord[] {
+function readChangeLogDocumentCount(
+  document: Record<string, unknown>,
+  key: string
+): number {
+  const value = safeNonNegativeInteger(document[key])
+  if (value === undefined) {
+    throw new Error(`Change log ${key} must be a non-negative safe integer`)
+  }
+  return value
+}
+
+function normalizeUnavailableChangeSerials(
+  value: unknown,
+  sourceChangeCount: number
+): number[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Change log unavailableChangeSerials must be an array')
+  }
+
+  const seen = new Set<number>()
+  return value.map((serial, index) => {
+    const serialNumber = typeof serial === 'number' ? serial : Number.NaN
+    if (!Number.isSafeInteger(serialNumber) || serialNumber <= 0) {
+      throw new Error(
+        `Change log unavailableChangeSerials[${index}] must be a positive safe integer`
+      )
+    }
+    if (serialNumber > sourceChangeCount) {
+      throw new Error(
+        `Change log unavailableChangeSerials[${index}] exceeds sourceChangeCount`
+      )
+    }
+    if (seen.has(serialNumber)) {
+      throw new Error(
+        `Change log unavailableChangeSerials[${index}] duplicates serial ${serialNumber}`
+      )
+    }
+    seen.add(serialNumber)
+    return serialNumber
+  })
+}
+
+function normalizeChangeLogFingerprint(
+  value: unknown,
+  key: 'before' | 'after'
+): ChangeLogFingerprint {
+  if (!isRecord(value)) {
+    throw new Error(`Change log ${key} fingerprint must be an object`)
+  }
+
+  const byteLength = safeNonNegativeInteger(value.byteLength)
+  if (byteLength === undefined) {
+    throw new Error(
+      `Change log ${key}.byteLength must be a non-negative safe integer`
+    )
+  }
+
+  if (!isRecord(value.digest)) {
+    throw new Error(`Change log ${key}.digest must be an object`)
+  }
+
+  const algorithm = value.digest.algorithm
+  if (typeof algorithm !== 'string' || !algorithm.trim()) {
+    throw new Error(`Change log ${key}.digest.algorithm must be a string`)
+  }
+
+  const digestValue = value.digest.value
+  if (typeof digestValue !== 'string' || !digestValue.trim()) {
+    throw new Error(`Change log ${key}.digest.value must be a string`)
+  }
+
+  return {
+    byteLength,
+    digest: {
+      algorithm: algorithm.trim().toLowerCase(),
+      value: digestValue.trim().toLowerCase(),
+    },
+  }
+}
+
+function describeUnavailableSerials(serials: number[]): string {
+  const preview = serials.slice(0, 10).join(', ')
+  const suffix = serials.length > 10 ? ', ...' : ''
+  return preview ? ` (serials: ${preview}${suffix})` : ''
+}
+
+function assertCompleteChangeLog(
+  action: 'export' | 'apply',
+  unavailableChangeSerials: number[]
+): void {
+  if (unavailableChangeSerials.length === 0) {
+    return
+  }
+
+  throw new Error(
+    `${
+      action === 'export'
+        ? 'Change log export is incomplete: the server no longer has details for every reported change'
+        : 'Change log is incomplete: unavailable change details cannot be replayed safely'
+    }${describeUnavailableSerials(unavailableChangeSerials)}`
+  )
+}
+
+async function getChangeLogFingerprint(
+  sessionId: string,
+  content: SessionFingerprintContent,
+  algorithm = DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM
+): Promise<ChangeLogFingerprint> {
+  const response = await getSessionFingerprint(sessionId, content, algorithm)
+  if (!response.fingerprint?.digest) {
+    throw new Error('Server fingerprint response is missing digest metadata')
+  }
+
+  return {
+    byteLength: response.fingerprint.byteLength,
+    digest: {
+      algorithm: response.fingerprint.digest.algorithm.toLowerCase(),
+      value: response.fingerprint.digest.value.toLowerCase(),
+    },
+  }
+}
+
+function fingerprintLabel(fingerprint: ChangeLogFingerprint): string {
+  return `${fingerprint.byteLength} bytes ${fingerprint.digest.algorithm}:${fingerprint.digest.value}`
+}
+
+function fingerprintsMatch(
+  actual: ChangeLogFingerprint,
+  expected: ChangeLogFingerprint
+): boolean {
+  return (
+    actual.byteLength === expected.byteLength &&
+    actual.digest.algorithm === expected.digest.algorithm &&
+    actual.digest.value === expected.digest.value
+  )
+}
+
+async function assertCurrentSessionFingerprint(
+  sessionId: string,
+  expected: ChangeLogFingerprint,
+  phase: 'before' | 'after'
+): Promise<void> {
+  const actual = await getChangeLogFingerprint(
+    sessionId,
+    SessionFingerprintContent.COMPUTED,
+    expected.digest.algorithm
+  )
+  if (fingerprintsMatch(actual, expected)) {
+    return
+  }
+
+  const preposition = phase === 'before' ? 'before applying' : 'after applying'
+  throw new Error(
+    `Change log ${phase} fingerprint mismatch ${preposition}: expected ${fingerprintLabel(
+      expected
+    )}, actual ${fingerprintLabel(actual)}`
+  )
+}
+
+function validateChangeLogDocumentMetadata(
+  document: Record<string, unknown>,
+  changes: ChangeRecord[]
+): void {
+  if (typeof document.complete !== 'boolean') {
+    throw new Error('Change log complete must be a boolean')
+  }
+
+  const changeCount = readChangeLogDocumentCount(document, 'changeCount')
+  const sourceChangeCount = readChangeLogDocumentCount(
+    document,
+    'sourceChangeCount'
+  )
+  const unavailableChangeCount = readChangeLogDocumentCount(
+    document,
+    'unavailableChangeCount'
+  )
+  if (changeCount !== changes.length) {
+    throw new Error('Change log changeCount must match changes length')
+  }
+  if (sourceChangeCount < changeCount) {
+    throw new Error('Change log sourceChangeCount must cover changeCount')
+  }
+
+  const unavailableChangeSerials = normalizeUnavailableChangeSerials(
+    document.unavailableChangeSerials,
+    sourceChangeCount
+  )
+  if (unavailableChangeCount !== unavailableChangeSerials.length) {
+    throw new Error(
+      'Change log unavailableChangeCount must match unavailableChangeSerials length'
+    )
+  }
+  if (document.complete !== (unavailableChangeCount === 0)) {
+    throw new Error(
+      'Change log complete must match unavailable change metadata'
+    )
+  }
+
+  assertCompleteChangeLog('apply', unavailableChangeSerials)
+}
+
+function parseChangeLog(content: Uint8Array): ParsedChangeLog {
   if (content.byteLength > MAX_CHANGE_LOG_BYTES) {
     throw new Error(
       `Change log is too large (${content.byteLength.toLocaleString()} bytes)`
@@ -996,20 +1224,22 @@ function parseChangeLog(content: Uint8Array): ChangeRecord[] {
   }
 
   let entries: unknown[] | undefined
-  if (Array.isArray(parsed)) {
-    entries = parsed
-  } else if (isRecord(parsed)) {
+  let document: Record<string, unknown> | undefined
+  if (isRecord(parsed)) {
     if (parsed.format !== CHANGE_LOG_FORMAT) {
       throw new Error('Unsupported change log format')
     }
     if (parsed.version !== CHANGE_LOG_VERSION) {
       throw new Error('Unsupported change log version')
     }
+    document = parsed
     entries = Array.isArray(parsed.changes) ? parsed.changes : undefined
   }
 
   if (!entries) {
-    throw new Error('Change log must be a JSON array or an object with changes')
+    throw new Error(
+      'Change log must be a versioned omega-edit.change-log document'
+    )
   }
   if (entries.length > MAX_CHANGE_LOG_ENTRIES) {
     throw new Error(
@@ -1025,7 +1255,15 @@ function parseChangeLog(content: Uint8Array): ChangeRecord[] {
     return change
   })
   validateChangeRecordMetadata(changes, entries)
-  return changes
+  if (document) {
+    validateChangeLogDocumentMetadata(document, changes)
+    return {
+      changes,
+      before: normalizeChangeLogFingerprint(document.before, 'before'),
+      after: normalizeChangeLogFingerprint(document.after, 'after'),
+    }
+  }
+  return { changes }
 }
 
 function backupIdToFilePath(backupId: string | undefined): string | undefined {
@@ -1727,7 +1965,11 @@ export class HexEditorProvider
         uri?: vscode.Uri
         changeCount: number
         sourceChangeCount?: number
-        foldedChangeCount?: number
+        complete?: boolean
+        before?: ChangeLogFingerprint
+        after?: ChangeLogFingerprint
+        unavailableChangeCount?: number
+        unavailableChangeSerials?: number[]
         cancelled?: boolean
       }
     | undefined
@@ -1738,6 +1980,20 @@ export class HexEditorProvider
       return
     }
 
+    const modelCheck = await checkSessionModel(session.sessionId)
+    if (!modelCheck.valid) {
+      throw new Error(
+        vscode.l10n.t(
+          'Change log export refused: OmegaEdit model integrity check failed with status {status}.',
+          { status: modelCheck.status }
+        )
+      )
+    }
+
+    const before = await getChangeLogFingerprint(
+      session.sessionId,
+      SessionFingerprintContent.ORIGINAL
+    )
     const sourceChangeCount = await getChangeCount(session.sessionId)
     const scriptUri =
       parseCommandOptionUri(options, 'targetUri') ??
@@ -1778,8 +2034,9 @@ export class HexEditorProvider
     }
 
     let changes: ChangeRecord[] = []
+    let unavailableChangeSerials: number[] = []
     if (sourceChangeCount > 0) {
-      changes = await vscode.window.withProgress(
+      const collected = await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
           title: vscode.l10n.t('Exporting {count} change log entries…', {
@@ -1807,18 +2064,30 @@ export class HexEditorProvider
           )
         }
       )
+      changes = collected.changes
+      unavailableChangeSerials = collected.unavailableChangeSerials
     }
+    assertCompleteChangeLog('export', unavailableChangeSerials)
+    const after = await getChangeLogFingerprint(
+      session.sessionId,
+      SessionFingerprintContent.COMPUTED,
+      before.digest.algorithm
+    )
     const changeCount = changes.length
-    const foldedChangeCount = sourceChangeCount - changeCount
+    const unavailableChangeCount = unavailableChangeSerials.length
 
     const content = Buffer.from(
       JSON.stringify(
         {
           format: CHANGE_LOG_FORMAT,
           version: CHANGE_LOG_VERSION,
+          complete: unavailableChangeCount === 0,
+          before,
+          after,
           changeCount,
           sourceChangeCount,
-          foldedChangeCount,
+          unavailableChangeCount,
+          unavailableChangeSerials,
           changes,
         },
         null,
@@ -1844,7 +2113,11 @@ export class HexEditorProvider
       uri: scriptUri,
       changeCount,
       sourceChangeCount,
-      foldedChangeCount,
+      complete: unavailableChangeCount === 0,
+      before,
+      after,
+      unavailableChangeCount,
+      unavailableChangeSerials,
     }
   }
 
@@ -1854,7 +2127,6 @@ export class HexEditorProvider
         uri?: vscode.Uri
         changeCount: number
         sourceChangeCount?: number
-        foldedChangeCount?: number
         cancelled?: boolean
       }
     | undefined
@@ -1894,9 +2166,9 @@ export class HexEditorProvider
     }
 
     const content = await vscode.workspace.fs.readFile(scriptUri)
-    let changes: ChangeRecord[]
+    let parsed: ParsedChangeLog
     try {
-      changes = parseChangeLog(content)
+      parsed = parseChangeLog(content)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       this.postSessionActionComplete(session, {
@@ -1917,6 +2189,15 @@ export class HexEditorProvider
         cancelled: true,
       }
     }
+    const { changes } = parsed
+    if (parsed.before) {
+      await assertCurrentSessionFingerprint(
+        session.sessionId,
+        parsed.before,
+        'before'
+      )
+    }
+
     let appliedChangeCount = 0
     await vscode.window.withProgress(
       {
@@ -1927,7 +2208,11 @@ export class HexEditorProvider
         cancellable: false,
       },
       async () => {
-        appliedChangeCount = await this.applyChangeLogEntries(session, changes)
+        appliedChangeCount = await this.applyChangeLogEntries(
+          session,
+          changes,
+          parsed.after
+        )
       }
     )
     this.postSessionActionComplete(session, {
@@ -3670,12 +3955,13 @@ export class HexEditorProvider
 
   private async applyChangeLogEntries(
     session: EditorSession,
-    changes: ChangeRecord[]
+    changes: ChangeRecord[],
+    expectedAfter?: ChangeLogFingerprint
   ): Promise<number> {
     if (!this.ensureSessionCanMutate(session, true)) {
       return 0
     }
-    if (changes.length === 0) {
+    if (changes.length === 0 && !expectedAfter) {
       return 0
     }
 
@@ -3716,15 +4002,24 @@ export class HexEditorProvider
     }
 
     try {
-      for (const change of changes) {
-        if (change.kind === 'TRANSFORM') {
-          await flushBatch()
-          await applyOne(change)
-        } else {
-          pendingBatch.push(change)
+      if (changes.length > 0) {
+        for (const change of changes) {
+          if (change.kind === 'TRANSFORM') {
+            await flushBatch()
+            await applyOne(change)
+          } else {
+            pendingBatch.push(change)
+          }
         }
+        await flushBatch()
       }
-      await flushBatch()
+      if (expectedAfter) {
+        await assertCurrentSessionFingerprint(
+          session.sessionId,
+          expectedAfter,
+          'after'
+        )
+      }
     } catch (error) {
       try {
         const rolledBack = await rollbackSessionToChangeCount(

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -33,6 +33,13 @@ const OBSERVE_FINAL_DELAY_MS = parseDelay(
   process.env.OMEGA_EDIT_OBSERVE_FINAL_DELAY_MS,
   10000
 )
+const ABC_SHA256_FINGERPRINT = {
+  byteLength: 3,
+  digest: {
+    algorithm: 'sha256',
+    value: 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+  },
+}
 
 suite('OmegaEdit VS Code extension', () => {
   let testPort
@@ -343,9 +350,18 @@ suite('OmegaEdit VS Code extension', () => {
 
     const script = JSON.parse(await fs.readFile(scriptPath, 'utf8'))
     assert.equal(script.format, 'omega-edit.change-log')
-    assert.equal(script.version, 1)
+    assert.equal(script.version, 2)
+    assert.equal(script.complete, true)
+    assert.equal(script.before.byteLength, 8)
+    assert.equal(script.before.digest.algorithm, 'sha256')
+    assert.match(script.before.digest.value, /^[0-9a-f]+$/)
+    assert.equal(script.after.byteLength, 12)
+    assert.equal(script.after.digest.algorithm, 'sha256')
+    assert.match(script.after.digest.value, /^[0-9a-f]+$/)
+    assert.notEqual(script.before.digest.value, script.after.digest.value)
     assert.equal(script.sourceChangeCount, script.changeCount)
-    assert.equal(script.foldedChangeCount, 0)
+    assert.equal(script.unavailableChangeCount, 0)
+    assert.deepEqual(script.unavailableChangeSerials, [])
     assert.ok(
       Array.isArray(script.changes),
       'Expected export to produce a change-log document'
@@ -422,10 +438,14 @@ suite('OmegaEdit VS Code extension', () => {
       scriptPath,
       JSON.stringify({
         format: 'omega-edit.change-log',
-        version: 1,
+        version: 2,
+        complete: true,
+        before: ABC_SHA256_FINGERPRINT,
+        after: ABC_SHA256_FINGERPRINT,
         changeCount: 2,
         sourceChangeCount: 2,
-        foldedChangeCount: 0,
+        unavailableChangeCount: 0,
+        unavailableChangeSerials: [],
         changes: [
           {
             serial: 1,
@@ -470,6 +490,31 @@ suite('OmegaEdit VS Code extension', () => {
 
     assert.equal(result?.cancelled, true)
     assert.equal(result?.changeCount, 0)
+    await assertSessionText(session.sessionId, 'abc')
+
+    await fs.writeFile(
+      scriptPath,
+      JSON.stringify({
+        format: 'omega-edit.change-log',
+        version: 2,
+        complete: false,
+        before: ABC_SHA256_FINGERPRINT,
+        after: ABC_SHA256_FINGERPRINT,
+        changeCount: 0,
+        sourceChangeCount: 1,
+        unavailableChangeCount: 1,
+        unavailableChangeSerials: [1],
+        changes: [],
+      })
+    )
+
+    const incompleteResult = await provider.applyChangeLog({
+      uri: document.uri,
+      sourceUri: vscode.Uri.file(scriptPath),
+    })
+
+    assert.equal(incompleteResult?.cancelled, true)
+    assert.equal(incompleteResult?.changeCount, 0)
     await assertSessionText(session.sessionId, 'abc')
 
     await panel.fireDidDispose()


### PR DESCRIPTION
## Summary

- Adds v2 change-log documents with explicit completeness metadata plus before/after byte length and digest fingerprints.
- Computes fingerprints server-side via the first-party OpenSSL digest transform plugin, with algorithm name/value metadata and plugin staging/default discovery in the server package.
- Rejects incomplete or unversioned change logs, validates serial/group metadata, and makes AI/VS Code apply paths all-or-none with preflight/postcondition fingerprint checks and rollback on failure.
- Adds native model checks, original/computed session fingerprint RPCs, and focused core/server support for plugin-backed streaming inspection.

## Validation

- `cmake --build .codex-tmp/native-core-build --target install`
- `cmake --build .codex-tmp/native-server-build --target omega-edit-grpc-server`
- `CPP_SERVER_BINARY=.codex-tmp/native-server-build/omega-edit-grpc-server OE_LIB_DIR=.codex-tmp/native-core-install/lib yarn workspace @omega-edit/server build`
- `yarn workspace @omega-edit/ai build && yarn workspace @omega-edit/ai lint`
- `CPP_SERVER_BINARY=.codex-tmp/native-server-build/omega-edit-grpc-server yarn workspace @omega-edit/ai test`
- `yarn workspace @omega-edit/client lint`
- `TMPDIR=/tmp TMP=/tmp TEMP=/tmp CPP_SERVER_BINARY=.codex-tmp/native-server-build/omega-edit-grpc-server OE_LIB_DIR=.codex-tmp/native-core-install/lib yarn workspace @omega-edit/client test`
- `npm --prefix vscode-extension run compile:extension && npm --prefix vscode-extension run lint`
- `git diff --check`

Note: the client suite was run with `TMPDIR=/tmp` under WSL so Unix-domain-socket tests use a Linux socket path instead of `/mnt/c/.../Temp`.
