### PR TITLE
chore: harden validation and event masks

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -382,7 +382,11 @@ This is the reported bug. Root causes are spread across all three layers.
     shared maximum length, NUL-character, printable/opaque-ID, or log-safe policy. Generated IDs
     are bounded, but caller-supplied IDs and paths can still be excessively large or log-hostile,
     and tightening creation-time validation would contain that shape for all later operations.
-    **Status: New.**
+    **Status: Fixed.** Desired session and viewport IDs are now bounded caller tokens
+    (1-128 bytes; letters, digits, `_`, `.`, and `-` only), while `file_path` and
+    `checkpoint_directory` reject overlong, NUL-containing, or control-character inputs before
+    filesystem/core API use. Client integration coverage now asserts accepted safe IDs and
+    rejected unsafe IDs/path arguments.
 
 35. **Default server host/port constants are duplicated across packages.**
     `packages/client/src/server.ts:47-48`, `packages/client/src/protobuf_ts/client.ts:36-37`,
@@ -477,9 +481,11 @@ This is the reported bug. Root causes are spread across all three layers.
     cap, compiled-regex cache, or timeout/backtracking guard. A plugin schema with a pathological
     pattern can make option validation unexpectedly expensive, and repeated transforms pay the
     regex compilation cost every time.
-    **Status: Partially fixed.** Schema regex validation now rejects oversized patterns and caches
-    compiled regex objects across validation calls; interruptible evaluation/backtracking limits
-    remain open.
+    **Status: Fixed.** Schema regex validation now rejects oversized patterns, caches compiled
+    regex objects across validation calls, and applies a conservative safety gate before
+    compilation/evaluation that rejects backreferences, lookaround-style groups, and quantified
+    groups containing quantifiers or alternation. Native coverage asserts safe validation still
+    works and the risky pattern families are rejected.
 
 44. **File-backed plugin allocation tracking is process-global.**
     Large plugin allocations are tracked through the process-wide
@@ -500,7 +506,10 @@ This is the reported bug. Root causes are spread across all three layers.
     sign bit, but the all-events sentinel relies on signed representation and differs from the
     TypeScript `ALL_EVENTS = ~NO_EVENTS` expression's 32-bit JavaScript behavior. A `uint32_t`
     mask or explicit all-events constant would make the ABI clearer.
-    **Status: New.**
+    **Status: Fixed.** The C API now exposes explicit `SESSION_EVENTS_ALL` and
+    `VIEWPORT_EVENTS_ALL` masks, with `ALL_EVENTS` preserved as their positive union for source
+    compatibility. The TypeScript client derives the matching masks from generated proto enums,
+    and event-mask tests now assert the explicit known-bit behavior instead of `~0`.
 
 46. **Edit APIs mix serial-returning and status-code-returning conventions.**
     Core mutators such as `omega_edit_insert`, `omega_edit_delete`, and `omega_edit_replace`

--- a/core/src/include/omega_edit/fwd_defs.h
+++ b/core/src/include/omega_edit/fwd_defs.h
@@ -61,8 +61,22 @@ typedef enum {
     VIEWPORT_EVT_CHANGES = 1 << 6//< Occurs when the viewport has changes to its data from some other activity
 } omega_viewport_event_t;
 
-/** Subscribe to all events */
-#define ALL_EVENTS (~0)
+/** Subscribe to all session events */
+#define SESSION_EVENTS_ALL                                                                                             \
+    (SESSION_EVT_CREATE | SESSION_EVT_EDIT | SESSION_EVT_UNDO | SESSION_EVT_CLEAR | SESSION_EVT_TRANSFORM |            \
+     SESSION_EVT_CREATE_CHECKPOINT | SESSION_EVT_DESTROY_CHECKPOINT | SESSION_EVT_SAVE | SESSION_EVT_CHANGES_PAUSED |  \
+     SESSION_EVT_CHANGES_RESUMED | SESSION_EVT_CREATE_VIEWPORT | SESSION_EVT_DESTROY_VIEWPORT |                       \
+     SESSION_EVT_TRANSACTION_STARTED | SESSION_EVT_TRANSACTION_ENDED | SESSION_EVT_TRANSFORM_STARTED |                 \
+     SESSION_EVT_TRANSFORM_PROGRESS | SESSION_EVT_TRANSFORM_COMPLETED | SESSION_EVT_TRANSFORM_FAILED |                 \
+     SESSION_EVT_RESTORE_CHECKPOINT)
+
+/** Subscribe to all viewport events */
+#define VIEWPORT_EVENTS_ALL                                                                                           \
+    (VIEWPORT_EVT_CREATE | VIEWPORT_EVT_EDIT | VIEWPORT_EVT_UNDO | VIEWPORT_EVT_CLEAR | VIEWPORT_EVT_TRANSFORM |      \
+     VIEWPORT_EVT_MODIFY | VIEWPORT_EVT_CHANGES)
+
+/** Subscribe to all known events */
+#define ALL_EVENTS (SESSION_EVENTS_ALL | VIEWPORT_EVENTS_ALL)
 
 /** Subscribe to no events */
 #define NO_EVENTS (0)

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -116,8 +116,123 @@ namespace {
     std::mutex g_schema_regex_cache_mutex;
     std::unordered_map<std::string, std::shared_ptr<const std::regex>> g_schema_regex_cache;
 
+    struct regex_group_context_t {
+        bool has_quantified_atom{};
+        bool has_alternation{};
+    };
+
+    auto schema_regex_is_safe_(const std::string &pattern_text) -> bool {
+        bool escaped = false;
+        bool in_character_class = false;
+        bool last_atom_exists = false;
+        bool last_atom_is_group = false;
+        bool last_group_has_risky_content = false;
+        std::vector<regex_group_context_t> groups;
+
+        auto remember_atom = [&](bool is_group, bool group_has_risky_content) {
+            last_atom_exists = true;
+            last_atom_is_group = is_group;
+            last_group_has_risky_content = group_has_risky_content;
+        };
+
+        auto forget_atom = [&]() {
+            last_atom_exists = false;
+            last_atom_is_group = false;
+            last_group_has_risky_content = false;
+        };
+
+        auto apply_quantifier = [&]() {
+            if (!last_atom_exists) { return true; }
+            if (last_atom_is_group && last_group_has_risky_content) { return false; }
+            if (!groups.empty()) { groups.back().has_quantified_atom = true; }
+            forget_atom();
+            return true;
+        };
+
+        for (size_t index = 0; index < pattern_text.size(); ++index) {
+            const auto ch = static_cast<unsigned char>(pattern_text[index]);
+
+            if (escaped) {
+                if (std::isdigit(ch) != 0) { return false; }
+                remember_atom(false, false);
+                escaped = false;
+                continue;
+            }
+
+            if (ch == '\\') {
+                escaped = true;
+                continue;
+            }
+
+            if (in_character_class) {
+                if (ch == ']') { in_character_class = false; }
+                continue;
+            }
+
+            switch (ch) {
+            case '[':
+                in_character_class = true;
+                remember_atom(false, false);
+                break;
+            case '(':
+                if (index + 1 < pattern_text.size() && pattern_text[index + 1] == '?') { return false; }
+                groups.push_back({});
+                forget_atom();
+                break;
+            case ')': {
+                if (groups.empty()) { return false; }
+                const auto group = groups.back();
+                groups.pop_back();
+                remember_atom(true, group.has_quantified_atom || group.has_alternation);
+                break;
+            }
+            case '|':
+                if (!groups.empty()) { groups.back().has_alternation = true; }
+                forget_atom();
+                break;
+            case '*':
+            case '+':
+            case '?':
+                if (!apply_quantifier()) { return false; }
+                break;
+            case '{': {
+                size_t end = index + 1;
+                bool has_digit = false;
+                bool valid_range_quantifier = true;
+                for (; end < pattern_text.size() && pattern_text[end] != '}'; ++end) {
+                    const auto range_ch = static_cast<unsigned char>(pattern_text[end]);
+                    if (std::isdigit(range_ch) != 0) {
+                        has_digit = true;
+                    } else if (range_ch != ',') {
+                        valid_range_quantifier = false;
+                        break;
+                    }
+                }
+                if (end < pattern_text.size() && valid_range_quantifier && has_digit) {
+                    if (!apply_quantifier()) { return false; }
+                    index = end;
+                } else {
+                    forget_atom();
+                }
+                break;
+            }
+            case '^':
+            case '$':
+                forget_atom();
+                break;
+            default:
+                remember_atom(false, false);
+                break;
+            }
+        }
+
+        return !escaped && !in_character_class && groups.empty();
+    }
+
     auto get_schema_regex_(const std::string &pattern_text) -> std::shared_ptr<const std::regex> {
-        if (pattern_text.size() > OMEGA_SCHEMA_REGEX_MAX_PATTERN_BYTES) { return nullptr; }
+        if (pattern_text.size() > OMEGA_SCHEMA_REGEX_MAX_PATTERN_BYTES || !schema_regex_is_safe_(pattern_text)) {
+            return nullptr;
+        }
         {
             std::lock_guard<std::mutex> lock(g_schema_regex_cache_mutex);
             const auto iter = g_schema_regex_cache.find(pattern_text);

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -16,6 +16,7 @@
 #include "omega_edit/character_counts.h"
 #include "omega_edit/check.h"
 #include "omega_edit/stl_string_adaptor.hpp"
+#include "omega_edit/transform.h"
 #include "omega_edit/utility.h"
 #include "../lib/impl_/safe_math.hpp"
 #include "../lib/impl_/data_def.hpp"
@@ -121,6 +122,43 @@ TEST_CASE("Byte APIs preserve embedded nulls with explicit lengths", "[EdgeCase]
     omega_search_destroy_context(search_context);
 
     omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Transform schema regex validation rejects risky patterns", "[EdgeCase][TransformSchema]") {
+    const char *safe_schema = R"json({
+        "type":"object",
+        "properties":{"name":{"type":"string","pattern":"^[A-Za-z0-9._-]{1,32}$"}},
+        "required":["name"],
+        "additionalProperties":false
+    })json";
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(R"json({"name":"abc-123_ok"})json", safe_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(R"json({"name":"bad space"})json", safe_schema));
+
+    const char *nested_quantifier_schema = R"json({
+        "type":"object",
+        "properties":{"name":{"type":"string","pattern":"^(a+)+$"}},
+        "required":["name"],
+        "additionalProperties":false
+    })json";
+    REQUIRE(-1 ==
+            omega_transform_plugin_options_match_args_schema(R"json({"name":"aaaa"})json", nested_quantifier_schema));
+
+    const char *alternating_group_schema = R"json({
+        "type":"object",
+        "properties":{"name":{"type":"string","pattern":"^(a|aa)+$"}},
+        "required":["name"],
+        "additionalProperties":false
+    })json";
+    REQUIRE(-1 ==
+            omega_transform_plugin_options_match_args_schema(R"json({"name":"aaaa"})json", alternating_group_schema));
+
+    const char *backreference_schema = R"json({
+        "type":"object",
+        "properties":{"name":{"type":"string","pattern":"^(a)\1$"}},
+        "required":["name"],
+        "additionalProperties":false
+    })json";
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(R"json({"name":"aa"})json", backreference_schema));
 }
 
 TEST_CASE("Byte APIs treat zero-length inputs as empty and keep string helpers convenient",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -24,12 +24,26 @@ import {
   resetClient as resetSharedClient,
   waitForReady as waitForReadySharedClient,
 } from './protobuf_ts/client'
+import {
+  SessionEventKind as ProtoSessionEventKind,
+  ViewportEventKind as ProtoViewportEventKind,
+} from './protobuf_ts/generated/omega_edit/v1/omega_edit'
 
 export type { ClientConnectionOptions }
 
+function combineEventMask(events: Record<string, string | number>): number {
+  let mask = 0
+  for (const value of Object.values(events)) {
+    if (typeof value === 'number') mask |= value
+  }
+  return mask
+}
+
 // subscription events
 export const NO_EVENTS = 0 // subscribe to no events
-export const ALL_EVENTS = ~NO_EVENTS // subscribe to all events
+export const SESSION_EVENTS_ALL = combineEventMask(ProtoSessionEventKind)
+export const VIEWPORT_EVENTS_ALL = combineEventMask(ProtoViewportEventKind)
+export const ALL_EVENTS = SESSION_EVENTS_ALL | VIEWPORT_EVENTS_ALL
 
 /**
  * Reset the client back to undefined.

--- a/packages/client/tests/specs/events.spec.ts
+++ b/packages/client/tests/specs/events.spec.ts
@@ -18,17 +18,36 @@
  */
 
 import { expect } from './common.js'
-import { ALL_EVENTS, NO_EVENTS, ViewportEventKind } from '@omega-edit/client'
+import {
+  ALL_EVENTS,
+  NO_EVENTS,
+  SESSION_EVENTS_ALL,
+  SessionEventKind,
+  VIEWPORT_EVENTS_ALL,
+  ViewportEventKind,
+} from '@omega-edit/client'
+
+function combineEventMask(events: Record<string, number>): number {
+  return Object.values(events).reduce((mask, event) => mask | event, 0)
+}
 
 describe('Events', () => {
   it('can be bitwise manipulated and tested', () => {
+    const expectedSessionEvents = combineEventMask(SessionEventKind)
+    const expectedViewportEvents = combineEventMask(ViewportEventKind)
+
     expect(NO_EVENTS).to.equal(0)
-    expect(~0).to.equal(-1)
-    expect(ALL_EVENTS).to.equal(-1)
-    expect(ALL_EVENTS).to.equal(~NO_EVENTS)
-    expect(NO_EVENTS).to.equal(~ALL_EVENTS)
-    expect(ALL_EVENTS & ~ViewportEventKind.EDIT).to.equal(-3)
+    expect(SESSION_EVENTS_ALL).to.equal(expectedSessionEvents)
+    expect(VIEWPORT_EVENTS_ALL).to.equal(expectedViewportEvents)
+    expect(ALL_EVENTS).to.equal(expectedSessionEvents | expectedViewportEvents)
+    expect(ALL_EVENTS).to.be.greaterThan(NO_EVENTS)
+    expect(ALL_EVENTS & SessionEventKind.RESTORE_CHECKPOINT).to.equal(
+      SessionEventKind.RESTORE_CHECKPOINT
+    )
     expect(ALL_EVENTS & ViewportEventKind.EDIT).to.equal(ViewportEventKind.EDIT)
+    expect(ALL_EVENTS & ~ViewportEventKind.EDIT).to.equal(
+      ALL_EVENTS - ViewportEventKind.EDIT
+    )
     expect(
       ALL_EVENTS & ~ViewportEventKind.EDIT & ViewportEventKind.EDIT
     ).to.equal(NO_EVENTS)

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -112,6 +112,21 @@ function touch(filePath: string) {
   fs.utimesSync(filePath, time, time)
 }
 
+async function expectInvalidArgument(
+  operation: () => Promise<unknown>,
+  expectedMessage: string
+): Promise<void> {
+  let rejected = false
+  try {
+    await operation()
+  } catch (err) {
+    rejected = true
+    expect((err as Error).message).to.include('INVALID_ARGUMENT')
+    expect((err as Error).message).to.include(expectedMessage)
+  }
+  expect(rejected, `expected ${expectedMessage} rejection`).to.equal(true)
+}
+
 describe('Sessions', () => {
   const iterations = 500
   const emptyFile = path.join(__dirname, 'data', 'empty.txt')
@@ -1284,6 +1299,55 @@ describe('Sessions', () => {
     expect(await getSessionCount()).to.equal(initialCount)
   })
 
+  it('Should validate caller chosen session IDs', async () => {
+    expect(await getClient(testPort)).to.not.be.undefined
+    const initialCount = await getSessionCount()
+    const safeSessionId = 'session.id-01_ok'
+    const session = await createSession('', safeSessionId)
+
+    try {
+      expect(session.getSessionId()).to.equal(safeSessionId)
+      expect(await getSessionCount()).to.equal(initialCount + 1)
+    } finally {
+      await destroySession(safeSessionId)
+    }
+
+    const nul = String.fromCharCode(0)
+    const unsafeSessionIds = [
+      'bad:id',
+      'bad/id',
+      'bad id',
+      `bad${nul}id`,
+      'a'.repeat(129),
+    ]
+
+    for (const sessionId of unsafeSessionIds) {
+      await expectInvalidArgument(
+        () => createSession('', sessionId),
+        'session id must be 1-128 bytes'
+      )
+    }
+
+    expect(await getSessionCount()).to.equal(initialCount)
+  })
+
+  it('Should reject malformed create-session path inputs', async () => {
+    expect(await getClient(testPort)).to.not.be.undefined
+    const initialCount = await getSessionCount()
+    const nul = String.fromCharCode(0)
+
+    await expectInvalidArgument(
+      () => createSession(`bad${nul}path`),
+      'file_path must be shorter than FILENAME_MAX'
+    )
+    await expectInvalidArgument(
+      () => createSession('', '', `bad${nul}checkpoint`),
+      'checkpoint_directory must be shorter than FILENAME_MAX'
+    )
+
+    expect(await getSessionCount()).to.equal(initialCount)
+  })
+
   it('Should reject duplicate desired viewport IDs within a session', async () => {
     const session = await createSession()
     const sessionId = session.getSessionId()
@@ -1306,6 +1370,41 @@ describe('Sessions', () => {
           `viewport already exists: ${desiredViewportId}`
         )
       }
+    } finally {
+      await destroySession(sessionId)
+    }
+  })
+
+  it('Should validate caller chosen viewport IDs', async () => {
+    expect(await getClient(testPort)).to.not.be.undefined
+    const session = await createSession()
+    const sessionId = session.getSessionId()
+    const safeViewportId = 'viewport.id-01_ok'
+
+    try {
+      const viewport = await createViewport(safeViewportId, sessionId, 0, 16)
+      expect(viewport.getViewportId()).to.equal(
+        `${sessionId}:${safeViewportId}`
+      )
+      expect(await getViewportCount(sessionId)).to.equal(1)
+
+      const nul = String.fromCharCode(0)
+      const unsafeViewportIds = [
+        'bad:id',
+        'bad/id',
+        'bad id',
+        `bad${nul}id`,
+        'a'.repeat(129),
+      ]
+
+      for (const viewportId of unsafeViewportIds) {
+        await expectInvalidArgument(
+          () => createViewport(viewportId, sessionId, 0, 16),
+          'viewport id must be 1-128 bytes'
+        )
+      }
+
+      expect(await getViewportCount(sessionId)).to.equal(1)
     } finally {
       await destroySession(sessionId)
     }

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <chrono>
 #include <cctype>
+#include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -79,6 +80,20 @@ static int get_cpu_count() {
 static constexpr char SESSION_FINGERPRINT_DIGEST_PLUGIN_ID[] = "omega.example.openssl_digests";
 static constexpr char DEFAULT_SESSION_FINGERPRINT_ALGORITHM[] = "sha256";
 static constexpr int64_t SESSION_FINGERPRINT_CHUNK_SIZE = 1024 * 1024;
+
+static bool path_argument_is_safe_for_core(const std::string &path) {
+    return path.size() < FILENAME_MAX &&
+           std::none_of(path.begin(), path.end(), [](unsigned char ch) {
+               return ch == '\0' || ch < 0x20U || ch == 0x7FU;
+           });
+}
+
+static grpc::Status validate_path_argument(const std::string &path, const char *field_name) {
+    if (path.empty() || path_argument_is_safe_for_core(path)) { return grpc::Status::OK; }
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                        std::string(field_name) +
+                                " must be shorter than FILENAME_MAX and contain no NUL or control characters");
+}
 
 static std::string normalize_digest_algorithm(std::string algorithm) {
     if (algorithm.empty()) { return DEFAULT_SESSION_FINGERPRINT_ALGORITHM; }
@@ -690,6 +705,8 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
 
     std::string file_path;
     if (request->has_file_path()) { file_path = request->file_path(); }
+    const auto file_path_status = validate_path_argument(file_path, "file_path");
+    if (!file_path_status.ok()) { return file_path_status; }
 
     const auto has_initial_data = request->has_initial_data();
     if (!file_path.empty() && has_initial_data) {
@@ -711,6 +728,8 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
 
     std::string checkpoint_dir;
     if (request->has_checkpoint_directory()) { checkpoint_dir = request->checkpoint_directory(); }
+    const auto checkpoint_dir_status = validate_path_argument(checkpoint_dir, "checkpoint_directory");
+    if (!checkpoint_dir_status.ok()) { return checkpoint_dir_status; }
 
     int64_t file_size = 0;
     std::string checkpoint_dir_out;
@@ -729,7 +748,15 @@ grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
     if (session_id.empty()) {
         switch (create_error) {
         case SessionCreateError::INVALID_ID:
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "session id contains reserved character ':'");
+            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                "session id must be 1-128 bytes and contain only letters, digits, '_', '.', or '-'");
+        case SessionCreateError::INVALID_FILE_PATH:
+            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                "file_path must be shorter than FILENAME_MAX and contain no NUL or control characters");
+        case SessionCreateError::INVALID_CHECKPOINT_DIRECTORY:
+            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                "checkpoint_directory must be shorter than FILENAME_MAX and contain no NUL or "
+                                "control characters");
         case SessionCreateError::ALREADY_EXISTS:
             return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, "session already exists: " + desired_id);
         default:
@@ -1035,7 +1062,7 @@ grpc::Status EditorServiceImpl::CreateViewport(grpc::ServerContext * /*context*/
             return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
         case ViewportCreateError::INVALID_VIEWPORT_ID:
             return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                "viewport id contains reserved character ':': " + desired_vp_id);
+                                "viewport id must be 1-128 bytes and contain only letters, digits, '_', '.', or '-'");
         case ViewportCreateError::DUPLICATE_VIEWPORT_ID:
             return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, "viewport already exists: " + desired_vp_id);
         case ViewportCreateError::TOO_MANY_VIEWPORTS:

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -60,6 +60,26 @@ constexpr char kManagedSessionPrefix[] = "session-";
 constexpr char kSessionIdPrefix[] = "sess_";
 constexpr char kViewportIdPrefix[] = "vp_";
 constexpr char kSubscriptionIdPrefix[] = "sub_";
+constexpr size_t kMaxCallerIdBytes = 128;
+
+bool is_valid_external_id_char(unsigned char ch) {
+    return std::isalnum(ch) != 0 || ch == '_' || ch == '-' || ch == '.';
+}
+
+bool is_valid_external_id(const std::string &id) {
+    return !id.empty() && id.size() <= kMaxCallerIdBytes &&
+           std::all_of(id.begin(), id.end(),
+                       [](unsigned char ch) { return is_valid_external_id_char(ch); });
+}
+
+bool is_control_or_nul_byte(unsigned char ch) {
+    return ch == '\0' || ch < 0x20U || ch == 0x7FU;
+}
+
+bool is_valid_external_path(const std::string &path) {
+    return path.size() < FILENAME_MAX &&
+           std::none_of(path.begin(), path.end(), [](unsigned char ch) { return is_control_or_nul_byte(ch); });
+}
 
 int get_current_process_id() {
 #ifdef _WIN32
@@ -478,6 +498,15 @@ std::string SessionManager::create_session(const std::string &file_path, const s
 
     if (error_out) { *error_out = SessionCreateError::SUCCESS; }
 
+    if (!file_path.empty() && !is_valid_external_path(file_path)) {
+        if (error_out) { *error_out = SessionCreateError::INVALID_FILE_PATH; }
+        return "";
+    }
+    if (!checkpoint_directory.empty() && !is_valid_external_path(checkpoint_directory)) {
+        if (error_out) { *error_out = SessionCreateError::INVALID_CHECKPOINT_DIRECTORY; }
+        return "";
+    }
+
     const bool has_file_backing = !file_path.empty() && initial_data == nullptr;
     std::string canonical_file_path;
     if (has_file_backing && !normalize_existing_file_path(file_path, canonical_file_path)) {
@@ -516,10 +545,9 @@ std::string SessionManager::create_session(const std::string &file_path, const s
     // Session ID priority: desired_id > generated opaque session ID
     std::string session_id;
     if (!desired_id.empty()) {
-        // The ':' character is reserved as the session:viewport FQID separator
-        if (desired_id.find(':') != std::string::npos) {
+        if (!is_valid_external_id(desired_id)) {
             if (error_out) { *error_out = SessionCreateError::INVALID_ID; }
-            return ""; // Invalid: contains reserved character
+            return "";
         }
         session_id = desired_id;
         if (sessions_.count(session_id) != 0) {
@@ -798,10 +826,9 @@ std::string SessionManager::create_viewport(const std::string &session_id, int64
         return "";
     }
 
-    // The ':' character is reserved as the session:viewport FQID separator
-    if (!desired_viewport_id.empty() && desired_viewport_id.find(':') != std::string::npos) {
+    if (!desired_viewport_id.empty() && !is_valid_external_id(desired_viewport_id)) {
         if (error_out) *error_out = ViewportCreateError::INVALID_VIEWPORT_ID;
-        return ""; // Invalid: contains reserved character
+        return "";
     }
 
     auto &session_info = sit->second;

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -210,16 +210,18 @@ struct LockedViewport {
 /// Error codes returned by SessionManager::create_session
 enum class SessionCreateError {
     SUCCESS,
-    INVALID_ID,     ///< desired_id contains the reserved ':' character
-    ALREADY_EXISTS, ///< a session with the given id already exists
-    CORE_ERROR,     ///< the underlying omega_edit API failed to create the session
+    INVALID_ID,                   ///< desired_id is not a bounded caller ID token
+    INVALID_FILE_PATH,            ///< file_path is not safe to pass to the core C API
+    INVALID_CHECKPOINT_DIRECTORY, ///< checkpoint_directory is not safe to pass to the core C API
+    ALREADY_EXISTS,               ///< a session with the given id already exists
+    CORE_ERROR,                   ///< the underlying omega_edit API failed to create the session
 };
 
 /// Error codes returned by SessionManager::create_viewport
 enum class ViewportCreateError {
     SUCCESS,
     SESSION_NOT_FOUND,
-    INVALID_VIEWPORT_ID,   ///< desired_viewport_id contains the reserved ':' character
+    INVALID_VIEWPORT_ID,   ///< desired_viewport_id is not a bounded caller ID token
     DUPLICATE_VIEWPORT_ID, ///< a viewport with the given id already exists
     TOO_MANY_VIEWPORTS,    ///< the session has reached the configured viewport limit
     CORE_ERROR,            ///< the underlying omega_edit API failed to create the viewport


### PR DESCRIPTION
## Summary

- Add server-side validation for caller-provided session IDs, viewport IDs, file paths, and checkpoint directories.
- Replace negative all-events sentinels with explicit known event masks in the C API and TypeScript client.
- Add a conservative schema-regex safety gate for transform plugin option validation.
- Expand native and client coverage for regex hardening, event masks, and rejected malformed caller inputs.
- Mark SHORTCOMINGS.md items #34, #43, and #45 fixed.

## Validation

- `yarn workspace @omega-edit/client lint`
- `yarn workspace @omega-edit/client build`
- `cmake --build .codex-tmp/wsl-root-build --target edge_case_tests omegaEdit_tests`
- `.codex-tmp/wsl-root-build/core/src/tests/edge_case_tests "[TransformSchema]"`
- `.codex-tmp/wsl-root-build/core/src/tests/omegaEdit_tests "Search-Forward"`
- `cmake --build .codex-tmp/native-server-build`
- Focused Vitest run with `CPP_SERVER_BINARY=.codex-tmp/native-server-build/omega-edit-grpc-server`: 4 passed, 23 skipped by filter
- `git diff --check`

## Notes

`yarn workspace @omega-edit/client test:prepare` is blocked locally by a stale Windows CMake cache under `server/cpp/build`, so the focused Vitest run used `CPP_SERVER_BINARY` pointed at the freshly built C++ server binary.