### PR TITLE
feat: add checkpoint restore and changelog replay coverage

### DIFF
--- a/.github/workflows/buf-publish.yml
+++ b/.github/workflows/buf-publish.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
       - name: Detect intentional major prerelease proto-breaking window
         id: proto_breaking_policy
         run: |
@@ -57,6 +59,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
       - name: Push to BSR
         env:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}

--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -6,8 +6,7 @@ Grouped by theme, roughly prioritized within each group. File:line references po
 offending code.
 
 Status notes:
-- `Fixed` means the current `codex/fix-transform-content-changed` branch addresses the
-  item directly.
+- `Fixed` means the current follow-up branch addresses the item directly.
 - `Partially fixed` means the branch reduces the risk but leaves a larger design gap.
 - `New` means the item is validated against the current tree but has not been addressed.
 
@@ -110,8 +109,10 @@ This is the reported bug. Root causes are spread across all three layers.
     on a *different* file (the whole point of a portable change log).
     **Status: Partially fixed.** Core/proto/server/client/export/import paths now carry
     `TRANSFORM` metadata, and direct VS Code transforms now record that metadata locally.
-    Transform replay still depends on the target having the same plugin semantics and rollback
-    still uses undo-to-start-count compensation rather than a dedicated atomic import primitive.
+    Import now replays transforms through the server and verifies the replayed size/replacement
+    metadata before reporting success. Transform replay still depends on the target having the
+    same plugin semantics, and rollback still uses undo-to-start-count compensation rather than
+    a dedicated native import primitive.
 
 11. **Checkpoint rollback names must not promise snapshot restore semantics.**
     The checkpoint operation calls `destroyLastCheckpoint`; there is no snapshot/restore
@@ -146,8 +147,8 @@ This is the reported bug. Root causes are spread across all three layers.
     The checkpoint path previously mixed rollback and restore vocabulary for closely-related
     concepts, confusing users and future maintainers.
     **Status: Fixed.** The checkpoint command/API/protocol/tooling path now consistently uses
-    rollback terminology; remaining restore wording is limited to unrelated backup restore and
-    future true snapshot-restore work.
+    rollback terminology for drop-last-checkpoint behavior; restore terminology is reserved for
+    the true snapshot-restore API.
 
 15. **Cancelled actions are reported as success-ish.**
     `exportChangeLog` cancel returns `{ cancelled: true }` but still posts a
@@ -259,8 +260,10 @@ This is the reported bug. Root causes are spread across all three layers.
 27. **`applyChangeLog` round-trip test only covers the happy path.**
     `packages/ai/tests/specs/toolkit.spec.ts` exercises a single OVERWRITE. No test for
     multi-entry logs, REPLACE entries, partial-failure/atomicity, or the entry/byte caps.
-    **Status: Partially fixed.** Added malformed wrapped-change-log import coverage and a
-    partial-failure rollback regression; multi-entry, REPLACE, and cap tests remain open.
+    **Status: Partially fixed.** Added malformed wrapped-change-log import coverage, a
+    partial-failure rollback regression, multi-entry/REPLACE atomicity coverage, transform
+    replay-metadata mismatch coverage, and true checkpoint-restore coverage. Cap-removal and
+    streaming-import coverage remain open.
 
 ---
 
@@ -273,6 +276,9 @@ This is the reported bug. Root causes are spread across all three layers.
   Requires: core/proto change-kind support, server to record transform-as-change, client wrapper,
   AI + extension change-log encode/decode, and undo-by-inverse-or-rerun semantics.
 - **G2 — True checkpoint restore** (snapshot + restore-to), distinct from drop-last-checkpoint.
+  **Status: Fixed.** Core/proto/server/client/AI/VS Code now expose restore-to-latest-checkpoint
+  semantics that keep the checkpoint snapshot, discard later edits/redo, refresh viewports, and
+  emit a distinct restore event.
 - **G3 — Streaming / file-backed change logs** to drop the in-memory and entry-count caps.
   **Status: Partially fixed.** File-backed export streams entries and the former hard caps are
   gone; streaming import/chunked payloads still need a format/API decision.

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -524,6 +524,16 @@ int omega_edit_create_checkpoint(omega_session_t *session_ptr);
  */
 int omega_edit_destroy_last_checkpoint(omega_session_t *session_ptr);
 
+/**
+ * Restores the current session content to the most recent checkpoint snapshot.
+ *
+ * Unlike omega_edit_destroy_last_checkpoint, this keeps the checkpoint model in
+ * place and discards only the edits made after that checkpoint snapshot.
+ * @param session_ptr session to restore
+ * @return zero on success, non-zero otherwise
+ */
+int omega_edit_restore_last_checkpoint(omega_session_t *session_ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/src/include/omega_edit/fwd_defs.h
+++ b/core/src/include/omega_edit/fwd_defs.h
@@ -45,7 +45,8 @@ typedef enum {
     SESSION_EVT_TRANSFORM_STARTED = 1 << 14,//< Occurs when a transform starts
     SESSION_EVT_TRANSFORM_PROGRESS = 1 << 15,//< Occurs when a running transform reports progress
     SESSION_EVT_TRANSFORM_COMPLETED = 1 << 16,//< Occurs when a transform completes successfully
-    SESSION_EVT_TRANSFORM_FAILED = 1 << 17//< Occurs when a transform fails
+    SESSION_EVT_TRANSFORM_FAILED = 1 << 17,//< Occurs when a transform fails
+    SESSION_EVT_RESTORE_CHECKPOINT = 1 << 18//< Occurs when a checkpoint snapshot is restored
 } omega_session_event_t;
 
 /** Enumeration of viewport events */

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -941,6 +941,25 @@ namespace {
         return -1;
     }
 
+    size_t checkpoint_snapshot_change_count_(const omega_model_t *model_ptr) {
+        if (!model_ptr || model_ptr->changes.empty()) { return 0; }
+        const auto &first_change_ptr = model_ptr->changes.front();
+        if (omega_change_get_kind_(first_change_ptr.get()) != change_kind_t::CHANGE_TRANSFORM ||
+            !first_change_ptr->transform_data) {
+            return 0;
+        }
+        return first_change_ptr->transform_data->checkpoint_file_path == model_ptr->file_path ? 1U : 0U;
+    }
+
+    void notify_checkpoint_restore_(omega_session_t *session_ptr) {
+        for (const auto &viewport_ptr : session_ptr->viewports_) {
+            viewport_ptr->data_segment.capacity =
+                    -1 * std::abs(viewport_ptr->data_segment.capacity);// indicate dirty read
+            omega_viewport_notify(viewport_ptr.get(), VIEWPORT_EVT_CHANGES, nullptr);
+        }
+        omega_session_notify(session_ptr, SESSION_EVT_RESTORE_CHECKPOINT, nullptr);
+    }
+
     inline auto determine_change_transaction_bit_(omega_session_t *session_ptr) -> bool {
         switch (omega_session_get_transaction_state(session_ptr)) {
             case 0:
@@ -2455,4 +2474,21 @@ int omega_edit_destroy_last_checkpoint(omega_session_t *session_ptr) {
         return 0;
     }
     return -1;
+}
+
+int omega_edit_restore_last_checkpoint(omega_session_t *session_ptr) {
+    if (!session_ptr || omega_session_get_num_checkpoints(session_ptr) <= 0) { return -1; }
+
+    auto *const model_ptr = session_ptr->models_.back().get();
+    const auto keep_count = checkpoint_snapshot_change_count_(model_ptr);
+    if (model_ptr->changes.size() > keep_count) {
+        model_ptr->changes.erase(model_ptr->changes.begin() + static_cast<std::ptrdiff_t>(keep_count),
+                                 model_ptr->changes.end());
+    }
+    free_model_changes_undone_(model_ptr);
+    if (0 != rebuild_model_to_change_count_(session_ptr, static_cast<int64_t>(keep_count))) { return -1; }
+
+    session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
+    notify_checkpoint_restore_(session_ptr);
+    return 0;
 }

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -21,6 +21,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_contains.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <algorithm>
 #include <vector>
 
 using Catch::Matchers::Contains;
@@ -147,6 +148,72 @@ TEST_CASE("Session Checkpoint Tests", "[SessionCheckpointTests]") {
                                  omega_io_flags_t::IO_FLG_OVERWRITE, nullptr));
     REQUIRE(0 == omega_util_compare_files(MAKE_PATH("test1.expected.checkpoint.1.dat"),
                                           MAKE_PATH("test1.actual.checkpoint.7.dat")));
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Restore Last Checkpoint Keeps Snapshot And Discards Later Edits",
+          "[SessionCheckpointTests][RestoreCheckpoint]") {
+    std::vector<omega_session_event_t> events;
+    const auto input = reinterpret_cast<const omega_byte_t *>("abcdef");
+    const auto session_ptr =
+            omega_edit_create_session_from_bytes(input, 6, record_session_event_cbk, &events, ALL_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(-1 == omega_edit_restore_last_checkpoint(session_ptr));
+    REQUIRE(1 == omega_edit_overwrite_string(session_ptr, 1, "Z"));
+    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(1 == omega_session_get_num_changes(session_ptr));
+    REQUIRE("aZcdef" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    REQUIRE(2 == omega_edit_insert_string(session_ptr, 2, "YY"));
+    REQUIRE(3 == omega_edit_delete(session_ptr, 4, 1));
+    REQUIRE(3 == omega_session_get_num_changes(session_ptr));
+    REQUIRE("aZYYdef" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    REQUIRE(0 == omega_edit_restore_last_checkpoint(session_ptr));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(1 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE("aZcdef" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(std::find(events.begin(), events.end(), SESSION_EVT_RESTORE_CHECKPOINT) != events.end());
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Restore Last Transform Checkpoint Preserves Transform Change",
+          "[SessionCheckpointTests][RestoreCheckpoint]") {
+    const auto input = reinterpret_cast<const omega_byte_t *>("abcXYZ");
+    const auto session_ptr =
+            omega_edit_create_session_from_bytes(input, 6, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 == omega_edit_apply_transform(session_ptr, to_lower, nullptr, 0, 0));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(1 == omega_session_get_num_changes(session_ptr));
+    const auto *transform_change = omega_session_get_last_change(session_ptr);
+    REQUIRE(transform_change);
+    REQUIRE('T' == omega_change_get_kind_as_char(transform_change));
+    REQUIRE("abcxyz" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    REQUIRE(2 == omega_edit_insert_string(session_ptr, 3, "--"));
+    REQUIRE("abc--xyz" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    REQUIRE(0 == omega_edit_restore_last_checkpoint(session_ptr));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(1 == omega_session_get_num_changes(session_ptr));
+    transform_change = omega_session_get_last_change(session_ptr);
+    REQUIRE(transform_change);
+    REQUIRE('T' == omega_change_get_kind_as_char(transform_change));
+    REQUIRE(1 == omega_change_get_serial(transform_change));
+    REQUIRE("abcxyz" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
     omega_edit_destroy_session(session_ptr);
 }
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -63,6 +63,7 @@ oe export-range --session <session-id> --offset 0 --length 128 --output ./header
 
 # Create checkpoints and broadcast/apply change logs
 oe create-checkpoint --session <session-id>
+oe restore-checkpoint --session <session-id>
 oe rollback-checkpoint --session <session-id>
 oe export-change-log --session <session-id> --output ./changes.json --overwrite
 oe apply-change-log --session <session-id> --input ./changes.json

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -36,6 +36,7 @@ function usage(): string {
     '  session-status --session <id>',
     '  create-checkpoint --session <id>',
     '  rollback-checkpoint --session <id>  # roll back the most recent checkpoint',
+    '  restore-checkpoint --session <id>   # restore content to the most recent checkpoint',
     '  export-change-log --session <id> [--output <path>] [--overwrite]',
     '  apply-change-log --session <id> --input <path> [--dry-run]',
     '  diff-session --session <id>',
@@ -269,6 +270,22 @@ async function runCommand(
         allowPositionals: false,
       })
       return await getToolkit(parsed.values).rollbackCheckpoint(
+        requireStringOption(
+          parsed.values.session as string | undefined,
+          'session'
+        )
+      )
+    }
+    case 'restore-checkpoint': {
+      const parsed = parseArgs({
+        args,
+        options: {
+          ...commonOptions,
+          session: { type: 'string' as const },
+        },
+        allowPositionals: false,
+      })
+      return await getToolkit(parsed.values).restoreCheckpoint(
         requireStringOption(
           parsed.values.session as string | undefined,
           'session'

--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -305,6 +305,23 @@ function buildTools(toolkit: OmegaEditToolkit): ToolDefinition[] {
       },
     },
     {
+      name: 'omega_edit_restore_checkpoint',
+      description:
+        'Restore session content to the most recent OmegaEdit checkpoint without dropping that checkpoint.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+      },
+      run: async (argumentsObject) => {
+        return await toolkit.restoreCheckpoint(
+          getString(argumentsObject, 'sessionId', true)!
+        )
+      },
+    },
+    {
       name: 'omega_edit_export_change_log',
       description:
         'Export the OmegaEdit change log for a session as JSON entries, optionally writing the same change-log document to a file.',

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -36,6 +36,7 @@ import {
   replace,
   replaceSession as replaceWholeSession,
   resetClient,
+  restoreLastCheckpoint as restoreClientCheckpoint,
   runSessionTransaction,
   saveSession,
   searchSession,
@@ -74,6 +75,7 @@ import {
   ReadRangeResult,
   ReplaceSessionRequest,
   ReplaceSessionResult,
+  RestoreCheckpointResult,
   RollbackCheckpointResult,
   SearchRequest,
   SearchResult,
@@ -1167,6 +1169,29 @@ export class OmegaEditToolkit {
     }
   }
 
+  async restoreCheckpoint(sessionId: string): Promise<RestoreCheckpointResult> {
+    await this.ensureServerRunning()
+    const existingCount = await this.getCheckpointCount(sessionId)
+    if (existingCount <= 0) {
+      return {
+        sessionId,
+        restored: false,
+        checkpointCount: 0,
+        changeCount: await getChangeCount(sessionId),
+        discardedChangeCount: 0,
+      }
+    }
+
+    const response = await restoreClientCheckpoint(sessionId)
+    return {
+      sessionId: response.sessionId,
+      restored: true,
+      checkpointCount: response.checkpointCount,
+      changeCount: response.changeCount,
+      discardedChangeCount: response.discardedChangeCount,
+    }
+  }
+
   async exportChangeLog(
     sessionId: string,
     outputPath?: string,
@@ -1269,7 +1294,6 @@ export class OmegaEditToolkit {
     const startChangeCount = await getChangeCount(request.sessionId)
     try {
       const applyChange = async (change: ChangeLogEntry) => {
-        const data = Buffer.from(change.data, 'hex')
         const offset = normalizeNonNegativeInt64ForClient(
           change.offset,
           'change log entry offset'
@@ -1280,30 +1304,89 @@ export class OmegaEditToolkit {
         )
         switch (change.kind) {
           case 'INSERT':
-            await insert(request.sessionId, offset, data)
+            await insert(
+              request.sessionId,
+              offset,
+              Buffer.from(change.data, 'hex')
+            )
             return true
           case 'DELETE':
             await del(request.sessionId, offset, length)
             return true
           case 'OVERWRITE':
-            await overwrite(request.sessionId, offset, data)
+            await overwrite(
+              request.sessionId,
+              offset,
+              Buffer.from(change.data, 'hex')
+            )
             return true
           case 'REPLACE':
-            await replace(request.sessionId, offset, length, data)
+            await replace(
+              request.sessionId,
+              offset,
+              length,
+              Buffer.from(change.data, 'hex')
+            )
             return true
-          case 'TRANSFORM':
+          case 'TRANSFORM': {
             if (!change.transformId) {
               throw new Error('TRANSFORM change requires transformId')
             }
-            return (
-              await applyClientTransformPlugin(
-                request.sessionId,
-                change.transformId,
-                offset,
-                length,
-                change.optionsJson
+            const expectedSizeBefore =
+              change.computedFileSizeBefore !== undefined
+                ? normalizeNonNegativeInt64ForClient(
+                    change.computedFileSizeBefore,
+                    'change log entry computedFileSizeBefore'
+                  )
+                : undefined
+            if (expectedSizeBefore !== undefined) {
+              const actualSizeBefore = await getComputedFileSize(
+                request.sessionId
               )
-            ).contentChanged
+              if (actualSizeBefore !== expectedSizeBefore) {
+                throw new Error(
+                  `TRANSFORM ${change.transformId} expected pre-transform size ${expectedSizeBefore}, found ${actualSizeBefore}`
+                )
+              }
+            }
+            const response = await applyClientTransformPlugin(
+              request.sessionId,
+              change.transformId,
+              offset,
+              length,
+              change.optionsJson
+            )
+            if (!response.contentChanged) {
+              throw new Error(
+                `TRANSFORM ${change.transformId} replay produced no content change`
+              )
+            }
+            if (
+              change.replacementLength !== undefined &&
+              response.replacementLength !==
+                normalizeNonNegativeInt64ForClient(
+                  change.replacementLength,
+                  'change log entry replacementLength'
+                )
+            ) {
+              throw new Error(
+                `TRANSFORM ${change.transformId} replacement length mismatch`
+              )
+            }
+            if (
+              change.computedFileSizeAfter !== undefined &&
+              response.computedFileSize !==
+                normalizeNonNegativeInt64ForClient(
+                  change.computedFileSizeAfter,
+                  'change log entry computedFileSizeAfter'
+                )
+            ) {
+              throw new Error(
+                `TRANSFORM ${change.transformId} post-transform size mismatch`
+              )
+            }
+            return true
+          }
         }
       }
       const applyAndCountChange = async (change: ChangeLogEntry) => {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -118,6 +118,14 @@ export interface RollbackCheckpointResult {
   checkpointCount: number
 }
 
+export interface RestoreCheckpointResult {
+  sessionId: string
+  restored: boolean
+  checkpointCount: number
+  changeCount: number
+  discardedChangeCount: number
+}
+
 export interface ReadRangeResult {
   sessionId: string
   offset: number

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'assert'
+import { createHash } from 'crypto'
 import * as fs from 'fs'
 import { createServer } from 'net'
 import * as os from 'os'
@@ -22,6 +23,17 @@ const ABCDEF_SHA256_FINGERPRINT = {
     algorithm: 'sha256',
     value: 'bef57ec7f53a6d40beb640a780a639c83bc29ac8a9816f1fc6c5c6dcd93c4721',
   },
+}
+
+function makeUtf8Fingerprint(text: string) {
+  const data = Buffer.from(text, 'utf8')
+  return {
+    byteLength: data.byteLength,
+    digest: {
+      algorithm: 'sha256',
+      value: createHash('sha256').update(data).digest('hex'),
+    },
+  }
 }
 
 function makeChangeLogDocument(
@@ -472,6 +484,18 @@ describe('@omega-edit/ai toolkit', () => {
 
       const checkpoint = await toolkit.createCheckpoint(createdSessionId)
       assert.ok(checkpoint.checkpointCount >= 1)
+      await toolkit.applyPatch({
+        sessionId: createdSessionId,
+        kind: 'insert',
+        offset: 6,
+        data: parseInputData('!', 'utf8'),
+      })
+      const restored = await toolkit.restoreCheckpoint(createdSessionId)
+      assert.equal(restored.restored, true)
+      assert.equal(restored.checkpointCount, checkpoint.checkpointCount)
+      assert.ok(restored.discardedChangeCount >= 1)
+      const afterRestore = await toolkit.readRange(createdSessionId, 0, 6)
+      assert.equal(afterRestore.data.utf8, 'aZcdef')
       const rolledBack = await toolkit.rollbackCheckpoint(createdSessionId)
       assert.equal(rolledBack.rolledBack, true)
       assert.ok(rolledBack.checkpointCount >= 0)
@@ -734,6 +758,132 @@ describe('@omega-edit/ai toolkit', () => {
         await firstToolkit.destroySession(firstSessionId).catch(() => undefined)
       }
       await firstToolkit.stopServer().catch(() => undefined)
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('applies multi-entry change logs with replace entries atomically', async function () {
+    const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
+    assert.ok(port, 'expected an available port for OmegaEdit')
+
+    const toolkit = new OmegaEditToolkit({ port: port!, autoStart: true })
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
+    const inputPath = path.join(tempDir, 'input.bin')
+    fs.writeFileSync(inputPath, Buffer.from('abcdef', 'utf8'))
+
+    let createdSessionId = ''
+
+    try {
+      const created = await toolkit.createSession(inputPath)
+      createdSessionId = created.sessionId
+
+      const result = await toolkit.applyChangeLog({
+        sessionId: createdSessionId,
+        changes: makeChangeLogDocument(
+          [
+            {
+              serial: 1,
+              kind: 'INSERT',
+              offset: 1,
+              length: 0,
+              data: Buffer.from('12', 'utf8').toString('hex'),
+            },
+            {
+              serial: 2,
+              kind: 'REPLACE',
+              offset: 4,
+              length: 2,
+              data: Buffer.from('ZZ', 'utf8').toString('hex'),
+            },
+            {
+              serial: 3,
+              kind: 'OVERWRITE',
+              offset: 7,
+              length: 1,
+              data: Buffer.from('!', 'utf8').toString('hex'),
+            },
+          ],
+          {
+            before: ABCDEF_SHA256_FINGERPRINT,
+            after: makeUtf8Fingerprint('a12bZZe!'),
+          }
+        ),
+      })
+      assert.equal(result.applied, true)
+      assert.equal(result.changeCount, 3)
+      assert.equal(result.inputChangeCount, 3)
+
+      const range = await toolkit.readRange(createdSessionId, 0, 8)
+      assert.equal(range.data.utf8, 'a12bZZe!')
+      const status = await toolkit.sessionStatus(createdSessionId)
+      assert.equal(status.changeCount, 3)
+    } finally {
+      if (createdSessionId) {
+        await toolkit.destroySession(createdSessionId).catch(() => undefined)
+      }
+      await toolkit.stopServer().catch(() => undefined)
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects transform change logs when replay metadata differs', async function () {
+    const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
+    assert.ok(port, 'expected an available port for OmegaEdit')
+
+    const toolkit = new OmegaEditToolkit({ port: port!, autoStart: true })
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
+    const sourcePath = path.join(tempDir, 'source.bin')
+    const replayPath = path.join(tempDir, 'replay.bin')
+    const changeLogPath = path.join(tempDir, 'changes.json')
+    fs.writeFileSync(sourcePath, Buffer.from('ABCDEFGH', 'utf8'))
+    fs.writeFileSync(replayPath, Buffer.from('ABCDEFGH', 'utf8'))
+
+    let sourceSessionId = ''
+    let replaySessionId = ''
+
+    try {
+      const source = await toolkit.createSession(sourcePath)
+      sourceSessionId = source.sessionId
+      await toolkit.applyTransformPlugin({
+        sessionId: sourceSessionId,
+        pluginId: 'omega.example.base64',
+        offset: 0,
+        length: 8,
+      })
+      await toolkit.exportChangeLog(sourceSessionId, changeLogPath, true)
+
+      const tamperedLog = JSON.parse(
+        await fs.promises.readFile(changeLogPath, 'utf8')
+      )
+      const transformChange = tamperedLog.changes.find(
+        (change: ChangeLogEntry) => change.kind === 'TRANSFORM'
+      )
+      assert.ok(transformChange, 'expected exported transform change')
+      transformChange.replacementLength = '999'
+
+      const replay = await toolkit.createSession(replayPath)
+      replaySessionId = replay.sessionId
+      await assert.rejects(
+        () =>
+          toolkit.applyChangeLog({
+            sessionId: replaySessionId,
+            changes: tamperedLog,
+          }),
+        /replacement length mismatch/
+      )
+
+      const replayedRange = await toolkit.readRange(replaySessionId, 0, 8)
+      assert.equal(replayedRange.data.utf8, 'ABCDEFGH')
+      const status = await toolkit.sessionStatus(replaySessionId)
+      assert.equal(status.changeCount, 0)
+    } finally {
+      if (sourceSessionId) {
+        await toolkit.destroySession(sourceSessionId).catch(() => undefined)
+      }
+      if (replaySessionId) {
+        await toolkit.destroySession(replaySessionId).catch(() => undefined)
+      }
+      await toolkit.stopServer().catch(() => undefined)
       fs.rmSync(tempDir, { recursive: true, force: true })
     }
   })

--- a/packages/client/src/editor_session_model.ts
+++ b/packages/client/src/editor_session_model.ts
@@ -111,7 +111,8 @@ export class EditorSessionModel {
       kind !== SessionEventKind.UNDO &&
       kind !== SessionEventKind.CLEAR &&
       kind !== SessionEventKind.TRANSFORM &&
-      kind !== SessionEventKind.CREATE_CHECKPOINT
+      kind !== SessionEventKind.CREATE_CHECKPOINT &&
+      kind !== SessionEventKind.RESTORE_CHECKPOINT
     ) {
       return false
     }

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -39,6 +39,8 @@ import type { ApplyTransformPluginResponse } from './omega_edit'
 import type { ApplyTransformPluginRequest } from './omega_edit'
 import type { ListTransformPluginsResponse } from './omega_edit'
 import type { ListTransformPluginsRequest } from './omega_edit'
+import type { RestoreLastCheckpointResponse } from './omega_edit'
+import type { RestoreLastCheckpointRequest } from './omega_edit'
 import type { DestroyLastCheckpointResponse } from './omega_edit'
 import type { DestroyLastCheckpointRequest } from './omega_edit'
 import type { CreateCheckpointResponse } from './omega_edit'
@@ -1551,6 +1553,44 @@ export interface IEditorServiceClient {
     callback: (
       err: grpc.ServiceError | null,
       value?: DestroyLastCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  /**
+   * Restore session content to the most recent checkpoint snapshot while
+   * keeping that checkpoint available.
+   *
+   * @generated from protobuf rpc: RestoreLastCheckpoint
+   */
+  restoreLastCheckpoint(
+    input: RestoreLastCheckpointRequest,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: RestoreLastCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  restoreLastCheckpoint(
+    input: RestoreLastCheckpointRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: RestoreLastCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  restoreLastCheckpoint(
+    input: RestoreLastCheckpointRequest,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: RestoreLastCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  restoreLastCheckpoint(
+    input: RestoreLastCheckpointRequest,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: RestoreLastCheckpointResponse
     ) => void
   ): grpc.ClientUnaryCall
   /**
@@ -3403,6 +3443,48 @@ export class EditorServiceClient
     )
   }
   /**
+   * Restore session content to the most recent checkpoint snapshot while
+   * keeping that checkpoint available.
+   *
+   * @generated from protobuf rpc: RestoreLastCheckpoint
+   */
+  restoreLastCheckpoint(
+    input: RestoreLastCheckpointRequest,
+    metadata:
+      | grpc.Metadata
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: RestoreLastCheckpointResponse
+        ) => void),
+    options?:
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: RestoreLastCheckpointResponse
+        ) => void),
+    callback?: (
+      err: grpc.ServiceError | null,
+      value?: RestoreLastCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall {
+    const method = EditorService.methods[37]
+    return this.makeUnaryRequest<
+      RestoreLastCheckpointRequest,
+      RestoreLastCheckpointResponse
+    >(
+      `/${EditorService.typeName}/${method.name}`,
+      (value: RestoreLastCheckpointRequest): Buffer =>
+        Buffer.from(method.I.toBinary(value, this._binaryOptions)),
+      (value: Buffer): RestoreLastCheckpointResponse =>
+        method.O.fromBinary(value, this._binaryOptions),
+      input,
+      metadata as any,
+      options as any,
+      callback as any
+    )
+  }
+  /**
    * List transform plugins registered with the native server.
    *
    * @generated from protobuf rpc: ListTransformPlugins
@@ -3427,7 +3509,7 @@ export class EditorServiceClient
       value?: ListTransformPluginsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[37]
+    const method = EditorService.methods[38]
     return this.makeUnaryRequest<
       ListTransformPluginsRequest,
       ListTransformPluginsResponse
@@ -3469,7 +3551,7 @@ export class EditorServiceClient
       value?: ApplyTransformPluginResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[38]
+    const method = EditorService.methods[39]
     return this.makeUnaryRequest<
       ApplyTransformPluginRequest,
       ApplyTransformPluginResponse
@@ -3511,7 +3593,7 @@ export class EditorServiceClient
       value?: GetByteFrequencyProfileResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[39]
+    const method = EditorService.methods[40]
     return this.makeUnaryRequest<
       GetByteFrequencyProfileRequest,
       GetByteFrequencyProfileResponse
@@ -3553,7 +3635,7 @@ export class EditorServiceClient
       value?: GetCharacterCountsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[40]
+    const method = EditorService.methods[41]
     return this.makeUnaryRequest<
       GetCharacterCountsRequest,
       GetCharacterCountsResponse
@@ -3598,7 +3680,7 @@ export class EditorServiceClient
       value?: ServerControlResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[41]
+    const method = EditorService.methods[42]
     return this.makeUnaryRequest<ServerControlRequest, ServerControlResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: ServerControlRequest): Buffer =>
@@ -3631,7 +3713,7 @@ export class EditorServiceClient
       value?: GetHeartbeatResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[42]
+    const method = EditorService.methods[43]
     return this.makeUnaryRequest<GetHeartbeatRequest, GetHeartbeatResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetHeartbeatRequest): Buffer =>
@@ -3660,7 +3742,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToSessionEventsResponse> {
-    const method = EditorService.methods[43]
+    const method = EditorService.methods[44]
     return this.makeServerStreamRequest<
       SubscribeToSessionEventsRequest,
       SubscribeToSessionEventsResponse
@@ -3686,7 +3768,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToViewportEventsResponse> {
-    const method = EditorService.methods[44]
+    const method = EditorService.methods[45]
     return this.makeServerStreamRequest<
       SubscribeToViewportEventsRequest,
       SubscribeToViewportEventsResponse
@@ -3726,7 +3808,7 @@ export class EditorServiceClient
       value?: UnsubscribeToSessionEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[45]
+    const method = EditorService.methods[46]
     return this.makeUnaryRequest<
       UnsubscribeToSessionEventsRequest,
       UnsubscribeToSessionEventsResponse
@@ -3767,7 +3849,7 @@ export class EditorServiceClient
       value?: UnsubscribeToViewportEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[46]
+    const method = EditorService.methods[47]
     return this.makeUnaryRequest<
       UnsubscribeToViewportEventsRequest,
       UnsubscribeToViewportEventsResponse

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -1650,6 +1650,40 @@ export interface DestroyLastCheckpointResponse {
   remainingCheckpoints: number // Remaining checkpoint count after revert.
 }
 /**
+ * Request to restore the most recent checkpoint snapshot without discarding it.
+ *
+ * @generated from protobuf message omega_edit.v1.RestoreLastCheckpointRequest
+ */
+export interface RestoreLastCheckpointRequest {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session to restore.
+}
+/**
+ * Result of restoring the most recent checkpoint snapshot.
+ *
+ * @generated from protobuf message omega_edit.v1.RestoreLastCheckpointResponse
+ */
+export interface RestoreLastCheckpointResponse {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session that was restored.
+  /**
+   * @generated from protobuf field: int64 checkpoint_count = 2
+   */
+  checkpointCount: number // Checkpoint count after restore.
+  /**
+   * @generated from protobuf field: int64 change_count = 3
+   */
+  changeCount: number // Session change count after restore.
+  /**
+   * @generated from protobuf field: int64 discarded_change_count = 4
+   */
+  discardedChangeCount: number // Number of active changes discarded.
+}
+/**
  * Metadata advertised by a registered transform plugin.
  *
  * @generated from protobuf message omega_edit.v1.TransformPluginInfo
@@ -2291,6 +2325,12 @@ export enum SessionEventKind {
    * @generated from protobuf enum value: SESSION_EVENT_KIND_TRANSFORM_FAILED = 131072;
    */
   TRANSFORM_FAILED = 131072,
+  /**
+   * A checkpoint snapshot was restored.
+   *
+   * @generated from protobuf enum value: SESSION_EVENT_KIND_RESTORE_CHECKPOINT = 262144;
+   */
+  RESTORE_CHECKPOINT = 262144,
 }
 /**
  * Viewport-level event kinds.  Values are powers of two so they can be OR'd
@@ -10577,6 +10617,196 @@ class DestroyLastCheckpointResponse$Type extends MessageType<DestroyLastCheckpoi
 export const DestroyLastCheckpointResponse =
   new DestroyLastCheckpointResponse$Type()
 // @generated message type with reflection information, may provide speed optimized methods
+class RestoreLastCheckpointRequest$Type extends MessageType<RestoreLastCheckpointRequest> {
+  constructor() {
+    super('omega_edit.v1.RestoreLastCheckpointRequest', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+    ])
+  }
+  create(
+    value?: PartialMessage<RestoreLastCheckpointRequest>
+  ): RestoreLastCheckpointRequest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    if (value !== undefined)
+      reflectionMergePartial<RestoreLastCheckpointRequest>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: RestoreLastCheckpointRequest
+  ): RestoreLastCheckpointRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: RestoreLastCheckpointRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.RestoreLastCheckpointRequest
+ */
+export const RestoreLastCheckpointRequest =
+  new RestoreLastCheckpointRequest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class RestoreLastCheckpointResponse$Type extends MessageType<RestoreLastCheckpointResponse> {
+  constructor() {
+    super('omega_edit.v1.RestoreLastCheckpointResponse', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'checkpoint_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 3,
+        name: 'change_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 4,
+        name: 'discarded_change_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<RestoreLastCheckpointResponse>
+  ): RestoreLastCheckpointResponse {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.checkpointCount = 0
+    message.changeCount = 0
+    message.discardedChangeCount = 0
+    if (value !== undefined)
+      reflectionMergePartial<RestoreLastCheckpointResponse>(
+        this,
+        message,
+        value
+      )
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: RestoreLastCheckpointResponse
+  ): RestoreLastCheckpointResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* int64 checkpoint_count */ 2:
+          message.checkpointCount = reader.int64().toNumber()
+          break
+        case /* int64 change_count */ 3:
+          message.changeCount = reader.int64().toNumber()
+          break
+        case /* int64 discarded_change_count */ 4:
+          message.discardedChangeCount = reader.int64().toNumber()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: RestoreLastCheckpointResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* int64 checkpoint_count = 2; */
+    if (message.checkpointCount !== 0)
+      writer.tag(2, WireType.Varint).int64(message.checkpointCount)
+    /* int64 change_count = 3; */
+    if (message.changeCount !== 0)
+      writer.tag(3, WireType.Varint).int64(message.changeCount)
+    /* int64 discarded_change_count = 4; */
+    if (message.discardedChangeCount !== 0)
+      writer.tag(4, WireType.Varint).int64(message.discardedChangeCount)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.RestoreLastCheckpointResponse
+ */
+export const RestoreLastCheckpointResponse =
+  new RestoreLastCheckpointResponse$Type()
+// @generated message type with reflection information, may provide speed optimized methods
 class TransformPluginInfo$Type extends MessageType<TransformPluginInfo> {
   constructor() {
     super('omega_edit.v1.TransformPluginInfo', [
@@ -12969,6 +13199,12 @@ export const EditorService = new ServiceType('omega_edit.v1.EditorService', [
     options: {},
     I: DestroyLastCheckpointRequest,
     O: DestroyLastCheckpointResponse,
+  },
+  {
+    name: 'RestoreLastCheckpoint',
+    options: {},
+    I: RestoreLastCheckpointRequest,
+    O: RestoreLastCheckpointResponse,
   },
   {
     name: 'ListTransformPlugins',

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -42,6 +42,7 @@ import {
   type ReplaceSessionResponse,
   type ReplaceSessionCheckpointedRequest,
   type ReplaceSessionCheckpointedResponse,
+  type RestoreLastCheckpointResponse,
   type SaveSessionRequest,
   type SaveSessionResponse,
   type SearchSessionRequest,
@@ -1314,6 +1315,55 @@ export async function replaceSessionCheckpointed(
           return resolve(required)
         } catch (error) {
           return reject(makeWrappedError('replaceSessionCheckpointed', error))
+        }
+      }
+    )
+  })
+}
+
+export async function restoreLastCheckpoint(
+  sessionId: string
+): Promise<RestoreLastCheckpointResponse> {
+  const log = getLogger()
+  const request = { sessionId }
+  debugLog(log, () => ({
+    fn: 'protobufTs.restoreLastCheckpoint',
+    rqst: request,
+  }))
+  const client = await getClient()
+
+  return new Promise<RestoreLastCheckpointResponse>((resolve, reject) => {
+    callUnary(
+      client,
+      client.restoreLastCheckpoint,
+      request,
+      (err, response) => {
+        if (err) {
+          log.error({
+            fn: 'protobufTs.restoreLastCheckpoint',
+            rqst: request,
+            err: {
+              msg: err.message,
+              details: err.details,
+              code: err.code,
+              stack: err.stack,
+            },
+          })
+          return reject(makeWrappedError('restoreLastCheckpoint', err))
+        }
+
+        try {
+          const required = requireResponse(
+            response as RestoreLastCheckpointResponse | undefined,
+            'restoreLastCheckpoint'
+          )
+          debugLog(log, () => ({
+            fn: 'protobufTs.restoreLastCheckpoint',
+            resp: required,
+          }))
+          return resolve(required)
+        } catch (error) {
+          return reject(makeWrappedError('restoreLastCheckpoint', error))
         }
       }
     )

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -26,6 +26,7 @@ import {
   type ApplyTransformPluginResponse as RawApplyTransformPluginResponse,
   type CheckSessionModelResponse as RawCheckSessionModelResponse,
   type GetSessionFingerprintResponse as RawGetSessionFingerprintResponse,
+  type RestoreLastCheckpointResponse as RawRestoreLastCheckpointResponse,
   type SessionContentFingerprint as RawSessionContentFingerprint,
   type TransformProgress,
   type TransformPluginInfo as RawTransformPluginInfo,
@@ -53,6 +54,7 @@ import {
   profileSession as rawProfileSession,
   replaceSession as rawReplaceSession,
   replaceSessionCheckpointed as rawReplaceSessionCheckpointed,
+  restoreLastCheckpoint as rawRestoreLastCheckpoint,
   resumeSessionChanges as rawResumeSessionChanges,
   saveSession as rawSaveSession,
   searchSession as rawSearchSession,
@@ -116,6 +118,7 @@ export const SessionEventKind = {
   TRANSFORM_PROGRESS: RawProtoSessionEventKind.TRANSFORM_PROGRESS,
   TRANSFORM_COMPLETED: RawProtoSessionEventKind.TRANSFORM_COMPLETED,
   TRANSFORM_FAILED: RawProtoSessionEventKind.TRANSFORM_FAILED,
+  RESTORE_CHECKPOINT: RawProtoSessionEventKind.RESTORE_CHECKPOINT,
 } as const
 export type SessionEventKind =
   (typeof SessionEventKind)[keyof typeof SessionEventKind]
@@ -152,6 +155,7 @@ export type TransformPluginOperation =
 
 export type TransformPluginInfo = RawTransformPluginInfo
 export type ApplyTransformPluginResponse = RawApplyTransformPluginResponse
+export type RestoreLastCheckpointResponse = RawRestoreLastCheckpointResponse
 export type CheckSessionModelResponse = RawCheckSessionModelResponse
 export type SessionContentFingerprint = RawSessionContentFingerprint
 export type GetSessionFingerprintResponse = RawGetSessionFingerprintResponse
@@ -251,6 +255,21 @@ export async function destroyLastCheckpoint(
       'remaining checkpoints',
       response.remainingCheckpoints
     )
+  })
+}
+
+export async function restoreLastCheckpoint(
+  session_id: string
+): Promise<RestoreLastCheckpointResponse> {
+  return await enqueueSessionMutation(session_id, async () => {
+    const response = await rawRestoreLastCheckpoint(session_id)
+    requireSafeIntegerOutput('checkpoint count', response.checkpointCount)
+    requireSafeIntegerOutput('change count', response.changeCount)
+    requireSafeIntegerOutput(
+      'discarded change count',
+      response.discardedChangeCount
+    )
+    return response
   })
 }
 

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -210,6 +210,11 @@ service EditorService {
   rpc DestroyLastCheckpoint(DestroyLastCheckpointRequest)
       returns (DestroyLastCheckpointResponse);
 
+  // Restore session content to the most recent checkpoint snapshot while
+  // keeping that checkpoint available.
+  rpc RestoreLastCheckpoint(RestoreLastCheckpointRequest)
+      returns (RestoreLastCheckpointResponse);
+
   // List transform plugins registered with the native server.
   rpc ListTransformPlugins(ListTransformPluginsRequest) returns (ListTransformPluginsResponse);
 
@@ -324,6 +329,8 @@ enum SessionEventKind {
   SESSION_EVENT_KIND_TRANSFORM_COMPLETED = 65536;
   // A transform failed.
   SESSION_EVENT_KIND_TRANSFORM_FAILED = 131072;
+  // A checkpoint snapshot was restored.
+  SESSION_EVENT_KIND_RESTORE_CHECKPOINT = 262144;
 }
 
 // Viewport-level event kinds.  Values are powers of two so they can be OR'd
@@ -1008,6 +1015,19 @@ message DestroyLastCheckpointRequest {
 message DestroyLastCheckpointResponse {
   string session_id = 1;             // Session that was reverted.
   int64 remaining_checkpoints = 2;   // Remaining checkpoint count after revert.
+}
+
+// Request to restore the most recent checkpoint snapshot without discarding it.
+message RestoreLastCheckpointRequest {
+  string session_id = 1; // Session to restore.
+}
+
+// Result of restoring the most recent checkpoint snapshot.
+message RestoreLastCheckpointResponse {
+  string session_id = 1;                // Session that was restored.
+  int64 checkpoint_count = 2;           // Checkpoint count after restore.
+  int64 change_count = 3;               // Session change count after restore.
+  int64 discarded_change_count = 4;     // Number of active changes discarded.
 }
 
 // Transform plugin operation mode.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -1741,6 +1741,34 @@ grpc::Status EditorServiceImpl::DestroyLastCheckpoint(grpc::ServerContext * /*co
     return grpc::Status::OK;
 }
 
+grpc::Status EditorServiceImpl::RestoreLastCheckpoint(grpc::ServerContext * /*context*/,
+                                                      const ::omega_edit::v1::RestoreLastCheckpointRequest *request,
+                                                      ::omega_edit::v1::RestoreLastCheckpointResponse *response) {
+    auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+    if (!mutation_guard) {
+        return status_for_session_operation_start(mutation_guard.result(), "restore checkpoint", request->session_id());
+    }
+
+    auto locked_session = session_manager_.lock_session(request->session_id());
+    if (!locked_session) {
+        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+    }
+    auto *session = locked_session.session();
+
+    const auto before_change_count = omega_session_get_num_changes(session);
+    if (0 != omega_edit_restore_last_checkpoint(session)) {
+        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "no checkpoint available to restore");
+    }
+
+    const auto after_change_count = omega_session_get_num_changes(session);
+    response->set_session_id(request->session_id());
+    response->set_checkpoint_count(omega_session_get_num_checkpoints(session));
+    response->set_change_count(after_change_count);
+    response->set_discarded_change_count(
+            before_change_count > after_change_count ? before_change_count - after_change_count : 0);
+    return grpc::Status::OK;
+}
+
 grpc::Status EditorServiceImpl::CreateCheckpoint(grpc::ServerContext * /*context*/,
                                                  const ::omega_edit::v1::CreateCheckpointRequest *request,
                                                  ::omega_edit::v1::CreateCheckpointResponse *response) {

--- a/server/cpp/src/editor_service.h
+++ b/server/cpp/src/editor_service.h
@@ -186,6 +186,11 @@ public:
         const ::omega_edit::v1::DestroyLastCheckpointRequest *request,
         ::omega_edit::v1::DestroyLastCheckpointResponse *response) override;
 
+    grpc::Status RestoreLastCheckpoint(
+        grpc::ServerContext *context,
+        const ::omega_edit::v1::RestoreLastCheckpointRequest *request,
+        ::omega_edit::v1::RestoreLastCheckpointResponse *response) override;
+
     grpc::Status ListTransformPlugins(grpc::ServerContext *context,
                                       const ::omega_edit::v1::ListTransformPluginsRequest *request,
                                       ::omega_edit::v1::ListTransformPluginsResponse *response) override;

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -146,6 +146,11 @@
         "enablement": "omegaEdit.hexEditorActive && !omegaEdit.transformInFlight"
       },
       {
+        "command": "omegaEdit.restoreCheckpoint",
+        "title": "%omegaEdit.command.restoreCheckpoint.title%",
+        "enablement": "omegaEdit.hexEditorActive && !omegaEdit.transformInFlight"
+      },
+      {
         "command": "omegaEdit.createCheckpoint",
         "title": "%omegaEdit.command.createCheckpoint.title%",
         "enablement": "omegaEdit.hexEditorActive && !omegaEdit.transformInFlight"
@@ -225,6 +230,10 @@
         },
         {
           "command": "omegaEdit.rollbackCheckpoint",
+          "when": "omegaEdit.hexEditorActive && !omegaEdit.transformInFlight"
+        },
+        {
+          "command": "omegaEdit.restoreCheckpoint",
           "when": "omegaEdit.hexEditorActive && !omegaEdit.transformInFlight"
         },
         {

--- a/vscode-extension/package.nls.json
+++ b/vscode-extension/package.nls.json
@@ -20,6 +20,7 @@
   "omegaEdit.command.applyChangeLog.title": "OmegaEdit: Apply Change Log",
   "omegaEdit.command.rollbackSession.title": "OmegaEdit: Roll Back Session",
   "omegaEdit.command.rollbackCheckpoint.title": "OmegaEdit: Roll Back Last Checkpoint",
+  "omegaEdit.command.restoreCheckpoint.title": "OmegaEdit: Restore Last Checkpoint",
   "omegaEdit.command.createCheckpoint.title": "OmegaEdit: Create Checkpoint",
   "omegaEdit.command.getEditorState.title": "OmegaEdit: Get Editor State",
   "omegaEdit.command.setExternalHighlights.title": "OmegaEdit: Set External Highlights",

--- a/vscode-extension/src/api.ts
+++ b/vscode-extension/src/api.ts
@@ -10,7 +10,7 @@ export const OMEGA_EDIT_EXTENSION_PUBLISHER = 'ctc-oss'
 export const OMEGA_EDIT_EXTENSION_NAME = 'omega-edit-data-editor'
 export const OMEGA_EDIT_EXTENSION_ID =
   `${OMEGA_EDIT_EXTENSION_PUBLISHER}.${OMEGA_EDIT_EXTENSION_NAME}` as const
-export const OMEGA_EDIT_EXTENSION_API_VERSION = 2
+export const OMEGA_EDIT_EXTENSION_API_VERSION = 3
 
 export type OmegaEditExternalHighlightKind = ExternalHighlightKind
 export type OmegaEditExternalHighlight = WebviewExternalHighlight
@@ -61,6 +61,14 @@ export interface OmegaEditRollbackCheckpointResult {
   state?: OmegaEditEditorState
   rolledBack: boolean
   checkpointCount: number
+}
+
+export interface OmegaEditRestoreCheckpointResult {
+  state?: OmegaEditEditorState
+  restored: boolean
+  checkpointCount: number
+  changeCount: number
+  discardedChangeCount: number
 }
 
 export interface OmegaEditChangeLogDigest {
@@ -127,6 +135,9 @@ export interface OmegaEditExtensionApi {
   rollbackCheckpoint(
     options?: vscode.Uri | string | OmegaEditCheckpointOptions
   ): Promise<OmegaEditRollbackCheckpointResult | undefined>
+  restoreCheckpoint(
+    options?: vscode.Uri | string | OmegaEditCheckpointOptions
+  ): Promise<OmegaEditRestoreCheckpointResult | undefined>
   exportChangeLog(
     options?: vscode.Uri | string | OmegaEditChangeLogExportOptions
   ): Promise<OmegaEditChangeLogResult | undefined>

--- a/vscode-extension/src/constants.ts
+++ b/vscode-extension/src/constants.ts
@@ -14,6 +14,8 @@ export const OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND = 'omegaEdit.applyChangeLog'
 export const OMEGA_EDIT_ROLLBACK_SESSION_COMMAND = 'omegaEdit.rollbackSession'
 export const OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND =
   'omegaEdit.rollbackCheckpoint'
+export const OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND =
+  'omegaEdit.restoreCheckpoint'
 export const OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND = 'omegaEdit.createCheckpoint'
 export const OMEGA_EDIT_GET_EDITOR_STATE_COMMAND = 'omegaEdit.getEditorState'
 export const OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND =

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -42,6 +42,7 @@ import {
   OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
   OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND,
   OMEGA_EDIT_REDO_COMMAND,
+  OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
   OMEGA_EDIT_ROLLBACK_SESSION_COMMAND,
   OMEGA_EDIT_SEARCH_NEXT_COMMAND,
   OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
@@ -560,6 +561,9 @@ function createOmegaEditExtensionApi(
     async rollbackCheckpoint(options) {
       return provider.rollbackCheckpoint(options)
     },
+    async restoreCheckpoint(options) {
+      return provider.restoreCheckpoint(options)
+    },
     async exportChangeLog(options) {
       return provider.exportChangeLog(options)
     },
@@ -806,6 +810,15 @@ export async function activate(
       OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
       async (options?: unknown) => {
         await provider.rollbackCheckpoint(options)
+      }
+    )
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
+      async (options?: unknown) => {
+        await provider.restoreCheckpoint(options)
       }
     )
   )

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -48,6 +48,7 @@ import {
   getChangeCount,
   getChangeDetails,
   getClientVersion,
+  getComputedFileSize,
   getContentType,
   getCounts,
   getLanguage,
@@ -66,6 +67,7 @@ import {
   profileSession,
   replaceSessionCheckpointed,
   redo,
+  restoreLastCheckpoint,
   runSessionTransaction,
   saveSession,
   SessionFingerprintContent,
@@ -359,6 +361,7 @@ function isMutationWebviewMessage(message: WebviewToHostMessage): boolean {
     case 'replaceAllMatches':
     case 'createCheckpoint':
     case 'rollbackCheckpoint':
+    case 'restoreCheckpoint':
     case 'applyChangeLog':
     case 'undo':
     case 'redo':
@@ -1989,7 +1992,8 @@ export class HexEditorProvider
           kind === ViewportEventKind.UNDO ||
           kind === ViewportEventKind.CLEAR ||
           kind === ViewportEventKind.TRANSFORM ||
-          kind === ViewportEventKind.MODIFY
+          kind === ViewportEventKind.MODIFY ||
+          kind === ViewportEventKind.CHANGES
         ) {
           await this.sendViewportData(session)
         }
@@ -2898,6 +2902,45 @@ export class HexEditorProvider
     }
   }
 
+  async restoreCheckpoint(options?: unknown): Promise<
+    | {
+        state: WebviewEditorState
+        restored: boolean
+        checkpointCount: number
+        changeCount: number
+        discardedChangeCount: number
+      }
+    | undefined
+  > {
+    const session = this.resolveCommandSession(options)
+    if (!session) {
+      void vscode.window.showWarningMessage(openEditorFirstMessage())
+      return
+    }
+    if (!this.ensureSessionCanMutate(session, true)) {
+      return
+    }
+
+    const result = await this.restoreLastCheckpoint(session, true)
+    this.postSessionActionComplete(session, {
+      action: 'restoreCheckpoint',
+      checkpointCount: result.checkpointCount,
+      cancelled: !result.restored,
+      message: result.restored
+        ? vscode.l10n.t('Restored latest OmegaEdit checkpoint')
+        : vscode.l10n.t('No OmegaEdit checkpoint to restore'),
+    })
+    if (result.restored) {
+      void vscode.window.showInformationMessage(
+        vscode.l10n.t('Restored latest OmegaEdit checkpoint')
+      )
+    }
+    return {
+      state: this.buildEditorState(session),
+      ...result,
+    }
+  }
+
   async rollbackActiveSession(): Promise<void> {
     if (!this.activeSession) {
       void vscode.window.showWarningMessage(openEditorFirstMessage())
@@ -3756,6 +3799,73 @@ export class HexEditorProvider
     }
   }
 
+  private async restoreLastCheckpoint(
+    session: EditorSession,
+    markDirty: boolean
+  ): Promise<{
+    restored: boolean
+    checkpointCount: number
+    changeCount: number
+    discardedChangeCount: number
+  }> {
+    if (!this.ensureSessionCanMutate(session, true)) {
+      return {
+        restored: false,
+        checkpointCount: await this.getCheckpointCount(session),
+        changeCount: await getChangeCount(session.sessionId),
+        discardedChangeCount: 0,
+      }
+    }
+
+    const checkpointCount = await this.getCheckpointCount(session)
+    if (checkpointCount <= 0) {
+      void vscode.window.showWarningMessage(
+        vscode.l10n.t('No OmegaEdit checkpoint to restore')
+      )
+      return {
+        restored: false,
+        checkpointCount,
+        changeCount: await getChangeCount(session.sessionId),
+        discardedChangeCount: 0,
+      }
+    }
+
+    this.postTransformStatus(
+      session,
+      true,
+      undefined,
+      vscode.l10n.t('Restoring checkpoint...')
+    )
+    let failureMessage: string | undefined
+    try {
+      const sessionSyncVersion = session.sessionSyncVersion
+      const response = await restoreLastCheckpoint(session.sessionId)
+      await this.waitForSessionSync(session, sessionSyncVersion)
+      await this.sendViewportData(session)
+      await this.resetSessionState(session, markDirty, markDirty, false)
+      this.clearSearchState(session)
+      this.postTransformStatus(
+        session,
+        false,
+        undefined,
+        vscode.l10n.t('Checkpoint restored')
+      )
+      return {
+        restored: true,
+        checkpointCount: response.checkpointCount,
+        changeCount: response.changeCount,
+        discardedChangeCount: response.discardedChangeCount,
+      }
+    } catch (error) {
+      failureMessage = error instanceof Error ? error.message : String(error)
+      throw error
+    } finally {
+      if (failureMessage) {
+        this.postTransformStatus(session, false, undefined, failureMessage)
+      }
+    }
+  }
+
   private async rollbackSession(
     session: EditorSession,
     markDirty: boolean
@@ -4367,6 +4477,23 @@ export class HexEditorProvider
           throw new Error('Transform change is missing transformId')
         }
 
+        const expectedSizeBefore =
+          change.computedFileSizeBefore !== undefined
+            ? normalizeNonNegativeInt64ForClient(
+                change.computedFileSizeBefore,
+                'change log entry computedFileSizeBefore'
+              )
+            : undefined
+        const actualSizeBefore = await getComputedFileSize(session.sessionId)
+        if (
+          expectedSizeBefore !== undefined &&
+          actualSizeBefore !== expectedSizeBefore
+        ) {
+          throw new Error(
+            `Transform ${change.transformId} expected pre-transform size ${expectedSizeBefore}, found ${actualSizeBefore}`
+          )
+        }
+
         const response = await applyTransformPlugin(
           session.sessionId,
           change.transformId,
@@ -4375,10 +4502,36 @@ export class HexEditorProvider
           change.optionsJson
         )
         if (!response.contentChanged) {
-          return undefined
+          throw new Error(
+            `Transform ${change.transformId} replay produced no content change`
+          )
         }
         if (response.serial === undefined) {
           throw new Error('Transform did not return a change serial')
+        }
+        if (
+          change.replacementLength !== undefined &&
+          response.replacementLength !==
+            normalizeNonNegativeInt64ForClient(
+              change.replacementLength,
+              'change log entry replacementLength'
+            )
+        ) {
+          throw new Error(
+            `Transform ${change.transformId} replacement length mismatch`
+          )
+        }
+        if (
+          change.computedFileSizeAfter !== undefined &&
+          response.computedFileSize !==
+            normalizeNonNegativeInt64ForClient(
+              change.computedFileSizeAfter,
+              'change log entry computedFileSizeAfter'
+            )
+        ) {
+          throw new Error(
+            `Transform ${change.transformId} post-transform size mismatch`
+          )
         }
 
         return {
@@ -4392,9 +4545,7 @@ export class HexEditorProvider
             ? { optionsJson: change.optionsJson }
             : {}),
           replacementLength: response.replacementLength,
-          ...(change.computedFileSizeBefore !== undefined
-            ? { computedFileSizeBefore: change.computedFileSizeBefore }
-            : {}),
+          computedFileSizeBefore: actualSizeBefore,
           computedFileSizeAfter: response.computedFileSize,
           ...(change.groupId ? { groupId: change.groupId } : {}),
         }
@@ -4830,6 +4981,11 @@ export class HexEditorProvider
 
         case 'rollbackCheckpoint': {
           await this.rollbackCheckpoint({ uri: session.document.uri })
+          break
+        }
+
+        case 'restoreCheckpoint': {
+          await this.restoreCheckpoint({ uri: session.document.uri })
           break
         }
 

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -146,6 +146,7 @@ export type WebviewToHostMessage =
   | { type: 'replaceRangeWithFile'; offset: number; length: number }
   | { type: 'createCheckpoint' }
   | { type: 'rollbackCheckpoint' }
+  | { type: 'restoreCheckpoint' }
   | { type: 'exportChangeLog' }
   | { type: 'applyChangeLog' }
   | { type: 'toggleEditMode' }
@@ -264,6 +265,7 @@ export type HostToWebviewMessage =
       action:
         | 'createCheckpoint'
         | 'rollbackCheckpoint'
+        | 'restoreCheckpoint'
         | 'exportChangeLog'
         | 'applyChangeLog'
       changeCount?: number
@@ -732,6 +734,7 @@ export function normalizeWebviewMessage(
     case 'requestTransformPlugins':
     case 'createCheckpoint':
     case 'rollbackCheckpoint':
+    case 'restoreCheckpoint':
     case 'exportChangeLog':
     case 'applyChangeLog':
     case 'undo':

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -21,6 +21,7 @@ const {
   OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
   OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND,
   OMEGA_EDIT_REDO_COMMAND,
+  OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
   OMEGA_EDIT_ROLLBACK_SESSION_COMMAND,
   OMEGA_EDIT_SEARCH_NEXT_COMMAND,
   OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
@@ -40,7 +41,7 @@ const {
 test('package.json matches shared extension constants', () => {
   assert.equal(packageJson.main, './out/extension.js')
   assert.equal(packageJson.types, './out/api.d.ts')
-  assert.equal(OMEGA_EDIT_EXTENSION_API_VERSION, 2)
+  assert.equal(OMEGA_EDIT_EXTENSION_API_VERSION, 3)
   assert.equal(packageJson.name, OMEGA_EDIT_EXTENSION_NAME)
   assert.equal(packageJson.publisher, OMEGA_EDIT_EXTENSION_PUBLISHER)
   assert.equal(
@@ -148,14 +149,22 @@ test('package.json matches shared extension constants', () => {
   )
   assert.equal(
     packageJson.contributes.commands[12].command,
-    OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND
+    OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND
   )
   assert.equal(
     packageJson.contributes.commands[12].enablement,
     'omegaEdit.hexEditorActive && !omegaEdit.transformInFlight'
   )
+  assert.equal(
+    packageJson.contributes.commands[13].command,
+    OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND
+  )
+  assert.equal(
+    packageJson.contributes.commands[13].enablement,
+    'omegaEdit.hexEditorActive && !omegaEdit.transformInFlight'
+  )
   assert.deepEqual(
-    packageJson.contributes.commands.slice(13).map((entry) => entry.command),
+    packageJson.contributes.commands.slice(14).map((entry) => entry.command),
     [
       OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
       OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
@@ -514,6 +523,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerJs, /revertCustomDocument/)
   assert.match(providerJs, /createCheckpoint/)
   assert.match(providerJs, /destroyLastCheckpoint/)
+  assert.match(providerJs, /restoreLastCheckpoint/)
   assert.match(providerJs, /clear/)
   assert.match(providerJs, /rollbackSession/)
   assert.match(providerJs, /revertSessionChanges/)
@@ -1353,6 +1363,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(extensionJs, /setInsertDirection/)
   assert.match(extensionJs, /rollbackActiveSession/)
   assert.match(extensionJs, /rollbackCheckpoint/)
+  assert.match(extensionJs, /restoreCheckpoint/)
   assert.match(extensionJs, /createCheckpoint/)
   assert.match(extensionJs, /getDefaultTransformPluginDirectories/)
   assert.match(extensionJs, /findRepositoryRoot/)

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -71,6 +71,7 @@ suite('OmegaEdit VS Code extension', () => {
     assert.equal(typeof extensionApi.clearExternalHighlights, 'function')
     assert.equal(typeof extensionApi.createCheckpoint, 'function')
     assert.equal(typeof extensionApi.rollbackCheckpoint, 'function')
+    assert.equal(typeof extensionApi.restoreCheckpoint, 'function')
     assert.equal(typeof extensionApi.exportChangeLog, 'function')
     assert.equal(typeof extensionApi.applyChangeLog, 'function')
     assert.equal(typeof extensionApi.onDidChangeEditorState, 'function')
@@ -284,9 +285,12 @@ suite('OmegaEdit VS Code extension', () => {
     )
     const sourcePath = path.join(tmpDir, 'source.bin')
     const replayPath = path.join(tmpDir, 'replay.bin')
+    const tamperedReplayPath = path.join(tmpDir, 'replay-tampered.bin')
     const scriptPath = path.join(tmpDir, 'changes.json')
+    const tamperedScriptPath = path.join(tmpDir, 'changes-tampered.json')
     await fs.writeFile(sourcePath, Buffer.from('ABCDEFGH', 'utf8'))
     await fs.writeFile(replayPath, Buffer.from('ABCDEFGH', 'utf8'))
+    await fs.writeFile(tamperedReplayPath, Buffer.from('ABCDEFGH', 'utf8'))
 
     const provider1 = new HexEditorProvider({ subscriptions: [] }, testPort)
     const panel1 = createMockWebviewPanel()
@@ -422,8 +426,50 @@ suite('OmegaEdit VS Code extension', () => {
     assert.equal(saved, 'QTEyRHh5Wlo=')
     assert.equal(replayed, saved)
 
+    const tamperedScript = structuredClone(script)
+    const tamperedTransformChange = tamperedScript.changes.find(
+      (change) => change.kind === 'TRANSFORM'
+    )
+    assert.ok(
+      tamperedTransformChange,
+      'Expected a transform change to tamper with'
+    )
+    tamperedTransformChange.replacementLength = '999'
+    await fs.writeFile(
+      tamperedScriptPath,
+      JSON.stringify(tamperedScript, null, 2)
+    )
+
+    const provider3 = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel3 = createMockWebviewPanel()
+    const document3 = await provider3.openCustomDocument(
+      vscode.Uri.file(tamperedReplayPath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider3.resolveCustomEditor(
+      document3,
+      panel3,
+      new vscode.CancellationTokenSource().token
+    )
+
+    await assert.rejects(
+      () =>
+        provider3.applyChangeLog({
+          uri: document3.uri,
+          sourceUri: vscode.Uri.file(tamperedScriptPath),
+        }),
+      /replacement length mismatch/
+    )
+    const session3 = provider3.getSessionForTesting(document3.uri)
+    assert.ok(session3, 'Expected a tampered replay session')
+    await assertSessionText(session3.sessionId, 'ABCDEFGH')
+    assert.equal(session3.history.getChangeLog().length, 0)
+
     await panel1.fireDidDispose()
     await panel2.fireDidDispose()
+    await panel3.fireDidDispose()
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
@@ -516,6 +562,59 @@ suite('OmegaEdit VS Code extension', () => {
     assert.equal(incompleteResult?.cancelled, true)
     assert.equal(incompleteResult?.changeCount, 0)
     await assertSessionText(session.sessionId, 'abc')
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('restores the latest checkpoint without dropping it', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-restore-checkpoint-')
+    )
+    const samplePath = path.join(tmpDir, 'sample.bin')
+    await fs.writeFile(samplePath, Buffer.from('abcdef', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a session for checkpoint restore')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'overwrite',
+      offset: 1,
+      data: Buffer.from('Z', 'utf8').toString('hex'),
+    })
+    await assertSessionText(session.sessionId, 'aZcdef')
+
+    const checkpoint = await provider.createCheckpoint({ uri: document.uri })
+    assert.ok(checkpoint)
+    assert.equal(checkpoint.checkpointCount, 1)
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'insert',
+      offset: 6,
+      data: Buffer.from('!', 'utf8').toString('hex'),
+    })
+    await assertSessionText(session.sessionId, 'aZcdef!')
+
+    const restored = await provider.restoreCheckpoint({ uri: document.uri })
+    assert.ok(restored)
+    assert.equal(restored.restored, true)
+    assert.equal(restored.checkpointCount, 1)
+    assert.equal(restored.discardedChangeCount, 1)
+    await assertSessionText(session.sessionId, 'aZcdef')
 
     await panel.fireDidDispose()
     await fs.rm(tmpDir, { recursive: true, force: true })

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -1453,6 +1453,16 @@
     postToHost({ type: 'rollbackCheckpoint' })
   }
 
+  function restoreCheckpoint(): void {
+    if (transformInFlight) {
+      return
+    }
+
+    transformInFlight = true
+    transformFeedback = strings.transform.restoringCheckpoint
+    postToHost({ type: 'restoreCheckpoint' })
+  }
+
   function exportChangeLog(): void {
     if (transformInFlight) {
       return
@@ -2259,6 +2269,7 @@
         if (
           !message.cancelled &&
           (message.action === 'rollbackCheckpoint' ||
+            message.action === 'restoreCheckpoint' ||
             message.action === 'applyChangeLog')
         ) {
           clearSearchResults()
@@ -2391,6 +2402,7 @@
     onToggleSearchPanel={toggleSearchPanelVisible}
     onCreateCheckpoint={createCheckpoint}
     onRollbackCheckpoint={rollbackCheckpoint}
+    onRestoreCheckpoint={restoreCheckpoint}
     onExportChangeLog={exportChangeLog}
     onApplyChangeLog={applyChangeLog}
   />

--- a/vscode-extension/webview-ui/src/components/Toolbar.svelte
+++ b/vscode-extension/webview-ui/src/components/Toolbar.svelte
@@ -54,6 +54,7 @@
     onToggleSearchPanel: () => void
     onCreateCheckpoint: () => void
     onRollbackCheckpoint: () => void
+    onRestoreCheckpoint: () => void
     onExportChangeLog: () => void
     onApplyChangeLog: () => void
   }
@@ -89,6 +90,7 @@
     onToggleSearchPanel,
     onCreateCheckpoint,
     onRollbackCheckpoint,
+    onRestoreCheckpoint,
     onExportChangeLog,
     onApplyChangeLog,
   }: Props = $props()
@@ -198,6 +200,7 @@
       {onOpenTransformResult}
       {onCreateCheckpoint}
       {onRollbackCheckpoint}
+      {onRestoreCheckpoint}
       {onExportChangeLog}
       {onApplyChangeLog}
     />

--- a/vscode-extension/webview-ui/src/components/TransformPanel.svelte
+++ b/vscode-extension/webview-ui/src/components/TransformPanel.svelte
@@ -16,6 +16,7 @@
   type SessionActionId =
     | 'createCheckpoint'
     | 'rollbackCheckpoint'
+    | 'restoreCheckpoint'
     | 'exportChangeLog'
     | 'applyChangeLog'
 
@@ -88,6 +89,7 @@
     onOpenTransformResult: (resultId: string) => void
     onCreateCheckpoint: () => void
     onRollbackCheckpoint: () => void
+    onRestoreCheckpoint: () => void
     onExportChangeLog: () => void
     onApplyChangeLog: () => void
   }
@@ -132,6 +134,7 @@
     onOpenTransformResult,
     onCreateCheckpoint,
     onRollbackCheckpoint,
+    onRestoreCheckpoint,
     onExportChangeLog,
     onApplyChangeLog,
   }: Props = $props()
@@ -424,6 +427,7 @@
     const action = value.slice(SESSION_ACTION_PREFIX.length)
     return action === 'createCheckpoint' ||
       action === 'rollbackCheckpoint' ||
+      action === 'restoreCheckpoint' ||
       action === 'exportChangeLog' ||
       action === 'applyChangeLog'
       ? action
@@ -1132,6 +1136,9 @@
       case 'rollbackCheckpoint':
         onRollbackCheckpoint()
         break
+      case 'restoreCheckpoint':
+        onRestoreCheckpoint()
+        break
       case 'exportChangeLog':
         onExportChangeLog()
         break
@@ -1280,6 +1287,9 @@
       </option>
       <option value={sessionActionValue('rollbackCheckpoint')}>
         {strings.transform.rollbackCheckpoint}
+      </option>
+      <option value={sessionActionValue('restoreCheckpoint')}>
+        {strings.transform.restoreCheckpoint}
       </option>
       <option value={sessionActionValue('exportChangeLog')}>
         {strings.transform.exportChangeLog}

--- a/vscode-extension/webview-ui/src/i18n.ts
+++ b/vscode-extension/webview-ui/src/i18n.ts
@@ -71,6 +71,7 @@ const englishStrings = {
     sessionGroup: 'Session',
     createCheckpoint: 'Checkpoint',
     rollbackCheckpoint: 'Roll back',
+    restoreCheckpoint: 'Restore',
     exportChangeLog: 'Export Log',
     applyChangeLog: 'Apply Log',
     loadTransforms: 'Load transforms...',
@@ -164,12 +165,15 @@ const englishStrings = {
     applying: (name: string) => `Applying ${name}...`,
     creatingCheckpoint: 'Creating checkpoint...',
     rollingBackCheckpoint: 'Rolling back checkpoint...',
+    restoringCheckpoint: 'Restoring checkpoint...',
     exportingChangeLog: 'Exporting change log...',
     applyingChangeLog: 'Applying change log...',
     checkpointCreated: (count: number) =>
       `Checkpoint created (${formatNumber(count)} total)`,
     checkpointRolledBack: (count: number) =>
       `Checkpoint rolled back (${formatNumber(count)} remaining)`,
+    checkpointRestored: (count: number) =>
+      `Checkpoint restored (${formatNumber(count)} total)`,
     changeLogExported: (count: number) =>
       `Exported ${formatNumber(count)} change${count === 1 ? '' : 's'}`,
     changeLogApplied: (count: number) =>


### PR DESCRIPTION
## Summary

This batch closes the high-impact change-log/checkpoint follow-ups by adding a true restore-to-latest-checkpoint primitive and wiring it through core, proto, server, client, AI tooling, and the VS Code extension.

It also tightens non-streaming change-log replay for TRANSFORM entries: import now replays through the server and fails loudly if pre-size, replacement length, post-size, or content-change metadata does not match. The VS Code viewport subscription now refreshes on general changed-viewport events as well, so external restore/changed notifications update the UI.

## Coverage

Added focused coverage for:

- core restore-to-checkpoint semantics, including transform checkpoint preservation
- AI restore checkpoint flow
- multi-entry REPLACE change-log atomicity
- transform replay metadata mismatch rejection
- VS Code API/command surface and integration coverage for restore checkpoint
- VS Code import rejection for inconsistent transform metadata

SHORTCOMINGS.md is updated to mark G2 fixed and reflect the new coverage honestly.

## Validation

- cmake --build .codex-tmp/native-core-build
- cmake --install .codex-tmp/native-core-build --prefix .codex-tmp/native-core-install
- cmake --build .codex-tmp/native-server-build
- .codex-tmp/native-core-build/core/src/tests/session_tests "[RestoreCheckpoint]"
- TMPDIR=/tmp TEMP=/tmp TMP=/tmp yarn workspace @omega-edit/client test
- yarn workspace @omega-edit/client lint
- CPP_SERVER_BINARY=/mnt/d/GitHub/omega-edit/.codex-tmp/native-server-build/omega-edit-grpc-server yarn workspace @omega-edit/ai test
- yarn workspace @omega-edit/ai lint
- npm run compile:extension from vscode-extension
- npm run lint from vscode-extension
- npm run test:unit from vscode-extension
- xvfb-run -a npm run test:integration from vscode-extension
- yarn lint
- git diff --check

Note: a full native core CTest sweep on this WSL checkout hit the pre-existing File Copy mode assertion when running under /mnt/d; the new restore checkpoint native tests passed directly, and the client UDS suite passed when temp dirs were forced to Linux /tmp.
