### PR TITLE
chore: reformat native sources

### DIFF
--- a/.github/workflows/cpp-format.yml
+++ b/.github/workflows/cpp-format.yml
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 Concurrent Technologies Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing permissions and limitations under the License.
+
+---
+name: C/C++ Clang-Format Checks
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: C/C++ source passes clang-format checks
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+          clang-format --version
+        shell: bash
+
+      - name: Check C/C++ source formatting
+        run: bash scripts/check-clang-format.sh
+        shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,14 @@ jobs:
           checkName: "TypeScript code passes Biome checks"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Check C/C++ format
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: cpp-format
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "C/C++ source passes clang-format checks"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
       - name: Check VS Code extension - Ubuntu 1.110.0
         uses: fountainhead/action-wait-for-check@v1.2.0
         id: vscode-ubuntu-floor
@@ -132,6 +140,7 @@ jobs:
         if: |
           steps.rat-check.outcome != 'success' ||
           steps.ts-format.outcome != 'success' ||
+          steps.cpp-format.outcome != 'success' ||
           steps.vscode-ubuntu-floor.outcome != 'success' ||
           steps.vscode-ubuntu-stable.outcome != 'success' ||
           steps.vscode-windows-floor.outcome != 'success' ||
@@ -144,6 +153,7 @@ jobs:
         run: |
           echo "Rat Check Status: ${{ steps.rat-check.outcome }}"
           echo "Typescript Format Status: ${{ steps.ts-format.outcome }}"
+          echo "C/C++ Format Status: ${{ steps.cpp-format.outcome }}"
           echo "VS Code Ubuntu 1.110.0 Status: ${{ steps.vscode-ubuntu-floor.outcome }}"
           echo "VS Code Ubuntu stable Status: ${{ steps.vscode-ubuntu-stable.outcome }}"
           echo "VS Code Windows 1.110.0 Status: ${{ steps.vscode-windows-floor.outcome }}"

--- a/core/src/examples/apply_script.cpp
+++ b/core/src/examples/apply_script.cpp
@@ -43,10 +43,8 @@ int main(int argc, char **argv) {
     static const omega_byte_t comma_space[] = ", ";
 
     const omega_edit_script_op_t ops[] = {
-            {0, 0, OMEGA_EDIT_SCRIPT_INSERT, hello_world, 11},
-            {6, 5, OMEGA_EDIT_SCRIPT_REPLACE, omega_edit, 9},
-            {0, 5, OMEGA_EDIT_SCRIPT_OVERWRITE, hello_upper, 5},
-            {5, 1, OMEGA_EDIT_SCRIPT_DELETE, nullptr, 0},
+            {0, 0, OMEGA_EDIT_SCRIPT_INSERT, hello_world, 11},   {6, 5, OMEGA_EDIT_SCRIPT_REPLACE, omega_edit, 9},
+            {0, 5, OMEGA_EDIT_SCRIPT_OVERWRITE, hello_upper, 5}, {5, 1, OMEGA_EDIT_SCRIPT_DELETE, nullptr, 0},
             {5, 0, OMEGA_EDIT_SCRIPT_INSERT, comma_space, 2},
     };
 
@@ -60,8 +58,8 @@ int main(int argc, char **argv) {
         return -1;
     }
 
-    cout << omega_session_get_segment_string(
-                    session_ptr.get(), 0, omega_session_get_computed_file_size(session_ptr.get()))
+    cout << omega_session_get_segment_string(session_ptr.get(), 0,
+                                             omega_session_get_computed_file_size(session_ptr.get()))
          << endl;
     return 0;
 }

--- a/core/src/examples/peek.cpp
+++ b/core/src/examples/peek.cpp
@@ -20,9 +20,7 @@
 
 using namespace std;
 
-enum class display_mode_t {
-    BIT_MODE, BYTE_MODE, CHAR_MODE
-};
+enum class display_mode_t { BIT_MODE, BYTE_MODE, CHAR_MODE };
 struct view_mode_t {
     display_mode_t display_mode = display_mode_t::BYTE_MODE;
 };

--- a/core/src/examples/play.cpp
+++ b/core/src/examples/play.cpp
@@ -96,9 +96,7 @@ void session_change_cbk(const omega_session_t *session_ptr, omega_session_event_
     }
 }
 
-enum class display_mode_t {
-    BIT_MODE, BYTE_MODE, CHAR_MODE
-};
+enum class display_mode_t { BIT_MODE, BYTE_MODE, CHAR_MODE };
 struct view_mode_t {
     display_mode_t display_mode = display_mode_t::CHAR_MODE;
 };
@@ -146,7 +144,7 @@ void vpt_change_cbk(const omega_viewport_t *viewport_ptr,
                  << " offset: " << omega_viewport_get_offset(viewport_ptr) << endl;
             if (omega_viewport_get_user_data_ptr(viewport_ptr)) {
                 switch (reinterpret_cast<const view_mode_t *>(omega_viewport_get_user_data_ptr(viewport_ptr))
-                        ->display_mode) {
+                                ->display_mode) {
                     case display_mode_t::BIT_MODE:
                         clog << " BIT MODE [";
                         write_pretty_bits(omega_viewport_get_data(viewport_ptr),

--- a/core/src/examples/simple.cpp
+++ b/core/src/examples/simple.cpp
@@ -23,9 +23,9 @@ inline void vpt_change_cbk(const omega_viewport_t *viewport_ptr, omega_viewport_
         case VIEWPORT_EVT_CREATE:
         case VIEWPORT_EVT_EDIT: {
             char change_kind = (viewport_event_ptr)
-                               ? omega_change_get_kind_as_char(
-                            reinterpret_cast<const omega_change_t *>(viewport_event_ptr))
-                               : 'R';
+                                       ? omega_change_get_kind_as_char(
+                                                 reinterpret_cast<const omega_change_t *>(viewport_event_ptr))
+                                       : 'R';
             clog << change_kind << ": [" << omega_viewport_get_string(viewport_ptr) << "]" << endl;
             break;
         }

--- a/core/src/examples/simple_c.c
+++ b/core/src/examples/simple_c.c
@@ -22,8 +22,8 @@ void vpt_change_cbk(const omega_viewport_t *viewport_ptr, omega_viewport_event_t
         case VIEWPORT_EVT_CREATE:
         case VIEWPORT_EVT_EDIT: {
             char change_kind = viewport_event_ptr
-                               ? omega_change_get_kind_as_char((const omega_change_t *) (viewport_event_ptr))
-                               : 'R';
+                                       ? omega_change_get_kind_as_char((const omega_change_t *) (viewport_event_ptr))
+                                       : 'R';
             fprintf((FILE *) (omega_viewport_get_user_data_ptr(viewport_ptr)), "%c: [%s]\n", change_kind,
                     omega_viewport_get_data(viewport_ptr));
             break;

--- a/core/src/include/omega_edit/config.h
+++ b/core/src/include/omega_edit/config.h
@@ -68,7 +68,7 @@
 #define OMEGA_BYTE_T unsigned char
 #endif//OMEGA_BYTE_T
 
-#if !defined(__CYGWIN__) && \
+#if !defined(__CYGWIN__) &&                                                                                            \
         (defined(WIN32) || defined(_WIN32) || defined(__WIN32) || defined(_WIN64) || defined(_MSC_BUILD))
 /** Define if building for Windows */
 #define OMEGA_BUILD_WINDOWS

--- a/core/src/include/omega_edit/fwd_defs.h
+++ b/core/src/include/omega_edit/fwd_defs.h
@@ -27,52 +27,52 @@ extern "C" {
 
 /** Enumeration of session events */
 typedef enum {
-    SESSION_EVT_UNDEFINED = 0,//< No session event interest is defined
-    SESSION_EVT_CREATE = 1,//< Occurs when the session has been successfully created
-    SESSION_EVT_EDIT = 1 << 1,//< Occurs when the session has successfully processed an edit
-    SESSION_EVT_UNDO = 1 << 2,//< Occurs when the session has successfully processed an undo
-    SESSION_EVT_CLEAR = 1 << 3,//< Occurs when the session has successfully processed a clear
-    SESSION_EVT_TRANSFORM = 1 << 4,//< Occurs when the session has successfully processed a transform
-    SESSION_EVT_CREATE_CHECKPOINT = 1 << 5,//< Occurs when the session has successfully created a checkpoint
-    SESSION_EVT_DESTROY_CHECKPOINT = 1 << 6,//< Occurs when the session has successfully destroyed a checkpoint
-    SESSION_EVT_SAVE = 1 << 7,//< Occurs when the session has been successfully saved to file
-    SESSION_EVT_CHANGES_PAUSED = 1 << 8,//< Occurs when session changes have been paused
-    SESSION_EVT_CHANGES_RESUMED = 1 << 9,//< Occurs when session changes have been resumed
-    SESSION_EVT_CREATE_VIEWPORT = 1 << 10,//< Occurs when the session has successfully created a viewport
-    SESSION_EVT_DESTROY_VIEWPORT = 1 << 11,//< Occurs when the session has successfully destroyed a viewport
+    SESSION_EVT_UNDEFINED = 0,                //< No session event interest is defined
+    SESSION_EVT_CREATE = 1,                   //< Occurs when the session has been successfully created
+    SESSION_EVT_EDIT = 1 << 1,                //< Occurs when the session has successfully processed an edit
+    SESSION_EVT_UNDO = 1 << 2,                //< Occurs when the session has successfully processed an undo
+    SESSION_EVT_CLEAR = 1 << 3,               //< Occurs when the session has successfully processed a clear
+    SESSION_EVT_TRANSFORM = 1 << 4,           //< Occurs when the session has successfully processed a transform
+    SESSION_EVT_CREATE_CHECKPOINT = 1 << 5,   //< Occurs when the session has successfully created a checkpoint
+    SESSION_EVT_DESTROY_CHECKPOINT = 1 << 6,  //< Occurs when the session has successfully destroyed a checkpoint
+    SESSION_EVT_SAVE = 1 << 7,                //< Occurs when the session has been successfully saved to file
+    SESSION_EVT_CHANGES_PAUSED = 1 << 8,      //< Occurs when session changes have been paused
+    SESSION_EVT_CHANGES_RESUMED = 1 << 9,     //< Occurs when session changes have been resumed
+    SESSION_EVT_CREATE_VIEWPORT = 1 << 10,    //< Occurs when the session has successfully created a viewport
+    SESSION_EVT_DESTROY_VIEWPORT = 1 << 11,   //< Occurs when the session has successfully destroyed a viewport
     SESSION_EVT_TRANSACTION_STARTED = 1 << 12,//< Occurs when a transaction is opened on the session
-    SESSION_EVT_TRANSACTION_ENDED = 1 << 13,//< Occurs when an open transaction is ended on the session
-    SESSION_EVT_TRANSFORM_STARTED = 1 << 14,//< Occurs when a transform starts
-    SESSION_EVT_TRANSFORM_PROGRESS = 1 << 15,//< Occurs when a running transform reports progress
+    SESSION_EVT_TRANSACTION_ENDED = 1 << 13,  //< Occurs when an open transaction is ended on the session
+    SESSION_EVT_TRANSFORM_STARTED = 1 << 14,  //< Occurs when a transform starts
+    SESSION_EVT_TRANSFORM_PROGRESS = 1 << 15, //< Occurs when a running transform reports progress
     SESSION_EVT_TRANSFORM_COMPLETED = 1 << 16,//< Occurs when a transform completes successfully
-    SESSION_EVT_TRANSFORM_FAILED = 1 << 17,//< Occurs when a transform fails
-    SESSION_EVT_RESTORE_CHECKPOINT = 1 << 18//< Occurs when a checkpoint snapshot is restored
+    SESSION_EVT_TRANSFORM_FAILED = 1 << 17,   //< Occurs when a transform fails
+    SESSION_EVT_RESTORE_CHECKPOINT = 1 << 18  //< Occurs when a checkpoint snapshot is restored
 } omega_session_event_t;
 
 /** Enumeration of viewport events */
 typedef enum {
-    VIEWPORT_EVT_UNDEFINED = 0,//< No viewport event interest is defined
-    VIEWPORT_EVT_CREATE = 1,//< Occurs when the viewport has been successfully created
-    VIEWPORT_EVT_EDIT = 1 << 1,//< Occurs when an edit affects the viewport
-    VIEWPORT_EVT_UNDO = 1 << 2,//< Occurs when an undo affects the viewport
-    VIEWPORT_EVT_CLEAR = 1 << 3,//< Occurs when a clear affects the viewport
+    VIEWPORT_EVT_UNDEFINED = 0,     //< No viewport event interest is defined
+    VIEWPORT_EVT_CREATE = 1,        //< Occurs when the viewport has been successfully created
+    VIEWPORT_EVT_EDIT = 1 << 1,     //< Occurs when an edit affects the viewport
+    VIEWPORT_EVT_UNDO = 1 << 2,     //< Occurs when an undo affects the viewport
+    VIEWPORT_EVT_CLEAR = 1 << 3,    //< Occurs when a clear affects the viewport
     VIEWPORT_EVT_TRANSFORM = 1 << 4,//< Occurs when a transform affects the viewport
-    VIEWPORT_EVT_MODIFY = 1 << 5,//< Occurs when the viewport itself has been modified
-    VIEWPORT_EVT_CHANGES = 1 << 6//< Occurs when the viewport has changes to its data from some other activity
+    VIEWPORT_EVT_MODIFY = 1 << 5,   //< Occurs when the viewport itself has been modified
+    VIEWPORT_EVT_CHANGES = 1 << 6   //< Occurs when the viewport has changes to its data from some other activity
 } omega_viewport_event_t;
 
 /** Subscribe to all session events */
 #define SESSION_EVENTS_ALL                                                                                             \
     (SESSION_EVT_CREATE | SESSION_EVT_EDIT | SESSION_EVT_UNDO | SESSION_EVT_CLEAR | SESSION_EVT_TRANSFORM |            \
      SESSION_EVT_CREATE_CHECKPOINT | SESSION_EVT_DESTROY_CHECKPOINT | SESSION_EVT_SAVE | SESSION_EVT_CHANGES_PAUSED |  \
-     SESSION_EVT_CHANGES_RESUMED | SESSION_EVT_CREATE_VIEWPORT | SESSION_EVT_DESTROY_VIEWPORT |                       \
+     SESSION_EVT_CHANGES_RESUMED | SESSION_EVT_CREATE_VIEWPORT | SESSION_EVT_DESTROY_VIEWPORT |                        \
      SESSION_EVT_TRANSACTION_STARTED | SESSION_EVT_TRANSACTION_ENDED | SESSION_EVT_TRANSFORM_STARTED |                 \
      SESSION_EVT_TRANSFORM_PROGRESS | SESSION_EVT_TRANSFORM_COMPLETED | SESSION_EVT_TRANSFORM_FAILED |                 \
      SESSION_EVT_RESTORE_CHECKPOINT)
 
 /** Subscribe to all viewport events */
-#define VIEWPORT_EVENTS_ALL                                                                                           \
-    (VIEWPORT_EVT_CREATE | VIEWPORT_EVT_EDIT | VIEWPORT_EVT_UNDO | VIEWPORT_EVT_CLEAR | VIEWPORT_EVT_TRANSFORM |      \
+#define VIEWPORT_EVENTS_ALL                                                                                            \
+    (VIEWPORT_EVT_CREATE | VIEWPORT_EVT_EDIT | VIEWPORT_EVT_UNDO | VIEWPORT_EVT_CLEAR | VIEWPORT_EVT_TRANSFORM |       \
      VIEWPORT_EVT_MODIFY | VIEWPORT_EVT_CHANGES)
 
 /** Subscribe to all known events */
@@ -83,8 +83,8 @@ typedef enum {
 
 /** Enumeration of IO flags */
 typedef enum {
-    IO_FLG_NONE = 0,//< No IO flags are defined
-    IO_FLG_OVERWRITE = 1,//< Overwrite original file, unless modified outside the session
+    IO_FLG_NONE = 0,               //< No IO flags are defined
+    IO_FLG_OVERWRITE = 1,          //< Overwrite original file, unless modified outside the session
     IO_FLG_FORCE_OVERWRITE = 1 << 1//< Force overwrite of original file, even if modified outside the session
 } omega_io_flags_t;
 
@@ -92,14 +92,10 @@ typedef enum {
 #define ORIGINAL_MODIFIED (-100)
 
 /** Mask types */
-typedef enum {
-    MASK_AND, MASK_OR, MASK_XOR
-} omega_mask_kind_t;
+typedef enum { MASK_AND, MASK_OR, MASK_XOR } omega_mask_kind_t;
 
 /** Byte order mark (BOM) types */
-typedef enum {
-    BOM_UNKNOWN = 0, BOM_NONE, BOM_UTF8, BOM_UTF16LE, BOM_UTF16BE, BOM_UTF32LE, BOM_UTF32BE
-} omega_bom_t;
+typedef enum { BOM_UNKNOWN = 0, BOM_NONE, BOM_UTF8, BOM_UTF16LE, BOM_UTF16BE, BOM_UTF32LE, BOM_UTF32BE } omega_bom_t;
 
 /** Opaque character counts */
 typedef struct omega_character_counts_struct omega_character_counts_t;

--- a/core/src/include/omega_edit/transform_plugin_sdk.h
+++ b/core/src/include/omega_edit/transform_plugin_sdk.h
@@ -37,8 +37,8 @@ static inline void *omega_transform_plugin_sdk_alloc(const omega_transform_plugi
     return request_ptr->alloc(size == 0 ? 1 : size, request_ptr->allocator_user_data_ptr);
 }
 
-static inline omega_byte_t *omega_transform_plugin_sdk_copy_bytes(
-        const omega_transform_plugin_request_t *request_ptr, const omega_byte_t *bytes, int64_t length) {
+static inline omega_byte_t *omega_transform_plugin_sdk_copy_bytes(const omega_transform_plugin_request_t *request_ptr,
+                                                                  const omega_byte_t *bytes, int64_t length) {
     if (!request_ptr || length < 0 || (length > 0 && !bytes)) { return NULL; }
     omega_byte_t *copy = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, (size_t) length);
     if (!copy) { return NULL; }
@@ -47,7 +47,7 @@ static inline omega_byte_t *omega_transform_plugin_sdk_copy_bytes(
 }
 
 static inline char *omega_transform_plugin_sdk_copy_cstring(const omega_transform_plugin_request_t *request_ptr,
-                                                           const char *value) {
+                                                            const char *value) {
     if (!value) { return NULL; }
     const size_t length = strlen(value);
     char *copy = (char *) omega_transform_plugin_sdk_alloc(request_ptr, length + 1);
@@ -56,15 +56,15 @@ static inline char *omega_transform_plugin_sdk_copy_cstring(const omega_transfor
     return copy;
 }
 
-static inline int omega_transform_plugin_sdk_report_progress(
-        const omega_transform_plugin_request_t *request_ptr, const omega_transform_plugin_progress_t *progress_ptr) {
+static inline int omega_transform_plugin_sdk_report_progress(const omega_transform_plugin_request_t *request_ptr,
+                                                             const omega_transform_plugin_progress_t *progress_ptr) {
     if (!request_ptr || !request_ptr->progress || !progress_ptr) { return 0; }
     return request_ptr->progress(progress_ptr, request_ptr->progress_user_data_ptr);
 }
 
-static inline int omega_transform_plugin_sdk_report_byte_progress(
-        const omega_transform_plugin_request_t *request_ptr, int64_t processed_bytes, int64_t total_bytes,
-        const char *phase, const char *message) {
+static inline int omega_transform_plugin_sdk_report_byte_progress(const omega_transform_plugin_request_t *request_ptr,
+                                                                  int64_t processed_bytes, int64_t total_bytes,
+                                                                  const char *phase, const char *message) {
     if (processed_bytes < 0 || total_bytes < 0) { return -1; }
     omega_transform_plugin_progress_t progress;
     memset(&progress, 0, sizeof(progress));
@@ -73,14 +73,13 @@ static inline int omega_transform_plugin_sdk_report_byte_progress(
     progress.percent = total_bytes > 0 ? ((double) processed_bytes / (double) total_bytes) * 100.0 : 100.0;
     progress.phase = phase;
     progress.message = message;
-    progress.flags = OMEGA_TRANSFORM_PROGRESS_HAS_PROCESSED_BYTES |
-                     OMEGA_TRANSFORM_PROGRESS_HAS_TOTAL_BYTES |
+    progress.flags = OMEGA_TRANSFORM_PROGRESS_HAS_PROCESSED_BYTES | OMEGA_TRANSFORM_PROGRESS_HAS_TOTAL_BYTES |
                      OMEGA_TRANSFORM_PROGRESS_HAS_PERCENT;
     return omega_transform_plugin_sdk_report_progress(request_ptr, &progress);
 }
 
-static inline int omega_transform_plugin_sdk_report_phase(
-        const omega_transform_plugin_request_t *request_ptr, const char *phase, const char *message) {
+static inline int omega_transform_plugin_sdk_report_phase(const omega_transform_plugin_request_t *request_ptr,
+                                                          const char *phase, const char *message) {
     omega_transform_plugin_progress_t progress;
     memset(&progress, 0, sizeof(progress));
     progress.phase = phase;
@@ -97,9 +96,9 @@ static inline int omega_transform_plugin_sdk_set_no_content_change(omega_transfo
     return 0;
 }
 
-static inline int omega_transform_plugin_sdk_set_replacement(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr,
-        const omega_byte_t *bytes, int64_t length) {
+static inline int omega_transform_plugin_sdk_set_replacement(const omega_transform_plugin_request_t *request_ptr,
+                                                             omega_transform_plugin_response_t *response_ptr,
+                                                             const omega_byte_t *bytes, int64_t length) {
     if (!request_ptr || !response_ptr || length < 0 || (length > 0 && !bytes)) { return -1; }
     if (length == 0 && request_ptr->input_length == 0) {
         return omega_transform_plugin_sdk_set_no_content_change(response_ptr);
@@ -110,9 +109,10 @@ static inline int omega_transform_plugin_sdk_set_replacement(
     return response_ptr->replacement_bytes ? 0 : -1;
 }
 
-static inline int omega_transform_plugin_sdk_set_text_result(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr,
-        const char *label, const char *value, const char *mime_type) {
+static inline int omega_transform_plugin_sdk_set_text_result(const omega_transform_plugin_request_t *request_ptr,
+                                                             omega_transform_plugin_response_t *response_ptr,
+                                                             const char *label, const char *value,
+                                                             const char *mime_type) {
     if (!request_ptr || !response_ptr || !value) { return -1; }
     const size_t value_length = strlen(value);
     response_ptr->result_bytes = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, value_length);

--- a/core/src/lib/check.cpp
+++ b/core/src/lib/check.cpp
@@ -33,7 +33,7 @@ int omega_check_model(const omega_session_t *session_ptr) {
         if (!model_ptr) { return -1; }
 
         int64_t expected_offset = 0;
-        for (const auto &segment: model_ptr->model_segments) {
+        for (const auto &segment : model_ptr->model_segments) {
             // Each segment must reference a valid change
             if (!segment || !segment->change_ptr) { return -1; }
 
@@ -86,8 +86,7 @@ int omega_check_model(const omega_session_t *session_ptr) {
     int64_t model_total_length = 0;
     if (!back_model->model_segments.empty() &&
         !safe_add_int64_(back_model->model_segments.back()->computed_offset,
-                         back_model->model_segments.back()->computed_length,
-                         model_total_length)) {
+                         back_model->model_segments.back()->computed_length, model_total_length)) {
         return -1;
     }
     if (model_total_length != computed_file_size) { return -1; }

--- a/core/src/lib/filesystem.cpp
+++ b/core/src/lib/filesystem.cpp
@@ -80,7 +80,7 @@ namespace {
         return false;
 #endif
     }
-}
+}// namespace
 
 int omega_util_mkstemp(char *tmpl, int mode) {
     if (!tmpl) {
@@ -103,9 +103,7 @@ int omega_util_mkstemp(char *tmpl, int mode) {
     std::uniform_int_distribution<size_t> dist(0, sizeof(letters) - 2);
 
     for (int count = 0; count < TMP_MAX; ++count) {
-        for (size_t i = 0; i < 6; ++i) {
-            template_end[i] = letters[dist(gen)];
-        }
+        for (size_t i = 0; i < 6; ++i) { template_end[i] = letters[dist(gen)]; }
 
         mode = (mode) ? omega_util_compute_mode(mode) : omega_util_compute_mode(0600);
         int fd = OPEN(tmpl, O_RDWR | O_CREAT | O_EXCL, mode);
@@ -301,20 +299,20 @@ char *omega_util_available_filename(char const *path, char *buffer) {
     if (!omega_util_file_exists(path)) {
         // Use std::string instead of direct memcpy to properly handle multi-byte characters
         std::string path_str(path);
-        size_t max_len = FILENAME_MAX - 1; // Reserve space for null-termination
+        size_t max_len = FILENAME_MAX - 1;// Reserve space for null-termination
         size_t utf8_len = 0;
         for (size_t i = 0; i < path_str.length() && utf8_len < max_len; ++i) {
             unsigned char c = static_cast<unsigned char>(path_str[i]);
-            if (c < 0x80 || (c >= 0xC0 && c <= 0xF7)) { // Start of a UTF-8 character
+            if (c < 0x80 || (c >= 0xC0 && c <= 0xF7)) {// Start of a UTF-8 character
                 if (utf8_len + (c < 0x80 ? 1 : (c < 0xE0 ? 2 : (c < 0xF0 ? 3 : 4))) > max_len) {
-                    break; // Stop if adding this character exceeds max_len
+                    break;// Stop if adding this character exceeds max_len
                 }
             }
             ++utf8_len;
         }
         std::string truncated_path = path_str.substr(0, utf8_len);
         truncated_path.copy(buffer, truncated_path.length());
-        buffer[truncated_path.length()] = '\0'; // Ensure null-termination
+        buffer[truncated_path.length()] = '\0';// Ensure null-termination
         return buffer;
     }
     int i = 0;
@@ -327,9 +325,7 @@ char *omega_util_available_filename(char const *path, char *buffer) {
     const std::string basename(basename_cstr);
     do {
         if (++i >= OMEGA_AVAILABLE_FILENAME_SUFFIX_ATTEMPTS) { return nullptr; }
-        auto const filename_str = fs::path(dirname)
-                .append(basename + "-" + std::to_string(i) + extension)
-                .string();
+        auto const filename_str = fs::path(dirname).append(basename + "-" + std::to_string(i) + extension).string();
         auto const len = filename_str.copy(buffer, filename_str.length());
         assert(len == filename_str.length());
         buffer[len] = '\0';
@@ -373,8 +369,8 @@ int omega_util_file_copy(const char *src_path, const char *dst_path, int mode) {
         fs::last_write_time(dst_fs_path, now_file_time);
 
         // Set the mode of the destination file (if the mode is 0, use the mode of the source file)
-        fs::permissions(dst_fs_path, (mode) ? static_cast<fs::perms>(mode & 07777)
-                                            : fs::status(src_fs_path).permissions(),
+        fs::permissions(dst_fs_path,
+                        (mode) ? static_cast<fs::perms>(mode & 07777) : fs::status(src_fs_path).permissions(),
                         fs::perm_options::replace);
 #ifndef OMEGA_BUILD_WINDOWS
         if (mode && chmod(dst_path, static_cast<mode_t>(mode & 07777)) != 0) { return -4; }

--- a/core/src/lib/impl_/find.cpp
+++ b/core/src/lib/impl_/find.cpp
@@ -23,7 +23,7 @@ struct omega_find_skip_table_t : public std::vector<std::ptrdiff_t> {
     int is_reverse_search;
 
     omega_find_skip_table_t(std::ptrdiff_t vec_size, std::ptrdiff_t fill, int isReverse)
-            : std::vector<std::ptrdiff_t>(vec_size, fill), is_reverse_search(isReverse) {}
+        : std::vector<std::ptrdiff_t>(vec_size, fill), is_reverse_search(isReverse) {}
 };
 
 int omega_find_is_reversed(const omega_find_skip_table_t *skip_table_ptr) {
@@ -88,8 +88,8 @@ const unsigned char *omega_find(const unsigned char *haystack, size_t haystack_l
     // If the needle is a single character, use memchr/memrchr instead of the skip table.
     if (needle_length == 1) {
         return skip_table_ptr->is_reverse_search
-               ? (const unsigned char *) omega_util_memrchr(haystack, *needle, haystack_length)
-               : (const unsigned char *) std::memchr(haystack, *needle, haystack_length);
+                       ? (const unsigned char *) omega_util_memrchr(haystack, *needle, haystack_length)
+                       : (const unsigned char *) std::memchr(haystack, *needle, haystack_length);
     }
 
     assert(skip_table_ptr);
@@ -104,7 +104,7 @@ const unsigned char *omega_find(const unsigned char *haystack, size_t haystack_l
         const auto skip = haystack[haystack_position + (skip_table_ptr->is_reverse_search ? 0 : needle_length_minus_1)];
 
         if (const auto probe = haystack + haystack_position;
-                last_needle_char == skip && std::memcmp(needle, probe, needle_length) == 0) {
+            last_needle_char == skip && std::memcmp(needle, probe, needle_length) == 0) {
             return probe;
         }
 

--- a/core/src/lib/impl_/internal_fun.cpp
+++ b/core/src/lib/impl_/internal_fun.cpp
@@ -27,141 +27,141 @@
 
 namespace omega_edit::internal {
 
-/**********************************************************************************************************************
+    /**********************************************************************************************************************
  * Data segment functions
  **********************************************************************************************************************/
 
-static inline int64_t read_segment_from_file_(FILE *from_file_ptr, int64_t offset, omega_byte_t *buffer,
-                                              int64_t capacity) noexcept {
-    assert(from_file_ptr);
-    assert(buffer);
-    // The model guarantees read ranges are within the file, so skip the SEEK_END file-size check.
-    // If the file was externally truncated, fread returns fewer bytes which the caller detects.
-    if (0 != FSEEK(from_file_ptr, offset, SEEK_SET)) { return -1; }
-    return static_cast<int64_t>(fread(buffer, sizeof(omega_byte_t), capacity, from_file_ptr));
-}
-
-int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr) noexcept {
-    assert(session_ptr);
-    assert(session_ptr->models_.back());
-    assert(data_segment_ptr);
-    const auto &model_ptr = session_ptr->models_.back();
-    data_segment_ptr->length = 0;
-    if (model_ptr->model_segments.empty()) { return 0; }
-    assert(0 <= data_segment_ptr->capacity);
-    const auto data_segment_capacity = data_segment_ptr->capacity;
-    int64_t data_segment_offset = 0;
-    if (!safe_add_int64_(data_segment_ptr->offset, data_segment_ptr->offset_adjustment, data_segment_offset)) {
-        return -1;
-    }
-    if (data_segment_offset < 0) { return -1; }
-    // Binary search for the first segment that could contain data_segment_offset.
-    // Segments are contiguous and sorted by computed_offset, so upper_bound finds the first segment
-    // with computed_offset > data_segment_offset, and we step back one to get the containing segment.
-    auto iter = std::upper_bound(
-            model_ptr->model_segments.cbegin(), model_ptr->model_segments.cend(), data_segment_offset,
-            [](int64_t offset, const omega_model_segment_ptr_t &seg) { return offset < seg->computed_offset; });
-    if (iter != model_ptr->model_segments.cbegin()) { --iter; }
-
-    // Verify the found segment contains the target offset
-    int64_t segment_end = 0;
-    if (!safe_add_int64_((*iter)->computed_offset, (*iter)->computed_length, segment_end) ||
-        data_segment_offset < (*iter)->computed_offset || data_segment_offset > segment_end) {
-        return -1;
+    static inline int64_t read_segment_from_file_(FILE *from_file_ptr, int64_t offset, omega_byte_t *buffer,
+                                                  int64_t capacity) noexcept {
+        assert(from_file_ptr);
+        assert(buffer);
+        // The model guarantees read ranges are within the file, so skip the SEEK_END file-size check.
+        // If the file was externally truncated, fread returns fewer bytes which the caller detects.
+        if (0 != FSEEK(from_file_ptr, offset, SEEK_SET)) { return -1; }
+        return static_cast<int64_t>(fread(buffer, sizeof(omega_byte_t), capacity, from_file_ptr));
     }
 
-    auto delta = data_segment_offset - (*iter)->computed_offset;
-    const auto data_segment_buffer = omega_segment_get_data(data_segment_ptr);
-    do {
-        // This is how much data remains to be filled
-        const auto remaining_capacity = data_segment_capacity - data_segment_ptr->length;
-        auto amount = (*iter)->computed_length - delta;
-        amount = (amount > remaining_capacity) ? remaining_capacity : amount;
-        switch (omega_model_segment_get_kind_(iter->get())) {
-            case model_segment_kind_t::SEGMENT_READ: {
-                // For read segments, we're reading a segment, or portion thereof, from the input file and
-                // writing it into the data segment.
-                // Coalesce with consecutive READ segments that are contiguous in the source file to reduce
-                // the number of fread system calls.
-                int64_t file_offset = 0;
-                if (!safe_add_int64_((*iter)->change_offset, delta, file_offset)) { return -1; }
-                auto coalesced = amount;
-                auto peek = iter;
-                while (coalesced < remaining_capacity && ++peek != model_ptr->model_segments.end() &&
-                       omega_model_segment_get_kind_(peek->get()) == model_segment_kind_t::SEGMENT_READ &&
-                       !add_overflows_int64_(file_offset, coalesced) &&
-                       (*peek)->change_offset == file_offset + coalesced) {
-                    const auto peek_amount = (std::min)(remaining_capacity - coalesced, (*peek)->computed_length);
-                    coalesced += peek_amount;
-                    // Only advance iter if we consumed the entire peek segment
-                    if (peek_amount == (*peek)->computed_length) {
-                        iter = peek;
-                    } else {
-                        break;
-                    }
-                }
-                if (read_segment_from_file_(session_ptr->models_.back()->file_ptr,
-                                            file_offset,
-                                            data_segment_buffer + data_segment_ptr->length, coalesced) != coalesced) {
-                    return -1;
-                }
-                amount = coalesced;
-                break;
-            }
-            case model_segment_kind_t::SEGMENT_INSERT: {
-                // For insert segments, we're writing the change byte buffer, or portion thereof, into the data
-                // segment
-                int64_t change_offset = 0;
-                if (!safe_add_int64_((*iter)->change_offset, delta, change_offset)) { return -1; }
-                memcpy(data_segment_buffer + data_segment_ptr->length,
-                       omega_change_get_bytes((*iter)->change_ptr.get()) + change_offset,
-                       amount);
-                break;
-            }
-            default:
-                ABORT(LOG_ERROR("Unhandled model segment kind"););
+    int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr) noexcept {
+        assert(session_ptr);
+        assert(session_ptr->models_.back());
+        assert(data_segment_ptr);
+        const auto &model_ptr = session_ptr->models_.back();
+        data_segment_ptr->length = 0;
+        if (model_ptr->model_segments.empty()) { return 0; }
+        assert(0 <= data_segment_ptr->capacity);
+        const auto data_segment_capacity = data_segment_ptr->capacity;
+        int64_t data_segment_offset = 0;
+        if (!safe_add_int64_(data_segment_ptr->offset, data_segment_ptr->offset_adjustment, data_segment_offset)) {
+            return -1;
         }
-        // Add the amount written to the data segment length
-        if (!safe_add_int64_(data_segment_ptr->length, amount, data_segment_ptr->length)) { return -1; }
-        // After the first segment is written, the delta should be zero from that point on
-        delta = 0;
-        // Keep writing segments until we run out of viewport capacity or run out of segments
-    } while (data_segment_ptr->length < data_segment_capacity && ++iter != model_ptr->model_segments.end());
-    assert(data_segment_ptr->length <= data_segment_capacity);
-    // data segment buffer allocation is its capacity plus one, so we can null-terminate it
-    data_segment_buffer[data_segment_ptr->length] = '\0';
-    return 0;
-}
+        if (data_segment_offset < 0) { return -1; }
+        // Binary search for the first segment that could contain data_segment_offset.
+        // Segments are contiguous and sorted by computed_offset, so upper_bound finds the first segment
+        // with computed_offset > data_segment_offset, and we step back one to get the containing segment.
+        auto iter = std::upper_bound(
+                model_ptr->model_segments.cbegin(), model_ptr->model_segments.cend(), data_segment_offset,
+                [](int64_t offset, const omega_model_segment_ptr_t &seg) { return offset < seg->computed_offset; });
+        if (iter != model_ptr->model_segments.cbegin()) { --iter; }
 
-/**********************************************************************************************************************
+        // Verify the found segment contains the target offset
+        int64_t segment_end = 0;
+        if (!safe_add_int64_((*iter)->computed_offset, (*iter)->computed_length, segment_end) ||
+            data_segment_offset < (*iter)->computed_offset || data_segment_offset > segment_end) {
+            return -1;
+        }
+
+        auto delta = data_segment_offset - (*iter)->computed_offset;
+        const auto data_segment_buffer = omega_segment_get_data(data_segment_ptr);
+        do {
+            // This is how much data remains to be filled
+            const auto remaining_capacity = data_segment_capacity - data_segment_ptr->length;
+            auto amount = (*iter)->computed_length - delta;
+            amount = (amount > remaining_capacity) ? remaining_capacity : amount;
+            switch (omega_model_segment_get_kind_(iter->get())) {
+                case model_segment_kind_t::SEGMENT_READ: {
+                    // For read segments, we're reading a segment, or portion thereof, from the input file and
+                    // writing it into the data segment.
+                    // Coalesce with consecutive READ segments that are contiguous in the source file to reduce
+                    // the number of fread system calls.
+                    int64_t file_offset = 0;
+                    if (!safe_add_int64_((*iter)->change_offset, delta, file_offset)) { return -1; }
+                    auto coalesced = amount;
+                    auto peek = iter;
+                    while (coalesced < remaining_capacity && ++peek != model_ptr->model_segments.end() &&
+                           omega_model_segment_get_kind_(peek->get()) == model_segment_kind_t::SEGMENT_READ &&
+                           !add_overflows_int64_(file_offset, coalesced) &&
+                           (*peek)->change_offset == file_offset + coalesced) {
+                        const auto peek_amount = (std::min)(remaining_capacity - coalesced, (*peek)->computed_length);
+                        coalesced += peek_amount;
+                        // Only advance iter if we consumed the entire peek segment
+                        if (peek_amount == (*peek)->computed_length) {
+                            iter = peek;
+                        } else {
+                            break;
+                        }
+                    }
+                    if (read_segment_from_file_(session_ptr->models_.back()->file_ptr, file_offset,
+                                                data_segment_buffer + data_segment_ptr->length,
+                                                coalesced) != coalesced) {
+                        return -1;
+                    }
+                    amount = coalesced;
+                    break;
+                }
+                case model_segment_kind_t::SEGMENT_INSERT: {
+                    // For insert segments, we're writing the change byte buffer, or portion thereof, into the data
+                    // segment
+                    int64_t change_offset = 0;
+                    if (!safe_add_int64_((*iter)->change_offset, delta, change_offset)) { return -1; }
+                    memcpy(data_segment_buffer + data_segment_ptr->length,
+                           omega_change_get_bytes((*iter)->change_ptr.get()) + change_offset, amount);
+                    break;
+                }
+                default:
+                    ABORT(LOG_ERROR("Unhandled model segment kind"););
+            }
+            // Add the amount written to the data segment length
+            if (!safe_add_int64_(data_segment_ptr->length, amount, data_segment_ptr->length)) { return -1; }
+            // After the first segment is written, the delta should be zero from that point on
+            delta = 0;
+            // Keep writing segments until we run out of viewport capacity or run out of segments
+        } while (data_segment_ptr->length < data_segment_capacity && ++iter != model_ptr->model_segments.end());
+        assert(data_segment_ptr->length <= data_segment_capacity);
+        // data segment buffer allocation is its capacity plus one, so we can null-terminate it
+        data_segment_buffer[data_segment_ptr->length] = '\0';
+        return 0;
+    }
+
+    /**********************************************************************************************************************
  * Model segment functions
  **********************************************************************************************************************/
 
-static inline void print_change_(const omega_change_t *change_ptr, std::ostream &out_stream) noexcept {
-    assert(change_ptr);
-    out_stream << R"({"serial": )" << omega_change_get_serial(change_ptr) << R"(, "kind": ")"
-               << omega_change_get_kind_as_char(change_ptr) << R"(", "offset": )" << omega_change_get_offset(change_ptr)
-               << R"(, "length": )" << omega_change_get_length(change_ptr);
-    if (const auto bytes = omega_change_get_bytes(change_ptr); bytes) {
-        out_stream << R"(, "bytes": ")" << std::string((char const *) bytes, omega_change_get_length(change_ptr))
-                   << R"(")";
+    static inline void print_change_(const omega_change_t *change_ptr, std::ostream &out_stream) noexcept {
+        assert(change_ptr);
+        out_stream << R"({"serial": )" << omega_change_get_serial(change_ptr) << R"(, "kind": ")"
+                   << omega_change_get_kind_as_char(change_ptr) << R"(", "offset": )"
+                   << omega_change_get_offset(change_ptr) << R"(, "length": )" << omega_change_get_length(change_ptr);
+        if (const auto bytes = omega_change_get_bytes(change_ptr); bytes) {
+            out_stream << R"(, "bytes": ")" << std::string((char const *) bytes, omega_change_get_length(change_ptr))
+                       << R"(")";
+        }
+        out_stream << "}";
     }
-    out_stream << "}";
-}
 
-static inline void print_model_segment_(const omega_model_segment_ptr_t &segment_ptr,
-                                        std::ostream &out_stream) noexcept {
-    out_stream << R"({"kind": ")" << omega_model_segment_kind_as_char_(omega_model_segment_get_kind_(segment_ptr.get()))
-               << R"(", "computed_offset": )" << segment_ptr->computed_offset << R"(, "computed_length": )"
-               << segment_ptr->computed_length << R"(, "change_offset": )" << segment_ptr->change_offset
-               << R"(, "change": )";
-    print_change_(segment_ptr->change_ptr.get(), out_stream);
-    out_stream << "}" << std::endl;
-}
+    static inline void print_model_segment_(const omega_model_segment_ptr_t &segment_ptr,
+                                            std::ostream &out_stream) noexcept {
+        out_stream << R"({"kind": ")"
+                   << omega_model_segment_kind_as_char_(omega_model_segment_get_kind_(segment_ptr.get()))
+                   << R"(", "computed_offset": )" << segment_ptr->computed_offset << R"(, "computed_length": )"
+                   << segment_ptr->computed_length << R"(, "change_offset": )" << segment_ptr->change_offset
+                   << R"(, "change": )";
+        print_change_(segment_ptr->change_ptr.get(), out_stream);
+        out_stream << "}" << std::endl;
+    }
 
-void print_model_segments_(const omega_model_t *model_ptr, std::ostream &out_stream) noexcept {
-    assert(model_ptr);
-    for (const auto &segment: model_ptr->model_segments) { print_model_segment_(segment, out_stream); }
-}
+    void print_model_segments_(const omega_model_t *model_ptr, std::ostream &out_stream) noexcept {
+        assert(model_ptr);
+        for (const auto &segment : model_ptr->model_segments) { print_model_segment_(segment, out_stream); }
+    }
 
 }// namespace omega_edit::internal

--- a/core/src/lib/impl_/internal_fun.hpp
+++ b/core/src/lib/impl_/internal_fun.hpp
@@ -22,15 +22,15 @@
 
 namespace omega_edit::internal {
 
-// Data segment functions
-int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr)
+    // Data segment functions
+    int populate_data_segment_(const omega_session_t *session_ptr, omega_segment_t *data_segment_ptr)
 
-noexcept;
+            noexcept;
 
-// Model segment functions
-void print_model_segments_(const omega_model_t *model_ptr, std::ostream &out_stream)
+    // Model segment functions
+    void print_model_segments_(const omega_model_t *model_ptr, std::ostream &out_stream)
 
-noexcept;
+            noexcept;
 
 }// namespace omega_edit::internal
 

--- a/core/src/lib/impl_/macros.h
+++ b/core/src/lib/impl_/macros.h
@@ -62,7 +62,7 @@
         LPSTR errMsgBuff = nullptr;                                                                                    \
         size_t size = FormatMessageA(                                                                                  \
                 FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,     \
-                errCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) &errMsgBuff, 0, NULL);                     \
+                errCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) & errMsgBuff, 0, NULL);                    \
         CLOG << LOCATION << "Windows error code=" << errCode << ": " << errMsgBuff << std::endl;                       \
         LocalFree(errMsgBuff);                                                                                         \
     } while (0)
@@ -84,7 +84,7 @@
         LPSTR errMsgBuff = nullptr;                                                                                    \
         size_t size = FormatMessageA(                                                                                  \
                 FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,     \
-                errCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) &errMsgBuff, 0, NULL);                     \
+                errCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) & errMsgBuff, 0, NULL);                    \
         fprintf(stderr, "%s@%d::%s: Windows error code=%lu: %s\n", SOURCE_FILENAME, __LINE__, __FUNCTION__, errCode,   \
                 errMsgBuff);                                                                                           \
         LocalFree(errMsgBuff);                                                                                         \

--- a/core/src/lib/impl_/model_segment_def.hpp
+++ b/core/src/lib/impl_/model_segment_def.hpp
@@ -20,9 +20,7 @@
 
 namespace omega_edit::internal {
 
-enum class model_segment_kind_t {
-    SEGMENT_READ, SEGMENT_INSERT
-};
+    enum class model_segment_kind_t { SEGMENT_READ, SEGMENT_INSERT };
 
 }// namespace omega_edit::internal
 
@@ -36,21 +34,22 @@ struct omega_model_segment_struct {
 
 namespace omega_edit::internal {
 
-inline model_segment_kind_t omega_model_segment_get_kind_(const omega_model_segment_t *model_segment_ptr) {
-    return (0 == omega_change_get_serial(model_segment_ptr->change_ptr.get())) ? model_segment_kind_t::SEGMENT_READ
-                                                                               : model_segment_kind_t::SEGMENT_INSERT;
-}
-
-inline char omega_model_segment_kind_as_char_(const model_segment_kind_t segment_kind) {
-    switch (segment_kind) {
-        case model_segment_kind_t::SEGMENT_READ:
-            return 'R';
-        case model_segment_kind_t::SEGMENT_INSERT:
-            return 'I';
-        default:
-            return '?';
+    inline model_segment_kind_t omega_model_segment_get_kind_(const omega_model_segment_t *model_segment_ptr) {
+        return (0 == omega_change_get_serial(model_segment_ptr->change_ptr.get()))
+                       ? model_segment_kind_t::SEGMENT_READ
+                       : model_segment_kind_t::SEGMENT_INSERT;
     }
-}
+
+    inline char omega_model_segment_kind_as_char_(const model_segment_kind_t segment_kind) {
+        switch (segment_kind) {
+            case model_segment_kind_t::SEGMENT_READ:
+                return 'R';
+            case model_segment_kind_t::SEGMENT_INSERT:
+                return 'I';
+            default:
+                return '?';
+        }
+    }
 
 }// namespace omega_edit::internal
 

--- a/core/src/lib/impl_/safe_math.hpp
+++ b/core/src/lib/impl_/safe_math.hpp
@@ -20,21 +20,21 @@
 
 namespace omega_edit::internal {
 
-inline bool add_overflows_int64_(int64_t lhs, int64_t rhs) {
-    return (rhs > 0 && lhs > (std::numeric_limits<int64_t>::max)() - rhs) ||
-           (rhs < 0 && lhs < (std::numeric_limits<int64_t>::min)() - rhs);
-}
+    inline bool add_overflows_int64_(int64_t lhs, int64_t rhs) {
+        return (rhs > 0 && lhs > (std::numeric_limits<int64_t>::max)() - rhs) ||
+               (rhs < 0 && lhs < (std::numeric_limits<int64_t>::min)() - rhs);
+    }
 
-inline bool safe_add_int64_(int64_t lhs, int64_t rhs, int64_t &result) {
-    if (add_overflows_int64_(lhs, rhs)) { return false; }
-    result = lhs + rhs;
-    return true;
-}
+    inline bool safe_add_int64_(int64_t lhs, int64_t rhs, int64_t &result) {
+        if (add_overflows_int64_(lhs, rhs)) { return false; }
+        result = lhs + rhs;
+        return true;
+    }
 
-inline bool valid_nonnegative_range_(int64_t offset, int64_t length) {
-    int64_t end = 0;
-    return offset >= 0 && length >= 0 && safe_add_int64_(offset, length, end);
-}
+    inline bool valid_nonnegative_range_(int64_t offset, int64_t length) {
+        int64_t end = 0;
+        return offset >= 0 && length >= 0 && safe_add_int64_(offset, length, end);
+    }
 
 }// namespace omega_edit::internal
 

--- a/core/src/lib/impl_/session_def.hpp
+++ b/core/src/lib/impl_/session_def.hpp
@@ -46,18 +46,18 @@ struct omega_session_struct {
     int8_t session_flags_{};                   ///< Internal state flags
     omega_session_event_t batched_session_event_kind_{SESSION_EVT_UNDEFINED};///< Event kind currently being batched
     omega_session_event_t pending_session_event_kind_{SESSION_EVT_UNDEFINED};///< Deferred event to flush at batch end
-    const void *pending_session_event_ptr_{};  ///< Deferred event payload to flush at batch end
-    std::string checkpoint_directory_{};       ///< Path to checkpoint directory
-    std::string checkpoint_file_name_{};       ///< Name of session checkpoint file
-    int64_t original_file_modification_time_{};///< Last synchronized modification time for the original file
+    const void *pending_session_event_ptr_{};     ///< Deferred event payload to flush at batch end
+    std::string checkpoint_directory_{};          ///< Path to checkpoint directory
+    std::string checkpoint_file_name_{};          ///< Name of session checkpoint file
+    int64_t original_file_modification_time_{};   ///< Last synchronized modification time for the original file
     bool original_file_modification_time_valid_{};///< True when original_file_modification_time_ can be compared
 };
 
 namespace omega_edit::internal {
 
-bool omega_session_get_transaction_bit_(const omega_session_t *session_ptr);
-void omega_session_begin_event_batch_(omega_session_t *session_ptr, omega_session_event_t session_event);
-void omega_session_end_event_batch_(omega_session_t *session_ptr);
+    bool omega_session_get_transaction_bit_(const omega_session_t *session_ptr);
+    void omega_session_begin_event_batch_(omega_session_t *session_ptr, omega_session_event_t session_event);
+    void omega_session_end_event_batch_(omega_session_t *session_ptr);
 
 }// namespace omega_edit::internal
 

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -170,59 +170,59 @@ namespace {
             }
 
             switch (ch) {
-            case '[':
-                in_character_class = true;
-                remember_atom(false, false);
-                break;
-            case '(':
-                if (index + 1 < pattern_text.size() && pattern_text[index + 1] == '?') { return false; }
-                groups.push_back({});
-                forget_atom();
-                break;
-            case ')': {
-                if (groups.empty()) { return false; }
-                const auto group = groups.back();
-                groups.pop_back();
-                remember_atom(true, group.has_quantified_atom || group.has_alternation);
-                break;
-            }
-            case '|':
-                if (!groups.empty()) { groups.back().has_alternation = true; }
-                forget_atom();
-                break;
-            case '*':
-            case '+':
-            case '?':
-                if (!apply_quantifier()) { return false; }
-                break;
-            case '{': {
-                size_t end = index + 1;
-                bool has_digit = false;
-                bool valid_range_quantifier = true;
-                for (; end < pattern_text.size() && pattern_text[end] != '}'; ++end) {
-                    const auto range_ch = static_cast<unsigned char>(pattern_text[end]);
-                    if (std::isdigit(range_ch) != 0) {
-                        has_digit = true;
-                    } else if (range_ch != ',') {
-                        valid_range_quantifier = false;
-                        break;
-                    }
-                }
-                if (end < pattern_text.size() && valid_range_quantifier && has_digit) {
-                    if (!apply_quantifier()) { return false; }
-                    index = end;
-                } else {
+                case '[':
+                    in_character_class = true;
+                    remember_atom(false, false);
+                    break;
+                case '(':
+                    if (index + 1 < pattern_text.size() && pattern_text[index + 1] == '?') { return false; }
+                    groups.push_back({});
                     forget_atom();
+                    break;
+                case ')': {
+                    if (groups.empty()) { return false; }
+                    const auto group = groups.back();
+                    groups.pop_back();
+                    remember_atom(true, group.has_quantified_atom || group.has_alternation);
+                    break;
                 }
-                break;
-            }
-            case '^':
-            case '$':
-                forget_atom();
-                break;
-            default:
-                remember_atom(false, false);
-                break;
+                case '|':
+                    if (!groups.empty()) { groups.back().has_alternation = true; }
+                    forget_atom();
+                    break;
+                case '*':
+                case '+':
+                case '?':
+                    if (!apply_quantifier()) { return false; }
+                    break;
+                case '{': {
+                    size_t end = index + 1;
+                    bool has_digit = false;
+                    bool valid_range_quantifier = true;
+                    for (; end < pattern_text.size() && pattern_text[end] != '}'; ++end) {
+                        const auto range_ch = static_cast<unsigned char>(pattern_text[end]);
+                        if (std::isdigit(range_ch) != 0) {
+                            has_digit = true;
+                        } else if (range_ch != ',') {
+                            valid_range_quantifier = false;
+                            break;
+                        }
+                    }
+                    if (end < pattern_text.size() && valid_range_quantifier && has_digit) {
+                        if (!apply_quantifier()) { return false; }
+                        index = end;
+                    } else {
+                        forget_atom();
+                    }
+                    break;
+                }
+                case '^':
+                case '$':
+                    forget_atom();
+                    break;
+                default:
+                    remember_atom(false, false);
+                    break;
             }
         }
 

--- a/core/src/lib/utility.c
+++ b/core/src/lib/utility.c
@@ -55,7 +55,7 @@ int omega_util_compute_mode(int mode) {
 #ifdef OMEGA_BUILD_WINDOWS
     // Convert Unix-style mode bits to the equivalent Windows style
     int winMode = 0;
-    if (mode & 0400) winMode |= _S_IREAD;// Owner read
+    if (mode & 0400) winMode |= _S_IREAD; // Owner read
     if (mode & 0200) winMode |= _S_IWRITE;// Owner write
     return winMode;
 #else
@@ -73,7 +73,9 @@ int64_t omega_util_write_segment_to_file(FILE *from_file_ptr, int64_t offset, in
     while (remaining) {
         const int64_t count = (int64_t) sizeof(buff) > remaining ? remaining : (int64_t) sizeof(buff);
         if (count != (int64_t) fread(buff, sizeof(omega_byte_t), count, from_file_ptr) ||
-            count != (int64_t) fwrite(buff, sizeof(omega_byte_t), count, to_file_ptr)) { break; }
+            count != (int64_t) fwrite(buff, sizeof(omega_byte_t), count, to_file_ptr)) {
+            break;
+        }
         remaining -= count;
     }
     return byte_count - remaining;
@@ -212,7 +214,9 @@ omega_byte_t omega_util_mask_byte(omega_byte_t byte, omega_byte_t mask, omega_ma
 int omega_util_strncmp(const char *s1, const char *s2, uint64_t sz) {
     if (!s1 || !s2) { return s1 == s2 ? 0 : (s1 ? 1 : -1); }
     int rc = 0;
-    for (uint64_t i = 0; i < sz; ++i) { if (0 != (rc = s1[i] - s2[i])) break; }
+    for (uint64_t i = 0; i < sz; ++i) {
+        if (0 != (rc = s1[i] - s2[i])) break;
+    }
     return rc;
 }
 
@@ -220,8 +224,7 @@ int omega_util_strnicmp(const char *s1, const char *s2, uint64_t sz) {
     if (!s1 || !s2) { return s1 == s2 ? 0 : (s1 ? 1 : -1); }
     int rc = 0;
     for (uint64_t i = 0; i < sz; ++i) {
-        if (0 !=
-            (rc = tolower((unsigned char) s1[i]) - tolower((unsigned char) s2[i]))) { break; }
+        if (0 != (rc = tolower((unsigned char) s1[i]) - tolower((unsigned char) s2[i]))) { break; }
     }
     return rc;
 }
@@ -238,17 +241,23 @@ char *omega_util_strndup(const char *s, size_t len) {
 const void *omega_util_memrchr(const void *s, int c, size_t n) {
     if (n >= 1) {
         const unsigned char *cp = (const unsigned char *) s;
-        for (const unsigned char *p = cp + n; p-- > cp;) { if (*p == c) { return p; } }
+        for (const unsigned char *p = cp + n; p-- > cp;) {
+            if (*p == c) { return p; }
+        }
     }
     return NULL;
 }
 
 omega_bom_t omega_util_detect_BOM_from_memory(const unsigned char *data, size_t length) {
-    if (length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) { return BOM_UTF8; } else if (
-        length >= 2 && data[0] == 0xFF && data[1] == 0xFE) {
+    if (length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) {
+        return BOM_UTF8;
+    } else if (length >= 2 && data[0] == 0xFF && data[1] == 0xFE) {
         return (length >= 4 && data[2] == 0x00 && data[3] == 0x00) ? BOM_UTF32LE : BOM_UTF16LE;
-    } else if (length >= 2 && data[0] == 0xFE && data[1] == 0xFF) { return BOM_UTF16BE; } else if (
-        length >= 4 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF) { return BOM_UTF32BE; }
+    } else if (length >= 2 && data[0] == 0xFE && data[1] == 0xFF) {
+        return BOM_UTF16BE;
+    } else if (length >= 4 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF) {
+        return BOM_UTF32BE;
+    }
     return BOM_NONE;
 }
 
@@ -280,7 +289,7 @@ char const *omega_util_BOM_to_cstring(omega_bom_t bom) {
             return "UTF-32LE";
         case BOM_UTF32BE:
             return "UTF-32BE";
-        case BOM_UNKNOWN: // fall through
+        case BOM_UNKNOWN:// fall through
         default:
             // Should never happen
             return "unknown";
@@ -288,12 +297,19 @@ char const *omega_util_BOM_to_cstring(omega_bom_t bom) {
 }
 
 omega_bom_t omega_util_cstring_to_BOM(char const *str) {
-    if (0 == omega_util_strnicmp(str, "none", 4)) { return BOM_NONE; } else if (
-        0 == omega_util_strnicmp(str, "UTF-8", 5)) { return BOM_UTF8; } else if (
-        0 == omega_util_strnicmp(str, "UTF-16LE", 8)) { return BOM_UTF16LE; } else if (
-        0 == omega_util_strnicmp(str, "UTF-16BE", 8)) { return BOM_UTF16BE; } else if (
-        0 == omega_util_strnicmp(str, "UTF-32LE", 8)) { return BOM_UTF32LE; } else if (
-        0 == omega_util_strnicmp(str, "UTF-32BE", 8)) { return BOM_UTF32BE; }
+    if (0 == omega_util_strnicmp(str, "none", 4)) {
+        return BOM_NONE;
+    } else if (0 == omega_util_strnicmp(str, "UTF-8", 5)) {
+        return BOM_UTF8;
+    } else if (0 == omega_util_strnicmp(str, "UTF-16LE", 8)) {
+        return BOM_UTF16LE;
+    } else if (0 == omega_util_strnicmp(str, "UTF-16BE", 8)) {
+        return BOM_UTF16BE;
+    } else if (0 == omega_util_strnicmp(str, "UTF-32LE", 8)) {
+        return BOM_UTF32LE;
+    } else if (0 == omega_util_strnicmp(str, "UTF-32BE", 8)) {
+        return BOM_UTF32BE;
+    }
     return BOM_UNKNOWN;
 }
 
@@ -357,7 +373,7 @@ void omega_util_count_characters(const unsigned char *data, size_t length, omega
     size_t i = 0;
     switch (counts_ptr->bom) {
         case BOM_UNKNOWN:// fall through, assume UTF-8 if the BOM is unknown
-        case BOM_NONE:// fall through, assume UTF-8 if the BOM is none
+        case BOM_NONE:   // fall through, assume UTF-8 if the BOM is none
         case BOM_UTF8:
             while (i < length) {
                 if ((data[i] & 0x80) == 0) {
@@ -400,14 +416,14 @@ void omega_util_count_characters(const unsigned char *data, size_t length, omega
             while (i + 1 < length) {
                 // Swap the bytes if the BOM is little endian
                 const uint16_t char16 = counts_ptr->bom == BOM_UTF16LE
-                                            ? (uint16_t) (data[i]) | (uint16_t) (data[i + 1]) << 8
-                                            : (uint16_t) (data[i]) << 8 | (uint16_t) (data[i + 1]);
+                                                ? (uint16_t) (data[i]) | (uint16_t) (data[i + 1]) << 8
+                                                : (uint16_t) (data[i]) << 8 | (uint16_t) (data[i + 1]);
 
                 if (is_lead_surrogate_UTF16_(char16)) {
                     if (i + 3 < length) {
                         const uint16_t next_char16 = counts_ptr->bom == BOM_UTF16LE
-                                                         ? (uint16_t) (data[i + 2]) | (uint16_t) (data[i + 3]) << 8
-                                                         : (uint16_t) (data[i + 2]) << 8 | (uint16_t) (data[i + 3]);
+                                                             ? (uint16_t) (data[i + 2]) | (uint16_t) (data[i + 3]) << 8
+                                                             : (uint16_t) (data[i + 2]) << 8 | (uint16_t) (data[i + 3]);
                         if (is_low_surrogate_UTF16_(next_char16)) {
                             ++counts_ptr->doubleByteChars;
                             i += 4;// skip the low surrogate as well
@@ -417,7 +433,7 @@ void omega_util_count_characters(const unsigned char *data, size_t length, omega
                         }
                     } else {
                         ++counts_ptr->invalidBytes;// incomplete surrogate pair at end of data
-                        break;// exit loop
+                        break;                     // exit loop
                     }
                 } else if (is_low_surrogate_UTF16_(char16)) {
                     ++counts_ptr->invalidBytes;// low surrogate without preceding high surrogate
@@ -438,8 +454,8 @@ void omega_util_count_characters(const unsigned char *data, size_t length, omega
                 // Swap the bytes if the BOM is little endian
                 const uint32_t char32 =
                         counts_ptr->bom == BOM_UTF32LE
-                            ? (data[i] | (data[i + 1] << 8) | (data[i + 2] << 16) | (data[i + 3] << 24))
-                            : ((data[i] << 24) | (data[i + 1] << 16) | (data[i + 2] << 8) | data[i + 3]);
+                                ? (data[i] | (data[i + 1] << 8) | (data[i + 2] << 16) | (data[i + 3] << 24))
+                                : ((data[i] << 24) | (data[i + 1] << 16) | (data[i + 2] << 8) | data[i + 3]);
 
                 if ((char32 >= 0xD800 && char32 <= 0xDFFF) || char32 > 0x10FFFF) {
                     ++counts_ptr->invalidBytes;// surrogate pairs and characters above 0x10FFFF are invalid in UTF-32
@@ -471,7 +487,7 @@ size_t omega_util_BOM_size(omega_bom_t bom) {
         case BOM_UTF32LE:// fall through
         case BOM_UTF32BE:
             return 4;
-        case BOM_NONE: // fall through
+        case BOM_NONE:// fall through
         default:
             return 0;
     }
@@ -495,8 +511,8 @@ const omega_byte_buffer_t *omega_util_BOM_to_buffer(omega_bom_t bom) {
             return &utf32le_bom;
         case BOM_UTF32BE:
             return &utf32be_bom;
-        case BOM_NONE:// fall through
-        case BOM_UNKNOWN: // fall through
+        case BOM_NONE:   // fall through
+        case BOM_UNKNOWN:// fall through
         default:
             return NULL;
     }

--- a/core/src/lib/viewport.cpp
+++ b/core/src/lib/viewport.cpp
@@ -59,8 +59,8 @@ int64_t omega_viewport_get_offset(const omega_viewport_t *viewport_ptr) {
     if (!viewport_ptr) { return -1; }
     int64_t offset = 0;
     return safe_add_int64_(viewport_ptr->data_segment.offset, viewport_ptr->data_segment.offset_adjustment, offset)
-           ? offset
-           : -1;
+                   ? offset
+                   : -1;
 }
 
 void *omega_viewport_get_user_data_ptr(const omega_viewport_t *viewport_ptr) {
@@ -94,9 +94,7 @@ int64_t omega_viewport_get_following_byte_count(const omega_viewport_t *viewport
     const auto viewport_offset = omega_viewport_get_offset(viewport_ptr);
     if (viewport_offset < 0) { return 0; }
     int64_t viewport_end = 0;
-    if (!safe_add_int64_(viewport_offset, omega_viewport_get_length(viewport_ptr), viewport_end)) {
-        return 0;
-    }
+    if (!safe_add_int64_(viewport_offset, omega_viewport_get_length(viewport_ptr), viewport_end)) { return 0; }
     if (viewport_end < 0) { return 0; }
     const auto computed_file_size = omega_session_get_computed_file_size(omega_viewport_get_session(viewport_ptr));
     if (computed_file_size < 0) { return 0; }
@@ -155,11 +153,10 @@ int omega_viewport_in_segment(const omega_viewport_t *viewport_ptr, int64_t offs
     int64_t segment_end = 0;
     int64_t viewport_end = 0;
     return safe_add_int64_(offset, length, segment_end) &&
-           safe_add_int64_(viewport_offset, omega_viewport_get_capacity(viewport_ptr), viewport_end) &&
-           segment_end >= viewport_offset &&
-           offset <= viewport_end
-           ? 1
-           : 0;
+                           safe_add_int64_(viewport_offset, omega_viewport_get_capacity(viewport_ptr), viewport_end) &&
+                           segment_end >= viewport_offset && offset <= viewport_end
+                   ? 1
+                   : 0;
 }
 
 int omega_viewport_notify(const omega_viewport_t *viewport_ptr, omega_viewport_event_t viewport_event,

--- a/core/src/lib/visit.cpp
+++ b/core/src/lib/visit.cpp
@@ -20,7 +20,7 @@
 int omega_visit_changes(const omega_session_t *session_ptr, omega_session_change_visitor_cbk_t cbk, void *user_data) {
     if (!session_ptr || !cbk) { return -1; }
     int rc = 0;
-    for (const auto &iter: session_ptr->models_.back()->changes) {
+    for (const auto &iter : session_ptr->models_.back()->changes) {
         if ((rc = cbk(iter.get(), user_data)) != 0) { break; }
     }
     return rc;
@@ -118,15 +118,15 @@ const omega_change_t *omega_visit_change_context_get_change(const omega_visit_ch
     if (change_context_ptr->reverse) {
         return (!change_context_ptr->change_iter.riter_ptr ||
                 *change_context_ptr->change_iter.riter_ptr ==
-                change_context_ptr->session_ptr->models_.back()->changes.rend())
-               ? nullptr
-               : (*change_context_ptr->change_iter.riter_ptr)->get();
+                        change_context_ptr->session_ptr->models_.back()->changes.rend())
+                       ? nullptr
+                       : (*change_context_ptr->change_iter.riter_ptr)->get();
     }
     return (!change_context_ptr->change_iter.iter_ptr ||
             *change_context_ptr->change_iter.iter_ptr ==
-            change_context_ptr->session_ptr->models_.back()->changes.cend())
-           ? nullptr
-           : (*change_context_ptr->change_iter.iter_ptr)->get();
+                    change_context_ptr->session_ptr->models_.back()->changes.cend())
+                   ? nullptr
+                   : (*change_context_ptr->change_iter.iter_ptr)->get();
 }
 
 void omega_visit_change_destroy_context(omega_visit_change_context_t *change_context_ptr) {

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -12,16 +12,16 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
+#include "../lib/impl_/data_def.hpp"
+#include "../lib/impl_/safe_math.hpp"
+#include "../lib/impl_/session_def.hpp"
+#include "../lib/impl_/viewport_def.hpp"
 #include "omega_edit.h"
 #include "omega_edit/character_counts.h"
 #include "omega_edit/check.h"
 #include "omega_edit/stl_string_adaptor.hpp"
 #include "omega_edit/transform.h"
 #include "omega_edit/utility.h"
-#include "../lib/impl_/safe_math.hpp"
-#include "../lib/impl_/data_def.hpp"
-#include "../lib/impl_/session_def.hpp"
-#include "../lib/impl_/viewport_def.hpp"
 
 #include <test_util.hpp>
 
@@ -396,7 +396,8 @@ TEST_CASE("UTF-8 Overwrite Preserves Surrounding Bytes", "[EdgeCase][Unicode]") 
     REQUIRE(session_ptr);
 
     // Insert "aéb" = 61 C3 A9 62 (4 bytes)
-    const std::string data = "a\xC3\xA9""b";
+    const std::string data = "a\xC3\xA9"
+                             "b";
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, data));
     REQUIRE(4 == omega_session_get_computed_file_size(session_ptr));
 
@@ -655,8 +656,7 @@ TEST_CASE("Viewport Negative Offset Sentinels Do Not Overflow Range Helpers", "[
 TEST_CASE("Data Segment Allocation Rejects Unrepresentable Null Terminator Capacity", "[EdgeCase][Overflow]") {
     omega_data_t data{};
 
-    REQUIRE_THROWS_AS(omega_edit::internal::omega_data_create_(
-                              &data, (std::numeric_limits<int64_t>::max)()),
+    REQUIRE_THROWS_AS(omega_edit::internal::omega_data_create_(&data, (std::numeric_limits<int64_t>::max)()),
                       std::bad_array_new_length);
 }
 
@@ -724,8 +724,8 @@ TEST_CASE("Floating Viewport Adjustment Overflow Is Rejected Without Undefined A
     const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
     REQUIRE(session_ptr);
 
-    auto *viewport_ptr = omega_edit_create_viewport(
-            session_ptr, (std::numeric_limits<int64_t>::max)() - 1, 1, 1, nullptr, nullptr, NO_EVENTS);
+    auto *viewport_ptr = omega_edit_create_viewport(session_ptr, (std::numeric_limits<int64_t>::max)() - 1, 1, 1,
+                                                    nullptr, nullptr, NO_EVENTS);
     REQUIRE(viewport_ptr);
 
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "x"));
@@ -756,8 +756,7 @@ TEST_CASE("Transform Rejects Negative Offsets Before Range Arithmetic", "[EdgeCa
     REQUIRE(session_ptr);
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
 
-    REQUIRE(-1 == omega_edit_apply_transform(session_ptr, to_upper, nullptr,
-                                             (std::numeric_limits<int64_t>::min)(), 0));
+    REQUIRE(-1 == omega_edit_apply_transform(session_ptr, to_upper, nullptr, (std::numeric_limits<int64_t>::min)(), 0));
     REQUIRE("abc" == omega_session_get_segment_string(session_ptr, 0, 3));
 
     omega_edit_destroy_session(session_ptr);
@@ -812,8 +811,7 @@ TEST_CASE("Save To Bytes Rejects Ranges Above Memory Buffer Limit", "[EdgeCase][
     REQUIRE(nullptr == bytes);
     REQUIRE(0 == length);
 
-    REQUIRE(-1 == omega_edit_save_segment_to_bytes(session_ptr, &bytes, &length, 0,
-                                                   OMEGA_MEMORY_BUFFER_LIMIT + 1));
+    REQUIRE(-1 == omega_edit_save_segment_to_bytes(session_ptr, &bytes, &length, 0, OMEGA_MEMORY_BUFFER_LIMIT + 1));
     REQUIRE(nullptr == bytes);
     REQUIRE(0 == length);
 
@@ -848,9 +846,10 @@ TEST_CASE("Viewport Notify Callback", "[EdgeCase][ViewportNotify]") {
     REQUIRE(viewport_notify_count == 2);
 
     // Pause viewport callbacks and try again
-    omega_session_pause_viewport_event_callbacks(const_cast<omega_session_t *>(omega_viewport_get_session(viewport_ptr)));
+    omega_session_pause_viewport_event_callbacks(
+            const_cast<omega_session_t *>(omega_viewport_get_session(viewport_ptr)));
     REQUIRE(0 == omega_viewport_notify(viewport_ptr, VIEWPORT_EVT_EDIT, nullptr));
-    REQUIRE(viewport_notify_count == 2); // Should not have incremented
+    REQUIRE(viewport_notify_count == 2);// Should not have incremented
 
     // Resume and notify again
     omega_session_resume_viewport_event_callbacks(
@@ -861,7 +860,7 @@ TEST_CASE("Viewport Notify Callback", "[EdgeCase][ViewportNotify]") {
     // Verify NO_EVENTS suppresses notifications
     REQUIRE(NO_EVENTS == omega_viewport_set_event_interest(viewport_ptr, NO_EVENTS));
     REQUIRE(0 == omega_viewport_notify(viewport_ptr, VIEWPORT_EVT_EDIT, nullptr));
-    REQUIRE(viewport_notify_count == 3); // Should not have incremented
+    REQUIRE(viewport_notify_count == 3);// Should not have incremented
 
     omega_edit_destroy_viewport(viewport_ptr);
     omega_edit_destroy_session(session_ptr);
@@ -910,13 +909,13 @@ TEST_CASE("Checkpoint Replace All Streams Non-Overlapping Matches", "[EdgeCase][
     const omega_byte_t replacement[] = {'b'};
     int64_t replacement_count = -1;
 
-    REQUIRE(0 == omega_edit_replace_all_bytes(session_ptr, pattern, static_cast<int64_t>(sizeof(pattern)),
-                                              replacement, static_cast<int64_t>(sizeof(replacement)), 0, 0, 0,
-                                              &replacement_count));
+    REQUIRE(0 == omega_edit_replace_all_bytes(session_ptr, pattern, static_cast<int64_t>(sizeof(pattern)), replacement,
+                                              static_cast<int64_t>(sizeof(replacement)), 0, 0, 0, &replacement_count));
     REQUIRE(2 == replacement_count);
     REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
     REQUIRE(1 == omega_session_get_num_changes(session_ptr));
-    REQUIRE(omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)) == "bb");
+    REQUIRE(omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)) ==
+            "bb");
     REQUIRE(0 == omega_check_model(session_ptr));
 
     omega_edit_destroy_session(session_ptr);
@@ -971,8 +970,8 @@ TEST_CASE("Transactional Replace Matches Uses Non-Overlapping Semantics", "[Edge
     int64_t delete_count = -1;
     int64_t insert_count = -1;
     int64_t overwrite_count = -1;
-    REQUIRE(0 == omega_edit_replace_matches(session_ptr, "aa", 0, "b", 0, 0, 0, 0, 0, 0, 1, 0,
-                                            &replacement_count, &delete_count, &insert_count, &overwrite_count));
+    REQUIRE(0 == omega_edit_replace_matches(session_ptr, "aa", 0, "b", 0, 0, 0, 0, 0, 0, 1, 0, &replacement_count,
+                                            &delete_count, &insert_count, &overwrite_count));
     REQUIRE(3 == replacement_count);
     REQUIRE(3 == delete_count);
     REQUIRE(3 == insert_count);
@@ -1023,8 +1022,8 @@ TEST_CASE("Transactional Replace Matches OverwriteOnly FrontToBack Uses Zero Off
     int64_t overwrite_count = -1;
     // Overwrite 'aa' (2 bytes) with 'x' (1 byte), overwrite_only=1, front_to_back=1.
     // Without the fix, match[1] would be adjusted by -1 and land at offset 3 instead of 4.
-    REQUIRE(0 == omega_edit_replace_matches(session_ptr, "aa", 0, "x", 0, 0, 0, 0, 0, 0, 1, 1,
-                                            &replacement_count, &delete_count, &insert_count, &overwrite_count));
+    REQUIRE(0 == omega_edit_replace_matches(session_ptr, "aa", 0, "x", 0, 0, 0, 0, 0, 0, 1, 1, &replacement_count,
+                                            &delete_count, &insert_count, &overwrite_count));
     REQUIRE(2 == replacement_count);
     REQUIRE(0 == delete_count);
     REQUIRE(0 == insert_count);
@@ -1082,8 +1081,7 @@ TEST_CASE("Checkpointed Replace Streams Through A New Model", "[EdgeCase][Checkp
 // ─── Session with empty file ─────────────────────────────────────────────────
 
 TEST_CASE("Operations on Session from Empty File", "[EdgeCase][EmptyFile]") {
-    const auto session_ptr =
-            omega_edit_create_session(MAKE_PATH("empty_file.dat"), nullptr, nullptr, 0, nullptr);
+    const auto session_ptr = omega_edit_create_session(MAKE_PATH("empty_file.dat"), nullptr, nullptr, 0, nullptr);
     REQUIRE(session_ptr);
     REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
 
@@ -1123,8 +1121,8 @@ TEST_CASE("Rapid Insert Delete Undo Cycles", "[EdgeCase][StressIntegrity]") {
     for (int i = 0; i < 100; ++i) {
         REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "x"));
         REQUIRE(0 < omega_edit_delete(session_ptr, 0, 1));
-        REQUIRE(0 != omega_edit_undo_last_change(session_ptr)); // undo delete
-        REQUIRE(0 != omega_edit_undo_last_change(session_ptr)); // undo insert
+        REQUIRE(0 != omega_edit_undo_last_change(session_ptr));// undo delete
+        REQUIRE(0 != omega_edit_undo_last_change(session_ptr));// undo insert
     }
 
     REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));

--- a/core/src/tests/encode_tests.cpp
+++ b/core/src/tests/encode_tests.cpp
@@ -19,10 +19,10 @@
 #include "omega_edit/encode.h"
 #include "omega_edit/stl_string_adaptor.hpp"
 #include "omega_edit/utility.h"
-#include <test_util.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_contains.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <test_util.hpp>
 
 #include <chrono>
 #include <cstdio>

--- a/core/src/tests/filesystem_tests.cpp
+++ b/core/src/tests/filesystem_tests.cpp
@@ -40,7 +40,7 @@ using Catch::Matchers::Equals;
  * @param seconds Number of seconds to sleep.
  */
 static inline void omega_util_sleep_(const int seconds) { std::this_thread::sleep_for(std::chrono::seconds(seconds)); }
-#endif // OMEGA_BUILD_WINDOWS
+#endif// OMEGA_BUILD_WINDOWS
 
 TEST_CASE("File Compare", "[UtilTests]") {
     SECTION("Identity") {
@@ -54,8 +54,8 @@ TEST_CASE("File Compare", "[UtilTests]") {
 }
 
 TEST_CASE("File Copy", "[UtilTests]") {
-    struct stat src_stat{};
-    struct stat dst_stat{};
+    struct stat src_stat {};
+    struct stat dst_stat {};
     omega_util_remove_file(MAKE_PATH("test1.copy.dat"));
 #ifdef OMEGA_BUILD_WINDOWS
     // sleep for 1 second to ensure the file modification time is different,
@@ -74,7 +74,7 @@ TEST_CASE("File Copy", "[UtilTests]") {
     REQUIRE(0 == stat(MAKE_PATH("test1.copy.dat"), &dst_stat));
 
     // The mode includes the file type
-    const int dst_mode = 0100600; // S_IFREG | S_IRUSR  regular file with owner read-only
+    const int dst_mode = 0100600;// S_IFREG | S_IRUSR  regular file with owner read-only
     REQUIRE(dst_mode != src_stat.st_mode);
     REQUIRE(src_stat.st_mode == dst_stat.st_mode);
 
@@ -134,7 +134,7 @@ TEST_CASE("File Touch", "[UtilTests]") {
     expected = dont_exist;
     REQUIRE_THAT(omega_util_available_filename(dont_exist.c_str(), nullptr), Equals(expected));
     omega_util_touch(dont_exist.c_str(),
-                     0); // logs an error as expected because create is false and the file does not exist
+                     0);// logs an error as expected because create is false and the file does not exist
     REQUIRE(!omega_util_file_exists(dont_exist.c_str()));
 #ifdef OMEGA_BUILD_WINDOWS
     // sleep for 1 second to ensure the file modification time is different,
@@ -247,18 +247,18 @@ TEST_CASE("File Extension", "[UtilTests]") {
 
 TEST_CASE("Emoji Filename Handling", "[FilesystemTests]") {
     const char *emoji_filenames[] = {
-        "test_😀.dat",
-        "test_👍.dat",
-        "test_🔥.dat",
-        "test 💩.dat", // Space in filename as well
-        "test_🚀.dat",
-        "test_👨‍👩‍👧‍👦.dat" // Family emoji with zero-width joiners
+            "test_😀.dat",
+            "test_👍.dat",
+            "test_🔥.dat",
+            "test 💩.dat",// Space in filename as well
+            "test_🚀.dat",
+            "test_👨‍👩‍👧‍👦.dat"// Family emoji with zero-width joiners
     };
 
     char buffer[FILENAME_MAX];
 
     // Test filesystem operations with emoji filenames
-    for (const auto &emoji_filename: emoji_filenames) {
+    for (const auto &emoji_filename : emoji_filenames) {
         const char dir_sep = omega_util_directory_separator();
         std::string base_path = std::string(DATA_DIR.string().c_str()) + dir_sep;
         std::string full_path = base_path + emoji_filename;

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -18,10 +18,10 @@
 
 #include <test_util.hpp>
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_contains.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <algorithm>
 #include <vector>
 
 using Catch::Matchers::Contains;
@@ -187,8 +187,7 @@ TEST_CASE("Restore Last Checkpoint Keeps Snapshot And Discards Later Edits",
 TEST_CASE("Restore Last Transform Checkpoint Preserves Transform Change",
           "[SessionCheckpointTests][RestoreCheckpoint]") {
     const auto input = reinterpret_cast<const omega_byte_t *>("abcXYZ");
-    const auto session_ptr =
-            omega_edit_create_session_from_bytes(input, 6, nullptr, nullptr, NO_EVENTS, nullptr);
+    const auto session_ptr = omega_edit_create_session_from_bytes(input, 6, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(session_ptr);
 
     REQUIRE(0 == omega_edit_apply_transform(session_ptr, to_lower, nullptr, 0, 0));

--- a/core/src/tests/undo_benchmark.cpp
+++ b/core/src/tests/undo_benchmark.cpp
@@ -37,16 +37,15 @@ namespace {
     }
 
     int64_t apply_uniform_replace_transaction(omega_session_t *session_ptr, int match_count,
-                                              const std::string_view from_token,
-                                              const std::string_view to_token) {
+                                              const std::string_view from_token, const std::string_view to_token) {
         if (!session_ptr) { return -1; }
         if (0 != omega_session_begin_transaction(session_ptr)) { return -1; }
 
         int64_t last_serial = 0;
         for (int i = match_count - 1; i >= 0; --i) {
-            last_serial = omega_edit_replace(session_ptr, static_cast<int64_t>(i) * static_cast<int64_t>(from_token.size()),
-                                             static_cast<int64_t>(from_token.size()), to_token.data(),
-                                             static_cast<int64_t>(to_token.size()));
+            last_serial = omega_edit_replace(
+                    session_ptr, static_cast<int64_t>(i) * static_cast<int64_t>(from_token.size()),
+                    static_cast<int64_t>(from_token.size()), to_token.data(), static_cast<int64_t>(to_token.size()));
             if (last_serial <= 0) { return -1; }
         }
 
@@ -96,8 +95,8 @@ TEST_CASE("Benchmark stacked replace-style transaction undo latency", "[.][UndoB
     const auto total = std::accumulate(undo_latencies_ms.begin(), undo_latencies_ms.end(), 0.0);
     const auto average = total / static_cast<double>(undo_latencies_ms.size());
 
-    std::cout << "\nUndo benchmark: " << transaction_rounds << " stacked replace-style transactions, "
-              << match_count << " matches each\n";
+    std::cout << "\nUndo benchmark: " << transaction_rounds << " stacked replace-style transactions, " << match_count
+              << " matches each\n";
     for (size_t i = 0; i < undo_latencies_ms.size(); ++i) {
         std::cout << "  undo " << (i + 1) << ": " << undo_latencies_ms[i] << " ms\n";
     }

--- a/core/src/tests/utility_tests.cpp
+++ b/core/src/tests/utility_tests.cpp
@@ -14,10 +14,10 @@
 
 #include "omega_edit/filesystem.h"
 #include "omega_edit/utility.h"
-#include <test_util.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_contains.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <test_util.hpp>
 
 using namespace std;
 namespace fs = std::filesystem;
@@ -116,17 +116,17 @@ TEST_CASE("Transformer", "[TransformerTest]") {
 
 TEST_CASE("File Transformer", "[TransformerTest]") {
     REQUIRE(0 == omega_util_apply_byte_transform_to_file(
-        MAKE_PATH("test1.dat"), MAKE_PATH("test1.actual.transformed.1.dat"), to_upper, nullptr, 0, 0));
+                         MAKE_PATH("test1.dat"), MAKE_PATH("test1.actual.transformed.1.dat"), to_upper, nullptr, 0, 0));
     REQUIRE(0 == omega_util_compare_files(MAKE_PATH("test1.expected.transformed.1.dat"),
-        MAKE_PATH("test1.actual.transformed.1.dat")));
+                                          MAKE_PATH("test1.actual.transformed.1.dat")));
     REQUIRE(0 == omega_util_apply_byte_transform_to_file(MAKE_PATH("test1.dat"),
-        MAKE_PATH("test1.actual.transformed.2.dat"), to_lower, nullptr,
-        37, 10));
+                                                         MAKE_PATH("test1.actual.transformed.2.dat"), to_lower, nullptr,
+                                                         37, 10));
     REQUIRE(0 == omega_util_compare_files(MAKE_PATH("test1.expected.transformed.2.dat"),
-        MAKE_PATH("test1.actual.transformed.2.dat")));
+                                          MAKE_PATH("test1.actual.transformed.2.dat")));
     REQUIRE(0 != omega_util_apply_byte_transform_to_file(MAKE_PATH("test1.dat"),
-        MAKE_PATH("test1.actual.transformed.3.dat"), to_lower, nullptr,
-        37, 100));
+                                                         MAKE_PATH("test1.actual.transformed.3.dat"), to_lower, nullptr,
+                                                         37, 100));
     REQUIRE(0 == omega_util_file_exists(MAKE_PATH("test1.actual.transformed.3.dat")));
 }
 

--- a/core/src/tests/viewport_stress_tests.cpp
+++ b/core/src/tests/viewport_stress_tests.cpp
@@ -39,9 +39,7 @@ TEST_CASE("Multi-Viewport Sync Under Edits", "[ViewportStress][MultiViewport]") 
     // Insert initial content: 200 bytes of known data
     std::string initial_data;
     initial_data.reserve(200);
-    for (int i = 0; i < 200; ++i) {
-        initial_data.push_back(static_cast<char>('A' + (i % 26)));
-    }
+    for (int i = 0; i < 200; ++i) { initial_data.push_back(static_cast<char>('A' + (i % 26))); }
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, initial_data));
     REQUIRE(200 == omega_session_get_computed_file_size(session_ptr));
 
@@ -52,10 +50,10 @@ TEST_CASE("Multi-Viewport Sync Under Edits", "[ViewportStress][MultiViewport]") 
     viewports.reserve(NUM_VIEWPORTS);
 
     for (int i = 0; i < NUM_VIEWPORTS; ++i) {
-        int64_t offset = i * 8; // staggered by 8 bytes, overlapping
+        int64_t offset = i * 8;// staggered by 8 bytes, overlapping
         if (offset + VP_CAPACITY > 200) { offset = 200 - VP_CAPACITY; }
-        auto *vp = omega_edit_create_viewport(session_ptr, offset, VP_CAPACITY, 0,
-                                              stress_viewport_event_cbk, nullptr, 0);
+        auto *vp =
+                omega_edit_create_viewport(session_ptr, offset, VP_CAPACITY, 0, stress_viewport_event_cbk, nullptr, 0);
         REQUIRE(vp);
         viewports.push_back(vp);
     }
@@ -195,9 +193,7 @@ TEST_CASE("Many Viewports With Interleaved Edits", "[ViewportStress][HeavyEdits]
     REQUIRE(session_ptr);
 
     // Build up 500 bytes of content
-    for (int i = 0; i < 50; ++i) {
-        REQUIRE(0 < omega_edit_insert_string(session_ptr, i * 10, "0123456789"));
-    }
+    for (int i = 0; i < 50; ++i) { REQUIRE(0 < omega_edit_insert_string(session_ptr, i * 10, "0123456789")); }
     REQUIRE(500 == omega_session_get_computed_file_size(session_ptr));
 
     // Create 20 floating viewports spread across the content
@@ -217,9 +213,7 @@ TEST_CASE("Many Viewports With Interleaved Edits", "[ViewportStress][HeavyEdits]
             // Delete 5 bytes from offset i*2 (clamped to file size)
             int64_t offset = (i * 2) % file_size;
             int64_t len = (offset + 5 > file_size) ? file_size - offset : 5;
-            if (len > 0) {
-                omega_edit_delete(session_ptr, offset, len);
-            }
+            if (len > 0) { omega_edit_delete(session_ptr, offset, len); }
         } else if (i % 3 == 1) {
             // Insert at position i*3 (clamped)
             int64_t offset = (file_size > 0) ? ((i * 3) % file_size) : 0;
@@ -248,9 +242,7 @@ TEST_CASE("Many Viewports With Interleaved Edits", "[ViewportStress][HeavyEdits]
     REQUIRE(0 == omega_check_model(session_ptr));
 
     // Undo all changes and verify viewports still stay in sync
-    while (omega_session_get_num_changes(session_ptr) > 0) {
-        omega_edit_undo_last_change(session_ptr);
-    }
+    while (omega_session_get_num_changes(session_ptr) > 0) { omega_edit_undo_last_change(session_ptr); }
 
     for (int i = 0; i < NUM_VIEWPORTS; ++i) {
         auto vp_offset = omega_viewport_get_offset(viewports[i]);
@@ -293,7 +285,7 @@ TEST_CASE("Viewport Modify Changes Offset and Capacity", "[ViewportStress][Viewp
 
     // Insert before the viewport offset — floating viewport should adjust
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "12345"));
-    REQUIRE(omega_viewport_get_offset(vp) == 25); // shifted by 5
+    REQUIRE(omega_viewport_get_offset(vp) == 25);// shifted by 5
     REQUIRE(omega_viewport_get_string(vp) == "UVWXYZ");
 
     omega_edit_destroy_viewport(vp);
@@ -311,13 +303,15 @@ TEST_CASE("Viewport In Segment Query", "[ViewportStress][ViewportInSegment]") {
 
     // Viewport at offset=5, capacity=10. The in_segment function uses inclusive boundaries:
     // (offset + length) >= viewport_offset && offset <= (viewport_offset + viewport_capacity)
-    REQUIRE(omega_viewport_in_segment(vp, 0, 20));  // segment [0,20) clearly overlaps
-    REQUIRE(omega_viewport_in_segment(vp, 5, 10));  // exact match
-    REQUIRE(omega_viewport_in_segment(vp, 10, 10)); // segment [10,20) overlaps
-    REQUIRE(omega_viewport_in_segment(vp, 0, 5));   // abutting at boundary (5 <= 5+10 and 0+5 >= 5) — library treats as in-segment
-    REQUIRE(omega_viewport_in_segment(vp, 15, 10)); // abutting at boundary (15 <= 5+10 and 15+10 >= 5) — library treats as in-segment
-    REQUIRE(!omega_viewport_in_segment(vp, 16, 10)); // segment [16,26) — truly no overlap (16 > 15)
-    REQUIRE(!omega_viewport_in_segment(vp, 0, 4));   // segment [0,4) — truly no overlap (4 < 5)
+    REQUIRE(omega_viewport_in_segment(vp, 0, 20)); // segment [0,20) clearly overlaps
+    REQUIRE(omega_viewport_in_segment(vp, 5, 10)); // exact match
+    REQUIRE(omega_viewport_in_segment(vp, 10, 10));// segment [10,20) overlaps
+    REQUIRE(omega_viewport_in_segment(
+            vp, 0, 5));// abutting at boundary (5 <= 5+10 and 0+5 >= 5) — library treats as in-segment
+    REQUIRE(omega_viewport_in_segment(
+            vp, 15, 10));// abutting at boundary (15 <= 5+10 and 15+10 >= 5) — library treats as in-segment
+    REQUIRE(!omega_viewport_in_segment(vp, 16, 10));// segment [16,26) — truly no overlap (16 > 15)
+    REQUIRE(!omega_viewport_in_segment(vp, 0, 4));  // segment [0,4) — truly no overlap (4 < 5)
 
     omega_edit_destroy_viewport(vp);
     omega_edit_destroy_session(session_ptr);
@@ -327,7 +321,7 @@ TEST_CASE("Following Byte Count", "[ViewportStress][FollowingByteCount]") {
     const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
     REQUIRE(session_ptr);
 
-    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "ABCDEFGHIJKLMNOPQRST"));  // 20 bytes
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "ABCDEFGHIJKLMNOPQRST"));// 20 bytes
     REQUIRE(20 == omega_session_get_computed_file_size(session_ptr));
 
     auto *vp = omega_edit_create_viewport(session_ptr, 0, 10, 0, nullptr, nullptr, 0);

--- a/plugins/src/base64.c
+++ b/plugins/src/base64.c
@@ -12,18 +12,15 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#include <omega_edit/transform_plugin_sdk.h>
 #include <ctype.h>
+#include <omega_edit/transform_plugin_sdk.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 static const char BASE64_ALPHABET[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-typedef enum omega_base64_direction_t {
-    OMEGA_BASE64_ENCODE,
-    OMEGA_BASE64_DECODE
-} omega_base64_direction_t;
+typedef enum omega_base64_direction_t { OMEGA_BASE64_ENCODE, OMEGA_BASE64_DECODE } omega_base64_direction_t;
 
 static const char BASE64_ARGS_SCHEMA[] =
         "{\"type\":\"object\",\"properties\":{\"direction\":{\"type\":\"string\",\"title\":\"Direction\","
@@ -190,9 +187,7 @@ static int base64_decode(const omega_transform_plugin_request_t *request_ptr,
     int64_t encoded_length = 0;
     int padding = 0;
     if (validate_base64(request_ptr, &encoded_length, &padding) != 0) { return -1; }
-    if (encoded_length == 0) {
-        return omega_transform_plugin_sdk_set_replacement(request_ptr, response_ptr, NULL, 0);
-    }
+    if (encoded_length == 0) { return omega_transform_plugin_sdk_set_replacement(request_ptr, response_ptr, NULL, 0); }
 
     const int64_t output_length = (encoded_length / 4) * 3 - padding;
     omega_byte_t *output = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, (size_t) output_length);
@@ -239,7 +234,7 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
 }
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
-                                                              omega_transform_plugin_response_t *response_ptr) {
+                                                               omega_transform_plugin_response_t *response_ptr) {
     if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0 ||
         (request_ptr->input_length > 0 && !request_ptr->input_bytes)) {
         return -1;

--- a/plugins/src/bitmask_options.h
+++ b/plugins/src/bitmask_options.h
@@ -15,8 +15,8 @@
 #ifndef OMEGA_EDIT_BITMASK_OPTIONS_H
 #define OMEGA_EDIT_BITMASK_OPTIONS_H
 
-#include <omega_edit/transform_plugin_sdk.h>
 #include <ctype.h>
+#include <omega_edit/transform_plugin_sdk.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -217,8 +217,7 @@ static int omega_bitmask_parse_mask_value(const char **cursor, omega_bitmask_opt
 }
 
 static int omega_bitmask_parse_options(const char *options_json, omega_byte_t default_byte,
-                                       omega_bitmask_operation_t default_operation,
-                                       omega_bitmask_options_t *mask_out) {
+                                       omega_bitmask_operation_t default_operation, omega_bitmask_options_t *mask_out) {
     if (!mask_out) { return -1; }
     mask_out->bytes[0] = default_byte;
     mask_out->length = 1;
@@ -267,7 +266,8 @@ static int omega_bitmask_parse_options(const char *options_json, omega_byte_t de
     return -1;
 }
 
-static omega_byte_t omega_bitmask_apply_byte(omega_byte_t value, omega_byte_t mask, omega_bitmask_operation_t operation) {
+static omega_byte_t omega_bitmask_apply_byte(omega_byte_t value, omega_byte_t mask,
+                                             omega_bitmask_operation_t operation) {
     switch (operation) {
         case OMEGA_BITMASK_AND:
             return (omega_byte_t) (value & mask);
@@ -315,8 +315,8 @@ static int omega_bitmask_apply_replace(const omega_transform_plugin_request_t *r
         return omega_transform_plugin_sdk_set_no_content_change(response_ptr);
     }
 
-    omega_byte_t *bytes = omega_transform_plugin_sdk_copy_bytes(request_ptr, request_ptr->input_bytes,
-                                                                request_ptr->input_length);
+    omega_byte_t *bytes =
+            omega_transform_plugin_sdk_copy_bytes(request_ptr, request_ptr->input_bytes, request_ptr->input_length);
     if (!bytes) { return -1; }
 
     for (int64_t i = 0; i < request_ptr->input_length; ++i) {

--- a/plugins/src/bitwise.c
+++ b/plugins/src/bitwise.c
@@ -31,7 +31,7 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
 }
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
-                                                              omega_transform_plugin_response_t *response_ptr) {
+                                                               omega_transform_plugin_response_t *response_ptr) {
     omega_bitmask_options_t options;
     if (omega_bitmask_parse_options(request_ptr ? request_ptr->options_json : NULL, 0xFF, OMEGA_BITMASK_XOR,
                                     &options) != 0) {

--- a/plugins/src/case_change.c
+++ b/plugins/src/case_change.c
@@ -12,14 +12,11 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#include <omega_edit/transform_plugin_sdk.h>
 #include <ctype.h>
+#include <omega_edit/transform_plugin_sdk.h>
 #include <string.h>
 
-typedef enum omega_case_change_mode_t {
-    OMEGA_CASE_CHANGE_UPPER,
-    OMEGA_CASE_CHANGE_LOWER
-} omega_case_change_mode_t;
+typedef enum omega_case_change_mode_t { OMEGA_CASE_CHANGE_UPPER, OMEGA_CASE_CHANGE_LOWER } omega_case_change_mode_t;
 
 static const char CASE_CHANGE_ARGS_SCHEMA[] =
         "{\"type\":\"object\",\"properties\":{\"case\":{\"type\":\"string\",\"title\":\"Case\","
@@ -101,12 +98,8 @@ static int case_change_parse_options(const char *options_json, omega_case_change
 }
 
 static omega_byte_t case_change_byte(omega_byte_t byte, omega_case_change_mode_t mode) {
-    if (mode == OMEGA_CASE_CHANGE_UPPER && byte >= 'a' && byte <= 'z') {
-        return (omega_byte_t) (byte - ('a' - 'A'));
-    }
-    if (mode == OMEGA_CASE_CHANGE_LOWER && byte >= 'A' && byte <= 'Z') {
-        return (omega_byte_t) (byte + ('a' - 'A'));
-    }
+    if (mode == OMEGA_CASE_CHANGE_UPPER && byte >= 'a' && byte <= 'z') { return (omega_byte_t) (byte - ('a' - 'A')); }
+    if (mode == OMEGA_CASE_CHANGE_LOWER && byte >= 'A' && byte <= 'Z') { return (omega_byte_t) (byte + ('a' - 'A')); }
     return byte;
 }
 
@@ -117,7 +110,8 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
     info_ptr->description = "Convert ASCII alphabetic bytes to upper or lower case.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_ONE_FOR_ONE | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
-    info_ptr->help = "Choose upper or lower case. Only ASCII alphabetic bytes are changed; all other bytes are preserved.";
+    info_ptr->help =
+            "Choose upper or lower case. Only ASCII alphabetic bytes are changed; all other bytes are preserved.";
     info_ptr->example = "{\"case\":\"lower\"}";
     info_ptr->default_args = "{\"case\":\"upper\"}";
     info_ptr->args_schema = CASE_CHANGE_ARGS_SCHEMA;
@@ -126,7 +120,7 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
 }
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
-                                                              omega_transform_plugin_response_t *response_ptr) {
+                                                               omega_transform_plugin_response_t *response_ptr) {
     if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0 ||
         (request_ptr->input_length > 0 && !request_ptr->input_bytes)) {
         return -1;

--- a/plugins/src/character_transcode.cpp
+++ b/plugins/src/character_transcode.cpp
@@ -22,354 +22,355 @@
 
 namespace {
 
-constexpr const char *CHARACTER_TRANSCODE_ARGS_SCHEMA =
-        "{\"type\":\"object\",\"properties\":{\"from\":{\"type\":\"string\",\"title\":\"From\","
-        "\"description\":\"Source character encoding.\",\"default\":\"utf-8\",\"enum\":[\"ascii\",\"utf-8\","
-        "\"utf-16le\",\"utf-16be\",\"utf-32le\",\"utf-32be\",\"iso-8859-1\",\"windows-1252\",\"ebcdic-037\","
-        "\"ibm037\",\"ebcdic-500\",\"ibm500\",\"ebcdic-1047\",\"ibm1047\",\"ebcdic-1140\",\"ibm1140\"]},"
-        "\"to\":{\"type\":\"string\",\"title\":\"To\",\"description\":\"Destination character encoding.\","
-        "\"default\":\"utf-16le\",\"enum\":[\"ascii\",\"utf-8\",\"utf-16le\",\"utf-16be\",\"utf-32le\","
-        "\"utf-32be\",\"iso-8859-1\",\"windows-1252\",\"ebcdic-037\",\"ibm037\",\"ebcdic-500\",\"ibm500\","
-        "\"ebcdic-1047\",\"ibm1047\",\"ebcdic-1140\",\"ibm1140\"]}},\"additionalProperties\":false}";
+    constexpr const char *CHARACTER_TRANSCODE_ARGS_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"from\":{\"type\":\"string\",\"title\":\"From\","
+            "\"description\":\"Source character encoding.\",\"default\":\"utf-8\",\"enum\":[\"ascii\",\"utf-8\","
+            "\"utf-16le\",\"utf-16be\",\"utf-32le\",\"utf-32be\",\"iso-8859-1\",\"windows-1252\",\"ebcdic-037\","
+            "\"ibm037\",\"ebcdic-500\",\"ibm500\",\"ebcdic-1047\",\"ibm1047\",\"ebcdic-1140\",\"ibm1140\"]},"
+            "\"to\":{\"type\":\"string\",\"title\":\"To\",\"description\":\"Destination character encoding.\","
+            "\"default\":\"utf-16le\",\"enum\":[\"ascii\",\"utf-8\",\"utf-16le\",\"utf-16be\",\"utf-32le\","
+            "\"utf-32be\",\"iso-8859-1\",\"windows-1252\",\"ebcdic-037\",\"ibm037\",\"ebcdic-500\",\"ibm500\","
+            "\"ebcdic-1047\",\"ibm1047\",\"ebcdic-1140\",\"ibm1140\"]}},\"additionalProperties\":false}";
 
-bool utf8_append(uint32_t codepoint, std::vector<omega_byte_t> &out) {
-    if (codepoint <= 0x7FU) {
-        out.push_back(static_cast<omega_byte_t>(codepoint));
-    } else if (codepoint <= 0x7FFU) {
-        out.push_back(static_cast<omega_byte_t>(0xC0U | (codepoint >> 6U)));
-        out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
-    } else if (codepoint <= 0xFFFFU) {
-        out.push_back(static_cast<omega_byte_t>(0xE0U | (codepoint >> 12U)));
-        out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 6U) & 0x3FU)));
-        out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
-    } else if (codepoint <= 0x10FFFFU) {
-        out.push_back(static_cast<omega_byte_t>(0xF0U | (codepoint >> 18U)));
-        out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 12U) & 0x3FU)));
-        out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 6U) & 0x3FU)));
-        out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
-    } else {
+    bool utf8_append(uint32_t codepoint, std::vector<omega_byte_t> &out) {
+        if (codepoint <= 0x7FU) {
+            out.push_back(static_cast<omega_byte_t>(codepoint));
+        } else if (codepoint <= 0x7FFU) {
+            out.push_back(static_cast<omega_byte_t>(0xC0U | (codepoint >> 6U)));
+            out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
+        } else if (codepoint <= 0xFFFFU) {
+            out.push_back(static_cast<omega_byte_t>(0xE0U | (codepoint >> 12U)));
+            out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 6U) & 0x3FU)));
+            out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
+        } else if (codepoint <= 0x10FFFFU) {
+            out.push_back(static_cast<omega_byte_t>(0xF0U | (codepoint >> 18U)));
+            out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 12U) & 0x3FU)));
+            out.push_back(static_cast<omega_byte_t>(0x80U | ((codepoint >> 6U) & 0x3FU)));
+            out.push_back(static_cast<omega_byte_t>(0x80U | (codepoint & 0x3FU)));
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    bool decode_utf8(const std::vector<omega_byte_t> &input, std::vector<uint32_t> &out) {
+        out.clear();
+        for (size_t i = 0; i < input.size();) {
+            const uint32_t byte = static_cast<uint8_t>(input[i++]);
+            if (byte < 0x80U) {
+                out.push_back(byte);
+            } else if ((byte & 0xE0U) == 0xC0U) {
+                if (byte < 0xC2U || i >= input.size() || (input[i] & 0xC0U) != 0x80U) { return false; }
+                out.push_back(((byte & 0x1FU) << 6U) | (static_cast<uint8_t>(input[i++]) & 0x3FU));
+            } else if ((byte & 0xF0U) == 0xE0U) {
+                if (i + 1 >= input.size() || (input[i] & 0xC0U) != 0x80U || (input[i + 1] & 0xC0U) != 0x80U ||
+                    (byte == 0xE0U && static_cast<uint8_t>(input[i]) < 0xA0U) ||
+                    (byte == 0xEDU && static_cast<uint8_t>(input[i]) > 0x9FU)) {
+                    return false;
+                }
+                out.push_back(((byte & 0x0FU) << 12U) | ((static_cast<uint8_t>(input[i]) & 0x3FU) << 6U) |
+                              (static_cast<uint8_t>(input[i + 1]) & 0x3FU));
+                i += 2;
+            } else if ((byte & 0xF8U) == 0xF0U) {
+                if (byte > 0xF4U || i + 2 >= input.size() || (input[i] & 0xC0U) != 0x80U ||
+                    (input[i + 1] & 0xC0U) != 0x80U || (input[i + 2] & 0xC0U) != 0x80U ||
+                    (byte == 0xF0U && static_cast<uint8_t>(input[i]) < 0x90U) ||
+                    (byte == 0xF4U && static_cast<uint8_t>(input[i]) > 0x8FU)) {
+                    return false;
+                }
+                out.push_back(((byte & 0x07U) << 18U) | ((static_cast<uint8_t>(input[i]) & 0x3FU) << 12U) |
+                              ((static_cast<uint8_t>(input[i + 1]) & 0x3FU) << 6U) |
+                              (static_cast<uint8_t>(input[i + 2]) & 0x3FU));
+                i += 3;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    uint32_t read_word(const std::vector<omega_byte_t> &input, size_t offset, bool little, int bytes) {
+        uint32_t value = 0;
+        if (little) {
+            for (int i = bytes - 1; i >= 0; --i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
+        } else {
+            for (int i = 0; i < bytes; ++i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
+        }
+        return value;
+    }
+
+    void write_word(uint32_t value, bool little, int bytes, std::vector<omega_byte_t> &out) {
+        if (little) {
+            for (int i = 0; i < bytes; ++i) { out.push_back(static_cast<omega_byte_t>((value >> (8U * i)) & 0xFFU)); }
+        } else {
+            for (int i = bytes - 1; i >= 0; --i) {
+                out.push_back(static_cast<omega_byte_t>((value >> (8U * i)) & 0xFFU));
+            }
+        }
+    }
+
+    bool decode_utf16(const std::vector<omega_byte_t> &input, bool little, std::vector<uint32_t> &out) {
+        if ((input.size() % 2) != 0) { return false; }
+        out.clear();
+        for (size_t i = 0; i < input.size(); i += 2) {
+            uint32_t word = read_word(input, i, little, 2);
+            if (word >= 0xD800U && word <= 0xDBFFU) {
+                if (i + 3 >= input.size()) { return false; }
+                const uint32_t low = read_word(input, i + 2, little, 2);
+                if (low < 0xDC00U || low > 0xDFFFU) { return false; }
+                word = 0x10000U + (((word - 0xD800U) << 10U) | (low - 0xDC00U));
+                i += 2;
+            }
+            out.push_back(word);
+        }
+        return true;
+    }
+
+    bool encode_utf16(const std::vector<uint32_t> &input, bool little, std::vector<omega_byte_t> &out) {
+        out.clear();
+        for (const auto codepoint : input) {
+            if (codepoint <= 0xFFFFU) {
+                if (codepoint >= 0xD800U && codepoint <= 0xDFFFU) { return false; }
+                write_word(codepoint, little, 2, out);
+            } else if (codepoint <= 0x10FFFFU) {
+                const uint32_t value = codepoint - 0x10000U;
+                write_word(0xD800U | (value >> 10U), little, 2, out);
+                write_word(0xDC00U | (value & 0x3FFU), little, 2, out);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool decode_fixed_width(const std::vector<omega_byte_t> &input, bool little, int bytes,
+                            std::vector<uint32_t> &out) {
+        if ((input.size() % static_cast<size_t>(bytes)) != 0) { return false; }
+        out.clear();
+        for (size_t i = 0; i < input.size(); i += static_cast<size_t>(bytes)) {
+            out.push_back(read_word(input, i, little, bytes));
+        }
+        return true;
+    }
+
+    uint32_t cp1252_decode(omega_byte_t byte) {
+        static const std::map<omega_byte_t, uint32_t> extra = {
+                {0x80, 0x20AC}, {0x82, 0x201A}, {0x83, 0x0192}, {0x84, 0x201E}, {0x85, 0x2026}, {0x86, 0x2020},
+                {0x87, 0x2021}, {0x88, 0x02C6}, {0x89, 0x2030}, {0x8A, 0x0160}, {0x8B, 0x2039}, {0x8C, 0x0152},
+                {0x8E, 0x017D}, {0x91, 0x2018}, {0x92, 0x2019}, {0x93, 0x201C}, {0x94, 0x201D}, {0x95, 0x2022},
+                {0x96, 0x2013}, {0x97, 0x2014}, {0x98, 0x02DC}, {0x99, 0x2122}, {0x9A, 0x0161}, {0x9B, 0x203A},
+                {0x9C, 0x0153}, {0x9E, 0x017E}, {0x9F, 0x0178}};
+        const auto iter = extra.find(byte);
+        return iter == extra.end() ? byte : iter->second;
+    }
+
+    bool cp1252_encode(uint32_t codepoint, omega_byte_t &byte) {
+        if ((codepoint <= 0x7FU) || (codepoint >= 0xA0U && codepoint <= 0xFFU)) {
+            byte = static_cast<omega_byte_t>(codepoint);
+            return true;
+        }
+        for (int candidate = 0x80; candidate <= 0x9F; ++candidate) {
+            if (cp1252_decode(static_cast<omega_byte_t>(candidate)) == codepoint) {
+                byte = static_cast<omega_byte_t>(candidate);
+                return true;
+            }
+        }
         return false;
     }
-    return true;
-}
 
-bool decode_utf8(const std::vector<omega_byte_t> &input, std::vector<uint32_t> &out) {
-    out.clear();
-    for (size_t i = 0; i < input.size();) {
-        const uint32_t byte = static_cast<uint8_t>(input[i++]);
-        if (byte < 0x80U) {
-            out.push_back(byte);
-        } else if ((byte & 0xE0U) == 0xC0U) {
-            if (byte < 0xC2U || i >= input.size() || (input[i] & 0xC0U) != 0x80U) { return false; }
-            out.push_back(((byte & 0x1FU) << 6U) | (static_cast<uint8_t>(input[i++]) & 0x3FU));
-        } else if ((byte & 0xF0U) == 0xE0U) {
-            if (i + 1 >= input.size() || (input[i] & 0xC0U) != 0x80U || (input[i + 1] & 0xC0U) != 0x80U ||
-                (byte == 0xE0U && static_cast<uint8_t>(input[i]) < 0xA0U) ||
-                (byte == 0xEDU && static_cast<uint8_t>(input[i]) > 0x9FU)) {
-                return false;
-            }
-            out.push_back(((byte & 0x0FU) << 12U) | ((static_cast<uint8_t>(input[i]) & 0x3FU) << 6U) |
-                          (static_cast<uint8_t>(input[i + 1]) & 0x3FU));
-            i += 2;
-        } else if ((byte & 0xF8U) == 0xF0U) {
-            if (byte > 0xF4U || i + 2 >= input.size() || (input[i] & 0xC0U) != 0x80U ||
-                (input[i + 1] & 0xC0U) != 0x80U || (input[i + 2] & 0xC0U) != 0x80U ||
-                (byte == 0xF0U && static_cast<uint8_t>(input[i]) < 0x90U) ||
-                (byte == 0xF4U && static_cast<uint8_t>(input[i]) > 0x8FU)) {
-                return false;
-            }
-            out.push_back(((byte & 0x07U) << 18U) | ((static_cast<uint8_t>(input[i]) & 0x3FU) << 12U) |
-                          ((static_cast<uint8_t>(input[i + 1]) & 0x3FU) << 6U) |
-                          (static_cast<uint8_t>(input[i + 2]) & 0x3FU));
-            i += 3;
-        } else {
-            return false;
+    uint32_t ebcdic037_decode(omega_byte_t byte) {
+        if (byte >= 0x81 && byte <= 0x89) { return 'a' + (byte - 0x81); }
+        if (byte >= 0x91 && byte <= 0x99) { return 'j' + (byte - 0x91); }
+        if (byte >= 0xA2 && byte <= 0xA9) { return 's' + (byte - 0xA2); }
+        if (byte >= 0xC1 && byte <= 0xC9) { return 'A' + (byte - 0xC1); }
+        if (byte >= 0xD1 && byte <= 0xD9) { return 'J' + (byte - 0xD1); }
+        if (byte >= 0xE2 && byte <= 0xE9) { return 'S' + (byte - 0xE2); }
+        if (byte >= 0xF0 && byte <= 0xF9) { return '0' + (byte - 0xF0); }
+        static const std::map<omega_byte_t, uint32_t> punctuation = {
+                {0x40, ' '}, {0x4B, '.'}, {0x4C, '<'},  {0x4D, '('}, {0x4E, '+'}, {0x4F, '|'}, {0x50, '&'},
+                {0x5A, '!'}, {0x5B, '$'}, {0x5C, '*'},  {0x5D, ')'}, {0x5E, ';'}, {0x60, '-'}, {0x61, '/'},
+                {0x6B, ','}, {0x6C, '%'}, {0x6D, '_'},  {0x6E, '>'}, {0x6F, '?'}, {0x79, '`'}, {0x7A, ':'},
+                {0x7B, '#'}, {0x7C, '@'}, {0x7D, '\''}, {0x7E, '='}, {0x7F, '"'}, {0xA1, '~'}, {0xBA, '['},
+                {0xBB, ']'}, {0xC0, '{'}, {0xD0, '}'},  {0xE0, '\\'}};
+        const auto iter = punctuation.find(byte);
+        return iter == punctuation.end() ? 0xFFFDU : iter->second;
+    }
+
+    uint32_t ebcdic_decode(const std::string &charset, omega_byte_t byte) {
+        if (charset == "ebcdic-500" || charset == "ibm500") {
+            if (byte == 0x4A) { return '['; }
+            if (byte == 0x4F) { return '!'; }
+            if (byte == 0x5A) { return ']'; }
+            if (byte == 0x5F) { return '^'; }
+            if (byte == 0xBB) { return '|'; }
+            return ebcdic037_decode(byte);
         }
-    }
-    return true;
-}
-
-uint32_t read_word(const std::vector<omega_byte_t> &input, size_t offset, bool little, int bytes) {
-    uint32_t value = 0;
-    if (little) {
-        for (int i = bytes - 1; i >= 0; --i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
-    } else {
-        for (int i = 0; i < bytes; ++i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
-    }
-    return value;
-}
-
-void write_word(uint32_t value, bool little, int bytes, std::vector<omega_byte_t> &out) {
-    if (little) {
-        for (int i = 0; i < bytes; ++i) { out.push_back(static_cast<omega_byte_t>((value >> (8U * i)) & 0xFFU)); }
-    } else {
-        for (int i = bytes - 1; i >= 0; --i) {
-            out.push_back(static_cast<omega_byte_t>((value >> (8U * i)) & 0xFFU));
+        if (charset == "ebcdic-1047" || charset == "ibm1047") {
+            if (byte == 0x5F) { return '^'; }
+            if (byte == 0xAD) { return '['; }
+            if (byte == 0xBD) { return ']'; }
+            return ebcdic037_decode(byte);
         }
-    }
-}
-
-bool decode_utf16(const std::vector<omega_byte_t> &input, bool little, std::vector<uint32_t> &out) {
-    if ((input.size() % 2) != 0) { return false; }
-    out.clear();
-    for (size_t i = 0; i < input.size(); i += 2) {
-        uint32_t word = read_word(input, i, little, 2);
-        if (word >= 0xD800U && word <= 0xDBFFU) {
-            if (i + 3 >= input.size()) { return false; }
-            const uint32_t low = read_word(input, i + 2, little, 2);
-            if (low < 0xDC00U || low > 0xDFFFU) { return false; }
-            word = 0x10000U + (((word - 0xD800U) << 10U) | (low - 0xDC00U));
-            i += 2;
-        }
-        out.push_back(word);
-    }
-    return true;
-}
-
-bool encode_utf16(const std::vector<uint32_t> &input, bool little, std::vector<omega_byte_t> &out) {
-    out.clear();
-    for (const auto codepoint: input) {
-        if (codepoint <= 0xFFFFU) {
-            if (codepoint >= 0xD800U && codepoint <= 0xDFFFU) { return false; }
-            write_word(codepoint, little, 2, out);
-        } else if (codepoint <= 0x10FFFFU) {
-            const uint32_t value = codepoint - 0x10000U;
-            write_word(0xD800U | (value >> 10U), little, 2, out);
-            write_word(0xDC00U | (value & 0x3FFU), little, 2, out);
-        } else {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool decode_fixed_width(const std::vector<omega_byte_t> &input, bool little, int bytes, std::vector<uint32_t> &out) {
-    if ((input.size() % static_cast<size_t>(bytes)) != 0) { return false; }
-    out.clear();
-    for (size_t i = 0; i < input.size(); i += static_cast<size_t>(bytes)) {
-        out.push_back(read_word(input, i, little, bytes));
-    }
-    return true;
-}
-
-uint32_t cp1252_decode(omega_byte_t byte) {
-    static const std::map<omega_byte_t, uint32_t> extra = {
-            {0x80, 0x20AC}, {0x82, 0x201A}, {0x83, 0x0192}, {0x84, 0x201E}, {0x85, 0x2026},
-            {0x86, 0x2020}, {0x87, 0x2021}, {0x88, 0x02C6}, {0x89, 0x2030}, {0x8A, 0x0160},
-            {0x8B, 0x2039}, {0x8C, 0x0152}, {0x8E, 0x017D}, {0x91, 0x2018}, {0x92, 0x2019},
-            {0x93, 0x201C}, {0x94, 0x201D}, {0x95, 0x2022}, {0x96, 0x2013}, {0x97, 0x2014},
-            {0x98, 0x02DC}, {0x99, 0x2122}, {0x9A, 0x0161}, {0x9B, 0x203A}, {0x9C, 0x0153},
-            {0x9E, 0x017E}, {0x9F, 0x0178}};
-    const auto iter = extra.find(byte);
-    return iter == extra.end() ? byte : iter->second;
-}
-
-bool cp1252_encode(uint32_t codepoint, omega_byte_t &byte) {
-    if ((codepoint <= 0x7FU) || (codepoint >= 0xA0U && codepoint <= 0xFFU)) {
-        byte = static_cast<omega_byte_t>(codepoint);
-        return true;
-    }
-    for (int candidate = 0x80; candidate <= 0x9F; ++candidate) {
-        if (cp1252_decode(static_cast<omega_byte_t>(candidate)) == codepoint) {
-            byte = static_cast<omega_byte_t>(candidate);
-            return true;
-        }
-    }
-    return false;
-}
-
-uint32_t ebcdic037_decode(omega_byte_t byte) {
-    if (byte >= 0x81 && byte <= 0x89) { return 'a' + (byte - 0x81); }
-    if (byte >= 0x91 && byte <= 0x99) { return 'j' + (byte - 0x91); }
-    if (byte >= 0xA2 && byte <= 0xA9) { return 's' + (byte - 0xA2); }
-    if (byte >= 0xC1 && byte <= 0xC9) { return 'A' + (byte - 0xC1); }
-    if (byte >= 0xD1 && byte <= 0xD9) { return 'J' + (byte - 0xD1); }
-    if (byte >= 0xE2 && byte <= 0xE9) { return 'S' + (byte - 0xE2); }
-    if (byte >= 0xF0 && byte <= 0xF9) { return '0' + (byte - 0xF0); }
-    static const std::map<omega_byte_t, uint32_t> punctuation = {
-            {0x40, ' '}, {0x4B, '.'}, {0x4C, '<'}, {0x4D, '('}, {0x4E, '+'}, {0x4F, '|'}, {0x50, '&'},
-            {0x5A, '!'}, {0x5B, '$'}, {0x5C, '*'}, {0x5D, ')'}, {0x5E, ';'}, {0x60, '-'}, {0x61, '/'},
-            {0x6B, ','}, {0x6C, '%'}, {0x6D, '_'}, {0x6E, '>'}, {0x6F, '?'}, {0x79, '`'}, {0x7A, ':'},
-            {0x7B, '#'}, {0x7C, '@'}, {0x7D, '\''}, {0x7E, '='}, {0x7F, '"'}, {0xA1, '~'}, {0xBA, '['},
-            {0xBB, ']'}, {0xC0, '{'}, {0xD0, '}'}, {0xE0, '\\'}};
-    const auto iter = punctuation.find(byte);
-    return iter == punctuation.end() ? 0xFFFDU : iter->second;
-}
-
-uint32_t ebcdic_decode(const std::string &charset, omega_byte_t byte) {
-    if (charset == "ebcdic-500" || charset == "ibm500") {
-        if (byte == 0x4A) { return '['; }
-        if (byte == 0x4F) { return '!'; }
-        if (byte == 0x5A) { return ']'; }
-        if (byte == 0x5F) { return '^'; }
-        if (byte == 0xBB) { return '|'; }
+        if ((charset == "ebcdic-1140" || charset == "ibm1140") && byte == 0x9F) { return 0x20ACU; }
         return ebcdic037_decode(byte);
     }
-    if (charset == "ebcdic-1047" || charset == "ibm1047") {
-        if (byte == 0x5F) { return '^'; }
-        if (byte == 0xAD) { return '['; }
-        if (byte == 0xBD) { return ']'; }
-        return ebcdic037_decode(byte);
-    }
-    if ((charset == "ebcdic-1140" || charset == "ibm1140") && byte == 0x9F) { return 0x20ACU; }
-    return ebcdic037_decode(byte);
-}
 
-bool ebcdic037_encode(uint32_t codepoint, omega_byte_t &byte) {
-    if (codepoint >= 'a' && codepoint <= 'i') {
-        byte = static_cast<omega_byte_t>(0x81 + (codepoint - 'a'));
+    bool ebcdic037_encode(uint32_t codepoint, omega_byte_t &byte) {
+        if (codepoint >= 'a' && codepoint <= 'i') {
+            byte = static_cast<omega_byte_t>(0x81 + (codepoint - 'a'));
+            return true;
+        }
+        if (codepoint >= 'j' && codepoint <= 'r') {
+            byte = static_cast<omega_byte_t>(0x91 + (codepoint - 'j'));
+            return true;
+        }
+        if (codepoint >= 's' && codepoint <= 'z') {
+            byte = static_cast<omega_byte_t>(0xA2 + (codepoint - 's'));
+            return true;
+        }
+        if (codepoint >= 'A' && codepoint <= 'I') {
+            byte = static_cast<omega_byte_t>(0xC1 + (codepoint - 'A'));
+            return true;
+        }
+        if (codepoint >= 'J' && codepoint <= 'R') {
+            byte = static_cast<omega_byte_t>(0xD1 + (codepoint - 'J'));
+            return true;
+        }
+        if (codepoint >= 'S' && codepoint <= 'Z') {
+            byte = static_cast<omega_byte_t>(0xE2 + (codepoint - 'S'));
+            return true;
+        }
+        if (codepoint >= '0' && codepoint <= '9') {
+            byte = static_cast<omega_byte_t>(0xF0 + (codepoint - '0'));
+            return true;
+        }
+        static const std::map<uint32_t, omega_byte_t> punctuation = {
+                {' ', 0x40}, {'.', 0x4B}, {'<', 0x4C},  {'(', 0x4D}, {'+', 0x4E}, {'|', 0x4F}, {'&', 0x50},
+                {'!', 0x5A}, {'$', 0x5B}, {'*', 0x5C},  {')', 0x5D}, {';', 0x5E}, {'-', 0x60}, {'/', 0x61},
+                {',', 0x6B}, {'%', 0x6C}, {'_', 0x6D},  {'>', 0x6E}, {'?', 0x6F}, {'`', 0x79}, {':', 0x7A},
+                {'#', 0x7B}, {'@', 0x7C}, {'\'', 0x7D}, {'=', 0x7E}, {'"', 0x7F}, {'~', 0xA1}, {'[', 0xBA},
+                {']', 0xBB}, {'{', 0xC0}, {'}', 0xD0},  {'\\', 0xE0}};
+        const auto iter = punctuation.find(codepoint);
+        if (iter == punctuation.end()) { return false; }
+        byte = iter->second;
         return true;
     }
-    if (codepoint >= 'j' && codepoint <= 'r') {
-        byte = static_cast<omega_byte_t>(0x91 + (codepoint - 'j'));
-        return true;
-    }
-    if (codepoint >= 's' && codepoint <= 'z') {
-        byte = static_cast<omega_byte_t>(0xA2 + (codepoint - 's'));
-        return true;
-    }
-    if (codepoint >= 'A' && codepoint <= 'I') {
-        byte = static_cast<omega_byte_t>(0xC1 + (codepoint - 'A'));
-        return true;
-    }
-    if (codepoint >= 'J' && codepoint <= 'R') {
-        byte = static_cast<omega_byte_t>(0xD1 + (codepoint - 'J'));
-        return true;
-    }
-    if (codepoint >= 'S' && codepoint <= 'Z') {
-        byte = static_cast<omega_byte_t>(0xE2 + (codepoint - 'S'));
-        return true;
-    }
-    if (codepoint >= '0' && codepoint <= '9') {
-        byte = static_cast<omega_byte_t>(0xF0 + (codepoint - '0'));
-        return true;
-    }
-    static const std::map<uint32_t, omega_byte_t> punctuation = {
-            {' ', 0x40}, {'.', 0x4B}, {'<', 0x4C}, {'(', 0x4D}, {'+', 0x4E}, {'|', 0x4F}, {'&', 0x50},
-            {'!', 0x5A}, {'$', 0x5B}, {'*', 0x5C}, {')', 0x5D}, {';', 0x5E}, {'-', 0x60}, {'/', 0x61},
-            {',', 0x6B}, {'%', 0x6C}, {'_', 0x6D}, {'>', 0x6E}, {'?', 0x6F}, {'`', 0x79}, {':', 0x7A},
-            {'#', 0x7B}, {'@', 0x7C}, {'\'', 0x7D}, {'=', 0x7E}, {'"', 0x7F}, {'~', 0xA1}, {'[', 0xBA},
-            {']', 0xBB}, {'{', 0xC0}, {'}', 0xD0}, {'\\', 0xE0}};
-    const auto iter = punctuation.find(codepoint);
-    if (iter == punctuation.end()) { return false; }
-    byte = iter->second;
-    return true;
-}
 
-bool ebcdic_encode(const std::string &charset, uint32_t codepoint, omega_byte_t &byte) {
-    if ((charset == "ebcdic-1140" || charset == "ibm1140") && codepoint == 0x20ACU) {
-        byte = 0x9F;
+    bool ebcdic_encode(const std::string &charset, uint32_t codepoint, omega_byte_t &byte) {
+        if ((charset == "ebcdic-1140" || charset == "ibm1140") && codepoint == 0x20ACU) {
+            byte = 0x9F;
+            return true;
+        }
+        if (charset == "ebcdic-500" || charset == "ibm500") {
+            if (codepoint == '[') {
+                byte = 0x4A;
+                return true;
+            }
+            if (codepoint == '!') {
+                byte = 0x4F;
+                return true;
+            }
+            if (codepoint == ']') {
+                byte = 0x5A;
+                return true;
+            }
+            if (codepoint == '^') {
+                byte = 0x5F;
+                return true;
+            }
+            if (codepoint == '|') {
+                byte = 0xBB;
+                return true;
+            }
+        }
+        if (charset == "ebcdic-1047" || charset == "ibm1047") {
+            if (codepoint == '^') {
+                byte = 0x5F;
+                return true;
+            }
+            if (codepoint == '[') {
+                byte = 0xAD;
+                return true;
+            }
+            if (codepoint == ']') {
+                byte = 0xBD;
+                return true;
+            }
+        }
+        return ebcdic037_encode(codepoint, byte);
+    }
+
+    bool is_ebcdic(const std::string &charset) {
+        return charset == "ebcdic-037" || charset == "ibm037" || charset == "ebcdic-500" || charset == "ibm500" ||
+               charset == "ebcdic-1047" || charset == "ibm1047" || charset == "ebcdic-1140" || charset == "ibm1140";
+    }
+
+    bool decode_charset(const std::vector<omega_byte_t> &input, const std::string &charset,
+                        std::vector<uint32_t> &out) {
+        if (charset == "utf-8") { return decode_utf8(input, out); }
+        if (charset == "utf-16le" || charset == "utf-16be") { return decode_utf16(input, charset == "utf-16le", out); }
+        if (charset == "utf-32le" || charset == "utf-32be") {
+            return decode_fixed_width(input, charset == "utf-32le", 4, out);
+        }
+        out.clear();
+        for (const auto byte : input) {
+            if (charset == "ascii") {
+                if (byte > 0x7FU) { return false; }
+                out.push_back(byte);
+            } else if (charset == "iso-8859-1") {
+                out.push_back(byte);
+            } else if (charset == "windows-1252") {
+                const uint32_t codepoint = cp1252_decode(byte);
+                if (codepoint == 0xFFFDU) { return false; }
+                out.push_back(codepoint);
+            } else if (is_ebcdic(charset)) {
+                const uint32_t codepoint = ebcdic_decode(charset, byte);
+                if (codepoint == 0xFFFDU) { return false; }
+                out.push_back(codepoint);
+            } else {
+                return false;
+            }
+        }
         return true;
     }
-    if (charset == "ebcdic-500" || charset == "ibm500") {
-        if (codepoint == '[') {
-            byte = 0x4A;
-            return true;
-        }
-        if (codepoint == '!') {
-            byte = 0x4F;
-            return true;
-        }
-        if (codepoint == ']') {
-            byte = 0x5A;
-            return true;
-        }
-        if (codepoint == '^') {
-            byte = 0x5F;
-            return true;
-        }
-        if (codepoint == '|') {
-            byte = 0xBB;
-            return true;
-        }
-    }
-    if (charset == "ebcdic-1047" || charset == "ibm1047") {
-        if (codepoint == '^') {
-            byte = 0x5F;
-            return true;
-        }
-        if (codepoint == '[') {
-            byte = 0xAD;
-            return true;
-        }
-        if (codepoint == ']') {
-            byte = 0xBD;
-            return true;
-        }
-    }
-    return ebcdic037_encode(codepoint, byte);
-}
 
-bool is_ebcdic(const std::string &charset) {
-    return charset == "ebcdic-037" || charset == "ibm037" || charset == "ebcdic-500" || charset == "ibm500" ||
-           charset == "ebcdic-1047" || charset == "ibm1047" || charset == "ebcdic-1140" || charset == "ibm1140";
-}
-
-bool decode_charset(const std::vector<omega_byte_t> &input, const std::string &charset, std::vector<uint32_t> &out) {
-    if (charset == "utf-8") { return decode_utf8(input, out); }
-    if (charset == "utf-16le" || charset == "utf-16be") { return decode_utf16(input, charset == "utf-16le", out); }
-    if (charset == "utf-32le" || charset == "utf-32be") {
-        return decode_fixed_width(input, charset == "utf-32le", 4, out);
-    }
-    out.clear();
-    for (const auto byte: input) {
-        if (charset == "ascii") {
-            if (byte > 0x7FU) { return false; }
+    bool encode_charset(const std::vector<uint32_t> &input, const std::string &charset,
+                        std::vector<omega_byte_t> &out) {
+        out.clear();
+        if (charset == "utf-8") {
+            for (const auto codepoint : input) {
+                if (!utf8_append(codepoint, out)) { return false; }
+            }
+            return true;
+        }
+        if (charset == "utf-16le" || charset == "utf-16be") { return encode_utf16(input, charset == "utf-16le", out); }
+        if (charset == "utf-32le" || charset == "utf-32be") {
+            for (const auto codepoint : input) { write_word(codepoint, charset == "utf-32le", 4, out); }
+            return true;
+        }
+        for (const auto codepoint : input) {
+            omega_byte_t byte = 0;
+            if (charset == "ascii") {
+                if (codepoint > 0x7FU) { return false; }
+                byte = static_cast<omega_byte_t>(codepoint);
+            } else if (charset == "iso-8859-1") {
+                if (codepoint > 0xFFU) { return false; }
+                byte = static_cast<omega_byte_t>(codepoint);
+            } else if (charset == "windows-1252") {
+                if (!cp1252_encode(codepoint, byte)) { return false; }
+            } else if (is_ebcdic(charset)) {
+                if (!ebcdic_encode(charset, codepoint, byte)) { return false; }
+            } else {
+                return false;
+            }
             out.push_back(byte);
-        } else if (charset == "iso-8859-1") {
-            out.push_back(byte);
-        } else if (charset == "windows-1252") {
-            const uint32_t codepoint = cp1252_decode(byte);
-            if (codepoint == 0xFFFDU) { return false; }
-            out.push_back(codepoint);
-        } else if (is_ebcdic(charset)) {
-            const uint32_t codepoint = ebcdic_decode(charset, byte);
-            if (codepoint == 0xFFFDU) { return false; }
-            out.push_back(codepoint);
-        } else {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool encode_charset(const std::vector<uint32_t> &input, const std::string &charset, std::vector<omega_byte_t> &out) {
-    out.clear();
-    if (charset == "utf-8") {
-        for (const auto codepoint: input) {
-            if (!utf8_append(codepoint, out)) { return false; }
         }
         return true;
     }
-    if (charset == "utf-16le" || charset == "utf-16be") { return encode_utf16(input, charset == "utf-16le", out); }
-    if (charset == "utf-32le" || charset == "utf-32be") {
-        for (const auto codepoint: input) { write_word(codepoint, charset == "utf-32le", 4, out); }
-        return true;
-    }
-    for (const auto codepoint: input) {
-        omega_byte_t byte = 0;
-        if (charset == "ascii") {
-            if (codepoint > 0x7FU) { return false; }
-            byte = static_cast<omega_byte_t>(codepoint);
-        } else if (charset == "iso-8859-1") {
-            if (codepoint > 0xFFU) { return false; }
-            byte = static_cast<omega_byte_t>(codepoint);
-        } else if (charset == "windows-1252") {
-            if (!cp1252_encode(codepoint, byte)) { return false; }
-        } else if (is_ebcdic(charset)) {
-            if (!ebcdic_encode(charset, codepoint, byte)) { return false; }
-        } else {
-            return false;
-        }
-        out.push_back(byte);
-    }
-    return true;
-}
 
-} // namespace
+}// namespace
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
-        omega_transform_plugin_info_t *info_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
     info_ptr->id = "omega.example.character_transcode";
     info_ptr->name = "Character Transcode";
@@ -387,12 +388,11 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
     return 0;
 }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                             omega_transform_plugin_response_t *response_ptr) {
     std::vector<omega_byte_t> input;
-    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
-        return -1;
-    }
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) { return -1; }
     std::map<std::string, std::string> options;
     if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
     const std::string from = omega_edit::plugin::option_or(options, "from", "utf-8");

--- a/plugins/src/common_checksums.cpp
+++ b/plugins/src/common_checksums.cpp
@@ -22,7 +22,7 @@
 
 namespace {
 
-constexpr const char *CHECKSUM_ARGS_SCHEMA = R"json({
+    constexpr const char *CHECKSUM_ARGS_SCHEMA = R"json({
   "type": "object",
   "properties": {
     "algorithm": {
@@ -93,376 +93,370 @@ constexpr const char *CHECKSUM_ARGS_SCHEMA = R"json({
   "additionalProperties": false
 })json";
 
-uint64_t mask_for_width(int width) {
-    return width == 64 ? UINT64_MAX : ((UINT64_C(1) << width) - UINT64_C(1));
-}
+    uint64_t mask_for_width(int width) { return width == 64 ? UINT64_MAX : ((UINT64_C(1) << width) - UINT64_C(1)); }
 
-uint64_t reflect_bits(uint64_t value, int width) {
-    uint64_t reflected = 0;
-    for (int i = 0; i < width; ++i) {
-        if (value & (UINT64_C(1) << i)) { reflected |= UINT64_C(1) << (width - 1 - i); }
+    uint64_t reflect_bits(uint64_t value, int width) {
+        uint64_t reflected = 0;
+        for (int i = 0; i < width; ++i) {
+            if (value & (UINT64_C(1) << i)) { reflected |= UINT64_C(1) << (width - 1 - i); }
+        }
+        return reflected;
     }
-    return reflected;
-}
 
-struct crc_model_t {
-    int width;
-    uint64_t polynomial;
-    uint64_t init;
-    uint64_t xor_out;
-    bool refin;
-    bool refout;
-};
+    struct crc_model_t {
+        int width;
+        uint64_t polynomial;
+        uint64_t init;
+        uint64_t xor_out;
+        bool refin;
+        bool refout;
+    };
 
-uint64_t crc_update(uint64_t state, const crc_model_t &model, const omega_byte_t *bytes, int64_t length) {
-    const uint64_t mask = mask_for_width(model.width);
-    if (model.refin) {
-        const uint64_t reflected_polynomial = reflect_bits(model.polynomial, model.width);
+    uint64_t crc_update(uint64_t state, const crc_model_t &model, const omega_byte_t *bytes, int64_t length) {
+        const uint64_t mask = mask_for_width(model.width);
+        if (model.refin) {
+            const uint64_t reflected_polynomial = reflect_bits(model.polynomial, model.width);
+            for (int64_t i = 0; i < length; ++i) {
+                state ^= static_cast<uint8_t>(bytes[i]);
+                for (int bit = 0; bit < 8; ++bit) {
+                    state = (state & 1U) ? ((state >> 1U) ^ reflected_polynomial) : (state >> 1U);
+                }
+                state &= mask;
+            }
+            return state;
+        }
+
+        const uint64_t top_bit = UINT64_C(1) << (model.width - 1);
         for (int64_t i = 0; i < length; ++i) {
-            state ^= static_cast<uint8_t>(bytes[i]);
+            state ^= static_cast<uint64_t>(static_cast<uint8_t>(bytes[i])) << (model.width - 8);
             for (int bit = 0; bit < 8; ++bit) {
-                state = (state & 1U) ? ((state >> 1U) ^ reflected_polynomial) : (state >> 1U);
+                state = (state & top_bit) ? ((state << 1U) ^ model.polynomial) : (state << 1U);
             }
             state &= mask;
         }
         return state;
     }
 
-    const uint64_t top_bit = UINT64_C(1) << (model.width - 1);
-    for (int64_t i = 0; i < length; ++i) {
-        state ^= static_cast<uint64_t>(static_cast<uint8_t>(bytes[i])) << (model.width - 8);
-        for (int bit = 0; bit < 8; ++bit) {
-            state = (state & top_bit) ? ((state << 1U) ^ model.polynomial) : (state << 1U);
+    uint64_t crc_finalize(uint64_t state, const crc_model_t &model) {
+        if (model.refin != model.refout) { state = reflect_bits(state, model.width); }
+        return (state ^ model.xor_out) & mask_for_width(model.width);
+    }
+
+    bool crc_model_for(const std::string &algorithm, crc_model_t &model, int &hex_width) {
+        if (algorithm == "crc32") {
+            model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0xFFFFFFFFU, true, true};
+            hex_width = 8;
+            return true;
         }
-        state &= mask;
-    }
-    return state;
-}
-
-uint64_t crc_finalize(uint64_t state, const crc_model_t &model) {
-    if (model.refin != model.refout) { state = reflect_bits(state, model.width); }
-    return (state ^ model.xor_out) & mask_for_width(model.width);
-}
-
-bool crc_model_for(const std::string &algorithm, crc_model_t &model, int &hex_width) {
-    if (algorithm == "crc32") {
-        model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0xFFFFFFFFU, true, true};
-        hex_width = 8;
-        return true;
-    }
-    if (algorithm == "crc32c") {
-        model = {32, 0x1EDC6F41U, 0xFFFFFFFFU, 0xFFFFFFFFU, true, true};
-        hex_width = 8;
-        return true;
-    }
-    if (algorithm == "crc32-mpeg2") {
-        model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0x00000000U, false, false};
-        hex_width = 8;
-        return true;
-    }
-    if (algorithm == "crc32-bzip2") {
-        model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0xFFFFFFFFU, false, false};
-        hex_width = 8;
-        return true;
-    }
-    if (algorithm == "crc16-ibm" || algorithm == "crc16-arc") {
-        model = {16, 0x8005U, 0x0000U, 0x0000U, true, true};
-        hex_width = 4;
-        return true;
-    }
-    if (algorithm == "crc16-modbus") {
-        model = {16, 0x8005U, 0xFFFFU, 0x0000U, true, true};
-        hex_width = 4;
-        return true;
-    }
-    if (algorithm == "crc16-ccitt-false") {
-        model = {16, 0x1021U, 0xFFFFU, 0x0000U, false, false};
-        hex_width = 4;
-        return true;
-    }
-    if (algorithm == "crc16-xmodem") {
-        model = {16, 0x1021U, 0x0000U, 0x0000U, false, false};
-        hex_width = 4;
-        return true;
-    }
-    if (algorithm == "crc16-kermit") {
-        model = {16, 0x1021U, 0x0000U, 0x0000U, true, true};
-        hex_width = 4;
-        return true;
-    }
-    if (algorithm == "crc8") {
-        model = {8, 0x07U, 0x00U, 0x00U, false, false};
-        hex_width = 2;
-        return true;
-    }
-    return false;
-}
-
-uint32_t rotl32(uint32_t value, int count) {
-    return (value << count) | (value >> (32 - count));
-}
-
-uint64_t rotl64(uint64_t value, int count) {
-    return (value << count) | (value >> (64 - count));
-}
-
-uint32_t read32le(const omega_byte_t *bytes) {
-    return static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8U) |
-           (static_cast<uint32_t>(bytes[2]) << 16U) | (static_cast<uint32_t>(bytes[3]) << 24U);
-}
-
-uint64_t read64le(const omega_byte_t *bytes) {
-    return static_cast<uint64_t>(read32le(bytes)) | (static_cast<uint64_t>(read32le(bytes + 4)) << 32U);
-}
-
-struct murmur3_32_t {
-    uint32_t h = 0;
-    uint64_t length = 0;
-    std::array<omega_byte_t, 4> tail{};
-    size_t tail_length = 0;
-
-    void block(uint32_t k) {
-        k *= 0xcc9e2d51U;
-        k = rotl32(k, 15);
-        k *= 0x1b873593U;
-        h ^= k;
-        h = rotl32(h, 13);
-        h = (h * 5U) + 0xe6546b64U;
-    }
-
-    void update(const omega_byte_t *bytes, int64_t byte_count) {
-        length += static_cast<uint64_t>(byte_count);
-        size_t index = 0;
-        if (tail_length > 0) {
-            while (tail_length < tail.size() && index < static_cast<size_t>(byte_count)) {
-                tail[tail_length++] = bytes[index++];
-            }
-            if (tail_length == tail.size()) {
-                block(read32le(tail.data()));
-                tail_length = 0;
-            }
+        if (algorithm == "crc32c") {
+            model = {32, 0x1EDC6F41U, 0xFFFFFFFFU, 0xFFFFFFFFU, true, true};
+            hex_width = 8;
+            return true;
         }
-        while (index + 4 <= static_cast<size_t>(byte_count)) {
-            block(read32le(bytes + index));
-            index += 4;
+        if (algorithm == "crc32-mpeg2") {
+            model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0x00000000U, false, false};
+            hex_width = 8;
+            return true;
         }
-        while (index < static_cast<size_t>(byte_count)) { tail[tail_length++] = bytes[index++]; }
+        if (algorithm == "crc32-bzip2") {
+            model = {32, 0x04C11DB7U, 0xFFFFFFFFU, 0xFFFFFFFFU, false, false};
+            hex_width = 8;
+            return true;
+        }
+        if (algorithm == "crc16-ibm" || algorithm == "crc16-arc") {
+            model = {16, 0x8005U, 0x0000U, 0x0000U, true, true};
+            hex_width = 4;
+            return true;
+        }
+        if (algorithm == "crc16-modbus") {
+            model = {16, 0x8005U, 0xFFFFU, 0x0000U, true, true};
+            hex_width = 4;
+            return true;
+        }
+        if (algorithm == "crc16-ccitt-false") {
+            model = {16, 0x1021U, 0xFFFFU, 0x0000U, false, false};
+            hex_width = 4;
+            return true;
+        }
+        if (algorithm == "crc16-xmodem") {
+            model = {16, 0x1021U, 0x0000U, 0x0000U, false, false};
+            hex_width = 4;
+            return true;
+        }
+        if (algorithm == "crc16-kermit") {
+            model = {16, 0x1021U, 0x0000U, 0x0000U, true, true};
+            hex_width = 4;
+            return true;
+        }
+        if (algorithm == "crc8") {
+            model = {8, 0x07U, 0x00U, 0x00U, false, false};
+            hex_width = 2;
+            return true;
+        }
+        return false;
     }
 
-    uint32_t final() const {
-        uint32_t result = h;
-        uint32_t k = 0;
-        switch (tail_length) {
-            case 3:
-                k ^= static_cast<uint32_t>(tail[2]) << 16U;
-                [[fallthrough]];
-            case 2:
-                k ^= static_cast<uint32_t>(tail[1]) << 8U;
-                [[fallthrough]];
-            case 1:
-                k ^= tail[0];
-                k *= 0xcc9e2d51U;
-                k = rotl32(k, 15);
-                k *= 0x1b873593U;
-                result ^= k;
-                break;
-            default:
-                break;
-        }
-        result ^= static_cast<uint32_t>(length);
-        result ^= result >> 16U;
-        result *= 0x85ebca6bU;
-        result ^= result >> 13U;
-        result *= 0xc2b2ae35U;
-        result ^= result >> 16U;
-        return result;
-    }
-};
+    uint32_t rotl32(uint32_t value, int count) { return (value << count) | (value >> (32 - count)); }
 
-struct xxhash32_t {
-    static constexpr uint32_t p1 = 2654435761U;
-    static constexpr uint32_t p2 = 2246822519U;
-    static constexpr uint32_t p3 = 3266489917U;
-    static constexpr uint32_t p4 = 668265263U;
-    static constexpr uint32_t p5 = 374761393U;
+    uint64_t rotl64(uint64_t value, int count) { return (value << count) | (value >> (64 - count)); }
 
-    uint64_t length = 0;
-    uint32_t v1 = p1 + p2;
-    uint32_t v2 = p2;
-    uint32_t v3 = 0;
-    uint32_t v4 = 0U - p1;
-    std::array<omega_byte_t, 16> memory{};
-    size_t memory_size = 0;
-
-    static uint32_t round(uint32_t acc, uint32_t input) {
-        acc += input * p2;
-        acc = rotl32(acc, 13);
-        return acc * p1;
+    uint32_t read32le(const omega_byte_t *bytes) {
+        return static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8U) |
+               (static_cast<uint32_t>(bytes[2]) << 16U) | (static_cast<uint32_t>(bytes[3]) << 24U);
     }
 
-    void stripe(const omega_byte_t *bytes) {
-        v1 = round(v1, read32le(bytes));
-        v2 = round(v2, read32le(bytes + 4));
-        v3 = round(v3, read32le(bytes + 8));
-        v4 = round(v4, read32le(bytes + 12));
+    uint64_t read64le(const omega_byte_t *bytes) {
+        return static_cast<uint64_t>(read32le(bytes)) | (static_cast<uint64_t>(read32le(bytes + 4)) << 32U);
     }
 
-    void update(const omega_byte_t *bytes, int64_t byte_count) {
-        length += static_cast<uint64_t>(byte_count);
-        size_t index = 0;
-        if (memory_size + static_cast<size_t>(byte_count) < memory.size()) {
-            std::memcpy(memory.data() + memory_size, bytes, static_cast<size_t>(byte_count));
-            memory_size += static_cast<size_t>(byte_count);
-            return;
-        }
-        if (memory_size > 0) {
-            const size_t fill = memory.size() - memory_size;
-            std::memcpy(memory.data() + memory_size, bytes, fill);
-            stripe(memory.data());
-            index += fill;
-            memory_size = 0;
-        }
-        while (index + memory.size() <= static_cast<size_t>(byte_count)) {
-            stripe(bytes + index);
-            index += memory.size();
-        }
-        if (index < static_cast<size_t>(byte_count)) {
-            memory_size = static_cast<size_t>(byte_count) - index;
-            std::memcpy(memory.data(), bytes + index, memory_size);
-        }
-    }
-
-    uint32_t final() const {
+    struct murmur3_32_t {
         uint32_t h = 0;
-        if (length >= 16) {
-            h = rotl32(v1, 1) + rotl32(v2, 7) + rotl32(v3, 12) + rotl32(v4, 18);
-        } else {
-            h = p5;
-        }
-        h += static_cast<uint32_t>(length);
-        size_t index = 0;
-        while (index + 4 <= memory_size) {
-            h += read32le(memory.data() + index) * p3;
-            h = rotl32(h, 17) * p4;
-            index += 4;
-        }
-        while (index < memory_size) {
-            h += memory[index] * p5;
-            h = rotl32(h, 11) * p1;
-            ++index;
-        }
-        h ^= h >> 15U;
-        h *= p2;
-        h ^= h >> 13U;
-        h *= p3;
-        h ^= h >> 16U;
-        return h;
-    }
-};
+        uint64_t length = 0;
+        std::array<omega_byte_t, 4> tail{};
+        size_t tail_length = 0;
 
-struct xxhash64_t {
-    static constexpr uint64_t p1 = 11400714785074694791ULL;
-    static constexpr uint64_t p2 = 14029467366897019727ULL;
-    static constexpr uint64_t p3 = 1609587929392839161ULL;
-    static constexpr uint64_t p4 = 9650029242287828579ULL;
-    static constexpr uint64_t p5 = 2870177450012600261ULL;
-
-    uint64_t length = 0;
-    uint64_t v1 = p1 + p2;
-    uint64_t v2 = p2;
-    uint64_t v3 = 0;
-    uint64_t v4 = 0U - p1;
-    std::array<omega_byte_t, 32> memory{};
-    size_t memory_size = 0;
-
-    static uint64_t round(uint64_t acc, uint64_t input) {
-        acc += input * p2;
-        acc = rotl64(acc, 31);
-        return acc * p1;
-    }
-
-    static uint64_t merge_round(uint64_t acc, uint64_t value) {
-        acc ^= round(0, value);
-        return (acc * p1) + p4;
-    }
-
-    void stripe(const omega_byte_t *bytes) {
-        v1 = round(v1, read64le(bytes));
-        v2 = round(v2, read64le(bytes + 8));
-        v3 = round(v3, read64le(bytes + 16));
-        v4 = round(v4, read64le(bytes + 24));
-    }
-
-    void update(const omega_byte_t *bytes, int64_t byte_count) {
-        length += static_cast<uint64_t>(byte_count);
-        size_t index = 0;
-        if (memory_size + static_cast<size_t>(byte_count) < memory.size()) {
-            std::memcpy(memory.data() + memory_size, bytes, static_cast<size_t>(byte_count));
-            memory_size += static_cast<size_t>(byte_count);
-            return;
+        void block(uint32_t k) {
+            k *= 0xcc9e2d51U;
+            k = rotl32(k, 15);
+            k *= 0x1b873593U;
+            h ^= k;
+            h = rotl32(h, 13);
+            h = (h * 5U) + 0xe6546b64U;
         }
-        if (memory_size > 0) {
-            const size_t fill = memory.size() - memory_size;
-            std::memcpy(memory.data() + memory_size, bytes, fill);
-            stripe(memory.data());
-            index += fill;
-            memory_size = 0;
-        }
-        while (index + memory.size() <= static_cast<size_t>(byte_count)) {
-            stripe(bytes + index);
-            index += memory.size();
-        }
-        if (index < static_cast<size_t>(byte_count)) {
-            memory_size = static_cast<size_t>(byte_count) - index;
-            std::memcpy(memory.data(), bytes + index, memory_size);
-        }
-    }
 
-    uint64_t final() const {
-        uint64_t h = 0;
-        if (length >= 32) {
-            h = rotl64(v1, 1) + rotl64(v2, 7) + rotl64(v3, 12) + rotl64(v4, 18);
-            h = merge_round(h, v1);
-            h = merge_round(h, v2);
-            h = merge_round(h, v3);
-            h = merge_round(h, v4);
-        } else {
-            h = p5;
+        void update(const omega_byte_t *bytes, int64_t byte_count) {
+            length += static_cast<uint64_t>(byte_count);
+            size_t index = 0;
+            if (tail_length > 0) {
+                while (tail_length < tail.size() && index < static_cast<size_t>(byte_count)) {
+                    tail[tail_length++] = bytes[index++];
+                }
+                if (tail_length == tail.size()) {
+                    block(read32le(tail.data()));
+                    tail_length = 0;
+                }
+            }
+            while (index + 4 <= static_cast<size_t>(byte_count)) {
+                block(read32le(bytes + index));
+                index += 4;
+            }
+            while (index < static_cast<size_t>(byte_count)) { tail[tail_length++] = bytes[index++]; }
         }
-        h += length;
-        size_t index = 0;
-        while (index + 8 <= memory_size) {
-            h ^= round(0, read64le(memory.data() + index));
-            h = (rotl64(h, 27) * p1) + p4;
-            index += 8;
-        }
-        if (index + 4 <= memory_size) {
-            h ^= static_cast<uint64_t>(read32le(memory.data() + index)) * p1;
-            h = (rotl64(h, 23) * p2) + p3;
-            index += 4;
-        }
-        while (index < memory_size) {
-            h ^= memory[index] * p5;
-            h = rotl64(h, 11) * p1;
-            ++index;
-        }
-        h ^= h >> 33U;
-        h *= p2;
-        h ^= h >> 29U;
-        h *= p3;
-        h ^= h >> 32U;
-        return h;
-    }
-};
 
-} // namespace
+        uint32_t final() const {
+            uint32_t result = h;
+            uint32_t k = 0;
+            switch (tail_length) {
+                case 3:
+                    k ^= static_cast<uint32_t>(tail[2]) << 16U;
+                    [[fallthrough]];
+                case 2:
+                    k ^= static_cast<uint32_t>(tail[1]) << 8U;
+                    [[fallthrough]];
+                case 1:
+                    k ^= tail[0];
+                    k *= 0xcc9e2d51U;
+                    k = rotl32(k, 15);
+                    k *= 0x1b873593U;
+                    result ^= k;
+                    break;
+                default:
+                    break;
+            }
+            result ^= static_cast<uint32_t>(length);
+            result ^= result >> 16U;
+            result *= 0x85ebca6bU;
+            result ^= result >> 13U;
+            result *= 0xc2b2ae35U;
+            result ^= result >> 16U;
+            return result;
+        }
+    };
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
-        omega_transform_plugin_info_t *info_ptr) {
+    struct xxhash32_t {
+        static constexpr uint32_t p1 = 2654435761U;
+        static constexpr uint32_t p2 = 2246822519U;
+        static constexpr uint32_t p3 = 3266489917U;
+        static constexpr uint32_t p4 = 668265263U;
+        static constexpr uint32_t p5 = 374761393U;
+
+        uint64_t length = 0;
+        uint32_t v1 = p1 + p2;
+        uint32_t v2 = p2;
+        uint32_t v3 = 0;
+        uint32_t v4 = 0U - p1;
+        std::array<omega_byte_t, 16> memory{};
+        size_t memory_size = 0;
+
+        static uint32_t round(uint32_t acc, uint32_t input) {
+            acc += input * p2;
+            acc = rotl32(acc, 13);
+            return acc * p1;
+        }
+
+        void stripe(const omega_byte_t *bytes) {
+            v1 = round(v1, read32le(bytes));
+            v2 = round(v2, read32le(bytes + 4));
+            v3 = round(v3, read32le(bytes + 8));
+            v4 = round(v4, read32le(bytes + 12));
+        }
+
+        void update(const omega_byte_t *bytes, int64_t byte_count) {
+            length += static_cast<uint64_t>(byte_count);
+            size_t index = 0;
+            if (memory_size + static_cast<size_t>(byte_count) < memory.size()) {
+                std::memcpy(memory.data() + memory_size, bytes, static_cast<size_t>(byte_count));
+                memory_size += static_cast<size_t>(byte_count);
+                return;
+            }
+            if (memory_size > 0) {
+                const size_t fill = memory.size() - memory_size;
+                std::memcpy(memory.data() + memory_size, bytes, fill);
+                stripe(memory.data());
+                index += fill;
+                memory_size = 0;
+            }
+            while (index + memory.size() <= static_cast<size_t>(byte_count)) {
+                stripe(bytes + index);
+                index += memory.size();
+            }
+            if (index < static_cast<size_t>(byte_count)) {
+                memory_size = static_cast<size_t>(byte_count) - index;
+                std::memcpy(memory.data(), bytes + index, memory_size);
+            }
+        }
+
+        uint32_t final() const {
+            uint32_t h = 0;
+            if (length >= 16) {
+                h = rotl32(v1, 1) + rotl32(v2, 7) + rotl32(v3, 12) + rotl32(v4, 18);
+            } else {
+                h = p5;
+            }
+            h += static_cast<uint32_t>(length);
+            size_t index = 0;
+            while (index + 4 <= memory_size) {
+                h += read32le(memory.data() + index) * p3;
+                h = rotl32(h, 17) * p4;
+                index += 4;
+            }
+            while (index < memory_size) {
+                h += memory[index] * p5;
+                h = rotl32(h, 11) * p1;
+                ++index;
+            }
+            h ^= h >> 15U;
+            h *= p2;
+            h ^= h >> 13U;
+            h *= p3;
+            h ^= h >> 16U;
+            return h;
+        }
+    };
+
+    struct xxhash64_t {
+        static constexpr uint64_t p1 = 11400714785074694791ULL;
+        static constexpr uint64_t p2 = 14029467366897019727ULL;
+        static constexpr uint64_t p3 = 1609587929392839161ULL;
+        static constexpr uint64_t p4 = 9650029242287828579ULL;
+        static constexpr uint64_t p5 = 2870177450012600261ULL;
+
+        uint64_t length = 0;
+        uint64_t v1 = p1 + p2;
+        uint64_t v2 = p2;
+        uint64_t v3 = 0;
+        uint64_t v4 = 0U - p1;
+        std::array<omega_byte_t, 32> memory{};
+        size_t memory_size = 0;
+
+        static uint64_t round(uint64_t acc, uint64_t input) {
+            acc += input * p2;
+            acc = rotl64(acc, 31);
+            return acc * p1;
+        }
+
+        static uint64_t merge_round(uint64_t acc, uint64_t value) {
+            acc ^= round(0, value);
+            return (acc * p1) + p4;
+        }
+
+        void stripe(const omega_byte_t *bytes) {
+            v1 = round(v1, read64le(bytes));
+            v2 = round(v2, read64le(bytes + 8));
+            v3 = round(v3, read64le(bytes + 16));
+            v4 = round(v4, read64le(bytes + 24));
+        }
+
+        void update(const omega_byte_t *bytes, int64_t byte_count) {
+            length += static_cast<uint64_t>(byte_count);
+            size_t index = 0;
+            if (memory_size + static_cast<size_t>(byte_count) < memory.size()) {
+                std::memcpy(memory.data() + memory_size, bytes, static_cast<size_t>(byte_count));
+                memory_size += static_cast<size_t>(byte_count);
+                return;
+            }
+            if (memory_size > 0) {
+                const size_t fill = memory.size() - memory_size;
+                std::memcpy(memory.data() + memory_size, bytes, fill);
+                stripe(memory.data());
+                index += fill;
+                memory_size = 0;
+            }
+            while (index + memory.size() <= static_cast<size_t>(byte_count)) {
+                stripe(bytes + index);
+                index += memory.size();
+            }
+            if (index < static_cast<size_t>(byte_count)) {
+                memory_size = static_cast<size_t>(byte_count) - index;
+                std::memcpy(memory.data(), bytes + index, memory_size);
+            }
+        }
+
+        uint64_t final() const {
+            uint64_t h = 0;
+            if (length >= 32) {
+                h = rotl64(v1, 1) + rotl64(v2, 7) + rotl64(v3, 12) + rotl64(v4, 18);
+                h = merge_round(h, v1);
+                h = merge_round(h, v2);
+                h = merge_round(h, v3);
+                h = merge_round(h, v4);
+            } else {
+                h = p5;
+            }
+            h += length;
+            size_t index = 0;
+            while (index + 8 <= memory_size) {
+                h ^= round(0, read64le(memory.data() + index));
+                h = (rotl64(h, 27) * p1) + p4;
+                index += 8;
+            }
+            if (index + 4 <= memory_size) {
+                h ^= static_cast<uint64_t>(read32le(memory.data() + index)) * p1;
+                h = (rotl64(h, 23) * p2) + p3;
+                index += 4;
+            }
+            while (index < memory_size) {
+                h ^= memory[index] * p5;
+                h = rotl64(h, 11) * p1;
+                ++index;
+            }
+            h ^= h >> 33U;
+            h *= p2;
+            h ^= h >> 29U;
+            h *= p3;
+            h ^= h >> 32U;
+            return h;
+        }
+    };
+
+}// namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
     info_ptr->id = "omega.example.common_checksums";
     info_ptr->name = "Common Checksums";
-    info_ptr->description = "Inspect the selected range with common CRC, checksum, and non-cryptographic hash variants.";
+    info_ptr->description =
+            "Inspect the selected range with common CRC, checksum, and non-cryptographic hash variants.";
     info_ptr->operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_TEXT_RESULT | OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE |
                       OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING;
@@ -478,8 +472,9 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
     return 0;
 }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                             omega_transform_plugin_response_t *response_ptr) {
     if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0 ||
         request_ptr->session_length < 0) {
         return -1;
@@ -493,15 +488,14 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
     int crc_hex_width = 0;
     if (crc_model_for(algorithm, crc_model, crc_hex_width)) {
         uint64_t crc = crc_model.init;
-        const bool ok = omega_edit::plugin::for_each_chunk(
-                request_ptr, [&](const omega_byte_t *bytes, int64_t length) {
-                    crc = crc_update(crc, crc_model, bytes, length);
-                    return true;
-                });
+        const bool ok = omega_edit::plugin::for_each_chunk(request_ptr, [&](const omega_byte_t *bytes, int64_t length) {
+            crc = crc_update(crc, crc_model, bytes, length);
+            return true;
+        });
         if (!ok) { return -1; }
-        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
-                                                   omega_edit::plugin::hex_value(crc_finalize(crc, crc_model),
-                                                                                crc_hex_width));
+        return omega_edit::plugin::set_text_result(
+                request_ptr, response_ptr, algorithm,
+                omega_edit::plugin::hex_value(crc_finalize(crc, crc_model), crc_hex_width));
     }
 
     uint32_t adler_a = 1;
@@ -524,74 +518,73 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
     bool have_odd_fletcher32_byte = false;
     omega_byte_t odd_fletcher32_byte = 0;
 
-    const bool ok = omega_edit::plugin::for_each_chunk(
-            request_ptr, [&](const omega_byte_t *bytes, int64_t length) {
-                if (algorithm == "murmur3-32") {
-                    murmur3.update(bytes, length);
-                    return true;
+    const bool ok = omega_edit::plugin::for_each_chunk(request_ptr, [&](const omega_byte_t *bytes, int64_t length) {
+        if (algorithm == "murmur3-32") {
+            murmur3.update(bytes, length);
+            return true;
+        }
+        if (algorithm == "xxhash32") {
+            xx32.update(bytes, length);
+            return true;
+        }
+        if (algorithm == "xxhash64") {
+            xx64.update(bytes, length);
+            return true;
+        }
+        for (int64_t i = 0; i < length; ++i) {
+            const uint8_t byte = static_cast<uint8_t>(bytes[i]);
+            if (algorithm == "adler32") {
+                adler_a = (adler_a + byte) % 65521U;
+                adler_b = (adler_b + adler_a) % 65521U;
+            } else if (algorithm == "fletcher16") {
+                fletcher_a = (fletcher_a + byte) % 255U;
+                fletcher_b = (fletcher_b + fletcher_a) % 255U;
+            } else if (algorithm == "fletcher32") {
+                uint16_t word = 0;
+                if (have_odd_fletcher32_byte) {
+                    word = static_cast<uint16_t>((odd_fletcher32_byte << 8U) | byte);
+                    have_odd_fletcher32_byte = false;
+                } else if (i + 1 < length) {
+                    word = static_cast<uint16_t>((byte << 8U) | static_cast<uint8_t>(bytes[++i]));
+                } else {
+                    odd_fletcher32_byte = byte;
+                    have_odd_fletcher32_byte = true;
+                    continue;
                 }
-                if (algorithm == "xxhash32") {
-                    xx32.update(bytes, length);
-                    return true;
+                fletcher32_a = (fletcher32_a + word) % 65535U;
+                fletcher32_b = (fletcher32_b + fletcher32_a) % 65535U;
+            } else if (algorithm == "internet-checksum") {
+                uint16_t word = 0;
+                if (have_odd_internet_byte) {
+                    word = static_cast<uint16_t>((odd_internet_byte << 8U) | byte);
+                    have_odd_internet_byte = false;
+                } else if (i + 1 < length) {
+                    word = static_cast<uint16_t>((byte << 8U) | static_cast<uint8_t>(bytes[++i]));
+                } else {
+                    odd_internet_byte = byte;
+                    have_odd_internet_byte = true;
+                    continue;
                 }
-                if (algorithm == "xxhash64") {
-                    xx64.update(bytes, length);
-                    return true;
-                }
-                for (int64_t i = 0; i < length; ++i) {
-                    const uint8_t byte = static_cast<uint8_t>(bytes[i]);
-                    if (algorithm == "adler32") {
-                        adler_a = (adler_a + byte) % 65521U;
-                        adler_b = (adler_b + adler_a) % 65521U;
-                    } else if (algorithm == "fletcher16") {
-                        fletcher_a = (fletcher_a + byte) % 255U;
-                        fletcher_b = (fletcher_b + fletcher_a) % 255U;
-                    } else if (algorithm == "fletcher32") {
-                        uint16_t word = 0;
-                        if (have_odd_fletcher32_byte) {
-                            word = static_cast<uint16_t>((odd_fletcher32_byte << 8U) | byte);
-                            have_odd_fletcher32_byte = false;
-                        } else if (i + 1 < length) {
-                            word = static_cast<uint16_t>((byte << 8U) | static_cast<uint8_t>(bytes[++i]));
-                        } else {
-                            odd_fletcher32_byte = byte;
-                            have_odd_fletcher32_byte = true;
-                            continue;
-                        }
-                        fletcher32_a = (fletcher32_a + word) % 65535U;
-                        fletcher32_b = (fletcher32_b + fletcher32_a) % 65535U;
-                    } else if (algorithm == "internet-checksum") {
-                        uint16_t word = 0;
-                        if (have_odd_internet_byte) {
-                            word = static_cast<uint16_t>((odd_internet_byte << 8U) | byte);
-                            have_odd_internet_byte = false;
-                        } else if (i + 1 < length) {
-                            word = static_cast<uint16_t>((byte << 8U) | static_cast<uint8_t>(bytes[++i]));
-                        } else {
-                            odd_internet_byte = byte;
-                            have_odd_internet_byte = true;
-                            continue;
-                        }
-                        internet_sum += word;
-                        internet_sum = (internet_sum & 0xFFFFU) + (internet_sum >> 16U);
-                    } else if (algorithm == "lrc") {
-                        lrc_sum = static_cast<uint8_t>(lrc_sum + byte);
-                    } else if (algorithm == "bcc") {
-                        bcc ^= byte;
-                    } else if (algorithm == "sum8" || algorithm == "sum16" || algorithm == "sum32") {
-                        sum += byte;
-                    } else if (algorithm == "fnv1a32") {
-                        fnv32 ^= byte;
-                        fnv32 *= 16777619U;
-                    } else if (algorithm == "fnv1a64") {
-                        fnv64 ^= byte;
-                        fnv64 *= 1099511628211ULL;
-                    } else {
-                        return false;
-                    }
-                }
-                return true;
-            });
+                internet_sum += word;
+                internet_sum = (internet_sum & 0xFFFFU) + (internet_sum >> 16U);
+            } else if (algorithm == "lrc") {
+                lrc_sum = static_cast<uint8_t>(lrc_sum + byte);
+            } else if (algorithm == "bcc") {
+                bcc ^= byte;
+            } else if (algorithm == "sum8" || algorithm == "sum16" || algorithm == "sum32") {
+                sum += byte;
+            } else if (algorithm == "fnv1a32") {
+                fnv32 ^= byte;
+                fnv32 *= 16777619U;
+            } else if (algorithm == "fnv1a64") {
+                fnv64 ^= byte;
+                fnv64 *= 1099511628211ULL;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    });
     if (!ok) { return -1; }
 
     if (algorithm == "adler32") {
@@ -618,8 +611,9 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
                                                    omega_edit::plugin::hex_value((~internet_sum) & 0xFFFFU, 4));
     }
     if (algorithm == "lrc") {
-        return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,
-                                                   omega_edit::plugin::hex_value(static_cast<uint8_t>(0U - lrc_sum), 2));
+        return omega_edit::plugin::set_text_result(
+                request_ptr, response_ptr, algorithm,
+                omega_edit::plugin::hex_value(static_cast<uint8_t>(0U - lrc_sum), 2));
     }
     if (algorithm == "bcc") {
         return omega_edit::plugin::set_text_result(request_ptr, response_ptr, algorithm,

--- a/plugins/src/decimal_codecs.cpp
+++ b/plugins/src/decimal_codecs.cpp
@@ -20,157 +20,152 @@
 
 namespace {
 
-constexpr const char *DECIMAL_CODEC_ARGS_SCHEMA =
-        "{\"type\":\"object\",\"properties\":{\"codec\":{\"type\":\"string\",\"title\":\"Codec\","
-        "\"description\":\"Decimal representation to encode or decode.\",\"default\":\"bcd\",\"enum\":[\"bcd\","
-        "\"packed-decimal\",\"comp-3\",\"zoned-decimal\",\"overpunch\"]},\"direction\":{\"type\":\"string\","
-        "\"title\":\"Direction\",\"default\":\"encode\",\"enum\":[\"encode\",\"decode\"]}},"
-        "\"additionalProperties\":false}";
+    constexpr const char *DECIMAL_CODEC_ARGS_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"codec\":{\"type\":\"string\",\"title\":\"Codec\","
+            "\"description\":\"Decimal representation to encode or decode.\",\"default\":\"bcd\",\"enum\":[\"bcd\","
+            "\"packed-decimal\",\"comp-3\",\"zoned-decimal\",\"overpunch\"]},\"direction\":{\"type\":\"string\","
+            "\"title\":\"Direction\",\"default\":\"encode\",\"enum\":[\"encode\",\"decode\"]}},"
+            "\"additionalProperties\":false}";
 
-bool is_ascii_space(omega_byte_t byte) {
-    return std::isspace(static_cast<unsigned char>(byte)) != 0;
-}
+    bool is_ascii_space(omega_byte_t byte) { return std::isspace(static_cast<unsigned char>(byte)) != 0; }
 
-bool is_ascii_digit(omega_byte_t byte) {
-    return std::isdigit(static_cast<unsigned char>(byte)) != 0;
-}
+    bool is_ascii_digit(omega_byte_t byte) { return std::isdigit(static_cast<unsigned char>(byte)) != 0; }
 
-bool digits_from_ascii(const std::vector<omega_byte_t> &input, std::string &digits, bool &negative) {
-    digits.clear();
-    negative = false;
-    for (const auto byte: input) {
-        if (byte == '+' || is_ascii_space(byte)) { continue; }
-        if (byte == '-') {
-            negative = true;
-            continue;
-        }
-        if (!is_ascii_digit(byte)) { return false; }
-        digits.push_back(static_cast<char>(byte));
-    }
-    return !digits.empty();
-}
-
-std::vector<omega_byte_t> ascii_bytes(const std::string &text) {
-    return std::vector<omega_byte_t>(text.begin(), text.end());
-}
-
-bool decode_nibble(unsigned int nibble, char &digit) {
-    if (nibble > 9U) { return false; }
-    digit = static_cast<char>('0' + nibble);
-    return true;
-}
-
-bool encode_bcd(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    std::string digits;
-    bool negative = false;
-    if (!digits_from_ascii(input, digits, negative) || negative) { return false; }
-    if ((digits.size() % 2) != 0) { digits.insert(digits.begin(), '0'); }
-    out.clear();
-    for (size_t i = 0; i < digits.size(); i += 2) {
-        out.push_back(static_cast<omega_byte_t>(((digits[i] - '0') << 4U) | (digits[i + 1] - '0')));
-    }
-    return true;
-}
-
-bool decode_bcd(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    std::string digits;
-    for (const auto byte: input) {
-        char high = 0;
-        char low = 0;
-        if (!decode_nibble((byte >> 4U) & 0x0FU, high) || !decode_nibble(byte & 0x0FU, low)) { return false; }
-        digits.push_back(high);
-        digits.push_back(low);
-    }
-    out = ascii_bytes(digits);
-    return true;
-}
-
-bool encode_packed(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    std::string digits;
-    bool negative = false;
-    if (!digits_from_ascii(input, digits, negative)) { return false; }
-    digits.push_back(negative ? 'D' : 'C');
-    if ((digits.size() % 2) != 0) { digits.insert(digits.begin(), '0'); }
-    out.clear();
-    for (size_t i = 0; i < digits.size(); i += 2) {
-        const unsigned int high = digits[i] >= 'A' ? 0x0DU : static_cast<unsigned int>(digits[i] - '0');
-        const unsigned int low = digits[i + 1] >= 'A' ? (digits[i + 1] == 'D' ? 0x0DU : 0x0CU)
-                                                      : static_cast<unsigned int>(digits[i + 1] - '0');
-        out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
-    }
-    return true;
-}
-
-bool decode_packed(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    if (input.empty()) { return false; }
-    std::string digits;
-    bool negative = false;
-    for (size_t i = 0; i < input.size(); ++i) {
-        const unsigned int high = (input[i] >> 4U) & 0x0FU;
-        const unsigned int low = input[i] & 0x0FU;
-        char digit = 0;
-        if (!decode_nibble(high, digit)) { return false; }
-        digits.push_back(digit);
-        if (i + 1 == input.size()) {
-            if (low == 0x0DU || low == 0x0BU) {
+    bool digits_from_ascii(const std::vector<omega_byte_t> &input, std::string &digits, bool &negative) {
+        digits.clear();
+        negative = false;
+        for (const auto byte : input) {
+            if (byte == '+' || is_ascii_space(byte)) { continue; }
+            if (byte == '-') {
                 negative = true;
-            } else if (low != 0x0CU && low != 0x0FU) {
-                return false;
+                continue;
             }
-        } else {
-            if (!decode_nibble(low, digit)) { return false; }
+            if (!is_ascii_digit(byte)) { return false; }
+            digits.push_back(static_cast<char>(byte));
+        }
+        return !digits.empty();
+    }
+
+    std::vector<omega_byte_t> ascii_bytes(const std::string &text) {
+        return std::vector<omega_byte_t>(text.begin(), text.end());
+    }
+
+    bool decode_nibble(unsigned int nibble, char &digit) {
+        if (nibble > 9U) { return false; }
+        digit = static_cast<char>('0' + nibble);
+        return true;
+    }
+
+    bool encode_bcd(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        std::string digits;
+        bool negative = false;
+        if (!digits_from_ascii(input, digits, negative) || negative) { return false; }
+        if ((digits.size() % 2) != 0) { digits.insert(digits.begin(), '0'); }
+        out.clear();
+        for (size_t i = 0; i < digits.size(); i += 2) {
+            out.push_back(static_cast<omega_byte_t>(((digits[i] - '0') << 4U) | (digits[i + 1] - '0')));
+        }
+        return true;
+    }
+
+    bool decode_bcd(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        std::string digits;
+        for (const auto byte : input) {
+            char high = 0;
+            char low = 0;
+            if (!decode_nibble((byte >> 4U) & 0x0FU, high) || !decode_nibble(byte & 0x0FU, low)) { return false; }
+            digits.push_back(high);
+            digits.push_back(low);
+        }
+        out = ascii_bytes(digits);
+        return true;
+    }
+
+    bool encode_packed(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        std::string digits;
+        bool negative = false;
+        if (!digits_from_ascii(input, digits, negative)) { return false; }
+        digits.push_back(negative ? 'D' : 'C');
+        if ((digits.size() % 2) != 0) { digits.insert(digits.begin(), '0'); }
+        out.clear();
+        for (size_t i = 0; i < digits.size(); i += 2) {
+            const unsigned int high = digits[i] >= 'A' ? 0x0DU : static_cast<unsigned int>(digits[i] - '0');
+            const unsigned int low = digits[i + 1] >= 'A' ? (digits[i + 1] == 'D' ? 0x0DU : 0x0CU)
+                                                          : static_cast<unsigned int>(digits[i + 1] - '0');
+            out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+        }
+        return true;
+    }
+
+    bool decode_packed(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        if (input.empty()) { return false; }
+        std::string digits;
+        bool negative = false;
+        for (size_t i = 0; i < input.size(); ++i) {
+            const unsigned int high = (input[i] >> 4U) & 0x0FU;
+            const unsigned int low = input[i] & 0x0FU;
+            char digit = 0;
+            if (!decode_nibble(high, digit)) { return false; }
             digits.push_back(digit);
+            if (i + 1 == input.size()) {
+                if (low == 0x0DU || low == 0x0BU) {
+                    negative = true;
+                } else if (low != 0x0CU && low != 0x0FU) {
+                    return false;
+                }
+            } else {
+                if (!decode_nibble(low, digit)) { return false; }
+                digits.push_back(digit);
+            }
         }
+        if (negative) { digits.insert(digits.begin(), '-'); }
+        out = ascii_bytes(digits);
+        return true;
     }
-    if (negative) { digits.insert(digits.begin(), '-'); }
-    out = ascii_bytes(digits);
-    return true;
-}
 
-bool encode_zoned(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out, bool overpunch) {
-    std::string digits;
-    bool negative = false;
-    if (!digits_from_ascii(input, digits, negative)) { return false; }
-    out.clear();
-    for (size_t i = 0; i < digits.size(); ++i) {
-        const unsigned int digit = static_cast<unsigned int>(digits[i] - '0');
-        if (overpunch && i + 1 == digits.size()) {
-            out.push_back(static_cast<omega_byte_t>((negative ? 0xD0U : 0xC0U) | digit));
-        } else {
-            out.push_back(static_cast<omega_byte_t>(0xF0U | digit));
+    bool encode_zoned(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out, bool overpunch) {
+        std::string digits;
+        bool negative = false;
+        if (!digits_from_ascii(input, digits, negative)) { return false; }
+        out.clear();
+        for (size_t i = 0; i < digits.size(); ++i) {
+            const unsigned int digit = static_cast<unsigned int>(digits[i] - '0');
+            if (overpunch && i + 1 == digits.size()) {
+                out.push_back(static_cast<omega_byte_t>((negative ? 0xD0U : 0xC0U) | digit));
+            } else {
+                out.push_back(static_cast<omega_byte_t>(0xF0U | digit));
+            }
         }
+        return true;
     }
-    return true;
-}
 
-bool decode_zoned(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out, bool overpunch) {
-    if (input.empty()) { return false; }
-    std::string digits;
-    bool negative = false;
-    for (size_t i = 0; i < input.size(); ++i) {
-        const unsigned int zone = (input[i] >> 4U) & 0x0FU;
-        const unsigned int digit = input[i] & 0x0FU;
-        if (digit > 9U) { return false; }
-        if (overpunch && i + 1 == input.size()) {
-            if (zone == 0x0DU) {
-                negative = true;
-            } else if (zone != 0x0CU && zone != 0x0FU) {
+    bool decode_zoned(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out, bool overpunch) {
+        if (input.empty()) { return false; }
+        std::string digits;
+        bool negative = false;
+        for (size_t i = 0; i < input.size(); ++i) {
+            const unsigned int zone = (input[i] >> 4U) & 0x0FU;
+            const unsigned int digit = input[i] & 0x0FU;
+            if (digit > 9U) { return false; }
+            if (overpunch && i + 1 == input.size()) {
+                if (zone == 0x0DU) {
+                    negative = true;
+                } else if (zone != 0x0CU && zone != 0x0FU) {
+                    return false;
+                }
+            } else if (zone != 0x0FU) {
                 return false;
             }
-        } else if (zone != 0x0FU) {
-            return false;
+            digits.push_back(static_cast<char>('0' + digit));
         }
-        digits.push_back(static_cast<char>('0' + digit));
+        if (negative) { digits.insert(digits.begin(), '-'); }
+        out = ascii_bytes(digits);
+        return true;
     }
-    if (negative) { digits.insert(digits.begin(), '-'); }
-    out = ascii_bytes(digits);
-    return true;
-}
 
-} // namespace
+}// namespace
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
-        omega_transform_plugin_info_t *info_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
     info_ptr->id = "omega.example.decimal_codecs";
     info_ptr->name = "Decimal Codecs";
@@ -188,12 +183,11 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
     return 0;
 }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                             omega_transform_plugin_response_t *response_ptr) {
     std::vector<omega_byte_t> input;
-    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
-        return -1;
-    }
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) { return -1; }
     std::map<std::string, std::string> options;
     if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
     std::string codec = omega_edit::plugin::option_or(options, "codec", "bcd");

--- a/plugins/src/endian_swap.cpp
+++ b/plugins/src/endian_swap.cpp
@@ -18,14 +18,13 @@
 #include <vector>
 
 namespace {
-constexpr const char *ENDIAN_SWAP_ARGS_SCHEMA =
-        "{\"type\":\"object\",\"properties\":{\"width\":{\"type\":\"integer\",\"title\":\"Field width\","
-        "\"description\":\"Bytes per integer field.\",\"default\":2,\"enum\":[2,4,8]}},"
-        "\"additionalProperties\":false}";
+    constexpr const char *ENDIAN_SWAP_ARGS_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"width\":{\"type\":\"integer\",\"title\":\"Field width\","
+            "\"description\":\"Bytes per integer field.\",\"default\":2,\"enum\":[2,4,8]}},"
+            "\"additionalProperties\":false}";
 }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
-        omega_transform_plugin_info_t *info_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
     info_ptr->id = "omega.example.endian_swap";
     info_ptr->name = "Endian Swap";
@@ -42,19 +41,17 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
     return 0;
 }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                             omega_transform_plugin_response_t *response_ptr) {
     std::vector<omega_byte_t> bytes;
-    if (!omega_edit::plugin::selected_bytes(request_ptr, bytes) || !response_ptr || !request_ptr->alloc) {
-        return -1;
-    }
+    if (!omega_edit::plugin::selected_bytes(request_ptr, bytes) || !response_ptr || !request_ptr->alloc) { return -1; }
     std::map<std::string, std::string> options;
     if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
     const int64_t width = omega_edit::plugin::option_int_or(options, "width", 2);
     if (!(width == 2 || width == 4 || width == 8)) { return -1; }
     using difference_type = std::vector<omega_byte_t>::difference_type;
-    for (size_t offset = 0; offset + static_cast<size_t>(width) <= bytes.size();
-         offset += static_cast<size_t>(width)) {
+    for (size_t offset = 0; offset + static_cast<size_t>(width) <= bytes.size(); offset += static_cast<size_t>(width)) {
         std::reverse(bytes.begin() + static_cast<difference_type>(offset),
                      bytes.begin() + static_cast<difference_type>(offset + static_cast<size_t>(width)));
     }

--- a/plugins/src/format_inspectors.cpp
+++ b/plugins/src/format_inspectors.cpp
@@ -22,164 +22,164 @@
 
 namespace {
 
-constexpr const char *FORMAT_INSPECTOR_ARGS_SCHEMA =
-        "{\"type\":\"object\",\"properties\":{\"format\":{\"type\":\"string\",\"title\":\"Format\","
-        "\"description\":\"Structure to inspect.\",\"default\":\"protobuf-varint\",\"enum\":[\"protobuf-varint\","
-        "\"asn1-ber\",\"asn1-der\",\"tlv\"]},\"tagBytes\":{\"type\":\"integer\",\"title\":\"Tag bytes\","
-        "\"default\":1,\"enum\":[1,2,3,4]},\"lengthBytes\":{\"type\":\"integer\",\"title\":\"Length bytes\","
-        "\"default\":1,\"enum\":[1,2,3,4]},\"endian\":{\"type\":\"string\",\"title\":\"Byte order\","
-        "\"default\":\"big\",\"enum\":[\"big\",\"little\"]}},\"additionalProperties\":false}";
+    constexpr const char *FORMAT_INSPECTOR_ARGS_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"format\":{\"type\":\"string\",\"title\":\"Format\","
+            "\"description\":\"Structure to inspect.\",\"default\":\"protobuf-varint\",\"enum\":[\"protobuf-varint\","
+            "\"asn1-ber\",\"asn1-der\",\"tlv\"]},\"tagBytes\":{\"type\":\"integer\",\"title\":\"Tag bytes\","
+            "\"default\":1,\"enum\":[1,2,3,4]},\"lengthBytes\":{\"type\":\"integer\",\"title\":\"Length bytes\","
+            "\"default\":1,\"enum\":[1,2,3,4]},\"endian\":{\"type\":\"string\",\"title\":\"Byte order\","
+            "\"default\":\"big\",\"enum\":[\"big\",\"little\"]}},\"additionalProperties\":false}";
 
-std::string inspect_protobuf_varints(const std::vector<omega_byte_t> &input) {
-    std::ostringstream out;
-    size_t offset = 0;
-    int index = 0;
-    while (offset < input.size()) {
-        const size_t start = offset;
-        uint64_t value = 0;
-        int shift = 0;
-        bool terminated = false;
-        while (offset < input.size() && shift < 64) {
-            const omega_byte_t byte = input[offset++];
-            value |= static_cast<uint64_t>(byte & 0x7FU) << shift;
-            if ((byte & 0x80U) == 0) {
-                terminated = true;
+    std::string inspect_protobuf_varints(const std::vector<omega_byte_t> &input) {
+        std::ostringstream out;
+        size_t offset = 0;
+        int index = 0;
+        while (offset < input.size()) {
+            const size_t start = offset;
+            uint64_t value = 0;
+            int shift = 0;
+            bool terminated = false;
+            while (offset < input.size() && shift < 64) {
+                const omega_byte_t byte = input[offset++];
+                value |= static_cast<uint64_t>(byte & 0x7FU) << shift;
+                if ((byte & 0x80U) == 0) {
+                    terminated = true;
+                    break;
+                }
+                shift += 7;
+            }
+            out << "varint[" << index++ << "] offset=" << start << " bytes=" << (offset - start);
+            if (terminated) {
+                out << " value=" << value << "\n";
+            } else {
+                out << " error=unterminated\n";
                 break;
             }
-            shift += 7;
         }
-        out << "varint[" << index++ << "] offset=" << start << " bytes=" << (offset - start);
-        if (terminated) {
-            out << " value=" << value << "\n";
-        } else {
-            out << " error=unterminated\n";
-            break;
+        if (input.empty()) { out << "No bytes selected.\n"; }
+        return out.str();
+    }
+
+    std::string asn1_class_name(unsigned int tag_class) {
+        switch (tag_class) {
+            case 0:
+                return "universal";
+            case 1:
+                return "application";
+            case 2:
+                return "context";
+            case 3:
+                return "private";
         }
+        return "unknown";
     }
-    if (input.empty()) { out << "No bytes selected.\n"; }
-    return out.str();
-}
 
-std::string asn1_class_name(unsigned int tag_class) {
-    switch (tag_class) {
-        case 0:
-            return "universal";
-        case 1:
-            return "application";
-        case 2:
-            return "context";
-        case 3:
-            return "private";
-    }
-    return "unknown";
-}
-
-std::string inspect_asn1(const std::vector<omega_byte_t> &input) {
-    std::ostringstream out;
-    size_t offset = 0;
-    int index = 0;
-    while (offset < input.size()) {
-        const size_t start = offset;
-        const omega_byte_t first = input[offset++];
-        const unsigned int tag_class = (first >> 6U) & 0x03U;
-        const bool constructed = (first & 0x20U) != 0;
-        uint64_t tag = first & 0x1FU;
-        if (tag == 0x1FU) {
-            tag = 0;
-            bool done = false;
-            while (offset < input.size()) {
-                const omega_byte_t byte = input[offset++];
-                tag = (tag << 7U) | (byte & 0x7FU);
-                if ((byte & 0x80U) == 0) {
-                    done = true;
+    std::string inspect_asn1(const std::vector<omega_byte_t> &input) {
+        std::ostringstream out;
+        size_t offset = 0;
+        int index = 0;
+        while (offset < input.size()) {
+            const size_t start = offset;
+            const omega_byte_t first = input[offset++];
+            const unsigned int tag_class = (first >> 6U) & 0x03U;
+            const bool constructed = (first & 0x20U) != 0;
+            uint64_t tag = first & 0x1FU;
+            if (tag == 0x1FU) {
+                tag = 0;
+                bool done = false;
+                while (offset < input.size()) {
+                    const omega_byte_t byte = input[offset++];
+                    tag = (tag << 7U) | (byte & 0x7FU);
+                    if ((byte & 0x80U) == 0) {
+                        done = true;
+                        break;
+                    }
+                }
+                if (!done) {
+                    out << "tlv[" << index << "] offset=" << start << " error=unterminated-high-tag\n";
                     break;
                 }
             }
-            if (!done) {
-                out << "tlv[" << index << "] offset=" << start << " error=unterminated-high-tag\n";
+            if (offset >= input.size()) {
+                out << "tlv[" << index << "] offset=" << start << " tag=" << tag << " error=missing-length\n";
                 break;
             }
-        }
-        if (offset >= input.size()) {
-            out << "tlv[" << index << "] offset=" << start << " tag=" << tag << " error=missing-length\n";
-            break;
-        }
-        const omega_byte_t length_byte = input[offset++];
-        bool indefinite = false;
-        uint64_t length = 0;
-        if ((length_byte & 0x80U) == 0) {
-            length = length_byte;
-        } else {
-            const unsigned int length_bytes = length_byte & 0x7FU;
-            if (length_bytes == 0) {
-                indefinite = true;
-            } else if (length_bytes > 8 || offset + length_bytes > input.size()) {
-                out << "tlv[" << index << "] offset=" << start << " tag=" << tag << " error=invalid-length\n";
-                break;
+            const omega_byte_t length_byte = input[offset++];
+            bool indefinite = false;
+            uint64_t length = 0;
+            if ((length_byte & 0x80U) == 0) {
+                length = length_byte;
             } else {
-                for (unsigned int i = 0; i < length_bytes; ++i) { length = (length << 8U) | input[offset++]; }
+                const unsigned int length_bytes = length_byte & 0x7FU;
+                if (length_bytes == 0) {
+                    indefinite = true;
+                } else if (length_bytes > 8 || offset + length_bytes > input.size()) {
+                    out << "tlv[" << index << "] offset=" << start << " tag=" << tag << " error=invalid-length\n";
+                    break;
+                } else {
+                    for (unsigned int i = 0; i < length_bytes; ++i) { length = (length << 8U) | input[offset++]; }
+                }
             }
-        }
 
-        out << "tlv[" << index++ << "] offset=" << start << " headerBytes=" << (offset - start)
-            << " class=" << asn1_class_name(tag_class) << " constructed=" << (constructed ? "true" : "false")
-            << " tag=" << tag;
-        if (indefinite) {
-            out << " length=indefinite\n";
-            break;
+            out << "tlv[" << index++ << "] offset=" << start << " headerBytes=" << (offset - start)
+                << " class=" << asn1_class_name(tag_class) << " constructed=" << (constructed ? "true" : "false")
+                << " tag=" << tag;
+            if (indefinite) {
+                out << " length=indefinite\n";
+                break;
+            }
+            out << " length=" << length;
+            if (offset + length > input.size()) {
+                out << " error=value-truncated\n";
+                break;
+            }
+            out << "\n";
+            offset += static_cast<size_t>(length);
         }
-        out << " length=" << length;
-        if (offset + length > input.size()) {
-            out << " error=value-truncated\n";
-            break;
-        }
-        out << "\n";
-        offset += static_cast<size_t>(length);
+        if (input.empty()) { out << "No bytes selected.\n"; }
+        return out.str();
     }
-    if (input.empty()) { out << "No bytes selected.\n"; }
-    return out.str();
-}
 
-uint64_t read_uint(const std::vector<omega_byte_t> &input, size_t offset, int64_t width, bool little_endian) {
-    uint64_t value = 0;
-    if (little_endian) {
-        for (int64_t i = width - 1; i >= 0; --i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
-    } else {
-        for (int64_t i = 0; i < width; ++i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
-    }
-    return value;
-}
-
-std::string inspect_tlv(const std::vector<omega_byte_t> &input, int64_t tag_bytes, int64_t length_bytes,
-                        bool little_endian) {
-    std::ostringstream out;
-    size_t offset = 0;
-    int index = 0;
-    const auto header = static_cast<size_t>(tag_bytes + length_bytes);
-    while (offset < input.size()) {
-        if (offset + header > input.size()) {
-            out << "tlv[" << index << "] offset=" << offset << " error=truncated-header\n";
-            break;
+    uint64_t read_uint(const std::vector<omega_byte_t> &input, size_t offset, int64_t width, bool little_endian) {
+        uint64_t value = 0;
+        if (little_endian) {
+            for (int64_t i = width - 1; i >= 0; --i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
+        } else {
+            for (int64_t i = 0; i < width; ++i) { value = (value << 8U) | input[offset + static_cast<size_t>(i)]; }
         }
-        const uint64_t tag = read_uint(input, offset, tag_bytes, little_endian);
-        const uint64_t length = read_uint(input, offset + static_cast<size_t>(tag_bytes), length_bytes, little_endian);
-        const size_t value_offset = offset + header;
-        out << "tlv[" << index++ << "] offset=" << offset << " tag=" << tag << " length=" << length;
-        if (value_offset + length > input.size()) {
-            out << " error=value-truncated\n";
-            break;
-        }
-        out << "\n";
-        offset = value_offset + static_cast<size_t>(length);
+        return value;
     }
-    if (input.empty()) { out << "No bytes selected.\n"; }
-    return out.str();
-}
 
-} // namespace
+    std::string inspect_tlv(const std::vector<omega_byte_t> &input, int64_t tag_bytes, int64_t length_bytes,
+                            bool little_endian) {
+        std::ostringstream out;
+        size_t offset = 0;
+        int index = 0;
+        const auto header = static_cast<size_t>(tag_bytes + length_bytes);
+        while (offset < input.size()) {
+            if (offset + header > input.size()) {
+                out << "tlv[" << index << "] offset=" << offset << " error=truncated-header\n";
+                break;
+            }
+            const uint64_t tag = read_uint(input, offset, tag_bytes, little_endian);
+            const uint64_t length =
+                    read_uint(input, offset + static_cast<size_t>(tag_bytes), length_bytes, little_endian);
+            const size_t value_offset = offset + header;
+            out << "tlv[" << index++ << "] offset=" << offset << " tag=" << tag << " length=" << length;
+            if (value_offset + length > input.size()) {
+                out << " error=value-truncated\n";
+                break;
+            }
+            out << "\n";
+            offset = value_offset + static_cast<size_t>(length);
+        }
+        if (input.empty()) { out << "No bytes selected.\n"; }
+        return out.str();
+    }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
-        omega_transform_plugin_info_t *info_ptr) {
+}// namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
     info_ptr->id = "omega.example.format_inspectors";
     info_ptr->name = "Format Inspectors";
@@ -196,12 +196,11 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
     return 0;
 }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                             omega_transform_plugin_response_t *response_ptr) {
     std::vector<omega_byte_t> input;
-    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
-        return -1;
-    }
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) { return -1; }
     std::map<std::string, std::string> options;
     if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
     const std::string format = omega_edit::plugin::option_or(options, "format", "protobuf-varint");
@@ -214,8 +213,8 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
         const int64_t tag_bytes = omega_edit::plugin::option_int_or(options, "tagBytes", 1);
         const int64_t length_bytes = omega_edit::plugin::option_int_or(options, "lengthBytes", 1);
         if (tag_bytes < 1 || tag_bytes > 4 || length_bytes < 1 || length_bytes > 4) { return -1; }
-        result = inspect_tlv(input, tag_bytes, length_bytes, omega_edit::plugin::option_or(options, "endian", "big") ==
-                                                                     "little");
+        result = inspect_tlv(input, tag_bytes, length_bytes,
+                             omega_edit::plugin::option_or(options, "endian", "big") == "little");
     } else {
         return -1;
     }

--- a/plugins/src/openssl_digests.c
+++ b/plugins/src/openssl_digests.c
@@ -12,8 +12,8 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#include <omega_edit/transform_plugin_sdk.h>
 #include <ctype.h>
+#include <omega_edit/transform_plugin_sdk.h>
 #include <openssl/evp.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -177,7 +177,7 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
 }
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
-                                                              omega_transform_plugin_response_t *response_ptr) {
+                                                               omega_transform_plugin_response_t *response_ptr) {
     if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0 ||
         request_ptr->session_length < 0) {
         return -1;

--- a/plugins/src/plugin_options.hpp
+++ b/plugins/src/plugin_options.hpp
@@ -28,202 +28,208 @@
 #include <vector>
 
 namespace omega_edit {
-namespace plugin {
+    namespace plugin {
 
-inline void skip_ws(const char *&cursor) {
-    while (*cursor && std::isspace(static_cast<unsigned char>(*cursor))) { ++cursor; }
-}
-
-inline bool parse_json_string(const char *&cursor, std::string &out) {
-    if (*cursor != '"') { return false; }
-    ++cursor;
-    out.clear();
-    while (*cursor && *cursor != '"') {
-        char ch = *cursor++;
-        if (ch == '\\') {
-            ch = *cursor++;
-            switch (ch) {
-                case '"':
-                case '\\':
-                case '/':
-                    out.push_back(ch);
-                    break;
-                case 'b':
-                    out.push_back('\b');
-                    break;
-                case 'f':
-                    out.push_back('\f');
-                    break;
-                case 'n':
-                    out.push_back('\n');
-                    break;
-                case 'r':
-                    out.push_back('\r');
-                    break;
-                case 't':
-                    out.push_back('\t');
-                    break;
-                default:
-                    return false;
-            }
-            continue;
+        inline void skip_ws(const char *&cursor) {
+            while (*cursor && std::isspace(static_cast<unsigned char>(*cursor))) { ++cursor; }
         }
-        out.push_back(ch);
-    }
-    if (*cursor != '"') { return false; }
-    ++cursor;
-    return true;
-}
 
-inline bool skip_json_value(const char *&cursor) {
-    skip_ws(cursor);
-    if (*cursor == '"') {
-        std::string ignored;
-        return parse_json_string(cursor, ignored);
-    }
-    if (*cursor == '{' || *cursor == '[') {
-        const char open = *cursor++;
-        const char close = open == '{' ? '}' : ']';
-        int depth = 1;
-        while (*cursor && depth > 0) {
+        inline bool parse_json_string(const char *&cursor, std::string &out) {
+            if (*cursor != '"') { return false; }
+            ++cursor;
+            out.clear();
+            while (*cursor && *cursor != '"') {
+                char ch = *cursor++;
+                if (ch == '\\') {
+                    ch = *cursor++;
+                    switch (ch) {
+                        case '"':
+                        case '\\':
+                        case '/':
+                            out.push_back(ch);
+                            break;
+                        case 'b':
+                            out.push_back('\b');
+                            break;
+                        case 'f':
+                            out.push_back('\f');
+                            break;
+                        case 'n':
+                            out.push_back('\n');
+                            break;
+                        case 'r':
+                            out.push_back('\r');
+                            break;
+                        case 't':
+                            out.push_back('\t');
+                            break;
+                        default:
+                            return false;
+                    }
+                    continue;
+                }
+                out.push_back(ch);
+            }
+            if (*cursor != '"') { return false; }
+            ++cursor;
+            return true;
+        }
+
+        inline bool skip_json_value(const char *&cursor) {
+            skip_ws(cursor);
             if (*cursor == '"') {
                 std::string ignored;
-                if (!parse_json_string(cursor, ignored)) { return false; }
-                continue;
+                return parse_json_string(cursor, ignored);
             }
-            if (*cursor == open) { ++depth; }
-            if (*cursor == close) { --depth; }
-            ++cursor;
+            if (*cursor == '{' || *cursor == '[') {
+                const char open = *cursor++;
+                const char close = open == '{' ? '}' : ']';
+                int depth = 1;
+                while (*cursor && depth > 0) {
+                    if (*cursor == '"') {
+                        std::string ignored;
+                        if (!parse_json_string(cursor, ignored)) { return false; }
+                        continue;
+                    }
+                    if (*cursor == open) { ++depth; }
+                    if (*cursor == close) { --depth; }
+                    ++cursor;
+                }
+                return depth == 0;
+            }
+            while (*cursor && *cursor != ',' && *cursor != '}' && *cursor != ']') { ++cursor; }
+            return true;
         }
-        return depth == 0;
-    }
-    while (*cursor && *cursor != ',' && *cursor != '}' && *cursor != ']') { ++cursor; }
-    return true;
-}
 
-inline bool parse_string_options(const char *json, std::map<std::string, std::string> &out) {
-    out.clear();
-    if (!json || !*json) { return true; }
-    const char *cursor = json;
-    skip_ws(cursor);
-    if (*cursor != '{') { return false; }
-    ++cursor;
-    skip_ws(cursor);
-    if (*cursor == '}') {
-        ++cursor;
-        skip_ws(cursor);
-        return *cursor == '\0';
-    }
-    while (*cursor) {
-        std::string key;
-        if (!parse_json_string(cursor, key)) { return false; }
-        skip_ws(cursor);
-        if (*cursor != ':') { return false; }
-        ++cursor;
-        skip_ws(cursor);
-        if (*cursor == '"') {
-            std::string value;
-            if (!parse_json_string(cursor, value)) { return false; }
-            out[key] = value;
-        } else {
-            const char *start = cursor;
-            if (!skip_json_value(cursor)) { return false; }
-            const char *end = cursor;
-            while (end > start && std::isspace(static_cast<unsigned char>(*(end - 1)))) { --end; }
-            out[key] = std::string(start, end);
-        }
-        skip_ws(cursor);
-        if (*cursor == '}') {
+        inline bool parse_string_options(const char *json, std::map<std::string, std::string> &out) {
+            out.clear();
+            if (!json || !*json) { return true; }
+            const char *cursor = json;
+            skip_ws(cursor);
+            if (*cursor != '{') { return false; }
             ++cursor;
             skip_ws(cursor);
-            return *cursor == '\0';
+            if (*cursor == '}') {
+                ++cursor;
+                skip_ws(cursor);
+                return *cursor == '\0';
+            }
+            while (*cursor) {
+                std::string key;
+                if (!parse_json_string(cursor, key)) { return false; }
+                skip_ws(cursor);
+                if (*cursor != ':') { return false; }
+                ++cursor;
+                skip_ws(cursor);
+                if (*cursor == '"') {
+                    std::string value;
+                    if (!parse_json_string(cursor, value)) { return false; }
+                    out[key] = value;
+                } else {
+                    const char *start = cursor;
+                    if (!skip_json_value(cursor)) { return false; }
+                    const char *end = cursor;
+                    while (end > start && std::isspace(static_cast<unsigned char>(*(end - 1)))) { --end; }
+                    out[key] = std::string(start, end);
+                }
+                skip_ws(cursor);
+                if (*cursor == '}') {
+                    ++cursor;
+                    skip_ws(cursor);
+                    return *cursor == '\0';
+                }
+                if (*cursor != ',') { return false; }
+                ++cursor;
+                skip_ws(cursor);
+            }
+            return false;
         }
-        if (*cursor != ',') { return false; }
-        ++cursor;
-        skip_ws(cursor);
-    }
-    return false;
-}
 
-inline std::string option_or(const std::map<std::string, std::string> &options, const char *key,
-                             const char *fallback) {
-    const auto iter = options.find(key);
-    return iter == options.end() ? std::string(fallback) : iter->second;
-}
+        inline std::string option_or(const std::map<std::string, std::string> &options, const char *key,
+                                     const char *fallback) {
+            const auto iter = options.find(key);
+            return iter == options.end() ? std::string(fallback) : iter->second;
+        }
 
-inline int64_t option_int_or(const std::map<std::string, std::string> &options, const char *key, int64_t fallback) {
-    const auto iter = options.find(key);
-    if (iter == options.end()) { return fallback; }
-    char *end_ptr = nullptr;
-    const auto parsed = std::strtoll(iter->second.c_str(), &end_ptr, 10);
-    return end_ptr && *end_ptr == '\0' ? parsed : fallback;
-}
+        inline int64_t option_int_or(const std::map<std::string, std::string> &options, const char *key,
+                                     int64_t fallback) {
+            const auto iter = options.find(key);
+            if (iter == options.end()) { return fallback; }
+            char *end_ptr = nullptr;
+            const auto parsed = std::strtoll(iter->second.c_str(), &end_ptr, 10);
+            return end_ptr && *end_ptr == '\0' ? parsed : fallback;
+        }
 
-inline int set_replacement(const omega_transform_plugin_request_t *request_ptr,
-                           omega_transform_plugin_response_t *response_ptr, const std::vector<omega_byte_t> &bytes) {
-    if (!request_ptr || !response_ptr || !request_ptr->alloc) { return -1; }
-    if (bytes.empty()) { return omega_transform_plugin_sdk_set_replacement(request_ptr, response_ptr, nullptr, 0); }
-    auto *copy = static_cast<omega_byte_t *>(omega_transform_plugin_sdk_alloc(request_ptr, bytes.size()));
-    if (!copy) { return -1; }
-    std::memcpy(copy, bytes.data(), bytes.size());
-    response_ptr->replacement_bytes = copy;
-    response_ptr->replacement_length = static_cast<int64_t>(bytes.size());
-    return 0;
-}
+        inline int set_replacement(const omega_transform_plugin_request_t *request_ptr,
+                                   omega_transform_plugin_response_t *response_ptr,
+                                   const std::vector<omega_byte_t> &bytes) {
+            if (!request_ptr || !response_ptr || !request_ptr->alloc) { return -1; }
+            if (bytes.empty()) {
+                return omega_transform_plugin_sdk_set_replacement(request_ptr, response_ptr, nullptr, 0);
+            }
+            auto *copy = static_cast<omega_byte_t *>(omega_transform_plugin_sdk_alloc(request_ptr, bytes.size()));
+            if (!copy) { return -1; }
+            std::memcpy(copy, bytes.data(), bytes.size());
+            response_ptr->replacement_bytes = copy;
+            response_ptr->replacement_length = static_cast<int64_t>(bytes.size());
+            return 0;
+        }
 
-inline int set_text_result(const omega_transform_plugin_request_t *request_ptr,
-                           omega_transform_plugin_response_t *response_ptr, const std::string &label,
-                           const std::string &value) {
-    return omega_transform_plugin_sdk_set_text_result(request_ptr, response_ptr, label.c_str(), value.c_str(),
-                                                      "text/plain");
-}
+        inline int set_text_result(const omega_transform_plugin_request_t *request_ptr,
+                                   omega_transform_plugin_response_t *response_ptr, const std::string &label,
+                                   const std::string &value) {
+            return omega_transform_plugin_sdk_set_text_result(request_ptr, response_ptr, label.c_str(), value.c_str(),
+                                                              "text/plain");
+        }
 
-inline bool selected_bytes(const omega_transform_plugin_request_t *request_ptr, std::vector<omega_byte_t> &out) {
-    out.clear();
-    if (!request_ptr || request_ptr->input_length < 0 ||
-        (request_ptr->input_length > 0 && !request_ptr->input_bytes)) {
-        return false;
-    }
-    out.assign(request_ptr->input_bytes, request_ptr->input_bytes + request_ptr->input_length);
-    return true;
-}
+        inline bool selected_bytes(const omega_transform_plugin_request_t *request_ptr,
+                                   std::vector<omega_byte_t> &out) {
+            out.clear();
+            if (!request_ptr || request_ptr->input_length < 0 ||
+                (request_ptr->input_length > 0 && !request_ptr->input_bytes)) {
+                return false;
+            }
+            out.assign(request_ptr->input_bytes, request_ptr->input_bytes + request_ptr->input_length);
+            return true;
+        }
 
-inline std::string hex_value(uint64_t value, int width) {
-    std::ostringstream stream;
-    stream << "0x";
-    stream.setf(std::ios::uppercase);
-    stream.fill('0');
-    stream.width(width);
-    stream << std::hex << value;
-    return stream.str();
-}
+        inline std::string hex_value(uint64_t value, int width) {
+            std::ostringstream stream;
+            stream << "0x";
+            stream.setf(std::ios::uppercase);
+            stream.fill('0');
+            stream.width(width);
+            stream << std::hex << value;
+            return stream.str();
+        }
 
-inline bool for_each_chunk(const omega_transform_plugin_request_t *request_ptr,
-                           const std::function<bool(const omega_byte_t *, int64_t)> &callback) {
-    if (!request_ptr || request_ptr->session_length < 0 || request_ptr->input_length < 0) { return false; }
-    if (!request_ptr->read) {
-        if (request_ptr->input_length > 0 && !request_ptr->input_bytes) { return false; }
-        return callback(request_ptr->input_bytes, request_ptr->input_length);
-    }
+        inline bool for_each_chunk(const omega_transform_plugin_request_t *request_ptr,
+                                   const std::function<bool(const omega_byte_t *, int64_t)> &callback) {
+            if (!request_ptr || request_ptr->session_length < 0 || request_ptr->input_length < 0) { return false; }
+            if (!request_ptr->read) {
+                if (request_ptr->input_length > 0 && !request_ptr->input_bytes) { return false; }
+                return callback(request_ptr->input_bytes, request_ptr->input_length);
+            }
 
-    const int64_t max_chunk = 1024 * 1024;
-    const int64_t fallback_chunk = 64 * 1024;
-    int64_t chunk_size = request_ptr->preferred_chunk_size > 0 ? request_ptr->preferred_chunk_size : fallback_chunk;
-    if (chunk_size > max_chunk) { chunk_size = max_chunk; }
-    std::vector<omega_byte_t> buffer(static_cast<size_t>(chunk_size));
-    for (int64_t position = 0; position < request_ptr->session_length;) {
-        const int64_t remaining = request_ptr->session_length - position;
-        const int64_t requested = remaining < chunk_size ? remaining : chunk_size;
-        const int64_t bytes_read =
-                request_ptr->read(position, buffer.data(), requested, request_ptr->reader_user_data_ptr);
-        if (bytes_read <= 0 || bytes_read > requested) { return false; }
-        if (!callback(buffer.data(), bytes_read)) { return false; }
-        position += bytes_read;
-    }
-    return true;
-}
+            const int64_t max_chunk = 1024 * 1024;
+            const int64_t fallback_chunk = 64 * 1024;
+            int64_t chunk_size =
+                    request_ptr->preferred_chunk_size > 0 ? request_ptr->preferred_chunk_size : fallback_chunk;
+            if (chunk_size > max_chunk) { chunk_size = max_chunk; }
+            std::vector<omega_byte_t> buffer(static_cast<size_t>(chunk_size));
+            for (int64_t position = 0; position < request_ptr->session_length;) {
+                const int64_t remaining = request_ptr->session_length - position;
+                const int64_t requested = remaining < chunk_size ? remaining : chunk_size;
+                const int64_t bytes_read =
+                        request_ptr->read(position, buffer.data(), requested, request_ptr->reader_user_data_ptr);
+                if (bytes_read <= 0 || bytes_read > requested) { return false; }
+                if (!callback(buffer.data(), bytes_read)) { return false; }
+                position += bytes_read;
+            }
+            return true;
+        }
 
-} // namespace plugin
-} // namespace omega_edit
+    }// namespace plugin
+}// namespace omega_edit
 
-#endif // OMEGA_EDIT_PLUGIN_OPTIONS_HPP
+#endif// OMEGA_EDIT_PLUGIN_OPTIONS_HPP

--- a/plugins/src/record_text_helpers.cpp
+++ b/plugins/src/record_text_helpers.cpp
@@ -21,243 +21,242 @@
 
 namespace {
 
-constexpr const char *RECORD_TEXT_ARGS_SCHEMA =
-        "{\"type\":\"object\",\"properties\":{\"action\":{\"type\":\"string\",\"title\":\"Action\","
-        "\"description\":\"Text or record operation to apply.\",\"default\":\"newline-lf\",\"enum\":[\"newline-lf\","
-        "\"newline-crlf\",\"newline-cr\",\"fixed-width-lines\",\"delimiter-escape\",\"delimiter-unescape\","
-        "\"csv-quote\",\"csv-unquote\",\"xml-escape\",\"xml-unescape\",\"json-escape\",\"json-unescape\"]},"
-        "\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"description\":\"Characters per fixed-width line.\","
-        "\"default\":80,\"minimum\":1,\"maximum\":4096},\"delimiter\":{\"type\":\"string\",\"title\":\"Delimiter\","
-        "\"description\":\"Delimiter character for delimiter escape actions.\",\"default\":\",\"},\"escape\":{"
-        "\"type\":\"string\",\"title\":\"Escape\",\"description\":\"Escape character for delimiter actions.\","
-        "\"default\":\"\\\\\"}},\"additionalProperties\":false}";
+    constexpr const char *RECORD_TEXT_ARGS_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"action\":{\"type\":\"string\",\"title\":\"Action\","
+            "\"description\":\"Text or record operation to "
+            "apply.\",\"default\":\"newline-lf\",\"enum\":[\"newline-lf\","
+            "\"newline-crlf\",\"newline-cr\",\"fixed-width-lines\",\"delimiter-escape\",\"delimiter-unescape\","
+            "\"csv-quote\",\"csv-unquote\",\"xml-escape\",\"xml-unescape\",\"json-escape\",\"json-unescape\"]},"
+            "\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"description\":\"Characters per fixed-width line.\","
+            "\"default\":80,\"minimum\":1,\"maximum\":4096},\"delimiter\":{\"type\":\"string\",\"title\":\"Delimiter\","
+            "\"description\":\"Delimiter character for delimiter escape actions.\",\"default\":\",\"},\"escape\":{"
+            "\"type\":\"string\",\"title\":\"Escape\",\"description\":\"Escape character for delimiter actions.\","
+            "\"default\":\"\\\\\"}},\"additionalProperties\":false}";
 
-std::vector<omega_byte_t> text_bytes(const std::string &text) {
-    return std::vector<omega_byte_t>(text.begin(), text.end());
-}
-
-std::string as_text(const std::vector<omega_byte_t> &input) {
-    return std::string(input.begin(), input.end());
-}
-
-int hex_value(omega_byte_t byte) {
-    if (byte >= '0' && byte <= '9') { return byte - '0'; }
-    if (byte >= 'a' && byte <= 'f') { return byte - 'a' + 10; }
-    if (byte >= 'A' && byte <= 'F') { return byte - 'A' + 10; }
-    return -1;
-}
-
-std::vector<omega_byte_t> normalize_newlines(const std::vector<omega_byte_t> &input, const std::string &newline) {
-    std::vector<omega_byte_t> out;
-    for (size_t i = 0; i < input.size(); ++i) {
-        if (input[i] == '\r') {
-            if (i + 1 < input.size() && input[i + 1] == '\n') { ++i; }
-            out.insert(out.end(), newline.begin(), newline.end());
-        } else if (input[i] == '\n') {
-            out.insert(out.end(), newline.begin(), newline.end());
-        } else {
-            out.push_back(input[i]);
-        }
+    std::vector<omega_byte_t> text_bytes(const std::string &text) {
+        return std::vector<omega_byte_t>(text.begin(), text.end());
     }
-    return out;
-}
 
-std::vector<omega_byte_t> fixed_width_lines(const std::vector<omega_byte_t> &input, int64_t width) {
-    std::vector<omega_byte_t> out;
-    for (size_t i = 0; i < input.size(); ++i) {
-        if (i > 0 && (i % static_cast<size_t>(width)) == 0) { out.push_back('\n'); }
-        out.push_back(input[i]);
+    std::string as_text(const std::vector<omega_byte_t> &input) { return std::string(input.begin(), input.end()); }
+
+    int hex_value(omega_byte_t byte) {
+        if (byte >= '0' && byte <= '9') { return byte - '0'; }
+        if (byte >= 'a' && byte <= 'f') { return byte - 'a' + 10; }
+        if (byte >= 'A' && byte <= 'F') { return byte - 'A' + 10; }
+        return -1;
     }
-    return out;
-}
 
-std::vector<omega_byte_t> delimiter_escape(const std::vector<omega_byte_t> &input, omega_byte_t delimiter,
-                                           omega_byte_t escape) {
-    std::vector<omega_byte_t> out;
-    for (const auto byte: input) {
-        if (byte == delimiter || byte == escape) { out.push_back(escape); }
-        out.push_back(byte);
-    }
-    return out;
-}
-
-bool delimiter_unescape(const std::vector<omega_byte_t> &input, omega_byte_t escape, std::vector<omega_byte_t> &out) {
-    out.clear();
-    bool escaped = false;
-    for (const auto byte: input) {
-        if (escaped) {
-            out.push_back(byte);
-            escaped = false;
-        } else if (byte == escape) {
-            escaped = true;
-        } else {
-            out.push_back(byte);
-        }
-    }
-    return !escaped;
-}
-
-std::vector<omega_byte_t> csv_quote(const std::vector<omega_byte_t> &input) {
-    std::vector<omega_byte_t> out;
-    out.push_back('"');
-    for (const auto byte: input) {
-        if (byte == '"') { out.push_back('"'); }
-        out.push_back(byte);
-    }
-    out.push_back('"');
-    return out;
-}
-
-bool csv_unquote(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    if (input.size() < 2 || input.front() != '"' || input.back() != '"') { return false; }
-    out.clear();
-    for (size_t i = 1; i + 1 < input.size(); ++i) {
-        if (input[i] == '"') {
-            if (i + 1 >= input.size() - 1 || input[i + 1] != '"') { return false; }
-            ++i;
-        }
-        out.push_back(input[i]);
-    }
-    return true;
-}
-
-std::vector<omega_byte_t> xml_escape(const std::vector<omega_byte_t> &input) {
-    std::string out;
-    for (const auto byte: input) {
-        switch (byte) {
-            case '&':
-                out += "&amp;";
-                break;
-            case '<':
-                out += "&lt;";
-                break;
-            case '>':
-                out += "&gt;";
-                break;
-            case '"':
-                out += "&quot;";
-                break;
-            case '\'':
-                out += "&apos;";
-                break;
-            default:
-                out.push_back(static_cast<char>(byte));
-                break;
-        }
-    }
-    return text_bytes(out);
-}
-
-bool replace_all(std::string &text, const std::string &from, const std::string &to) {
-    size_t pos = 0;
-    while ((pos = text.find(from, pos)) != std::string::npos) {
-        text.replace(pos, from.size(), to);
-        pos += to.size();
-    }
-    return true;
-}
-
-std::vector<omega_byte_t> xml_unescape(const std::vector<omega_byte_t> &input) {
-    std::string text = as_text(input);
-    replace_all(text, "&lt;", "<");
-    replace_all(text, "&gt;", ">");
-    replace_all(text, "&quot;", "\"");
-    replace_all(text, "&apos;", "'");
-    replace_all(text, "&amp;", "&");
-    return text_bytes(text);
-}
-
-std::vector<omega_byte_t> json_escape(const std::vector<omega_byte_t> &input) {
-    std::string out;
-    for (const auto byte: input) {
-        switch (byte) {
-            case '"':
-                out += "\\\"";
-                break;
-            case '\\':
-                out += "\\\\";
-                break;
-            case '\b':
-                out += "\\b";
-                break;
-            case '\f':
-                out += "\\f";
-                break;
-            case '\n':
-                out += "\\n";
-                break;
-            case '\r':
-                out += "\\r";
-                break;
-            case '\t':
-                out += "\\t";
-                break;
-            default:
-                if (byte < 0x20) {
-                    char escaped[7];
-                    std::snprintf(escaped, sizeof(escaped), "\\u%04X", byte);
-                    out += escaped;
-                } else {
-                    out.push_back(static_cast<char>(byte));
-                }
-                break;
-        }
-    }
-    return text_bytes(out);
-}
-
-bool json_unescape(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    out.clear();
-    for (size_t i = 0; i < input.size(); ++i) {
-        if (input[i] != '\\') {
-            out.push_back(input[i]);
-            continue;
-        }
-        if (++i >= input.size()) { return false; }
-        switch (input[i]) {
-            case '"':
-            case '\\':
-            case '/':
+    std::vector<omega_byte_t> normalize_newlines(const std::vector<omega_byte_t> &input, const std::string &newline) {
+        std::vector<omega_byte_t> out;
+        for (size_t i = 0; i < input.size(); ++i) {
+            if (input[i] == '\r') {
+                if (i + 1 < input.size() && input[i + 1] == '\n') { ++i; }
+                out.insert(out.end(), newline.begin(), newline.end());
+            } else if (input[i] == '\n') {
+                out.insert(out.end(), newline.begin(), newline.end());
+            } else {
                 out.push_back(input[i]);
-                break;
-            case 'b':
-                out.push_back('\b');
-                break;
-            case 'f':
-                out.push_back('\f');
-                break;
-            case 'n':
-                out.push_back('\n');
-                break;
-            case 'r':
-                out.push_back('\r');
-                break;
-            case 't':
-                out.push_back('\t');
-                break;
-            case 'u': {
-                if (i + 4 >= input.size()) { return false; }
-                int value = 0;
-                for (int n = 0; n < 4; ++n) {
-                    const int nibble = hex_value(input[++i]);
-                    if (nibble < 0) { return false; }
-                    value = (value << 4) | nibble;
-                }
-                if (value > 0x7F) { return false; }
-                out.push_back(static_cast<omega_byte_t>(value));
-                break;
             }
-            default:
-                return false;
         }
+        return out;
     }
-    return true;
-}
 
-} // namespace
+    std::vector<omega_byte_t> fixed_width_lines(const std::vector<omega_byte_t> &input, int64_t width) {
+        std::vector<omega_byte_t> out;
+        for (size_t i = 0; i < input.size(); ++i) {
+            if (i > 0 && (i % static_cast<size_t>(width)) == 0) { out.push_back('\n'); }
+            out.push_back(input[i]);
+        }
+        return out;
+    }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
-        omega_transform_plugin_info_t *info_ptr) {
+    std::vector<omega_byte_t> delimiter_escape(const std::vector<omega_byte_t> &input, omega_byte_t delimiter,
+                                               omega_byte_t escape) {
+        std::vector<omega_byte_t> out;
+        for (const auto byte : input) {
+            if (byte == delimiter || byte == escape) { out.push_back(escape); }
+            out.push_back(byte);
+        }
+        return out;
+    }
+
+    bool delimiter_unescape(const std::vector<omega_byte_t> &input, omega_byte_t escape,
+                            std::vector<omega_byte_t> &out) {
+        out.clear();
+        bool escaped = false;
+        for (const auto byte : input) {
+            if (escaped) {
+                out.push_back(byte);
+                escaped = false;
+            } else if (byte == escape) {
+                escaped = true;
+            } else {
+                out.push_back(byte);
+            }
+        }
+        return !escaped;
+    }
+
+    std::vector<omega_byte_t> csv_quote(const std::vector<omega_byte_t> &input) {
+        std::vector<omega_byte_t> out;
+        out.push_back('"');
+        for (const auto byte : input) {
+            if (byte == '"') { out.push_back('"'); }
+            out.push_back(byte);
+        }
+        out.push_back('"');
+        return out;
+    }
+
+    bool csv_unquote(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        if (input.size() < 2 || input.front() != '"' || input.back() != '"') { return false; }
+        out.clear();
+        for (size_t i = 1; i + 1 < input.size(); ++i) {
+            if (input[i] == '"') {
+                if (i + 1 >= input.size() - 1 || input[i + 1] != '"') { return false; }
+                ++i;
+            }
+            out.push_back(input[i]);
+        }
+        return true;
+    }
+
+    std::vector<omega_byte_t> xml_escape(const std::vector<omega_byte_t> &input) {
+        std::string out;
+        for (const auto byte : input) {
+            switch (byte) {
+                case '&':
+                    out += "&amp;";
+                    break;
+                case '<':
+                    out += "&lt;";
+                    break;
+                case '>':
+                    out += "&gt;";
+                    break;
+                case '"':
+                    out += "&quot;";
+                    break;
+                case '\'':
+                    out += "&apos;";
+                    break;
+                default:
+                    out.push_back(static_cast<char>(byte));
+                    break;
+            }
+        }
+        return text_bytes(out);
+    }
+
+    bool replace_all(std::string &text, const std::string &from, const std::string &to) {
+        size_t pos = 0;
+        while ((pos = text.find(from, pos)) != std::string::npos) {
+            text.replace(pos, from.size(), to);
+            pos += to.size();
+        }
+        return true;
+    }
+
+    std::vector<omega_byte_t> xml_unescape(const std::vector<omega_byte_t> &input) {
+        std::string text = as_text(input);
+        replace_all(text, "&lt;", "<");
+        replace_all(text, "&gt;", ">");
+        replace_all(text, "&quot;", "\"");
+        replace_all(text, "&apos;", "'");
+        replace_all(text, "&amp;", "&");
+        return text_bytes(text);
+    }
+
+    std::vector<omega_byte_t> json_escape(const std::vector<omega_byte_t> &input) {
+        std::string out;
+        for (const auto byte : input) {
+            switch (byte) {
+                case '"':
+                    out += "\\\"";
+                    break;
+                case '\\':
+                    out += "\\\\";
+                    break;
+                case '\b':
+                    out += "\\b";
+                    break;
+                case '\f':
+                    out += "\\f";
+                    break;
+                case '\n':
+                    out += "\\n";
+                    break;
+                case '\r':
+                    out += "\\r";
+                    break;
+                case '\t':
+                    out += "\\t";
+                    break;
+                default:
+                    if (byte < 0x20) {
+                        char escaped[7];
+                        std::snprintf(escaped, sizeof(escaped), "\\u%04X", byte);
+                        out += escaped;
+                    } else {
+                        out.push_back(static_cast<char>(byte));
+                    }
+                    break;
+            }
+        }
+        return text_bytes(out);
+    }
+
+    bool json_unescape(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        out.clear();
+        for (size_t i = 0; i < input.size(); ++i) {
+            if (input[i] != '\\') {
+                out.push_back(input[i]);
+                continue;
+            }
+            if (++i >= input.size()) { return false; }
+            switch (input[i]) {
+                case '"':
+                case '\\':
+                case '/':
+                    out.push_back(input[i]);
+                    break;
+                case 'b':
+                    out.push_back('\b');
+                    break;
+                case 'f':
+                    out.push_back('\f');
+                    break;
+                case 'n':
+                    out.push_back('\n');
+                    break;
+                case 'r':
+                    out.push_back('\r');
+                    break;
+                case 't':
+                    out.push_back('\t');
+                    break;
+                case 'u': {
+                    if (i + 4 >= input.size()) { return false; }
+                    int value = 0;
+                    for (int n = 0; n < 4; ++n) {
+                        const int nibble = hex_value(input[++i]);
+                        if (nibble < 0) { return false; }
+                        value = (value << 4) | nibble;
+                    }
+                    if (value > 0x7F) { return false; }
+                    out.push_back(static_cast<omega_byte_t>(value));
+                    break;
+                }
+                default:
+                    return false;
+            }
+        }
+        return true;
+    }
+
+}// namespace
+
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
     info_ptr->id = "omega.example.record_text_helpers";
     info_ptr->name = "Record/Text Helpers";
@@ -275,12 +274,11 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
     return 0;
 }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                             omega_transform_plugin_response_t *response_ptr) {
     std::vector<omega_byte_t> input;
-    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
-        return -1;
-    }
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) { return -1; }
     std::map<std::string, std::string> options;
     if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
     const std::string action = omega_edit::plugin::option_or(options, "action", "newline-lf");

--- a/plugins/src/repeat.c
+++ b/plugins/src/repeat.c
@@ -31,14 +31,14 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
 }
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
-                                                              omega_transform_plugin_response_t *response_ptr) {
+                                                               omega_transform_plugin_response_t *response_ptr) {
     if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0) { return -1; }
     if (request_ptr->input_length > INT64_MAX / 2) { return -1; }
     const int64_t replacement_length = request_ptr->input_length * 2;
     response_ptr->replacement_length = replacement_length;
     if (replacement_length == 0) { return omega_transform_plugin_sdk_set_no_content_change(response_ptr); }
-    response_ptr->replacement_bytes = (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr,
-                                                                                       (size_t) replacement_length);
+    response_ptr->replacement_bytes =
+            (omega_byte_t *) omega_transform_plugin_sdk_alloc(request_ptr, (size_t) replacement_length);
     if (!response_ptr->replacement_bytes) { return -1; }
     memcpy(response_ptr->replacement_bytes, request_ptr->input_bytes, (size_t) request_ptr->input_length);
     memcpy(response_ptr->replacement_bytes + request_ptr->input_length, request_ptr->input_bytes,

--- a/plugins/src/text_codecs.cpp
+++ b/plugins/src/text_codecs.cpp
@@ -23,473 +23,466 @@
 
 namespace {
 
-constexpr const char *TEXT_CODEC_ARGS_SCHEMA =
-        "{\"type\":\"object\",\"properties\":{\"codec\":{\"type\":\"string\",\"title\":\"Codec\","
-        "\"description\":\"Text-safe encoding to apply.\",\"default\":\"hex\",\"enum\":[\"hex\",\"base16\","
-        "\"base64url\",\"base32\",\"base32-crockford\",\"ascii85\",\"base85\",\"z85\",\"base58\",\"percent\","
-        "\"url\",\"quoted-printable\",\"uuencode\",\"yenc\"]},\"direction\":{\"type\":\"string\",\"title\":"
-        "\"Direction\",\"default\":\"encode\",\"enum\":[\"encode\",\"decode\"]}},\"additionalProperties\":false}";
+    constexpr const char *TEXT_CODEC_ARGS_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"codec\":{\"type\":\"string\",\"title\":\"Codec\","
+            "\"description\":\"Text-safe encoding to apply.\",\"default\":\"hex\",\"enum\":[\"hex\",\"base16\","
+            "\"base64url\",\"base32\",\"base32-crockford\",\"ascii85\",\"base85\",\"z85\",\"base58\",\"percent\","
+            "\"url\",\"quoted-printable\",\"uuencode\",\"yenc\"]},\"direction\":{\"type\":\"string\",\"title\":"
+            "\"Direction\",\"default\":\"encode\",\"enum\":[\"encode\",\"decode\"]}},\"additionalProperties\":false}";
 
-int hex_value(omega_byte_t byte) {
-    if (byte >= '0' && byte <= '9') { return byte - '0'; }
-    if (byte >= 'a' && byte <= 'f') { return byte - 'a' + 10; }
-    if (byte >= 'A' && byte <= 'F') { return byte - 'A' + 10; }
-    return -1;
-}
+    int hex_value(omega_byte_t byte) {
+        if (byte >= '0' && byte <= '9') { return byte - '0'; }
+        if (byte >= 'a' && byte <= 'f') { return byte - 'a' + 10; }
+        if (byte >= 'A' && byte <= 'F') { return byte - 'A' + 10; }
+        return -1;
+    }
 
-bool is_ascii_space(omega_byte_t byte) {
-    return std::isspace(static_cast<unsigned char>(byte)) != 0;
-}
+    bool is_ascii_space(omega_byte_t byte) { return std::isspace(static_cast<unsigned char>(byte)) != 0; }
 
-bool is_ascii_alnum(omega_byte_t byte) {
-    return std::isalnum(static_cast<unsigned char>(byte)) != 0;
-}
+    bool is_ascii_alnum(omega_byte_t byte) { return std::isalnum(static_cast<unsigned char>(byte)) != 0; }
 
-omega_byte_t uppercase_ascii(omega_byte_t byte) {
-    return static_cast<omega_byte_t>(std::toupper(static_cast<unsigned char>(byte)));
-}
+    omega_byte_t uppercase_ascii(omega_byte_t byte) {
+        return static_cast<omega_byte_t>(std::toupper(static_cast<unsigned char>(byte)));
+    }
 
-std::vector<omega_byte_t> hex_encode(const std::vector<omega_byte_t> &input) {
-    static constexpr char alphabet[] = "0123456789abcdef";
-    std::vector<omega_byte_t> out;
-    out.reserve(input.size() * 2);
-    for (const auto byte: input) {
-        out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
-        out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
-    }
-    return out;
-}
-
-bool hex_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    out.clear();
-    int high = -1;
-    for (const auto byte: input) {
-        if (is_ascii_space(byte)) { continue; }
-        const int value = hex_value(byte);
-        if (value < 0) { return false; }
-        if (high < 0) {
-            high = value;
-        } else {
-            out.push_back(static_cast<omega_byte_t>((high << 4U) | value));
-            high = -1;
-        }
-    }
-    return high < 0;
-}
-
-std::vector<omega_byte_t> base64url_encode(const std::vector<omega_byte_t> &input) {
-    static constexpr char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-    std::vector<omega_byte_t> out;
-    out.reserve(((input.size() + 2) / 3) * 4);
-    for (size_t i = 0; i < input.size();) {
-        const unsigned int a = input[i++];
-        const bool has_b = i < input.size();
-        const unsigned int b = has_b ? input[i++] : 0;
-        const bool has_c = i < input.size();
-        const unsigned int c = has_c ? input[i++] : 0;
-        const unsigned int triple = (a << 16U) | (b << 8U) | c;
-        out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 18U) & 0x3FU]));
-        out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 12U) & 0x3FU]));
-        if (has_b) { out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 6U) & 0x3FU])); }
-        if (has_c) { out.push_back(static_cast<omega_byte_t>(alphabet[triple & 0x3FU])); }
-    }
-    return out;
-}
-
-int base64url_value(omega_byte_t byte) {
-    if (byte >= 'A' && byte <= 'Z') { return byte - 'A'; }
-    if (byte >= 'a' && byte <= 'z') { return byte - 'a' + 26; }
-    if (byte >= '0' && byte <= '9') { return byte - '0' + 52; }
-    if (byte == '-' || byte == '+') { return 62; }
-    if (byte == '_' || byte == '/') { return 63; }
-    if (byte == '=') { return -2; }
-    return -1;
-}
-
-bool base64url_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    std::vector<int> values;
-    size_t padding_count = 0;
-    bool saw_padding = false;
-    for (const auto byte: input) {
-        if (is_ascii_space(byte)) { continue; }
-        const int value = base64url_value(byte);
-        if (value == -1) { return false; }
-        if (value == -2) {
-            saw_padding = true;
-            if (++padding_count > 2) { return false; }
-            continue;
-        }
-        if (saw_padding) { return false; }
-        values.push_back(value);
-    }
-    const size_t value_count = values.size();
-    if ((value_count % 4) == 1) { return false; }
-    if (padding_count > 0) {
-        if (((value_count + padding_count) % 4) != 0) { return false; }
-        if ((padding_count == 1 && (value_count % 4) != 3) ||
-            (padding_count == 2 && (value_count % 4) != 2)) {
-            return false;
-        }
-    }
-    while ((values.size() % 4) != 0) { values.push_back(0); }
-    out.clear();
-    for (size_t i = 0; i < values.size(); i += 4) {
-        const unsigned int triple = (static_cast<unsigned int>(values[i]) << 18U) |
-                                    (static_cast<unsigned int>(values[i + 1]) << 12U) |
-                                    (static_cast<unsigned int>(values[i + 2]) << 6U) |
-                                    static_cast<unsigned int>(values[i + 3]);
-        out.push_back(static_cast<omega_byte_t>((triple >> 16U) & 0xFFU));
-        if (i + 2 < values.size()) { out.push_back(static_cast<omega_byte_t>((triple >> 8U) & 0xFFU)); }
-        if (i + 3 < values.size()) { out.push_back(static_cast<omega_byte_t>(triple & 0xFFU)); }
-    }
-    out.resize((value_count * 6U) / 8U);
-    return true;
-}
-
-std::vector<omega_byte_t> base32_encode(const std::vector<omega_byte_t> &input, bool crockford) {
-    const char *alphabet = crockford ? "0123456789ABCDEFGHJKMNPQRSTVWXYZ" : "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-    std::vector<omega_byte_t> out;
-    uint32_t buffer = 0;
-    int bits = 0;
-    for (const auto byte: input) {
-        buffer = (buffer << 8U) | byte;
-        bits += 8;
-        while (bits >= 5) {
-            out.push_back(static_cast<omega_byte_t>(alphabet[(buffer >> (bits - 5)) & 0x1FU]));
-            bits -= 5;
-        }
-    }
-    if (bits > 0) { out.push_back(static_cast<omega_byte_t>(alphabet[(buffer << (5 - bits)) & 0x1FU])); }
-    if (!crockford) {
-        while ((out.size() % 8) != 0) { out.push_back('='); }
-    }
-    return out;
-}
-
-int base32_value(omega_byte_t byte, bool crockford) {
-    byte = uppercase_ascii(byte);
-    if (crockford) {
-        if (byte == 'O') { return 0; }
-        if (byte == 'I' || byte == 'L') { return 1; }
-        static constexpr char alphabet[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-        const char *found = std::find(std::begin(alphabet), std::end(alphabet) - 1, byte);
-        return found == std::end(alphabet) - 1 ? -1 : static_cast<int>(found - alphabet);
-    }
-    if (byte >= 'A' && byte <= 'Z') { return byte - 'A'; }
-    if (byte >= '2' && byte <= '7') { return byte - '2' + 26; }
-    return -1;
-}
-
-bool base32_decode(const std::vector<omega_byte_t> &input, bool crockford, std::vector<omega_byte_t> &out) {
-    out.clear();
-    uint32_t buffer = 0;
-    int bits = 0;
-    for (const auto byte: input) {
-        if (is_ascii_space(byte) || byte == '=') { continue; }
-        const int value = base32_value(byte, crockford);
-        if (value < 0) { return false; }
-        buffer = (buffer << 5U) | static_cast<uint32_t>(value);
-        bits += 5;
-        if (bits >= 8) {
-            out.push_back(static_cast<omega_byte_t>((buffer >> (bits - 8)) & 0xFFU));
-            bits -= 8;
-        }
-    }
-    return true;
-}
-
-std::vector<omega_byte_t> base58_encode(const std::vector<omega_byte_t> &input) {
-    static constexpr char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    std::vector<omega_byte_t> digits(1, 0);
-    for (const auto byte: input) {
-        int carry = byte;
-        for (auto &digit: digits) {
-            carry += digit << 8U;
-            digit = static_cast<omega_byte_t>(carry % 58);
-            carry /= 58;
-        }
-        while (carry) {
-            digits.push_back(static_cast<omega_byte_t>(carry % 58));
-            carry /= 58;
-        }
-    }
-    std::vector<omega_byte_t> out;
-    for (const auto byte: input) {
-        if (byte == 0) {
-            out.push_back('1');
-        } else {
-            break;
-        }
-    }
-    for (auto iter = digits.rbegin(); iter != digits.rend(); ++iter) {
-        out.push_back(static_cast<omega_byte_t>(alphabet[*iter]));
-    }
-    return out;
-}
-
-bool base58_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    static constexpr char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    std::vector<omega_byte_t> bytes(1, 0);
-    for (const auto ch: input) {
-        if (is_ascii_space(ch)) { continue; }
-        const char *found = std::find(std::begin(alphabet), std::end(alphabet) - 1, ch);
-        if (found == std::end(alphabet) - 1) { return false; }
-        int carry = static_cast<int>(found - alphabet);
-        for (auto &byte: bytes) {
-            carry += byte * 58;
-            byte = static_cast<omega_byte_t>(carry & 0xFF);
-            carry >>= 8U;
-        }
-        while (carry) {
-            bytes.push_back(static_cast<omega_byte_t>(carry & 0xFF));
-            carry >>= 8U;
-        }
-    }
-    out.clear();
-    for (const auto ch: input) {
-        if (ch == '1') {
-            out.push_back(0);
-        } else if (!is_ascii_space(ch)) {
-            break;
-        }
-    }
-    for (auto iter = bytes.rbegin(); iter != bytes.rend(); ++iter) { out.push_back(*iter); }
-    return true;
-}
-
-std::vector<omega_byte_t> percent_encode(const std::vector<omega_byte_t> &input) {
-    static constexpr char alphabet[] = "0123456789ABCDEF";
-    std::vector<omega_byte_t> out;
-    for (const auto byte: input) {
-        if (is_ascii_alnum(byte) || byte == '-' || byte == '_' || byte == '.' || byte == '~') {
-            out.push_back(byte);
-        } else {
-            out.push_back('%');
+    std::vector<omega_byte_t> hex_encode(const std::vector<omega_byte_t> &input) {
+        static constexpr char alphabet[] = "0123456789abcdef";
+        std::vector<omega_byte_t> out;
+        out.reserve(input.size() * 2);
+        for (const auto byte : input) {
             out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
             out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
         }
+        return out;
     }
-    return out;
-}
 
-bool percent_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    out.clear();
-    for (size_t i = 0; i < input.size(); ++i) {
-        if (input[i] != '%') {
-            out.push_back(input[i]);
-            continue;
+    bool hex_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        out.clear();
+        int high = -1;
+        for (const auto byte : input) {
+            if (is_ascii_space(byte)) { continue; }
+            const int value = hex_value(byte);
+            if (value < 0) { return false; }
+            if (high < 0) {
+                high = value;
+            } else {
+                out.push_back(static_cast<omega_byte_t>((high << 4U) | value));
+                high = -1;
+            }
         }
-        if (i + 2 >= input.size()) { return false; }
-        const int high = hex_value(input[++i]);
-        const int low = hex_value(input[++i]);
-        if (high < 0 || low < 0) { return false; }
-        out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+        return high < 0;
     }
-    return true;
-}
 
-std::vector<omega_byte_t> quoted_printable_encode(const std::vector<omega_byte_t> &input) {
-    static constexpr char alphabet[] = "0123456789ABCDEF";
-    std::vector<omega_byte_t> out;
-    for (const auto byte: input) {
-        if ((byte >= 33 && byte <= 60) || (byte >= 62 && byte <= 126) || byte == '\t' || byte == ' ') {
-            out.push_back(byte);
-        } else {
-            out.push_back('=');
-            out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
-            out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
+    std::vector<omega_byte_t> base64url_encode(const std::vector<omega_byte_t> &input) {
+        static constexpr char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        std::vector<omega_byte_t> out;
+        out.reserve(((input.size() + 2) / 3) * 4);
+        for (size_t i = 0; i < input.size();) {
+            const unsigned int a = input[i++];
+            const bool has_b = i < input.size();
+            const unsigned int b = has_b ? input[i++] : 0;
+            const bool has_c = i < input.size();
+            const unsigned int c = has_c ? input[i++] : 0;
+            const unsigned int triple = (a << 16U) | (b << 8U) | c;
+            out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 18U) & 0x3FU]));
+            out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 12U) & 0x3FU]));
+            if (has_b) { out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 6U) & 0x3FU])); }
+            if (has_c) { out.push_back(static_cast<omega_byte_t>(alphabet[triple & 0x3FU])); }
         }
+        return out;
     }
-    return out;
-}
 
-bool quoted_printable_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    out.clear();
-    for (size_t i = 0; i < input.size(); ++i) {
-        if (input[i] != '=') {
-            out.push_back(input[i]);
-            continue;
-        }
-        if (i + 1 < input.size() && (input[i + 1] == '\r' || input[i + 1] == '\n')) {
-            while (i + 1 < input.size() && (input[i + 1] == '\r' || input[i + 1] == '\n')) { ++i; }
-            continue;
-        }
-        if (i + 2 >= input.size()) { return false; }
-        const int high = hex_value(input[++i]);
-        const int low = hex_value(input[++i]);
-        if (high < 0 || low < 0) { return false; }
-        out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+    int base64url_value(omega_byte_t byte) {
+        if (byte >= 'A' && byte <= 'Z') { return byte - 'A'; }
+        if (byte >= 'a' && byte <= 'z') { return byte - 'a' + 26; }
+        if (byte >= '0' && byte <= '9') { return byte - '0' + 52; }
+        if (byte == '-' || byte == '+') { return 62; }
+        if (byte == '_' || byte == '/') { return 63; }
+        if (byte == '=') { return -2; }
+        return -1;
     }
-    return true;
-}
 
-omega_byte_t uu_char(unsigned int value) {
-    value &= 0x3FU;
-    return static_cast<omega_byte_t>(value == 0 ? '`' : value + 32U);
-}
-
-int uu_value(omega_byte_t byte) {
-    if (byte == '`' || byte == ' ') { return 0; }
-    if (byte >= 33 && byte <= 95) { return (byte - 32) & 0x3F; }
-    return -1;
-}
-
-std::vector<omega_byte_t> uuencode(const std::vector<omega_byte_t> &input) {
-    std::vector<omega_byte_t> out;
-    for (size_t line = 0; line < input.size(); line += 45) {
-        const size_t count = std::min<size_t>(45, input.size() - line);
-        out.push_back(uu_char(static_cast<unsigned int>(count)));
-        for (size_t i = 0; i < count; i += 3) {
-            const unsigned int a = input[line + i];
-            const unsigned int b = i + 1 < count ? input[line + i + 1] : 0;
-            const unsigned int c = i + 2 < count ? input[line + i + 2] : 0;
-            out.push_back(uu_char(a >> 2U));
-            out.push_back(uu_char(((a << 4U) | (b >> 4U))));
-            out.push_back(uu_char(((b << 2U) | (c >> 6U))));
-            out.push_back(uu_char(c));
+    bool base64url_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        std::vector<int> values;
+        size_t padding_count = 0;
+        bool saw_padding = false;
+        for (const auto byte : input) {
+            if (is_ascii_space(byte)) { continue; }
+            const int value = base64url_value(byte);
+            if (value == -1) { return false; }
+            if (value == -2) {
+                saw_padding = true;
+                if (++padding_count > 2) { return false; }
+                continue;
+            }
+            if (saw_padding) { return false; }
+            values.push_back(value);
         }
+        const size_t value_count = values.size();
+        if ((value_count % 4) == 1) { return false; }
+        if (padding_count > 0) {
+            if (((value_count + padding_count) % 4) != 0) { return false; }
+            if ((padding_count == 1 && (value_count % 4) != 3) || (padding_count == 2 && (value_count % 4) != 2)) {
+                return false;
+            }
+        }
+        while ((values.size() % 4) != 0) { values.push_back(0); }
+        out.clear();
+        for (size_t i = 0; i < values.size(); i += 4) {
+            const unsigned int triple =
+                    (static_cast<unsigned int>(values[i]) << 18U) | (static_cast<unsigned int>(values[i + 1]) << 12U) |
+                    (static_cast<unsigned int>(values[i + 2]) << 6U) | static_cast<unsigned int>(values[i + 3]);
+            out.push_back(static_cast<omega_byte_t>((triple >> 16U) & 0xFFU));
+            if (i + 2 < values.size()) { out.push_back(static_cast<omega_byte_t>((triple >> 8U) & 0xFFU)); }
+            if (i + 3 < values.size()) { out.push_back(static_cast<omega_byte_t>(triple & 0xFFU)); }
+        }
+        out.resize((value_count * 6U) / 8U);
+        return true;
+    }
+
+    std::vector<omega_byte_t> base32_encode(const std::vector<omega_byte_t> &input, bool crockford) {
+        const char *alphabet = crockford ? "0123456789ABCDEFGHJKMNPQRSTVWXYZ" : "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        std::vector<omega_byte_t> out;
+        uint32_t buffer = 0;
+        int bits = 0;
+        for (const auto byte : input) {
+            buffer = (buffer << 8U) | byte;
+            bits += 8;
+            while (bits >= 5) {
+                out.push_back(static_cast<omega_byte_t>(alphabet[(buffer >> (bits - 5)) & 0x1FU]));
+                bits -= 5;
+            }
+        }
+        if (bits > 0) { out.push_back(static_cast<omega_byte_t>(alphabet[(buffer << (5 - bits)) & 0x1FU])); }
+        if (!crockford) {
+            while ((out.size() % 8) != 0) { out.push_back('='); }
+        }
+        return out;
+    }
+
+    int base32_value(omega_byte_t byte, bool crockford) {
+        byte = uppercase_ascii(byte);
+        if (crockford) {
+            if (byte == 'O') { return 0; }
+            if (byte == 'I' || byte == 'L') { return 1; }
+            static constexpr char alphabet[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+            const char *found = std::find(std::begin(alphabet), std::end(alphabet) - 1, byte);
+            return found == std::end(alphabet) - 1 ? -1 : static_cast<int>(found - alphabet);
+        }
+        if (byte >= 'A' && byte <= 'Z') { return byte - 'A'; }
+        if (byte >= '2' && byte <= '7') { return byte - '2' + 26; }
+        return -1;
+    }
+
+    bool base32_decode(const std::vector<omega_byte_t> &input, bool crockford, std::vector<omega_byte_t> &out) {
+        out.clear();
+        uint32_t buffer = 0;
+        int bits = 0;
+        for (const auto byte : input) {
+            if (is_ascii_space(byte) || byte == '=') { continue; }
+            const int value = base32_value(byte, crockford);
+            if (value < 0) { return false; }
+            buffer = (buffer << 5U) | static_cast<uint32_t>(value);
+            bits += 5;
+            if (bits >= 8) {
+                out.push_back(static_cast<omega_byte_t>((buffer >> (bits - 8)) & 0xFFU));
+                bits -= 8;
+            }
+        }
+        return true;
+    }
+
+    std::vector<omega_byte_t> base58_encode(const std::vector<omega_byte_t> &input) {
+        static constexpr char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+        std::vector<omega_byte_t> digits(1, 0);
+        for (const auto byte : input) {
+            int carry = byte;
+            for (auto &digit : digits) {
+                carry += digit << 8U;
+                digit = static_cast<omega_byte_t>(carry % 58);
+                carry /= 58;
+            }
+            while (carry) {
+                digits.push_back(static_cast<omega_byte_t>(carry % 58));
+                carry /= 58;
+            }
+        }
+        std::vector<omega_byte_t> out;
+        for (const auto byte : input) {
+            if (byte == 0) {
+                out.push_back('1');
+            } else {
+                break;
+            }
+        }
+        for (auto iter = digits.rbegin(); iter != digits.rend(); ++iter) {
+            out.push_back(static_cast<omega_byte_t>(alphabet[*iter]));
+        }
+        return out;
+    }
+
+    bool base58_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        static constexpr char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+        std::vector<omega_byte_t> bytes(1, 0);
+        for (const auto ch : input) {
+            if (is_ascii_space(ch)) { continue; }
+            const char *found = std::find(std::begin(alphabet), std::end(alphabet) - 1, ch);
+            if (found == std::end(alphabet) - 1) { return false; }
+            int carry = static_cast<int>(found - alphabet);
+            for (auto &byte : bytes) {
+                carry += byte * 58;
+                byte = static_cast<omega_byte_t>(carry & 0xFF);
+                carry >>= 8U;
+            }
+            while (carry) {
+                bytes.push_back(static_cast<omega_byte_t>(carry & 0xFF));
+                carry >>= 8U;
+            }
+        }
+        out.clear();
+        for (const auto ch : input) {
+            if (ch == '1') {
+                out.push_back(0);
+            } else if (!is_ascii_space(ch)) {
+                break;
+            }
+        }
+        for (auto iter = bytes.rbegin(); iter != bytes.rend(); ++iter) { out.push_back(*iter); }
+        return true;
+    }
+
+    std::vector<omega_byte_t> percent_encode(const std::vector<omega_byte_t> &input) {
+        static constexpr char alphabet[] = "0123456789ABCDEF";
+        std::vector<omega_byte_t> out;
+        for (const auto byte : input) {
+            if (is_ascii_alnum(byte) || byte == '-' || byte == '_' || byte == '.' || byte == '~') {
+                out.push_back(byte);
+            } else {
+                out.push_back('%');
+                out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
+                out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
+            }
+        }
+        return out;
+    }
+
+    bool percent_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        out.clear();
+        for (size_t i = 0; i < input.size(); ++i) {
+            if (input[i] != '%') {
+                out.push_back(input[i]);
+                continue;
+            }
+            if (i + 2 >= input.size()) { return false; }
+            const int high = hex_value(input[++i]);
+            const int low = hex_value(input[++i]);
+            if (high < 0 || low < 0) { return false; }
+            out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+        }
+        return true;
+    }
+
+    std::vector<omega_byte_t> quoted_printable_encode(const std::vector<omega_byte_t> &input) {
+        static constexpr char alphabet[] = "0123456789ABCDEF";
+        std::vector<omega_byte_t> out;
+        for (const auto byte : input) {
+            if ((byte >= 33 && byte <= 60) || (byte >= 62 && byte <= 126) || byte == '\t' || byte == ' ') {
+                out.push_back(byte);
+            } else {
+                out.push_back('=');
+                out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
+                out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
+            }
+        }
+        return out;
+    }
+
+    bool quoted_printable_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        out.clear();
+        for (size_t i = 0; i < input.size(); ++i) {
+            if (input[i] != '=') {
+                out.push_back(input[i]);
+                continue;
+            }
+            if (i + 1 < input.size() && (input[i + 1] == '\r' || input[i + 1] == '\n')) {
+                while (i + 1 < input.size() && (input[i + 1] == '\r' || input[i + 1] == '\n')) { ++i; }
+                continue;
+            }
+            if (i + 2 >= input.size()) { return false; }
+            const int high = hex_value(input[++i]);
+            const int low = hex_value(input[++i]);
+            if (high < 0 || low < 0) { return false; }
+            out.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+        }
+        return true;
+    }
+
+    omega_byte_t uu_char(unsigned int value) {
+        value &= 0x3FU;
+        return static_cast<omega_byte_t>(value == 0 ? '`' : value + 32U);
+    }
+
+    int uu_value(omega_byte_t byte) {
+        if (byte == '`' || byte == ' ') { return 0; }
+        if (byte >= 33 && byte <= 95) { return (byte - 32) & 0x3F; }
+        return -1;
+    }
+
+    std::vector<omega_byte_t> uuencode(const std::vector<omega_byte_t> &input) {
+        std::vector<omega_byte_t> out;
+        for (size_t line = 0; line < input.size(); line += 45) {
+            const size_t count = std::min<size_t>(45, input.size() - line);
+            out.push_back(uu_char(static_cast<unsigned int>(count)));
+            for (size_t i = 0; i < count; i += 3) {
+                const unsigned int a = input[line + i];
+                const unsigned int b = i + 1 < count ? input[line + i + 1] : 0;
+                const unsigned int c = i + 2 < count ? input[line + i + 2] : 0;
+                out.push_back(uu_char(a >> 2U));
+                out.push_back(uu_char(((a << 4U) | (b >> 4U))));
+                out.push_back(uu_char(((b << 2U) | (c >> 6U))));
+                out.push_back(uu_char(c));
+            }
+            out.push_back('\n');
+        }
+        out.push_back('`');
         out.push_back('\n');
+        return out;
     }
-    out.push_back('`');
-    out.push_back('\n');
-    return out;
-}
 
-bool uudecode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    out.clear();
-    size_t cursor = 0;
-    while (cursor < input.size()) {
-        while (cursor < input.size() && (input[cursor] == '\r' || input[cursor] == '\n')) { ++cursor; }
-        if (cursor >= input.size()) { break; }
-        const int count = uu_value(input[cursor++]);
-        if (count < 0) { return false; }
-        if (count == 0) { return true; }
-        int produced = 0;
-        while (produced < count) {
-            if (cursor + 4 > input.size()) { return false; }
-            const int a = uu_value(input[cursor++]);
-            const int b = uu_value(input[cursor++]);
-            const int c = uu_value(input[cursor++]);
-            const int d = uu_value(input[cursor++]);
-            if (a < 0 || b < 0 || c < 0 || d < 0) { return false; }
-            const omega_byte_t one = static_cast<omega_byte_t>((a << 2U) | (b >> 4U));
-            const omega_byte_t two = static_cast<omega_byte_t>((b << 4U) | (c >> 2U));
-            const omega_byte_t three = static_cast<omega_byte_t>((c << 6U) | d);
-            out.push_back(one);
-            if (++produced < count) {
-                out.push_back(two);
-                ++produced;
+    bool uudecode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        out.clear();
+        size_t cursor = 0;
+        while (cursor < input.size()) {
+            while (cursor < input.size() && (input[cursor] == '\r' || input[cursor] == '\n')) { ++cursor; }
+            if (cursor >= input.size()) { break; }
+            const int count = uu_value(input[cursor++]);
+            if (count < 0) { return false; }
+            if (count == 0) { return true; }
+            int produced = 0;
+            while (produced < count) {
+                if (cursor + 4 > input.size()) { return false; }
+                const int a = uu_value(input[cursor++]);
+                const int b = uu_value(input[cursor++]);
+                const int c = uu_value(input[cursor++]);
+                const int d = uu_value(input[cursor++]);
+                if (a < 0 || b < 0 || c < 0 || d < 0) { return false; }
+                const omega_byte_t one = static_cast<omega_byte_t>((a << 2U) | (b >> 4U));
+                const omega_byte_t two = static_cast<omega_byte_t>((b << 4U) | (c >> 2U));
+                const omega_byte_t three = static_cast<omega_byte_t>((c << 6U) | d);
+                out.push_back(one);
+                if (++produced < count) {
+                    out.push_back(two);
+                    ++produced;
+                }
+                if (produced < count) {
+                    out.push_back(three);
+                    ++produced;
+                }
             }
-            if (produced < count) {
-                out.push_back(three);
-                ++produced;
+            while (cursor < input.size() && input[cursor] != '\n') { ++cursor; }
+        }
+        return true;
+    }
+
+    std::vector<omega_byte_t> yenc_encode(const std::vector<omega_byte_t> &input) {
+        std::vector<omega_byte_t> out;
+        for (const auto byte : input) {
+            omega_byte_t encoded = static_cast<omega_byte_t>(byte + 42U);
+            if (encoded == 0 || encoded == '\n' || encoded == '\r' || encoded == '=') {
+                out.push_back('=');
+                encoded = static_cast<omega_byte_t>(encoded + 64U);
+            }
+            out.push_back(encoded);
+        }
+        return out;
+    }
+
+    bool yenc_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+        out.clear();
+        for (size_t i = 0; i < input.size(); ++i) {
+            omega_byte_t byte = input[i];
+            if (byte == '=') {
+                if (++i >= input.size()) { return false; }
+                byte = static_cast<omega_byte_t>(input[i] - 64U);
+            }
+            out.push_back(static_cast<omega_byte_t>(byte - 42U));
+        }
+        return true;
+    }
+
+    std::vector<omega_byte_t> ascii85_encode(const std::vector<omega_byte_t> &input, bool z85) {
+        static constexpr char z85_alphabet[] =
+                "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
+        std::vector<omega_byte_t> out;
+        for (size_t i = 0; i < input.size(); i += 4) {
+            const size_t count = std::min<size_t>(4, input.size() - i);
+            uint32_t value = 0;
+            for (size_t j = 0; j < 4; ++j) { value = (value << 8U) | (j < count ? input[i + j] : 0); }
+            if (!z85 && count == 4 && value == 0) {
+                out.push_back('z');
+                continue;
+            }
+            std::array<omega_byte_t, 5> encoded{};
+            for (int j = 4; j >= 0; --j) {
+                encoded[static_cast<size_t>(j)] =
+                        static_cast<omega_byte_t>(z85 ? z85_alphabet[value % 85U] : (value % 85U) + 33U);
+                value /= 85U;
+            }
+            const size_t emit = z85 ? 5 : count + 1;
+            out.insert(out.end(), encoded.begin(),
+                       encoded.begin() + static_cast<std::array<omega_byte_t, 5>::difference_type>(emit));
+        }
+        return out;
+    }
+
+    int ascii85_value(omega_byte_t byte, bool z85) {
+        static constexpr char z85_alphabet[] =
+                "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
+        if (z85) {
+            const char *found = std::find(std::begin(z85_alphabet), std::end(z85_alphabet) - 1, byte);
+            return found == std::end(z85_alphabet) - 1 ? -1 : static_cast<int>(found - z85_alphabet);
+        }
+        return byte >= '!' && byte <= 'u' ? byte - '!' : -1;
+    }
+
+    bool ascii85_decode(const std::vector<omega_byte_t> &input, bool z85, std::vector<omega_byte_t> &out) {
+        out.clear();
+        std::array<int, 5> group{};
+        int group_size = 0;
+        for (const auto byte : input) {
+            if (is_ascii_space(byte)) { continue; }
+            if (!z85 && byte == 'z') {
+                if (group_size != 0) { return false; }
+                out.insert(out.end(), {0, 0, 0, 0});
+                continue;
+            }
+            const int value = ascii85_value(byte, z85);
+            if (value < 0) { return false; }
+            group[static_cast<size_t>(group_size++)] = value;
+            if (group_size != 5) { continue; }
+            uint32_t decoded = 0;
+            for (const int item : group) { decoded = (decoded * 85U) + static_cast<uint32_t>(item); }
+            out.push_back(static_cast<omega_byte_t>((decoded >> 24U) & 0xFFU));
+            out.push_back(static_cast<omega_byte_t>((decoded >> 16U) & 0xFFU));
+            out.push_back(static_cast<omega_byte_t>((decoded >> 8U) & 0xFFU));
+            out.push_back(static_cast<omega_byte_t>(decoded & 0xFFU));
+            group_size = 0;
+        }
+        if (group_size > 0) {
+            if (z85 || group_size == 1) { return false; }
+            for (int i = group_size; i < 5; ++i) { group[static_cast<size_t>(i)] = 84; }
+            uint32_t decoded = 0;
+            for (const int item : group) { decoded = (decoded * 85U) + static_cast<uint32_t>(item); }
+            for (int i = 0; i < group_size - 1; ++i) {
+                out.push_back(static_cast<omega_byte_t>((decoded >> (24U - (8U * i))) & 0xFFU));
             }
         }
-        while (cursor < input.size() && input[cursor] != '\n') { ++cursor; }
+        return true;
     }
-    return true;
-}
 
-std::vector<omega_byte_t> yenc_encode(const std::vector<omega_byte_t> &input) {
-    std::vector<omega_byte_t> out;
-    for (const auto byte: input) {
-        omega_byte_t encoded = static_cast<omega_byte_t>(byte + 42U);
-        if (encoded == 0 || encoded == '\n' || encoded == '\r' || encoded == '=') {
-            out.push_back('=');
-            encoded = static_cast<omega_byte_t>(encoded + 64U);
-        }
-        out.push_back(encoded);
-    }
-    return out;
-}
+}// namespace
 
-bool yenc_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
-    out.clear();
-    for (size_t i = 0; i < input.size(); ++i) {
-        omega_byte_t byte = input[i];
-        if (byte == '=') {
-            if (++i >= input.size()) { return false; }
-            byte = static_cast<omega_byte_t>(input[i] - 64U);
-        }
-        out.push_back(static_cast<omega_byte_t>(byte - 42U));
-    }
-    return true;
-}
-
-std::vector<omega_byte_t> ascii85_encode(const std::vector<omega_byte_t> &input, bool z85) {
-    static constexpr char z85_alphabet[] =
-            "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
-    std::vector<omega_byte_t> out;
-    for (size_t i = 0; i < input.size(); i += 4) {
-        const size_t count = std::min<size_t>(4, input.size() - i);
-        uint32_t value = 0;
-        for (size_t j = 0; j < 4; ++j) { value = (value << 8U) | (j < count ? input[i + j] : 0); }
-        if (!z85 && count == 4 && value == 0) {
-            out.push_back('z');
-            continue;
-        }
-        std::array<omega_byte_t, 5> encoded{};
-        for (int j = 4; j >= 0; --j) {
-            encoded[static_cast<size_t>(j)] =
-                    static_cast<omega_byte_t>(z85 ? z85_alphabet[value % 85U] : (value % 85U) + 33U);
-            value /= 85U;
-        }
-        const size_t emit = z85 ? 5 : count + 1;
-        out.insert(out.end(), encoded.begin(),
-                   encoded.begin() + static_cast<std::array<omega_byte_t, 5>::difference_type>(emit));
-    }
-    return out;
-}
-
-int ascii85_value(omega_byte_t byte, bool z85) {
-    static constexpr char z85_alphabet[] =
-            "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
-    if (z85) {
-        const char *found = std::find(std::begin(z85_alphabet), std::end(z85_alphabet) - 1, byte);
-        return found == std::end(z85_alphabet) - 1 ? -1 : static_cast<int>(found - z85_alphabet);
-    }
-    return byte >= '!' && byte <= 'u' ? byte - '!' : -1;
-}
-
-bool ascii85_decode(const std::vector<omega_byte_t> &input, bool z85, std::vector<omega_byte_t> &out) {
-    out.clear();
-    std::array<int, 5> group{};
-    int group_size = 0;
-    for (const auto byte: input) {
-        if (is_ascii_space(byte)) { continue; }
-        if (!z85 && byte == 'z') {
-            if (group_size != 0) { return false; }
-            out.insert(out.end(), {0, 0, 0, 0});
-            continue;
-        }
-        const int value = ascii85_value(byte, z85);
-        if (value < 0) { return false; }
-        group[static_cast<size_t>(group_size++)] = value;
-        if (group_size != 5) { continue; }
-        uint32_t decoded = 0;
-        for (const int item: group) { decoded = (decoded * 85U) + static_cast<uint32_t>(item); }
-        out.push_back(static_cast<omega_byte_t>((decoded >> 24U) & 0xFFU));
-        out.push_back(static_cast<omega_byte_t>((decoded >> 16U) & 0xFFU));
-        out.push_back(static_cast<omega_byte_t>((decoded >> 8U) & 0xFFU));
-        out.push_back(static_cast<omega_byte_t>(decoded & 0xFFU));
-        group_size = 0;
-    }
-    if (group_size > 0) {
-        if (z85 || group_size == 1) { return false; }
-        for (int i = group_size; i < 5; ++i) { group[static_cast<size_t>(i)] = 84; }
-        uint32_t decoded = 0;
-        for (const int item: group) { decoded = (decoded * 85U) + static_cast<uint32_t>(item); }
-        for (int i = 0; i < group_size - 1; ++i) {
-            out.push_back(static_cast<omega_byte_t>((decoded >> (24U - (8U * i))) & 0xFFU));
-        }
-    }
-    return true;
-}
-
-} // namespace
-
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
-        omega_transform_plugin_info_t *info_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transform_plugin_info_t *info_ptr) {
     if (!info_ptr) { return -1; }
     info_ptr->id = "omega.example.text_codecs";
     info_ptr->name = "Text Codecs";
@@ -507,12 +500,11 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(
     return 0;
 }
 
-extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(
-        const omega_transform_plugin_request_t *request_ptr, omega_transform_plugin_response_t *response_ptr) {
+extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int
+omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
+                             omega_transform_plugin_response_t *response_ptr) {
     std::vector<omega_byte_t> input;
-    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) {
-        return -1;
-    }
+    if (!omega_edit::plugin::selected_bytes(request_ptr, input) || !response_ptr || !request_ptr->alloc) { return -1; }
     std::map<std::string, std::string> options;
     if (!omega_edit::plugin::parse_string_options(request_ptr->options_json, options)) { return -1; }
     std::string codec = omega_edit::plugin::option_or(options, "codec", "hex");

--- a/plugins/src/zlib.c
+++ b/plugins/src/zlib.c
@@ -12,18 +12,15 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#include <omega_edit/transform_plugin_sdk.h>
 #include <ctype.h>
 #include <limits.h>
+#include <omega_edit/transform_plugin_sdk.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <zlib.h>
 
-typedef enum omega_zlib_action_t {
-    OMEGA_ZLIB_COMPRESS,
-    OMEGA_ZLIB_DECOMPRESS
-} omega_zlib_action_t;
+typedef enum omega_zlib_action_t { OMEGA_ZLIB_COMPRESS, OMEGA_ZLIB_DECOMPRESS } omega_zlib_action_t;
 
 typedef struct omega_zlib_options_t {
     omega_zlib_action_t action;
@@ -234,7 +231,7 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
 }
 
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
-                                                              omega_transform_plugin_response_t *response_ptr) {
+                                                               omega_transform_plugin_response_t *response_ptr) {
     if (!request_ptr || !response_ptr || !request_ptr->alloc || request_ptr->input_length < 0 ||
         (request_ptr->input_length > 0 && !request_ptr->input_bytes)) {
         return -1;

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -47,8 +47,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     const auto base64_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.base64");
     REQUIRE("Base64" == std::string(base64_info->name));
     REQUIRE("{\"direction\":\"encode\"}" == std::string(base64_info->default_args));
-    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"direction\":\"decode\"}",
-                                                                  base64_info->args_schema));
+    REQUIRE(0 ==
+            omega_transform_plugin_options_match_args_schema("{\"direction\":\"decode\"}", base64_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"level\":9}", base64_info->args_schema));
     const auto bitwise_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.bitwise");
     REQUIRE("Bitwise" == std::string(bitwise_info->name));
@@ -57,7 +57,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE("{\"operator\":\"xor\",\"byte\":\"0xFF\"}" == std::string(bitwise_info->default_args));
     REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"operator\":\"xor\",\"mask\":[\"0x01\",\"0x02\"]}",
                                                                   bitwise_info->args_schema));
-    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"\\u0062yte\":\"0x01\"}", bitwise_info->args_schema));
+    REQUIRE(0 ==
+            omega_transform_plugin_options_match_args_schema("{\"\\u0062yte\":\"0x01\"}", bitwise_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"operator\":\"nand\",\"byte\":\"0x01\"}",
                                                                    bitwise_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"bytes\":[\"0x01\",\"0x02\"]}",
@@ -81,10 +82,10 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     const auto case_change_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.case_change");
     REQUIRE("Case Change" == std::string(case_change_info->name));
     REQUIRE("{\"case\":\"upper\"}" == std::string(case_change_info->default_args));
-    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"case\":\"lower\"}",
-                                                                  case_change_info->args_schema));
-    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"case\":\"title\"}",
-                                                                   case_change_info->args_schema));
+    REQUIRE(0 ==
+            omega_transform_plugin_options_match_args_schema("{\"case\":\"lower\"}", case_change_info->args_schema));
+    REQUIRE(-1 ==
+            omega_transform_plugin_options_match_args_schema("{\"case\":\"title\"}", case_change_info->args_schema));
     const auto zlib_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib");
     REQUIRE("Zlib" == std::string(zlib_info->name));
     REQUIRE(std::string(zlib_info->help).find("Compression level") != std::string::npos);
@@ -92,8 +93,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE("{\"action\":\"compress\",\"level\":-1}" == std::string(zlib_info->default_args));
     REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"action\":\"compress\",\"level\":9}",
                                                                   zlib_info->args_schema));
-    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"action\":\"decompress\"}",
-                                                                  zlib_info->args_schema));
+    REQUIRE(0 ==
+            omega_transform_plugin_options_match_args_schema("{\"action\":\"decompress\"}", zlib_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"action\":\"compress\",\"level\":10}",
                                                                    zlib_info->args_schema));
     const auto digest_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.openssl_digests");
@@ -101,64 +102,61 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(std::string(digest_info->description).find("SHA") != std::string::npos);
     REQUIRE("{\"algorithm\":\"sha256\"}" == std::string(digest_info->default_args));
     REQUIRE(std::string(digest_info->args_schema).find("\"x-omega-enumGroups\"") != std::string::npos);
-    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"algorithm\":\"sha256\"}",
-                                                                  digest_info->args_schema));
-    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"algorithm\":\"sha0\"}",
-                                                                   digest_info->args_schema));
+    REQUIRE(0 ==
+            omega_transform_plugin_options_match_args_schema("{\"algorithm\":\"sha256\"}", digest_info->args_schema));
+    REQUIRE(-1 ==
+            omega_transform_plugin_options_match_args_schema("{\"algorithm\":\"sha0\"}", digest_info->args_schema));
 
     const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(session_ptr);
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "ABCD"));
 
     omega_transform_plugin_response_t response{};
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.repeat", session_ptr,
-                                                                  1, 2, nullptr, &response));
-    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
-                                                         omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.repeat", session_ptr, 1,
+                                                                  2, nullptr, &response));
+    REQUIRE("ABCBCD" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.common_checksums", session_ptr, 0, 0,
-                         "{\"algorithm\":\"sum8\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.common_checksums",
+                                                                  session_ptr, 0, 0, "{\"algorithm\":\"sum8\"}",
+                                                                  &response));
     REQUIRE(4 == response.result_length);
     REQUIRE("0x8F" == std::string(reinterpret_cast<const char *>(response.result_bytes),
                                   static_cast<size_t>(response.result_length)));
     REQUIRE("sum8" == std::string(response.result_label));
-    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
-                                                         omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("ABCBCD" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
     omega_transform_plugin_response_clear(&response);
 
     const auto identity_bitwise_change_count = omega_session_get_num_changes(session_ptr);
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.bitwise", session_ptr, 0, 6,
-                         "{\"operator\":\"xor\",\"byte\":\"0x00\"}",
-                         &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.bitwise", session_ptr, 0,
+                                                                  6, "{\"operator\":\"xor\",\"byte\":\"0x00\"}",
+                                                                  &response));
     REQUIRE(0 == response.replacement_length);
     REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
-    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
-                                                         omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("ABCBCD" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(identity_bitwise_change_count == omega_session_get_num_changes(session_ptr));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.bitwise", session_ptr, 0,
+                                                                  6, "{\"operator\":\"and\",\"byte\":\"0xFF\"}",
+                                                                  &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE("ABCBCD" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
     REQUIRE(identity_bitwise_change_count == omega_session_get_num_changes(session_ptr));
     omega_transform_plugin_response_clear(&response);
 
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.bitwise", session_ptr, 0, 6,
-                         "{\"operator\":\"and\",\"byte\":\"0xFF\"}",
-                         &response));
+                         "{\"operator\":\"or\",\"mask\":[\"0x00\",\"0x00\"]}", &response));
     REQUIRE(0 == response.replacement_length);
     REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
-    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
-                                                         omega_session_get_computed_file_size(session_ptr)));
-    REQUIRE(identity_bitwise_change_count == omega_session_get_num_changes(session_ptr));
-    omega_transform_plugin_response_clear(&response);
-
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.bitwise", session_ptr, 0, 6,
-                         "{\"operator\":\"or\",\"mask\":[\"0x00\",\"0x00\"]}",
-                         &response));
-    REQUIRE(0 == response.replacement_length);
-    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
-    REQUIRE("ABCBCD" == omega_session_get_segment_string(session_ptr, 0,
-                                                         omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("ABCBCD" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
     REQUIRE(identity_bitwise_change_count == omega_session_get_num_changes(session_ptr));
     omega_transform_plugin_response_clear(&response);
 
@@ -166,8 +164,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(case_session_ptr);
     REQUIRE(0 < omega_edit_insert_string(case_session_ptr, 0, "abC!09z"));
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.case_change",
-                                                                  case_session_ptr, 0, 7,
-                                                                  "{\"case\":\"upper\"}", &response));
+                                                                  case_session_ptr, 0, 7, "{\"case\":\"upper\"}",
+                                                                  &response));
     REQUIRE(7 == response.replacement_length);
     REQUIRE("ABC!09Z" == omega_session_get_segment_string(case_session_ptr, 0,
                                                           omega_session_get_computed_file_size(case_session_ptr)));
@@ -205,48 +203,47 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     omega_edit_destroy_session(case_session_ptr);
 
     const auto empty_transform_change_count = omega_session_get_num_changes(session_ptr);
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.repeat", session_ptr,
-                         omega_session_get_computed_file_size(session_ptr), 0, nullptr, &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.repeat", session_ptr,
+                                                                  omega_session_get_computed_file_size(session_ptr), 0,
+                                                                  nullptr, &response));
     REQUIRE(0 == response.replacement_length);
     REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
     REQUIRE(empty_transform_change_count == omega_session_get_num_changes(session_ptr));
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.base64", session_ptr,
-                         omega_session_get_computed_file_size(session_ptr), 0,
-                         "{\"direction\":\"encode\"}", &response));
-    REQUIRE(0 == response.replacement_length);
-    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
-    REQUIRE(empty_transform_change_count == omega_session_get_num_changes(session_ptr));
-    omega_transform_plugin_response_clear(&response);
-
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.bitwise", session_ptr,
-                         omega_session_get_computed_file_size(session_ptr), 0,
-                         "{\"operator\":\"xor\",\"byte\":\"0xFF\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64", session_ptr,
+                                                                  omega_session_get_computed_file_size(session_ptr), 0,
+                                                                  "{\"direction\":\"encode\"}", &response));
     REQUIRE(0 == response.replacement_length);
     REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
     REQUIRE(empty_transform_change_count == omega_session_get_num_changes(session_ptr));
     omega_transform_plugin_response_clear(&response);
 
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.bitwise", session_ptr,
-                                                                  0, 1, nullptr, &response));
+                                                                  omega_session_get_computed_file_size(session_ptr), 0,
+                                                                  "{\"operator\":\"xor\",\"byte\":\"0xFF\"}",
+                                                                  &response));
+    REQUIRE(0 == response.replacement_length);
+    REQUIRE((response.flags & OMEGA_TRANSFORM_PLUGIN_RESPONSE_NO_CONTENT_CHANGE) != 0U);
+    REQUIRE(empty_transform_change_count == omega_session_get_num_changes(session_ptr));
+    omega_transform_plugin_response_clear(&response);
+
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.bitwise", session_ptr, 0,
+                                                                  1, nullptr, &response));
     REQUIRE(std::string({static_cast<char>(0xBE), 'B', 'C', 'B', 'C', 'D'}) ==
             omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.bitwise", session_ptr,
-                                                                  1, 1,
-                                                                  "{\"operator\":\"xor\",\"byte\":\"0x42\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.bitwise", session_ptr, 1,
+                                                                  1, "{\"operator\":\"xor\",\"byte\":\"0x42\"}",
+                                                                  &response));
     REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42), 'C', 'B', 'C', 'D'}) ==
             omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
     omega_transform_plugin_response_clear(&response);
 
     REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.bitwise", session_ptr,
-                                                                   1, 1,
-                                                                   "{\"operator\":\"xor\",\"byte\":256}", &response));
+                                                                   1, 1, "{\"operator\":\"xor\",\"byte\":256}",
+                                                                   &response));
 
     REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(
                           registry_ptr, "omega.example.bitwise", session_ptr, 2, 2,
@@ -255,27 +252,23 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.bitwise", session_ptr, 2, 2,
                          "{\"operator\":\"xor\",\"mask\":[\"0x01\",\"0x02\"]}", &response));
-    REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42),
-                         static_cast<char>('C' ^ 0x01), static_cast<char>('B' ^ 0x02), 'C', 'D'}) ==
+    REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42), static_cast<char>('C' ^ 0x01),
+                         static_cast<char>('B' ^ 0x02), 'C', 'D'}) ==
             omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
     omega_transform_plugin_response_clear(&response);
 
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.bitwise", session_ptr, 2, 2,
-                         "{\"operator\":\"and\",\"mask\":[\"0x0F\",\"0xF0\"]}",
-                         &response));
-    REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42),
-                         static_cast<char>(('C' ^ 0x01) & 0x0F),
+                         "{\"operator\":\"and\",\"mask\":[\"0x0F\",\"0xF0\"]}", &response));
+    REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42), static_cast<char>(('C' ^ 0x01) & 0x0F),
                          static_cast<char>(('B' ^ 0x02) & 0xF0), 'C', 'D'}) ==
             omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
     omega_transform_plugin_response_clear(&response);
 
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.bitwise", session_ptr, 4, 2,
-                         "{\"operator\":\"or\",\"mask\":[\"0x01\",\"0x02\"]}",
-                         &response));
-    REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42),
-                         static_cast<char>(('C' ^ 0x01) & 0x0F),
+                         "{\"operator\":\"or\",\"mask\":[\"0x01\",\"0x02\"]}", &response));
+    REQUIRE(std::string({static_cast<char>(0xBE), static_cast<char>('B' ^ 0x42), static_cast<char>(('C' ^ 0x01) & 0x0F),
                          static_cast<char>(('B' ^ 0x02) & 0xF0), static_cast<char>('C' | 0x01),
                          static_cast<char>('D' | 0x02)}) ==
             omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
@@ -288,36 +281,35 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64",
                                                                   codec_session_ptr, 0, 5, nullptr, &response));
     REQUIRE("aGVsbG8=" == omega_session_get_segment_string(codec_session_ptr, 0,
-                                                          omega_session_get_computed_file_size(codec_session_ptr)));
+                                                           omega_session_get_computed_file_size(codec_session_ptr)));
     REQUIRE(8 == response.replacement_length);
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64",
-                                                                   codec_session_ptr, 0, 5, "{\"level\":9}",
-                                                                   &response));
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(
+                          registry_ptr, "omega.example.base64", codec_session_ptr, 0, 5, "{\"level\":9}", &response));
 
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64",
-                                                                  codec_session_ptr, 0, 0,
-                                                                  "{\"direction\":\"decode\"}", &response));
+                                                                  codec_session_ptr, 0, 0, "{\"direction\":\"decode\"}",
+                                                                  &response));
     REQUIRE("hello" == omega_session_get_segment_string(codec_session_ptr, 0,
                                                         omega_session_get_computed_file_size(codec_session_ptr)));
     REQUIRE(5 == response.replacement_length);
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.common_checksums", codec_session_ptr, 0, 5,
-                         "{\"algorithm\":\"fnv1a64\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.common_checksums",
+                                                                  codec_session_ptr, 0, 5,
+                                                                  "{\"algorithm\":\"fnv1a64\"}", &response));
     REQUIRE(18 == response.result_length);
     REQUIRE("0xA430D84680AABD0B" == std::string(reinterpret_cast<const char *>(response.result_bytes),
-                                               static_cast<size_t>(response.result_length)));
+                                                static_cast<size_t>(response.result_length)));
     REQUIRE("fnv1a64" == std::string(response.result_label));
     omega_transform_plugin_response_clear(&response);
 
     const auto require_digest_result = [&](const char *algorithm, const char *label, const char *expected) {
         const std::string options = std::string("{\"algorithm\":\"") + algorithm + "\"}";
-        REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                             registry_ptr, "omega.example.openssl_digests", codec_session_ptr, 0, 5,
-                             options.c_str(), &response));
+        REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.openssl_digests",
+                                                                      codec_session_ptr, 0, 5, options.c_str(),
+                                                                      &response));
         REQUIRE(static_cast<int64_t>(std::string(expected).size()) == response.result_length);
         REQUIRE(expected == std::string(reinterpret_cast<const char *>(response.result_bytes),
                                         static_cast<size_t>(response.result_length)));
@@ -327,18 +319,15 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
 
     require_digest_result("md5", "md5", "5d41402abc4b2a76b9719d911017c592");
     require_digest_result("sha1", "sha1", "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
-    require_digest_result("sha224", "sha224",
-                          "ea09ae9cc6768c50fcee903ed054556e5bfc8347907f12598aa24193");
-    require_digest_result("sha256", "sha256",
-                          "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    require_digest_result("sha224", "sha224", "ea09ae9cc6768c50fcee903ed054556e5bfc8347907f12598aa24193");
+    require_digest_result("sha256", "sha256", "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
     require_digest_result("sha384", "sha384",
                           "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f"
                           "90397bdf5f6a13de828684f");
     require_digest_result("sha512", "sha512",
                           "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c"
                           "3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043");
-    require_digest_result("sha3-256", "sha3-256",
-                          "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392");
+    require_digest_result("sha3-256", "sha3-256", "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392");
     require_digest_result("sha3-512", "sha3-512",
                           "75d527c368f2efe848ecf6b073a36767800805e9eef2b1857d5f984f036eb6df891d75f72d9b"
                           "154518c1cd58835286d1da9a38deba3de98b5a53e5ed78a84976");
@@ -354,24 +343,24 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(0 < omega_edit_insert_bytes(large_session_ptr, 0, large_bytes.data(),
                                         static_cast<int64_t>(large_bytes.size())));
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.common_checksums", large_session_ptr, 0, 0,
-                         "{\"algorithm\":\"sum8\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.common_checksums",
+                                                                  large_session_ptr, 0, 0, "{\"algorithm\":\"sum8\"}",
+                                                                  &response));
     REQUIRE(4 == response.result_length);
     REQUIRE("0x00" == std::string(reinterpret_cast<const char *>(response.result_bytes),
                                   static_cast<size_t>(response.result_length)));
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.common_checksums", large_session_ptr, 0, 0,
-                         "{\"algorithm\":\"fnv1a64\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.common_checksums",
+                                                                  large_session_ptr, 0, 0,
+                                                                  "{\"algorithm\":\"fnv1a64\"}", &response));
     REQUIRE(18 == response.result_length);
     REQUIRE("fnv1a64" == std::string(response.result_label));
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.openssl_digests", large_session_ptr, 0, 0,
-                         "{\"algorithm\":\"sha256\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.openssl_digests",
+                                                                  large_session_ptr, 0, 0, "{\"algorithm\":\"sha256\"}",
+                                                                  &response));
     REQUIRE(64 == response.result_length);
     REQUIRE("c283e17a1b90a352c91de2c445b711c5c4126279eff884b8ffc44893576b19ef" ==
             std::string(reinterpret_cast<const char *>(response.result_bytes),
@@ -380,9 +369,9 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(large_session_ptr);
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.common_checksums", codec_session_ptr, 0, 5,
-                         "{\"algorithm\":\"crc32\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.common_checksums",
+                                                                  codec_session_ptr, 0, 5, "{\"algorithm\":\"crc32\"}",
+                                                                  &response));
     REQUIRE("0x3610A686" == std::string(reinterpret_cast<const char *>(response.result_bytes),
                                         static_cast<size_t>(response.result_length)));
     REQUIRE("crc32" == std::string(response.result_label));
@@ -433,8 +422,9 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.text_codecs", text_codec_session_ptr, 0, 5,
                          "{\"codec\":\"hex\",\"direction\":\"encode\"}", &response));
-    REQUIRE("68656c6c6f" == omega_session_get_segment_string(text_codec_session_ptr, 0,
-                                                            omega_session_get_computed_file_size(text_codec_session_ptr)));
+    REQUIRE("68656c6c6f" ==
+            omega_session_get_segment_string(text_codec_session_ptr, 0,
+                                             omega_session_get_computed_file_size(text_codec_session_ptr)));
     omega_transform_plugin_response_clear(&response);
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.text_codecs", text_codec_session_ptr, 0, 0,
@@ -445,8 +435,9 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.text_codecs", text_codec_session_ptr, 0, 5,
                          "{\"codec\":\"base64url\",\"direction\":\"encode\"}", &response));
-    REQUIRE("aGVsbG8" == omega_session_get_segment_string(text_codec_session_ptr, 0,
-                                                          omega_session_get_computed_file_size(text_codec_session_ptr)));
+    REQUIRE("aGVsbG8" ==
+            omega_session_get_segment_string(text_codec_session_ptr, 0,
+                                             omega_session_get_computed_file_size(text_codec_session_ptr)));
     omega_transform_plugin_response_clear(&response);
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.text_codecs", text_codec_session_ptr, 0, 0,
@@ -463,7 +454,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                          registry_ptr, "omega.example.character_transcode", charset_session_ptr, 0, 3,
                          "{\"from\":\"utf-8\",\"to\":\"ebcdic-037\"}", &response));
     REQUIRE(std::string({static_cast<char>(0xC1), static_cast<char>(0xC2), static_cast<char>(0xC3)}) ==
-            omega_session_get_segment_string(charset_session_ptr, 0, omega_session_get_computed_file_size(charset_session_ptr)));
+            omega_session_get_segment_string(charset_session_ptr, 0,
+                                             omega_session_get_computed_file_size(charset_session_ptr)));
     omega_transform_plugin_response_clear(&response);
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
                          registry_ptr, "omega.example.character_transcode", charset_session_ptr, 0, 3,
@@ -490,7 +482,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                                   helper_session_ptr, 0, 4, "{\"width\":2}",
                                                                   &response));
     REQUIRE(std::string({2, 1, 4, 3}) ==
-            omega_session_get_segment_string(helper_session_ptr, 0, omega_session_get_computed_file_size(helper_session_ptr)));
+            omega_session_get_segment_string(helper_session_ptr, 0,
+                                             omega_session_get_computed_file_size(helper_session_ptr)));
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(helper_session_ptr);
 
@@ -514,7 +507,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                          registry_ptr, "omega.example.decimal_codecs", decimal_session_ptr, 0, 3,
                          "{\"codec\":\"packed-decimal\",\"direction\":\"encode\"}", &response));
     REQUIRE(std::string({static_cast<char>(0x12), static_cast<char>(0x3C)}) ==
-            omega_session_get_segment_string(decimal_session_ptr, 0, omega_session_get_computed_file_size(decimal_session_ptr)));
+            omega_session_get_segment_string(decimal_session_ptr, 0,
+                                             omega_session_get_computed_file_size(decimal_session_ptr)));
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(decimal_session_ptr);
 
@@ -522,61 +516,59 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(format_session_ptr);
     const omega_byte_t varint_bytes[] = {0x96, 0x01};
     REQUIRE(0 < omega_edit_insert_bytes(format_session_ptr, 0, varint_bytes, 2));
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.format_inspectors", format_session_ptr, 0, 2,
-                         "{\"format\":\"protobuf-varint\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.format_inspectors",
+                                                                  format_session_ptr, 0, 2,
+                                                                  "{\"format\":\"protobuf-varint\"}", &response));
     REQUIRE(std::string(reinterpret_cast<const char *>(response.result_bytes),
-                        static_cast<size_t>(response.result_length)).find("value=150") != std::string::npos);
+                        static_cast<size_t>(response.result_length))
+                    .find("value=150") != std::string::npos);
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(format_session_ptr);
 
     const auto record_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(record_session_ptr);
     REQUIRE(0 < omega_edit_insert_string(record_session_ptr, 0, "<&"));
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(
-                         registry_ptr, "omega.example.record_text_helpers", record_session_ptr, 0, 2,
-                         "{\"action\":\"xml-escape\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.record_text_helpers",
+                                                                  record_session_ptr, 0, 2,
+                                                                  "{\"action\":\"xml-escape\"}", &response));
     REQUIRE("&lt;&amp;" == omega_session_get_segment_string(record_session_ptr, 0,
-                                                           omega_session_get_computed_file_size(record_session_ptr)));
+                                                            omega_session_get_computed_file_size(record_session_ptr)));
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(record_session_ptr);
 
     const auto invalid_csv_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(invalid_csv_session_ptr);
     REQUIRE(0 < omega_edit_insert_string(invalid_csv_session_ptr, 0, "\"abc\"\""));
-    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(
-                          registry_ptr, "omega.example.record_text_helpers", invalid_csv_session_ptr, 0, 6,
-                          "{\"action\":\"csv-unquote\"}", &response));
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.record_text_helpers",
+                                                                   invalid_csv_session_ptr, 0, 6,
+                                                                   "{\"action\":\"csv-unquote\"}", &response));
     omega_edit_destroy_session(invalid_csv_session_ptr);
 
-    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib",
-                                                                   codec_session_ptr, 0, 5,
-                                                                   "{\"action\":\"compress\",\"level\":10}",
-                                                                   &response));
+    REQUIRE(-1 ==
+            omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib", codec_session_ptr, 0,
+                                                             5, "{\"action\":\"compress\",\"level\":10}", &response));
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib",
-                                                                  codec_session_ptr, 0, 5,
-                                                                  "{\"action\":\"compress\",\"level\":9}",
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib", codec_session_ptr,
+                                                                  0, 5, "{\"action\":\"compress\",\"level\":9}",
                                                                   &response));
     REQUIRE(0 < response.replacement_length);
     {
-        const auto compressed = omega_session_get_segment_string(codec_session_ptr, 0,
-                                                                omega_session_get_computed_file_size(codec_session_ptr));
+        const auto compressed = omega_session_get_segment_string(
+                codec_session_ptr, 0, omega_session_get_computed_file_size(codec_session_ptr));
         REQUIRE(response.replacement_length == static_cast<int64_t>(compressed.size()));
         REQUIRE(8 == (static_cast<unsigned char>(compressed[0]) & 0x0F));
     }
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib",
-                                                                  codec_session_ptr, 0, 0,
-                                                                  "{\"action\":\"decompress\"}", &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib", codec_session_ptr,
+                                                                  0, 0, "{\"action\":\"decompress\"}", &response));
     REQUIRE("hello" == omega_session_get_segment_string(codec_session_ptr, 0,
                                                         omega_session_get_computed_file_size(codec_session_ptr)));
     REQUIRE(5 == response.replacement_length);
     omega_transform_plugin_response_clear(&response);
 
-    REQUIRE(0 < omega_edit_insert_string(codec_session_ptr, omega_session_get_computed_file_size(codec_session_ptr),
-                                         "!"));
+    REQUIRE(0 <
+            omega_edit_insert_string(codec_session_ptr, omega_session_get_computed_file_size(codec_session_ptr), "!"));
     REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.base64",
                                                                    codec_session_ptr, 0, 0,
                                                                    "{\"direction\":\"decode\"}", &response));
@@ -598,17 +590,15 @@ TEST_CASE("Large Transform Replacement Uses File-Backed Checkpoint", "[Transform
 
     const auto input_length = static_cast<int64_t>((OMEGA_MEMORY_BUFFER_LIMIT / 2) + 1);
     std::vector<omega_byte_t> input(static_cast<size_t>(input_length));
-    for (int64_t i = 0; i < input_length; ++i) {
-        input[static_cast<size_t>(i)] = static_cast<omega_byte_t>(i % 251);
-    }
+    for (int64_t i = 0; i < input_length; ++i) { input[static_cast<size_t>(i)] = static_cast<omega_byte_t>(i % 251); }
 
-    const auto session_ptr = omega_edit_create_session_from_bytes(input.data(), input_length, nullptr, nullptr,
-                                                                  NO_EVENTS, nullptr);
+    const auto session_ptr =
+            omega_edit_create_session_from_bytes(input.data(), input_length, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(session_ptr);
 
     omega_transform_plugin_response_t response{};
-    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.repeat", session_ptr,
-                                                                  0, input_length, nullptr, &response));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.repeat", session_ptr, 0,
+                                                                  input_length, nullptr, &response));
     REQUIRE(input_length * 2 == response.replacement_length);
     REQUIRE(input_length * 2 == omega_session_get_computed_file_size(session_ptr));
     REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));

--- a/plugins/tools/transform_plugin_harness.cpp
+++ b/plugins/tools/transform_plugin_harness.cpp
@@ -39,12 +39,11 @@ namespace {
     };
 
     void print_usage(const char *argv0) {
-        std::cerr
-                << "Usage:\n"
-                << "  " << argv0 << " --plugin-dir DIR --list\n"
-                << "  " << argv0 << " --plugin PATH --run ID --input TEXT [--expect-output TEXT]\n"
-                << "  " << argv0 << " --plugin-dir DIR --run ID --input-hex HEX [--offset N] [--length N]\n"
-                << "       [--options JSON] [--expect-output-hex HEX] [--expect-result TEXT]\n";
+        std::cerr << "Usage:\n"
+                  << "  " << argv0 << " --plugin-dir DIR --list\n"
+                  << "  " << argv0 << " --plugin PATH --run ID --input TEXT [--expect-output TEXT]\n"
+                  << "  " << argv0 << " --plugin-dir DIR --run ID --input-hex HEX [--offset N] [--length N]\n"
+                  << "       [--options JSON] [--expect-output-hex HEX] [--expect-result TEXT]\n";
     }
 
     auto parse_i64(const char *value, int64_t &out) -> bool {
@@ -73,9 +72,9 @@ namespace {
     }
 
     auto parse_hex(std::string hex, std::vector<omega_byte_t> &bytes) -> bool {
-        hex.erase(std::remove_if(hex.begin(), hex.end(), [](unsigned char ch) {
-            return std::isspace(ch) != 0 || ch == ':' || ch == '-';
-        }), hex.end());
+        hex.erase(std::remove_if(hex.begin(), hex.end(),
+                                 [](unsigned char ch) { return std::isspace(ch) != 0 || ch == ':' || ch == '-'; }),
+                  hex.end());
         if ((hex.size() % 2) != 0) { return false; }
         bytes.clear();
         bytes.reserve(hex.size() / 2);
@@ -194,13 +193,13 @@ namespace {
     }
 
     auto register_plugins(omega_transform_plugin_registry_t *registry_ptr, const options_t &options) -> bool {
-        for (const auto &path: options.plugin_paths) {
+        for (const auto &path : options.plugin_paths) {
             if (0 != omega_transform_plugin_registry_register_plugin(registry_ptr, path.c_str())) {
                 std::cerr << "failed to register plugin: " << path << "\n";
                 return false;
             }
         }
-        for (const auto &dir: options.plugin_dirs) {
+        for (const auto &dir : options.plugin_dirs) {
             if (0 > omega_transform_plugin_registry_register_directory(registry_ptr, dir.c_str())) {
                 std::cerr << "failed to register plugin directory: " << dir << "\n";
                 return false;
@@ -215,9 +214,8 @@ namespace {
         for (int64_t i = 0; i < count; ++i) {
             const auto *info = omega_transform_plugin_registry_get_info(registry_ptr, i);
             if (!info) { continue; }
-            std::cout << info->id << "\t" << (info->name ? info->name : "") << "\t"
-                      << operation_name(info->operation) << "\t" << info->flags << "\t"
-                      << (info->description ? info->description : "") << "\n";
+            std::cout << info->id << "\t" << (info->name ? info->name : "") << "\t" << operation_name(info->operation)
+                      << "\t" << info->flags << "\t" << (info->description ? info->description : "") << "\n";
         }
         return 0;
     }
@@ -233,9 +231,9 @@ namespace {
         }
 
         const auto &input = *options.input;
-        auto *session_ptr = omega_edit_create_session_from_bytes(
-                input.empty() ? nullptr : input.data(), static_cast<int64_t>(input.size()), nullptr, nullptr,
-                NO_EVENTS, nullptr);
+        auto *session_ptr = omega_edit_create_session_from_bytes(input.empty() ? nullptr : input.data(),
+                                                                 static_cast<int64_t>(input.size()), nullptr, nullptr,
+                                                                 NO_EVENTS, nullptr);
         if (!session_ptr) {
             std::cerr << "failed to create session\n";
             return 1;
@@ -277,16 +275,17 @@ namespace {
             const auto &expected = *options.expect_output;
             if (expected.size() != static_cast<size_t>(output_length) ||
                 std::memcmp(expected.data(), output_ptr, expected.size()) != 0) {
-                std::cerr << "output mismatch: expected " << to_hex(expected.data(), static_cast<int64_t>(expected.size()))
-                          << " got " << to_hex(output_ptr, output_length) << "\n";
+                std::cerr << "output mismatch: expected "
+                          << to_hex(expected.data(), static_cast<int64_t>(expected.size())) << " got "
+                          << to_hex(output_ptr, output_length) << "\n";
                 result = 1;
             }
         }
         if (options.expect_result.has_value()) {
             const std::string actual = response.result_length > 0 && response.result_bytes != nullptr
-                                       ? std::string(reinterpret_cast<const char *>(response.result_bytes),
-                                                     static_cast<size_t>(response.result_length))
-                                       : std::string();
+                                               ? std::string(reinterpret_cast<const char *>(response.result_bytes),
+                                                             static_cast<size_t>(response.result_length))
+                                               : std::string();
             if (*options.expect_result != actual) {
                 std::cerr << "result mismatch: expected '" << *options.expect_result << "' got '" << actual << "'\n";
                 result = 1;
@@ -298,7 +297,7 @@ namespace {
         omega_edit_destroy_session(session_ptr);
         return result;
     }
-}
+}// namespace
 
 int main(int argc, char **argv) {
     options_t options;

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -44,221 +44,217 @@ option cc_enable_arenas = true;
 // - **Event stream** – Server-push notifications for session and viewport
 //   state changes, delivered via gRPC server-streaming RPCs.
 service EditorService {
-  // Return server metadata: version, hostname, process ID, and resource info.
-  rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+    // Return server metadata: version, hostname, process ID, and resource info.
+    rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
 
-  // ---------------------------------------------------------------------------
-  // Session lifecycle
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Session lifecycle
+    // ---------------------------------------------------------------------------
 
-  // Create a new editing session, optionally backed by an existing file.
-  // Returns the assigned session ID, checkpoint directory, and (if a file was
-  // provided) the original file size. If the server has begun shutdown or is
-  // draining existing sessions, this RPC fails with UNAVAILABLE.
-  rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
+    // Create a new editing session, optionally backed by an existing file.
+    // Returns the assigned session ID, checkpoint directory, and (if a file was
+    // provided) the original file size. If the server has begun shutdown or is
+    // draining existing sessions, this RPC fails with UNAVAILABLE.
+    rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
 
-  // Persist the session's computed content to disk.  The caller specifies the
-  // target path and IO flags (overwrite behaviour).  An optional byte range
-  // can limit the save to a sub-section of the data.
-  rpc SaveSession(SaveSessionRequest) returns (SaveSessionResponse);
+    // Persist the session's computed content to disk.  The caller specifies the
+    // target path and IO flags (overwrite behaviour).  An optional byte range
+    // can limit the save to a sub-section of the data.
+    rpc SaveSession(SaveSessionRequest) returns (SaveSessionResponse);
 
-  // Detach the caller from a session. The backing session and its resources
-  // are released when the last attachment is destroyed or reaped.
-  rpc DestroySession(DestroySessionRequest) returns (DestroySessionResponse);
+    // Detach the caller from a session. The backing session and its resources
+    // are released when the last attachment is destroyed or reaped.
+    rpc DestroySession(DestroySessionRequest) returns (DestroySessionResponse);
 
-  // ---------------------------------------------------------------------------
-  // Editing operations
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Editing operations
+    // ---------------------------------------------------------------------------
 
-  // Submit a single change (insert, delete, or overwrite) to a session.
-  // Returns the serial number assigned to the new change.
-  rpc SubmitChange(SubmitChangeRequest) returns (SubmitChangeResponse);
+    // Submit a single change (insert, delete, or overwrite) to a session.
+    // Returns the serial number assigned to the new change.
+    rpc SubmitChange(SubmitChangeRequest) returns (SubmitChangeResponse);
 
-  // Undo the most recent change in the session.  Returns the serial number of
-  // the change that was undone.
-  rpc UndoLastChange(UndoLastChangeRequest) returns (UndoLastChangeResponse);
+    // Undo the most recent change in the session.  Returns the serial number of
+    // the change that was undone.
+    rpc UndoLastChange(UndoLastChangeRequest) returns (UndoLastChangeResponse);
 
-  // Redo the most recently undone change.  Returns the serial number of the
-  // change that was re-applied.
-  rpc RedoLastUndo(RedoLastUndoRequest) returns (RedoLastUndoResponse);
+    // Redo the most recently undone change.  Returns the serial number of the
+    // change that was re-applied.
+    rpc RedoLastUndo(RedoLastUndoRequest) returns (RedoLastUndoResponse);
 
-  // Undo *all* changes in the session, returning it to its original state.
-  rpc ClearChanges(ClearChangesRequest) returns (ClearChangesResponse);
+    // Undo *all* changes in the session, returning it to its original state.
+    rpc ClearChanges(ClearChangesRequest) returns (ClearChangesResponse);
 
-  // Pause acceptance of new changes on the session.  Any SubmitChange calls
-  // while paused will be rejected.
-  rpc PauseSessionChanges(PauseSessionChangesRequest) returns (PauseSessionChangesResponse);
+    // Pause acceptance of new changes on the session.  Any SubmitChange calls
+    // while paused will be rejected.
+    rpc PauseSessionChanges(PauseSessionChangesRequest) returns (PauseSessionChangesResponse);
 
-  // Resume acceptance of changes after a pause.
-  rpc ResumeSessionChanges(ResumeSessionChangesRequest) returns (ResumeSessionChangesResponse);
+    // Resume acceptance of changes after a pause.
+    rpc ResumeSessionChanges(ResumeSessionChangesRequest) returns (ResumeSessionChangesResponse);
 
-  // ---------------------------------------------------------------------------
-  // Transactions (atomic change groups)
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Transactions (atomic change groups)
+    // ---------------------------------------------------------------------------
 
-  // Begin an atomic transaction.  All changes submitted between
-  // SessionBeginTransaction and SessionEndTransaction are treated as a single
-  // undoable unit.
-  rpc SessionBeginTransaction(SessionBeginTransactionRequest) returns (SessionBeginTransactionResponse);
+    // Begin an atomic transaction.  All changes submitted between
+    // SessionBeginTransaction and SessionEndTransaction are treated as a single
+    // undoable unit.
+    rpc SessionBeginTransaction(SessionBeginTransactionRequest) returns (SessionBeginTransactionResponse);
 
-  // End the current transaction, committing the grouped changes.
-  rpc SessionEndTransaction(SessionEndTransactionRequest) returns (SessionEndTransactionResponse);
+    // End the current transaction, committing the grouped changes.
+    rpc SessionEndTransaction(SessionEndTransactionRequest) returns (SessionEndTransactionResponse);
 
-  // ---------------------------------------------------------------------------
-  // Viewport lifecycle
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Viewport lifecycle
+    // ---------------------------------------------------------------------------
 
-  // Create a viewport – a window of `capacity` bytes starting at `offset`
-  // into the session's computed content.  Returns the initial data.
-  rpc CreateViewport(CreateViewportRequest) returns (CreateViewportResponse);
+    // Create a viewport – a window of `capacity` bytes starting at `offset`
+    // into the session's computed content.  Returns the initial data.
+    rpc CreateViewport(CreateViewportRequest) returns (CreateViewportResponse);
 
-  // Move and/or resize an existing viewport.  Returns the updated data.
-  rpc ModifyViewport(ModifyViewportRequest) returns (ModifyViewportResponse);
+    // Move and/or resize an existing viewport.  Returns the updated data.
+    rpc ModifyViewport(ModifyViewportRequest) returns (ModifyViewportResponse);
 
-  // Check whether a viewport's content has been invalidated by edits since it
-  // was last read.
-  rpc ViewportHasChanges(ViewportHasChangesRequest) returns (ViewportHasChangesResponse);
+    // Check whether a viewport's content has been invalidated by edits since it
+    // was last read.
+    rpc ViewportHasChanges(ViewportHasChangesRequest) returns (ViewportHasChangesResponse);
 
-  // Read the current content of a viewport.
-  rpc GetViewportData(GetViewportDataRequest) returns (GetViewportDataResponse);
+    // Read the current content of a viewport.
+    rpc GetViewportData(GetViewportDataRequest) returns (GetViewportDataResponse);
 
-  // Destroy a viewport and release its resources.
-  rpc DestroyViewport(DestroyViewportRequest) returns (DestroyViewportResponse);
+    // Destroy a viewport and release its resources.
+    rpc DestroyViewport(DestroyViewportRequest) returns (DestroyViewportResponse);
 
-  // Pause delivery of viewport-change events for the given session.
-  rpc PauseViewportEvents(PauseViewportEventsRequest) returns (PauseViewportEventsResponse);
+    // Pause delivery of viewport-change events for the given session.
+    rpc PauseViewportEvents(PauseViewportEventsRequest) returns (PauseViewportEventsResponse);
 
-  // Resume delivery of viewport-change events.
-  rpc ResumeViewportEvents(ResumeViewportEventsRequest) returns (ResumeViewportEventsResponse);
+    // Resume delivery of viewport-change events.
+    rpc ResumeViewportEvents(ResumeViewportEventsRequest) returns (ResumeViewportEventsResponse);
 
-  // Force-notify all viewports attached to a session whose content has
-  // changed.  Returns the number of viewports notified.
-  rpc NotifyChangedViewports(NotifyChangedViewportsRequest) returns (NotifyChangedViewportsResponse);
+    // Force-notify all viewports attached to a session whose content has
+    // changed.  Returns the number of viewports notified.
+    rpc NotifyChangedViewports(NotifyChangedViewportsRequest) returns (NotifyChangedViewportsResponse);
 
-  // ---------------------------------------------------------------------------
-  // Change inspection
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Change inspection
+    // ---------------------------------------------------------------------------
 
-  // Retrieve full details of a specific change identified by its serial
-  // number (carried inside the SessionEvent).
-  rpc GetChangeDetails(GetChangeDetailsRequest) returns (GetChangeDetailsResponse);
+    // Retrieve full details of a specific change identified by its serial
+    // number (carried inside the SessionEvent).
+    rpc GetChangeDetails(GetChangeDetailsRequest) returns (GetChangeDetailsResponse);
 
-  // Retrieve details of the most recent change in a session.
-  rpc GetLastChange(GetLastChangeRequest) returns (GetLastChangeResponse);
+    // Retrieve details of the most recent change in a session.
+    rpc GetLastChange(GetLastChangeRequest) returns (GetLastChangeResponse);
 
-  // Retrieve details of the most recent undone change in a session.
-  rpc GetLastUndo(GetLastUndoRequest) returns (GetLastUndoResponse);
+    // Retrieve details of the most recent undone change in a session.
+    rpc GetLastUndo(GetLastUndoRequest) returns (GetLastUndoResponse);
 
-  // ---------------------------------------------------------------------------
-  // Data inspection
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Data inspection
+    // ---------------------------------------------------------------------------
 
-  // Return the logical (computed) file size of a session after all edits.
-  rpc GetComputedFileSize(GetComputedFileSizeRequest) returns (GetComputedFileSizeResponse);
+    // Return the logical (computed) file size of a session after all edits.
+    rpc GetComputedFileSize(GetComputedFileSizeRequest) returns (GetComputedFileSizeResponse);
 
-  // Detect the byte-order mark (BOM) at the beginning of the session data.
-  rpc GetByteOrderMark(GetByteOrderMarkRequest) returns (GetByteOrderMarkResponse);
+    // Detect the byte-order mark (BOM) at the beginning of the session data.
+    rpc GetByteOrderMark(GetByteOrderMarkRequest) returns (GetByteOrderMarkResponse);
 
-  // Detect the content/MIME type of a segment of session data.
-  rpc GetContentType(GetContentTypeRequest) returns (GetContentTypeResponse);
+    // Detect the content/MIME type of a segment of session data.
+    rpc GetContentType(GetContentTypeRequest) returns (GetContentTypeResponse);
 
-  // Detect the natural language of a UTF-encoded text segment, returned as an
-  // ISO 639-1 two-letter code.
-  rpc GetLanguage(GetLanguageRequest) returns (GetLanguageResponse);
+    // Detect the natural language of a UTF-encoded text segment, returned as an
+    // ISO 639-1 two-letter code.
+    rpc GetLanguage(GetLanguageRequest) returns (GetLanguageResponse);
 
-  // Return one or more counts for a session (file size, changes, undos,
-  // viewports, checkpoints, etc.) in a single round-trip.
-  rpc GetCount(GetCountRequest) returns (GetCountResponse);
+    // Return one or more counts for a session (file size, changes, undos,
+    // viewports, checkpoints, etc.) in a single round-trip.
+    rpc GetCount(GetCountRequest) returns (GetCountResponse);
 
-  // Check the native session model for internal consistency.
-  rpc CheckSessionModel(CheckSessionModelRequest) returns (CheckSessionModelResponse);
+    // Check the native session model for internal consistency.
+    rpc CheckSessionModel(CheckSessionModelRequest) returns (CheckSessionModelResponse);
 
-  // Compute a server-side fingerprint for original or computed session content.
-  rpc GetSessionFingerprint(GetSessionFingerprintRequest) returns (GetSessionFingerprintResponse);
+    // Compute a server-side fingerprint for original or computed session content.
+    rpc GetSessionFingerprint(GetSessionFingerprintRequest) returns (GetSessionFingerprintResponse);
 
-  // Return the total number of active sessions on the server.
-  rpc GetSessionCount(GetSessionCountRequest) returns (GetSessionCountResponse);
+    // Return the total number of active sessions on the server.
+    rpc GetSessionCount(GetSessionCountRequest) returns (GetSessionCountResponse);
 
-  // Read a raw byte segment from the session's computed content.
-  rpc GetSegment(GetSegmentRequest) returns (GetSegmentResponse);
+    // Read a raw byte segment from the session's computed content.
+    rpc GetSegment(GetSegmentRequest) returns (GetSegmentResponse);
 
-  // ---------------------------------------------------------------------------
-  // Search and profiling
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Search and profiling
+    // ---------------------------------------------------------------------------
 
-  // Search for a byte pattern in a session.  Supports case-insensitive and
-  // reverse search, with optional offset/length bounds and a match limit.
-  rpc SearchSession(SearchSessionRequest) returns (SearchSessionResponse);
+    // Search for a byte pattern in a session.  Supports case-insensitive and
+    // reverse search, with optional offset/length bounds and a match limit.
+    rpc SearchSession(SearchSessionRequest) returns (SearchSessionResponse);
 
-  // Replace non-overlapping matches in a session range by applying a native
-  // transactional edit script. Returns the number of matches selected and the
-  // lowered edit-operation counts.
-  rpc ReplaceSession(ReplaceSessionRequest) returns (ReplaceSessionResponse);
+    // Replace non-overlapping matches in a session range by applying a native
+    // transactional edit script. Returns the number of matches selected and the
+    // lowered edit-operation counts.
+    rpc ReplaceSession(ReplaceSessionRequest) returns (ReplaceSessionResponse);
 
-  // Replace all non-overlapping matches in a session range by streaming the
-  // rewritten content into a checkpoint-backed model. Returns the number of
-  // replacements performed.
-  rpc ReplaceSessionCheckpointed(ReplaceSessionCheckpointedRequest)
-      returns (ReplaceSessionCheckpointedResponse);
+    // Replace all non-overlapping matches in a session range by streaming the
+    // rewritten content into a checkpoint-backed model. Returns the number of
+    // replacements performed.
+    rpc ReplaceSessionCheckpointed(ReplaceSessionCheckpointedRequest) returns (ReplaceSessionCheckpointedResponse);
 
-  // Create a checkpoint from the session's current computed content.
-  rpc CreateCheckpoint(CreateCheckpointRequest)
-      returns (CreateCheckpointResponse);
+    // Create a checkpoint from the session's current computed content.
+    rpc CreateCheckpoint(CreateCheckpointRequest) returns (CreateCheckpointResponse);
 
-  // Revert the most recent checkpoint-backed rewrite by destroying the last
-  // checkpoint model and exposing the previous model again.
-  rpc DestroyLastCheckpoint(DestroyLastCheckpointRequest)
-      returns (DestroyLastCheckpointResponse);
+    // Revert the most recent checkpoint-backed rewrite by destroying the last
+    // checkpoint model and exposing the previous model again.
+    rpc DestroyLastCheckpoint(DestroyLastCheckpointRequest) returns (DestroyLastCheckpointResponse);
 
-  // Restore session content to the most recent checkpoint snapshot while
-  // keeping that checkpoint available.
-  rpc RestoreLastCheckpoint(RestoreLastCheckpointRequest)
-      returns (RestoreLastCheckpointResponse);
+    // Restore session content to the most recent checkpoint snapshot while
+    // keeping that checkpoint available.
+    rpc RestoreLastCheckpoint(RestoreLastCheckpointRequest) returns (RestoreLastCheckpointResponse);
 
-  // List transform plugins registered with the native server.
-  rpc ListTransformPlugins(ListTransformPluginsRequest) returns (ListTransformPluginsResponse);
+    // List transform plugins registered with the native server.
+    rpc ListTransformPlugins(ListTransformPluginsRequest) returns (ListTransformPluginsResponse);
 
-  // Apply a transform plugin to a session range. Plugins may replace content,
-  // inspect content and return derived bytes, or do both.
-  rpc ApplyTransformPlugin(ApplyTransformPluginRequest) returns (ApplyTransformPluginResponse);
+    // Apply a transform plugin to a session range. Plugins may replace content,
+    // inspect content and return derived bytes, or do both.
+    rpc ApplyTransformPlugin(ApplyTransformPluginRequest) returns (ApplyTransformPluginResponse);
 
-  // Compute a byte-frequency histogram (256 buckets, one per byte value) over
-  // a range of session data.  Bucket 256 counts DOS-style CR+LF line endings.
-  rpc GetByteFrequencyProfile(GetByteFrequencyProfileRequest) returns (GetByteFrequencyProfileResponse);
+    // Compute a byte-frequency histogram (256 buckets, one per byte value) over
+    // a range of session data.  Bucket 256 counts DOS-style CR+LF line endings.
+    rpc GetByteFrequencyProfile(GetByteFrequencyProfileRequest) returns (GetByteFrequencyProfileResponse);
 
-  // Count characters by byte-width (single, double, triple, quad) in a
-  // UTF-encoded text segment.  Also reports invalid bytes.
-  rpc GetCharacterCounts(GetCharacterCountsRequest) returns (GetCharacterCountsResponse);
+    // Count characters by byte-width (single, double, triple, quad) in a
+    // UTF-encoded text segment.  Also reports invalid bytes.
+    rpc GetCharacterCounts(GetCharacterCountsRequest) returns (GetCharacterCountsResponse);
 
-  // ---------------------------------------------------------------------------
-  // Server management
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Server management
+    // ---------------------------------------------------------------------------
 
-  // Send a control command to the server (graceful or immediate shutdown).
-  rpc ServerControl(ServerControlRequest) returns (ServerControlResponse);
+    // Send a control command to the server (graceful or immediate shutdown).
+    rpc ServerControl(ServerControlRequest) returns (ServerControlResponse);
 
-  // Exchange a heartbeat with the server. The client sends the session IDs it
-  // still holds so the server can keep them alive and return resource metrics.
-  rpc GetHeartbeat(GetHeartbeatRequest) returns (GetHeartbeatResponse);
+    // Exchange a heartbeat with the server. The client sends the session IDs it
+    // still holds so the server can keep them alive and return resource metrics.
+    rpc GetHeartbeat(GetHeartbeatRequest) returns (GetHeartbeatResponse);
 
-  // ---------------------------------------------------------------------------
-  // Event streams
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // Event streams
+    // ---------------------------------------------------------------------------
 
-  // Subscribe to a server-streaming feed of session-level events (edits,
-  // undos, saves, viewport creation/destruction, etc.).  The interest bitmask
-  // controls which event kinds are delivered.
-  rpc SubscribeToSessionEvents(SubscribeToSessionEventsRequest) returns (stream SubscribeToSessionEventsResponse);
+    // Subscribe to a server-streaming feed of session-level events (edits,
+    // undos, saves, viewport creation/destruction, etc.).  The interest bitmask
+    // controls which event kinds are delivered.
+    rpc SubscribeToSessionEvents(SubscribeToSessionEventsRequest) returns (stream SubscribeToSessionEventsResponse);
 
-  // Subscribe to a server-streaming feed of viewport-level events (content
-  // changes, modifications, etc.).
-  rpc SubscribeToViewportEvents(SubscribeToViewportEventsRequest) returns (stream SubscribeToViewportEventsResponse);
+    // Subscribe to a server-streaming feed of viewport-level events (content
+    // changes, modifications, etc.).
+    rpc SubscribeToViewportEvents(SubscribeToViewportEventsRequest) returns (stream SubscribeToViewportEventsResponse);
 
-  // Cancel all active session-event subscriptions for the session ID.
-  rpc UnsubscribeToSessionEvents(UnsubscribeToSessionEventsRequest) returns (UnsubscribeToSessionEventsResponse);
+    // Cancel all active session-event subscriptions for the session ID.
+    rpc UnsubscribeToSessionEvents(UnsubscribeToSessionEventsRequest) returns (UnsubscribeToSessionEventsResponse);
 
-  // Cancel an active viewport-event subscription.
-  rpc UnsubscribeToViewportEvents(UnsubscribeToViewportEventsRequest) returns (UnsubscribeToViewportEventsResponse);
+    // Cancel an active viewport-event subscription.
+    rpc UnsubscribeToViewportEvents(UnsubscribeToViewportEventsRequest) returns (UnsubscribeToViewportEventsResponse);
 }
 
 // ===========================================================================
@@ -267,131 +263,131 @@ service EditorService {
 
 // Flags controlling file I/O behaviour for SaveSession.
 enum IOFlags {
-  // No special flags — fail if the target file already exists.
-  IO_FLAGS_UNSPECIFIED = 0;
-  // Overwrite the target file if it already exists.
-  IO_FLAGS_OVERWRITE = 1;
-  // Overwrite the target file even if it is the session's source file.
-  IO_FLAGS_FORCE_OVERWRITE = 2;
+    // No special flags — fail if the target file already exists.
+    IO_FLAGS_UNSPECIFIED = 0;
+    // Overwrite the target file if it already exists.
+    IO_FLAGS_OVERWRITE = 1;
+    // Overwrite the target file even if it is the session's source file.
+    IO_FLAGS_FORCE_OVERWRITE = 2;
 }
 
 // The kind of atomic edit applied to a session.
 enum ChangeKind {
-  CHANGE_KIND_UNSPECIFIED = 0;
-  // Delete `length` bytes starting at `offset`.
-  CHANGE_KIND_DELETE = 1;
-  // Insert `data` at `offset` without removing existing bytes.
-  CHANGE_KIND_INSERT = 2;
-  // Overwrite bytes at `offset` with `data`.
-  CHANGE_KIND_OVERWRITE = 3;
-  // Transform bytes through a checkpoint-backed operation.
-  CHANGE_KIND_TRANSFORM = 4;
+    CHANGE_KIND_UNSPECIFIED = 0;
+    // Delete `length` bytes starting at `offset`.
+    CHANGE_KIND_DELETE = 1;
+    // Insert `data` at `offset` without removing existing bytes.
+    CHANGE_KIND_INSERT = 2;
+    // Overwrite bytes at `offset` with `data`.
+    CHANGE_KIND_OVERWRITE = 3;
+    // Transform bytes through a checkpoint-backed operation.
+    CHANGE_KIND_TRANSFORM = 4;
 }
 
 // Session-level event kinds.  Values are powers of two so they can be OR'd
 // into an interest bitmask for event subscription requests.
 // Make sure these match the session events defined in fwd_defs.h
 enum SessionEventKind {
-  SESSION_EVENT_KIND_UNSPECIFIED = 0;
-  // A new session was created.
-  SESSION_EVENT_KIND_CREATE = 1;
-  // A change (insert/delete/overwrite) was applied.
-  SESSION_EVENT_KIND_EDIT = 2;
-  // A change was undone.
-  SESSION_EVENT_KIND_UNDO = 4;
-  // All changes were cleared.
-  SESSION_EVENT_KIND_CLEAR = 8;
-  // A transform was applied.
-  SESSION_EVENT_KIND_TRANSFORM = 16;
-  // A checkpoint was created.
-  SESSION_EVENT_KIND_CREATE_CHECKPOINT = 32;
-  // A checkpoint was destroyed.
-  SESSION_EVENT_KIND_DESTROY_CHECKPOINT = 64;
-  // The session was saved to disk.
-  SESSION_EVENT_KIND_SAVE = 128;
-  // Change acceptance was paused.
-  SESSION_EVENT_KIND_CHANGES_PAUSED = 256;
-  // Change acceptance was resumed.
-  SESSION_EVENT_KIND_CHANGES_RESUMED = 512;
-  // A viewport was created on this session.
-  SESSION_EVENT_KIND_CREATE_VIEWPORT = 1024;
-  // A viewport was destroyed on this session.
-  SESSION_EVENT_KIND_DESTROY_VIEWPORT = 2048;
-  // A transaction was opened on this session.
-  SESSION_EVENT_KIND_TRANSACTION_STARTED = 4096;
-  // An open transaction was ended on this session.
-  SESSION_EVENT_KIND_TRANSACTION_ENDED = 8192;
-  // A transform started running on this session.
-  SESSION_EVENT_KIND_TRANSFORM_STARTED = 16384;
-  // A running transform reported progress.
-  SESSION_EVENT_KIND_TRANSFORM_PROGRESS = 32768;
-  // A transform completed successfully.
-  SESSION_EVENT_KIND_TRANSFORM_COMPLETED = 65536;
-  // A transform failed.
-  SESSION_EVENT_KIND_TRANSFORM_FAILED = 131072;
-  // A checkpoint snapshot was restored.
-  SESSION_EVENT_KIND_RESTORE_CHECKPOINT = 262144;
+    SESSION_EVENT_KIND_UNSPECIFIED = 0;
+    // A new session was created.
+    SESSION_EVENT_KIND_CREATE = 1;
+    // A change (insert/delete/overwrite) was applied.
+    SESSION_EVENT_KIND_EDIT = 2;
+    // A change was undone.
+    SESSION_EVENT_KIND_UNDO = 4;
+    // All changes were cleared.
+    SESSION_EVENT_KIND_CLEAR = 8;
+    // A transform was applied.
+    SESSION_EVENT_KIND_TRANSFORM = 16;
+    // A checkpoint was created.
+    SESSION_EVENT_KIND_CREATE_CHECKPOINT = 32;
+    // A checkpoint was destroyed.
+    SESSION_EVENT_KIND_DESTROY_CHECKPOINT = 64;
+    // The session was saved to disk.
+    SESSION_EVENT_KIND_SAVE = 128;
+    // Change acceptance was paused.
+    SESSION_EVENT_KIND_CHANGES_PAUSED = 256;
+    // Change acceptance was resumed.
+    SESSION_EVENT_KIND_CHANGES_RESUMED = 512;
+    // A viewport was created on this session.
+    SESSION_EVENT_KIND_CREATE_VIEWPORT = 1024;
+    // A viewport was destroyed on this session.
+    SESSION_EVENT_KIND_DESTROY_VIEWPORT = 2048;
+    // A transaction was opened on this session.
+    SESSION_EVENT_KIND_TRANSACTION_STARTED = 4096;
+    // An open transaction was ended on this session.
+    SESSION_EVENT_KIND_TRANSACTION_ENDED = 8192;
+    // A transform started running on this session.
+    SESSION_EVENT_KIND_TRANSFORM_STARTED = 16384;
+    // A running transform reported progress.
+    SESSION_EVENT_KIND_TRANSFORM_PROGRESS = 32768;
+    // A transform completed successfully.
+    SESSION_EVENT_KIND_TRANSFORM_COMPLETED = 65536;
+    // A transform failed.
+    SESSION_EVENT_KIND_TRANSFORM_FAILED = 131072;
+    // A checkpoint snapshot was restored.
+    SESSION_EVENT_KIND_RESTORE_CHECKPOINT = 262144;
 }
 
 // Viewport-level event kinds.  Values are powers of two so they can be OR'd
 // into an interest bitmask for event subscription requests.
 // Make sure these match the viewport events defined in fwd_defs.h
 enum ViewportEventKind {
-  VIEWPORT_EVENT_KIND_UNSPECIFIED = 0;
-  // The viewport was created.
-  VIEWPORT_EVENT_KIND_CREATE = 1;
-  // An edit in the underlying session affected this viewport's range.
-  VIEWPORT_EVENT_KIND_EDIT = 2;
-  // An undo in the underlying session affected this viewport's range.
-  VIEWPORT_EVENT_KIND_UNDO = 4;
-  // All changes were cleared in the underlying session.
-  VIEWPORT_EVENT_KIND_CLEAR = 8;
-  // A transform affected this viewport's range.
-  VIEWPORT_EVENT_KIND_TRANSFORM = 16;
-  // The viewport was moved or resized via ModifyViewport.
-  VIEWPORT_EVENT_KIND_MODIFY = 32;
-  // The viewport's content bytes have changed (general notification).
-  VIEWPORT_EVENT_KIND_CHANGES = 64;
+    VIEWPORT_EVENT_KIND_UNSPECIFIED = 0;
+    // The viewport was created.
+    VIEWPORT_EVENT_KIND_CREATE = 1;
+    // An edit in the underlying session affected this viewport's range.
+    VIEWPORT_EVENT_KIND_EDIT = 2;
+    // An undo in the underlying session affected this viewport's range.
+    VIEWPORT_EVENT_KIND_UNDO = 4;
+    // All changes were cleared in the underlying session.
+    VIEWPORT_EVENT_KIND_CLEAR = 8;
+    // A transform affected this viewport's range.
+    VIEWPORT_EVENT_KIND_TRANSFORM = 16;
+    // The viewport was moved or resized via ModifyViewport.
+    VIEWPORT_EVENT_KIND_MODIFY = 32;
+    // The viewport's content bytes have changed (general notification).
+    VIEWPORT_EVENT_KIND_CHANGES = 64;
 }
 
 // Categories of counts that can be requested via GetCount.
 enum CountKind {
-  COUNT_KIND_UNSPECIFIED = 0;
-  // Logical (computed) file size in bytes after all edits.
-  COUNT_KIND_COMPUTED_FILE_SIZE = 1;
-  // Number of changes applied (undo stack depth).
-  COUNT_KIND_CHANGES = 2;
-  // Number of undone changes (redo stack depth).
-  COUNT_KIND_UNDOS = 3;
-  // Number of active viewports on the session.
-  COUNT_KIND_VIEWPORTS = 4;
-  // Number of checkpoints.
-  COUNT_KIND_CHECKPOINTS = 5;
-  // Number of active search contexts.
-  COUNT_KIND_SEARCH_CONTEXTS = 6;
-  // Number of change transactions.
-  COUNT_KIND_CHANGE_TRANSACTIONS = 7;
-  // Number of undo transactions.
-  COUNT_KIND_UNDO_TRANSACTIONS = 8;
+    COUNT_KIND_UNSPECIFIED = 0;
+    // Logical (computed) file size in bytes after all edits.
+    COUNT_KIND_COMPUTED_FILE_SIZE = 1;
+    // Number of changes applied (undo stack depth).
+    COUNT_KIND_CHANGES = 2;
+    // Number of undone changes (redo stack depth).
+    COUNT_KIND_UNDOS = 3;
+    // Number of active viewports on the session.
+    COUNT_KIND_VIEWPORTS = 4;
+    // Number of checkpoints.
+    COUNT_KIND_CHECKPOINTS = 5;
+    // Number of active search contexts.
+    COUNT_KIND_SEARCH_CONTEXTS = 6;
+    // Number of change transactions.
+    COUNT_KIND_CHANGE_TRANSACTIONS = 7;
+    // Number of undo transactions.
+    COUNT_KIND_UNDO_TRANSACTIONS = 8;
 }
 
 // Server control command types.
 enum ServerControlKind {
-  SERVER_CONTROL_KIND_UNSPECIFIED = 0;
-  // Graceful shutdown: stop accepting new sessions, exit when all existing
-  // sessions are destroyed.
-  SERVER_CONTROL_KIND_GRACEFUL_SHUTDOWN = 1;
-  // Immediate shutdown: stop accepting new sessions and exit right away.
-  SERVER_CONTROL_KIND_IMMEDIATE_SHUTDOWN = 2;
+    SERVER_CONTROL_KIND_UNSPECIFIED = 0;
+    // Graceful shutdown: stop accepting new sessions, exit when all existing
+    // sessions are destroyed.
+    SERVER_CONTROL_KIND_GRACEFUL_SHUTDOWN = 1;
+    // Immediate shutdown: stop accepting new sessions and exit right away.
+    SERVER_CONTROL_KIND_IMMEDIATE_SHUTDOWN = 2;
 }
 
 // Status reported after a server-control command is accepted.
 enum ServerControlStatus {
-  SERVER_CONTROL_STATUS_UNSPECIFIED = 0;
-  // The requested shutdown path has completed and the server is stopping.
-  SERVER_CONTROL_STATUS_COMPLETED = 1;
-  // Graceful shutdown was accepted, but the server is still draining sessions.
-  SERVER_CONTROL_STATUS_DRAINING = 2;
+    SERVER_CONTROL_STATUS_UNSPECIFIED = 0;
+    // The requested shutdown path has completed and the server is stopping.
+    SERVER_CONTROL_STATUS_COMPLETED = 1;
+    // Graceful shutdown was accepted, but the server is still draining sessions.
+    SERVER_CONTROL_STATUS_DRAINING = 2;
 }
 
 // ===========================================================================
@@ -403,54 +399,72 @@ message GetServerInfoRequest {}
 
 // Server metadata returned by GetServerInfo.
 message GetServerInfoResponse {
-  string hostname = 1;             // Server hostname.
-  int32 process_id = 2;            // Server OS process ID.
-  string server_version = 3;       // Omega Edit server version string.
-  string jvm_version = 4 [deprecated = true]; // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
-  string jvm_vendor = 5 [deprecated = true];  // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
-  string jvm_path = 6 [deprecated = true];    // Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
-  int32 available_processors = 7;  // Number of logical CPU cores.
-  string runtime_kind = 8;         // Runtime family, e.g. "native" or "jvm".
-  string runtime_name = 9;         // Runtime implementation name, e.g. "C++".
-  string platform = 10;            // Host platform and architecture summary.
-  string compiler = 11;            // Compiler or toolchain used to build the server.
-  string build_type = 12;          // Build configuration, e.g. "Release" or "Debug".
-  string cpp_standard = 13;        // C++ standard used, e.g. "C++17".
+    string hostname = 1;      // Server hostname.
+    int32 process_id = 2;     // Server OS process ID.
+    string server_version = 3;// Omega Edit server version string.
+    string jvm_version = 4 [
+        deprecated = true
+    ];// Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
+    string jvm_vendor = 5 [
+        deprecated = true
+    ];// Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
+    string jvm_path = 6 [
+        deprecated = true
+    ];// Legacy JVM field; the native server leaves it unset so it reads as the proto default empty string.
+    int32 available_processors = 7;// Number of logical CPU cores.
+    string runtime_kind = 8;       // Runtime family, e.g. "native" or "jvm".
+    string runtime_name = 9;       // Runtime implementation name, e.g. "C++".
+    string platform = 10;          // Host platform and architecture summary.
+    string compiler = 11;          // Compiler or toolchain used to build the server.
+    string build_type = 12;        // Build configuration, e.g. "Release" or "Debug".
+    string cpp_standard = 13;      // C++ standard used, e.g. "C++17".
 }
 
 // Request to send a control command to the server.
 message ServerControlRequest {
-  ServerControlKind kind = 1; // The command to execute.
+    ServerControlKind kind = 1;// The command to execute.
 }
 
 // Response acknowledging a server control command.
 message ServerControlResponse {
-  ServerControlKind kind = 1; // The command that was executed.
-  int32 pid = 2;              // Server process ID.
-  int32 response_code = 3 [deprecated = true]; // Legacy field: 0 when the command was accepted, non-zero only for compatibility with older clients.
-  optional ServerControlStatus status = 4;     // Explicit shutdown progress for accepted commands; optional so clients can detect older servers that omitted the field and fall back to legacy compatibility handling.
+    ServerControlKind kind = 1;// The command that was executed.
+    int32 pid = 2;             // Server process ID.
+    int32 response_code = 3 [
+        deprecated = true
+    ];// Legacy field: 0 when the command was accepted, non-zero only for compatibility with older clients.
+    optional ServerControlStatus status =
+            4;// Explicit shutdown progress for accepted commands; optional so clients can detect older servers that omitted the field and fall back to legacy compatibility handling.
 }
 
 // Client heartbeat request. The client lists the session IDs it still holds so
 // the server can track liveness.
 message GetHeartbeatRequest {
-  repeated string session_ids = 1; // Session IDs the client currently holds.
+    repeated string session_ids = 1;// Session IDs the client currently holds.
 }
 
 // Server heartbeat response with resource metrics.
 message GetHeartbeatResponse {
-  int32 session_count = 1;                  // Total active sessions on the server.
-  int64 timestamp = 2;                      // Server wall-clock time in milliseconds since epoch.
-  int64 uptime = 3;                         // Server uptime in milliseconds.
-  int32 cpu_count = 4;                      // Number of logical CPU cores.
-  double cpu_load_average = 5 [deprecated = true]; // Legacy load average field mirrored from load_average when available, otherwise left unset so it reads as the proto default 0.
-  int64 max_memory = 6 [deprecated = true];        // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
-  int64 committed_memory = 7 [deprecated = true];  // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
-  int64 used_memory = 8 [deprecated = true];       // Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
-  optional double load_average = 9;                // 1-min load average when the platform can report it.
-  optional int64 resident_memory_bytes = 10;       // Resident set size (RSS) in bytes.
-  optional int64 virtual_memory_bytes = 11;        // Virtual address space usage in bytes when the platform can report it consistently.
-  optional int64 peak_resident_memory_bytes = 12;  // Peak RSS in bytes.
+    int32 session_count = 1;// Total active sessions on the server.
+    int64 timestamp = 2;    // Server wall-clock time in milliseconds since epoch.
+    int64 uptime = 3;       // Server uptime in milliseconds.
+    int32 cpu_count = 4;    // Number of logical CPU cores.
+    double cpu_load_average = 5 [
+        deprecated = true
+    ];// Legacy load average field mirrored from load_average when available, otherwise left unset so it reads as the proto default 0.
+    int64 max_memory = 6 [
+        deprecated = true
+    ];// Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
+    int64 committed_memory = 7 [
+        deprecated = true
+    ];// Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
+    int64 used_memory = 8 [
+        deprecated = true
+    ];// Legacy JVM heap field; the native server leaves it unset so it reads as the proto default 0.
+    optional double load_average = 9;         // 1-min load average when the platform can report it.
+    optional int64 resident_memory_bytes = 10;// Resident set size (RSS) in bytes.
+    optional int64 virtual_memory_bytes =
+            11;// Virtual address space usage in bytes when the platform can report it consistently.
+    optional int64 peak_resident_memory_bytes = 12;// Peak RSS in bytes.
 }
 
 // ===========================================================================
@@ -459,48 +473,48 @@ message GetHeartbeatResponse {
 
 // Request to create a new editing session.
 message CreateSessionRequest {
-  // Path to the file to load.  Omit to create an empty session.
-  optional string file_path = 1;
-  // Caller-chosen session ID. Must be unique; duplicates are rejected with
-  // ALREADY_EXISTS rather than being silently reassigned.
-  optional string session_id_desired = 2;
-  // Directory for checkpoint files.  Defaults to a system temp directory.
-  optional string checkpoint_directory = 3;
-  // Initial bytes to seed the session with.  Mutually exclusive with file_path.
-  optional bytes initial_data = 4;
+    // Path to the file to load.  Omit to create an empty session.
+    optional string file_path = 1;
+    // Caller-chosen session ID. Must be unique; duplicates are rejected with
+    // ALREADY_EXISTS rather than being silently reassigned.
+    optional string session_id_desired = 2;
+    // Directory for checkpoint files.  Defaults to a system temp directory.
+    optional string checkpoint_directory = 3;
+    // Initial bytes to seed the session with.  Mutually exclusive with file_path.
+    optional bytes initial_data = 4;
 }
 
 // Response after a session is successfully created.
 message CreateSessionResponse {
-  string session_id = 1;          // Assigned session ID.
-  string checkpoint_directory = 2; // Resolved checkpoint directory path.
-  optional int64 file_size = 3;   // Original file size in bytes (absent for empty sessions).
+    string session_id = 1;          // Assigned session ID.
+    string checkpoint_directory = 2;// Resolved checkpoint directory path.
+    optional int64 file_size = 3;   // Original file size in bytes (absent for empty sessions).
 }
 
 // Request to save a session's computed content to disk.
 message SaveSessionRequest {
-  string session_id = 1;   // Session to save.
-  string file_path = 2;    // Target file path.
-  int32 io_flags = 3;      // Bitmask of IOFlags values.
-  optional int64 offset = 4; // Start of the byte range to save (default: 0).
-  optional int64 length = 5; // Length of the byte range to save (default: entire file).
+    string session_id = 1;    // Session to save.
+    string file_path = 2;     // Target file path.
+    int32 io_flags = 3;       // Bitmask of IOFlags values.
+    optional int64 offset = 4;// Start of the byte range to save (default: 0).
+    optional int64 length = 5;// Length of the byte range to save (default: entire file).
 }
 
 // Response after a save operation.
 message SaveSessionResponse {
-  string session_id = 1;  // Session that was saved.
-  string file_path = 2;   // Path the data was written to.
-  int32 save_status = 3;  // 0 on success, non-zero on failure.
+    string session_id = 1;// Session that was saved.
+    string file_path = 2; // Path the data was written to.
+    int32 save_status = 3;// 0 on success, non-zero on failure.
 }
 
 // Request to destroy a session.
 message DestroySessionRequest {
-  string id = 1; // Session ID to destroy.
+    string id = 1;// Session ID to destroy.
 }
 
 // Response after a session is destroyed.
 message DestroySessionResponse {
-  string id = 1; // Session ID that was destroyed.
+    string id = 1;// Session ID that was destroyed.
 }
 
 // ===========================================================================
@@ -509,69 +523,69 @@ message DestroySessionResponse {
 
 // Request to submit a single edit to a session.
 message SubmitChangeRequest {
-  string session_id = 1;   // Target session.
-  ChangeKind kind = 2;     // Type of edit (insert, delete, overwrite).
-  int64 offset = 3;        // Byte offset where the edit is applied.
-  int64 length = 4;        // Number of bytes to delete (CHANGE_KIND_DELETE/CHANGE_KIND_OVERWRITE).
-  optional bytes data = 5; // Payload bytes (CHANGE_KIND_INSERT/CHANGE_KIND_OVERWRITE).
+    string session_id = 1;  // Target session.
+    ChangeKind kind = 2;    // Type of edit (insert, delete, overwrite).
+    int64 offset = 3;       // Byte offset where the edit is applied.
+    int64 length = 4;       // Number of bytes to delete (CHANGE_KIND_DELETE/CHANGE_KIND_OVERWRITE).
+    optional bytes data = 5;// Payload bytes (CHANGE_KIND_INSERT/CHANGE_KIND_OVERWRITE).
 }
 
 // Response after a change is successfully applied.
 message SubmitChangeResponse {
-  string session_id = 1; // Session that was modified.
-  int64 serial = 2;      // Monotonically increasing serial number of the change.
+    string session_id = 1;// Session that was modified.
+    int64 serial = 2;     // Monotonically increasing serial number of the change.
 }
 
 // Request to undo the most recent change.
 message UndoLastChangeRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after undoing a change.
 message UndoLastChangeResponse {
-  string session_id = 1; // Session that was modified.
-  int64 serial = 2;      // Serial number of the undone change.
+    string session_id = 1;// Session that was modified.
+    int64 serial = 2;     // Serial number of the undone change.
 }
 
 // Request to redo the most recently undone change.
 message RedoLastUndoRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after redoing a change.
 message RedoLastUndoResponse {
-  string session_id = 1; // Session that was modified.
-  int64 serial = 2;      // Serial number of the re-applied change.
+    string session_id = 1;// Session that was modified.
+    int64 serial = 2;     // Serial number of the re-applied change.
 }
 
 // Request to undo all changes in a session.
 message ClearChangesRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after clearing all changes.
 message ClearChangesResponse {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Request to pause change acceptance on a session.
 message PauseSessionChangesRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after pausing change acceptance.
 message PauseSessionChangesResponse {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Request to resume change acceptance on a session.
 message ResumeSessionChangesRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after resuming change acceptance.
 message ResumeSessionChangesResponse {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // ===========================================================================
@@ -580,22 +594,22 @@ message ResumeSessionChangesResponse {
 
 // Request to begin an atomic transaction.
 message SessionBeginTransactionRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after beginning a transaction.
 message SessionBeginTransactionResponse {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Request to end (commit) the current transaction.
 message SessionEndTransactionRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after ending a transaction.
 message SessionEndTransactionResponse {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // ===========================================================================
@@ -604,104 +618,98 @@ message SessionEndTransactionResponse {
 
 // Request to create a viewport on a session.
 message CreateViewportRequest {
-  string session_id = 1;                // Session to observe.
-  int64 capacity = 2;                   // Maximum number of bytes the viewport holds.
-  int64 offset = 3;                     // Starting byte offset in the session.
-  bool is_floating = 4;                 // When true, the viewport follows edits automatically.
-  // Optional caller-chosen viewport ID. Must be unique within the session;
-  // duplicates are rejected with ALREADY_EXISTS.
-  optional string viewport_id_desired = 5;
+    string session_id = 1;// Session to observe.
+    int64 capacity = 2;   // Maximum number of bytes the viewport holds.
+    int64 offset = 3;     // Starting byte offset in the session.
+    bool is_floating = 4; // When true, the viewport follows edits automatically.
+    // Optional caller-chosen viewport ID. Must be unique within the session;
+    // duplicates are rejected with ALREADY_EXISTS.
+    optional string viewport_id_desired = 5;
 }
 
 // Response carrying a viewport's content.
 message CreateViewportResponse {
-  string viewport_id = 1;         // Viewport ID.
-  int64 offset = 2;               // Current byte offset in the session.
-  int64 length = 3;               // Number of bytes actually returned (may be < capacity).
-  bytes data = 4;                 // The viewport content.
-  int64 following_byte_count = 5; // Number of bytes remaining after the viewport's range.
+    string viewport_id = 1;        // Viewport ID.
+    int64 offset = 2;              // Current byte offset in the session.
+    int64 length = 3;              // Number of bytes actually returned (may be < capacity).
+    bytes data = 4;                // The viewport content.
+    int64 following_byte_count = 5;// Number of bytes remaining after the viewport's range.
 }
 
 // Request to move or resize an existing viewport.
 message ModifyViewportRequest {
-  string viewport_id = 1; // Viewport to modify.
-  int64 offset = 2;       // New byte offset.
-  int64 capacity = 3;     // New capacity.
-  bool is_floating = 4;   // New floating flag.
+    string viewport_id = 1;// Viewport to modify.
+    int64 offset = 2;      // New byte offset.
+    int64 capacity = 3;    // New capacity.
+    bool is_floating = 4;  // New floating flag.
 }
 
 // Response after modifying a viewport.
 message ModifyViewportResponse {
-  string viewport_id = 1;         // Viewport ID.
-  int64 offset = 2;               // Updated byte offset.
-  int64 length = 3;               // Number of bytes returned.
-  bytes data = 4;                 // Updated viewport content.
-  int64 following_byte_count = 5; // Bytes remaining after viewport range.
+    string viewport_id = 1;        // Viewport ID.
+    int64 offset = 2;              // Updated byte offset.
+    int64 length = 3;              // Number of bytes returned.
+    bytes data = 4;                // Updated viewport content.
+    int64 following_byte_count = 5;// Bytes remaining after viewport range.
 }
 
 // Request to check whether a viewport has pending changes.
 message ViewportHasChangesRequest {
-  string id = 1; // Viewport ID.
+    string id = 1;// Viewport ID.
 }
 
 // Response indicating whether a viewport has pending changes.
-message ViewportHasChangesResponse {
-  bool result = 1;
-}
+message ViewportHasChangesResponse { bool result = 1; }
 
 // Request to read a viewport's current data.
-message GetViewportDataRequest {
-  string viewport_id = 1;
-}
+message GetViewportDataRequest { string viewport_id = 1; }
 
 // Response carrying a viewport's current content.
 message GetViewportDataResponse {
-  string viewport_id = 1;         // Viewport ID.
-  int64 offset = 2;               // Current byte offset in the session.
-  int64 length = 3;               // Number of bytes actually returned (may be < capacity).
-  bytes data = 4;                 // The viewport content.
-  int64 following_byte_count = 5; // Number of bytes remaining after the viewport's range.
+    string viewport_id = 1;        // Viewport ID.
+    int64 offset = 2;              // Current byte offset in the session.
+    int64 length = 3;              // Number of bytes actually returned (may be < capacity).
+    bytes data = 4;                // The viewport content.
+    int64 following_byte_count = 5;// Number of bytes remaining after the viewport's range.
 }
 
 // Request to destroy a viewport.
 message DestroyViewportRequest {
-  string id = 1; // Viewport ID.
+    string id = 1;// Viewport ID.
 }
 
 // Response after a viewport is destroyed.
 message DestroyViewportResponse {
-  string id = 1; // Viewport ID.
+    string id = 1;// Viewport ID.
 }
 
 // Request to pause viewport-change events for a session.
 message PauseViewportEventsRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after pausing viewport events.
 message PauseViewportEventsResponse {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Request to resume viewport-change events.
 message ResumeViewportEventsRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after resuming viewport events.
 message ResumeViewportEventsResponse {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Request to force-notify changed viewports.
 message NotifyChangedViewportsRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response with the number of viewports that were notified.
-message NotifyChangedViewportsResponse {
-  int64 count = 1;
-}
+message NotifyChangedViewportsResponse { int64 count = 1; }
 
 // ===========================================================================
 // Request / Response messages — Change inspection
@@ -709,64 +717,64 @@ message NotifyChangedViewportsResponse {
 
 // Request to retrieve details of a specific change by serial number.
 message GetChangeDetailsRequest {
-  string session_id = 1;                   // Session ID.
-  SessionEventKind session_event_kind = 2; // Compatibility field; ignored by the server.
-  int64 computed_file_size = 3;            // Compatibility field; ignored by the server.
-  int64 change_count = 4;                  // Compatibility field; ignored by the server.
-  int64 undo_count = 5;                    // Compatibility field; ignored by the server.
-  optional int64 serial = 6;               // Serial number of the change.
+    string session_id = 1;                  // Session ID.
+    SessionEventKind session_event_kind = 2;// Compatibility field; ignored by the server.
+    int64 computed_file_size = 3;           // Compatibility field; ignored by the server.
+    int64 change_count = 4;                 // Compatibility field; ignored by the server.
+    int64 undo_count = 5;                   // Compatibility field; ignored by the server.
+    optional int64 serial = 6;              // Serial number of the change.
 }
 
 // Response with full details of a single change.
 message GetChangeDetailsResponse {
-  string session_id = 1;   // Session the change belongs to.
-  int64 serial = 2;        // Unique serial number.
-  ChangeKind kind = 3;     // Type of edit.
-  int64 offset = 4;        // Byte offset.
-  int64 length = 5;        // Number of bytes affected.
-  optional bytes data = 6; // Payload bytes (for insert/overwrite).
-  optional TransformChangeDetails transform = 7; // Transform metadata (for transform changes).
+    string session_id = 1;                        // Session the change belongs to.
+    int64 serial = 2;                             // Unique serial number.
+    ChangeKind kind = 3;                          // Type of edit.
+    int64 offset = 4;                             // Byte offset.
+    int64 length = 5;                             // Number of bytes affected.
+    optional bytes data = 6;                      // Payload bytes (for insert/overwrite).
+    optional TransformChangeDetails transform = 7;// Transform metadata (for transform changes).
 }
 
 // Request to retrieve the most recent change in a session.
 message GetLastChangeRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response with details of the most recent change.
 message GetLastChangeResponse {
-  string session_id = 1;   // Session the change belongs to.
-  int64 serial = 2;        // Unique serial number.
-  ChangeKind kind = 3;     // Type of edit.
-  int64 offset = 4;        // Byte offset.
-  int64 length = 5;        // Number of bytes affected.
-  optional bytes data = 6; // Payload bytes (for insert/overwrite).
-  optional TransformChangeDetails transform = 7; // Transform metadata (for transform changes).
+    string session_id = 1;                        // Session the change belongs to.
+    int64 serial = 2;                             // Unique serial number.
+    ChangeKind kind = 3;                          // Type of edit.
+    int64 offset = 4;                             // Byte offset.
+    int64 length = 5;                             // Number of bytes affected.
+    optional bytes data = 6;                      // Payload bytes (for insert/overwrite).
+    optional TransformChangeDetails transform = 7;// Transform metadata (for transform changes).
 }
 
 // Request to retrieve the most recent undone change in a session.
 message GetLastUndoRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response with details of the most recent undone change.
 message GetLastUndoResponse {
-  string session_id = 1;   // Session the change belongs to.
-  int64 serial = 2;        // Unique serial number.
-  ChangeKind kind = 3;     // Type of edit.
-  int64 offset = 4;        // Byte offset.
-  int64 length = 5;        // Number of bytes affected.
-  optional bytes data = 6; // Payload bytes (for insert/overwrite).
-  optional TransformChangeDetails transform = 7; // Transform metadata (for transform changes).
+    string session_id = 1;                        // Session the change belongs to.
+    int64 serial = 2;                             // Unique serial number.
+    ChangeKind kind = 3;                          // Type of edit.
+    int64 offset = 4;                             // Byte offset.
+    int64 length = 5;                             // Number of bytes affected.
+    optional bytes data = 6;                      // Payload bytes (for insert/overwrite).
+    optional TransformChangeDetails transform = 7;// Transform metadata (for transform changes).
 }
 
 // Metadata for a checkpoint-backed transform change.
 message TransformChangeDetails {
-  string transform_id = 1;                    // Stable transform or plugin identifier.
-  optional string options_json = 2;           // Plugin-specific transform options.
-  int64 replacement_length = 3;               // Number of bytes materialized into the checkpoint.
-  int64 computed_file_size_before = 4;        // Session size before the transform.
-  int64 computed_file_size_after = 5;         // Session size after the transform.
+    string transform_id = 1;            // Stable transform or plugin identifier.
+    optional string options_json = 2;   // Plugin-specific transform options.
+    int64 replacement_length = 3;       // Number of bytes materialized into the checkpoint.
+    int64 computed_file_size_before = 4;// Session size before the transform.
+    int64 computed_file_size_after = 5; // Session size after the transform.
 }
 
 // ===========================================================================
@@ -775,145 +783,144 @@ message TransformChangeDetails {
 
 // Request to get the computed file size of a session.
 message GetComputedFileSizeRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Computed file size after all edits.
 message GetComputedFileSizeResponse {
-  string session_id = 1;        // Session ID.
-  int64 computed_file_size = 2; // Size in bytes.
+    string session_id = 1;       // Session ID.
+    int64 computed_file_size = 2;// Size in bytes.
 }
 
 // Request to detect the byte-order mark of a session.
 message GetByteOrderMarkRequest {
-  string session_id = 1; // Session ID.
-  int64 offset = 2;      // Starting byte offset.
-  int64 length = 3;      // Number of bytes to examine.
+    string session_id = 1;// Session ID.
+    int64 offset = 2;     // Starting byte offset.
+    int64 length = 3;     // Number of bytes to examine.
 }
 
 // Byte-order mark detection result.
 message GetByteOrderMarkResponse {
-  string session_id = 1;      // Session ID.
-  int64 offset = 2;           // Byte offset of the BOM.
-  int64 length = 3;           // BOM length in bytes (0, 2, 3, or 4).
-  string byte_order_mark = 4; // Human-readable BOM name: "UTF-8", "UTF-16LE", "UTF-16BE", "UTF-32LE", "UTF-32BE", or "none".
+    string session_id = 1;// Session ID.
+    int64 offset = 2;     // Byte offset of the BOM.
+    int64 length = 3;     // BOM length in bytes (0, 2, 3, or 4).
+    string byte_order_mark =
+            4;// Human-readable BOM name: "UTF-8", "UTF-16LE", "UTF-16BE", "UTF-32LE", "UTF-32BE", or "none".
 }
 
 // Request to detect the content/MIME type of a segment.
 message GetContentTypeRequest {
-  string session_id = 1; // Session ID.
-  int64 offset = 2;      // Starting byte offset.
-  int64 length = 3;      // Number of bytes to examine.
+    string session_id = 1;// Session ID.
+    int64 offset = 2;     // Starting byte offset.
+    int64 length = 3;     // Number of bytes to examine.
 }
 
 // Content/MIME type detection result.
 message GetContentTypeResponse {
-  string session_id = 1;   // Session ID.
-  int64 offset = 2;        // Byte offset where detection started.
-  int64 length = 3;        // Number of bytes examined.
-  string content_type = 4; // Detected MIME type.
+    string session_id = 1;  // Session ID.
+    int64 offset = 2;       // Byte offset where detection started.
+    int64 length = 3;       // Number of bytes examined.
+    string content_type = 4;// Detected MIME type.
 }
 
 // Request to detect the natural language of a text segment.
 message GetLanguageRequest {
-  string session_id = 1;      // Session ID.
-  int64 offset = 2;           // Starting byte offset.
-  int64 length = 3;           // Number of bytes to read.
-  string byte_order_mark = 4; // Encoding hint.
+    string session_id = 1;     // Session ID.
+    int64 offset = 2;          // Starting byte offset.
+    int64 length = 3;          // Number of bytes to read.
+    string byte_order_mark = 4;// Encoding hint.
 }
 
 // Natural language detection result.
 message GetLanguageResponse {
-  string session_id = 1; // Session ID.
-  int64 offset = 2;      // Byte offset where detection started.
-  int64 length = 3;      // Number of bytes examined.
-  string language = 4;   // ISO 639-1 two-letter language code.
+    string session_id = 1;// Session ID.
+    int64 offset = 2;     // Byte offset where detection started.
+    int64 length = 3;     // Number of bytes examined.
+    string language = 4;  // ISO 639-1 two-letter language code.
 }
 
 // Request one or more counts for a session.
 message GetCountRequest {
-  string session_id = 1;
-  // The set of count kinds to retrieve.
-  repeated CountKind kind = 2;
+    string session_id = 1;
+    // The set of count kinds to retrieve.
+    repeated CountKind kind = 2;
 }
 
 // A single (kind, value) count pair.
 message SingleCount {
-  CountKind kind = 1;
-  int64 count = 2;
+    CountKind kind = 1;
+    int64 count = 2;
 }
 
 // Response carrying the requested counts.
 message GetCountResponse {
-  string session_id = 1;
-  repeated SingleCount counts = 2;
+    string session_id = 1;
+    repeated SingleCount counts = 2;
 }
 
 // Request to run the native model-integrity check for a session.
 message CheckSessionModelRequest {
-  string session_id = 1; // Session to check.
+    string session_id = 1;// Session to check.
 }
 
 // Result of the native model-integrity check.
 message CheckSessionModelResponse {
-  string session_id = 1; // Session that was checked.
-  bool valid = 2;        // True when omega_check_model returned 0.
-  int32 status = 3;      // Raw omega_check_model return code.
+    string session_id = 1;// Session that was checked.
+    bool valid = 2;       // True when omega_check_model returned 0.
+    int32 status = 3;     // Raw omega_check_model return code.
 }
 
 // Which session content should be fingerprinted.
 enum SessionFingerprintContent {
-  SESSION_FINGERPRINT_CONTENT_UNSPECIFIED = 0;
-  SESSION_FINGERPRINT_CONTENT_ORIGINAL = 1; // Content captured when the session was created.
-  SESSION_FINGERPRINT_CONTENT_COMPUTED = 2; // Current logical content after edits.
+    SESSION_FINGERPRINT_CONTENT_UNSPECIFIED = 0;
+    SESSION_FINGERPRINT_CONTENT_ORIGINAL = 1;// Content captured when the session was created.
+    SESSION_FINGERPRINT_CONTENT_COMPUTED = 2;// Current logical content after edits.
 }
 
 // Digest metadata for a content fingerprint.
 message ContentDigest {
-  string algorithm = 1; // Digest algorithm identifier, e.g. "sha256".
-  string value = 2;     // Lowercase hexadecimal digest value.
+    string algorithm = 1;// Digest algorithm identifier, e.g. "sha256".
+    string value = 2;    // Lowercase hexadecimal digest value.
 }
 
 // Size and digest for a session content snapshot.
 message SessionContentFingerprint {
-  int64 byte_length = 1;    // Content size in bytes.
-  ContentDigest digest = 2; // Digest of the content bytes.
+    int64 byte_length = 1;   // Content size in bytes.
+    ContentDigest digest = 2;// Digest of the content bytes.
 }
 
 // Request a server-side fingerprint for original or computed session content.
 message GetSessionFingerprintRequest {
-  string session_id = 1;                    // Session to fingerprint.
-  SessionFingerprintContent content = 2;    // Original or computed content.
-  optional string algorithm = 3;            // Digest algorithm; defaults to "sha256".
+    string session_id = 1;                // Session to fingerprint.
+    SessionFingerprintContent content = 2;// Original or computed content.
+    optional string algorithm = 3;        // Digest algorithm; defaults to "sha256".
 }
 
 // Server-side content fingerprint result.
 message GetSessionFingerprintResponse {
-  string session_id = 1;                         // Session that was fingerprinted.
-  SessionFingerprintContent content = 2;         // Content that was fingerprinted.
-  SessionContentFingerprint fingerprint = 3;     // Size and digest.
+    string session_id = 1;                    // Session that was fingerprinted.
+    SessionFingerprintContent content = 2;    // Content that was fingerprinted.
+    SessionContentFingerprint fingerprint = 3;// Size and digest.
 }
 
 // Request the total number of active sessions.
 message GetSessionCountRequest {}
 
 // Response with the session count.
-message GetSessionCountResponse {
-  int64 count = 1;
-}
+message GetSessionCountResponse { int64 count = 1; }
 
 // Request to read a raw byte segment from a session.
 message GetSegmentRequest {
-  string session_id = 1; // Session ID.
-  int64 offset = 2;      // Starting byte offset.
-  int64 length = 3;      // Number of bytes to read.
+    string session_id = 1;// Session ID.
+    int64 offset = 2;     // Starting byte offset.
+    int64 length = 3;     // Number of bytes to read.
 }
 
 // Response carrying a raw byte segment.
 message GetSegmentResponse {
-  string session_id = 1; // Session ID.
-  int64 offset = 2;      // Starting byte offset of the returned data.
-  bytes data = 3;        // Raw bytes.
+    string session_id = 1;// Session ID.
+    int64 offset = 2;     // Starting byte offset of the returned data.
+    bytes data = 3;       // Raw bytes.
 }
 
 // ===========================================================================
@@ -922,217 +929,216 @@ message GetSegmentResponse {
 
 // Request to search for a byte pattern in a session.
 message SearchSessionRequest {
-  string session_id = 1;                 // Session to search.
-  bytes pattern = 2;                     // Byte pattern to find.
-  optional bool is_case_insensitive = 3; // When true, perform case-insensitive matching.
-  optional bool is_reverse = 4;          // When true, search backward from the end of the range.
-  optional int64 offset = 5;            // Starting byte offset (default: 0 or end if reverse).
-  optional int64 length = 6;             // Number of bytes to search within.
-  optional int64 limit = 7;             // Maximum number of matches to return (0 = unlimited).
+    string session_id = 1;                // Session to search.
+    bytes pattern = 2;                    // Byte pattern to find.
+    optional bool is_case_insensitive = 3;// When true, perform case-insensitive matching.
+    optional bool is_reverse = 4;         // When true, search backward from the end of the range.
+    optional int64 offset = 5;            // Starting byte offset (default: 0 or end if reverse).
+    optional int64 length = 6;            // Number of bytes to search within.
+    optional int64 limit = 7;             // Maximum number of matches to return (0 = unlimited).
 }
 
 // Search results.
 message SearchSessionResponse {
-  string session_id = 1;           // Session that was searched.
-  bytes pattern = 2;               // The pattern that was searched for.
-  bool is_case_insensitive = 3;    // Whether the search was case-insensitive.
-  bool is_reverse = 4;             // Whether the search was reversed.
-  int64 offset = 5;                // Starting offset of the search range.
-  int64 length = 6;                // Length of the search range.
-  repeated int64 match_offset = 7; // Byte offsets of each match.
+    string session_id = 1;          // Session that was searched.
+    bytes pattern = 2;              // The pattern that was searched for.
+    bool is_case_insensitive = 3;   // Whether the search was case-insensitive.
+    bool is_reverse = 4;            // Whether the search was reversed.
+    int64 offset = 5;               // Starting offset of the search range.
+    int64 length = 6;               // Length of the search range.
+    repeated int64 match_offset = 7;// Byte offsets of each match.
 }
 
 // Request to replace non-overlapping matches in a session range transactionally.
 message ReplaceSessionRequest {
-  string session_id = 1;                 // Session to edit.
-  bytes pattern = 2;                     // Byte pattern to replace.
-  bytes replacement = 3;                 // Replacement bytes.
-  optional bool is_case_insensitive = 4; // When true, perform case-insensitive matching.
-  optional bool is_reverse = 5;          // When true, search backward before selecting matches.
-  optional int64 offset = 6;             // Starting byte offset of the replace range.
-  optional int64 length = 7;             // Number of bytes to process within the session.
-  optional int64 limit = 8;              // Maximum number of matches to replace (0 = unlimited).
-  optional bool front_to_back = 9;       // When true, apply replacements from low offsets to high offsets.
-  optional bool overwrite_only = 10;     // When true, overwrite replacement bytes in place.
+    string session_id = 1;                // Session to edit.
+    bytes pattern = 2;                    // Byte pattern to replace.
+    bytes replacement = 3;                // Replacement bytes.
+    optional bool is_case_insensitive = 4;// When true, perform case-insensitive matching.
+    optional bool is_reverse = 5;         // When true, search backward before selecting matches.
+    optional int64 offset = 6;            // Starting byte offset of the replace range.
+    optional int64 length = 7;            // Number of bytes to process within the session.
+    optional int64 limit = 8;             // Maximum number of matches to replace (0 = unlimited).
+    optional bool front_to_back = 9;      // When true, apply replacements from low offsets to high offsets.
+    optional bool overwrite_only = 10;    // When true, overwrite replacement bytes in place.
 }
 
 // Result of a transactional replace operation.
 message ReplaceSessionResponse {
-  string session_id = 1;         // Session that was edited.
-  bytes pattern = 2;             // Pattern that was replaced.
-  bytes replacement = 3;         // Replacement bytes that were written.
-  bool is_case_insensitive = 4;  // Whether the match was case-insensitive.
-  bool is_reverse = 5;           // Whether the search that selected matches was reversed.
-  int64 offset = 6;              // Starting offset of the processed range.
-  int64 length = 7;              // Length of the processed range.
-  int64 limit = 8;               // Maximum number of matches requested.
-  bool front_to_back = 9;        // Whether replacements were applied from low offsets to high offsets.
-  bool overwrite_only = 10;      // Whether replacement bytes were applied as raw overwrites.
-  int64 replacement_count = 11;  // Number of matches selected for replacement.
-  int64 delete_count = 12;       // Number of lowered delete ops applied.
-  int64 insert_count = 13;       // Number of lowered insert ops applied.
-  int64 overwrite_count = 14;    // Number of lowered overwrite ops applied.
+    string session_id = 1;       // Session that was edited.
+    bytes pattern = 2;           // Pattern that was replaced.
+    bytes replacement = 3;       // Replacement bytes that were written.
+    bool is_case_insensitive = 4;// Whether the match was case-insensitive.
+    bool is_reverse = 5;         // Whether the search that selected matches was reversed.
+    int64 offset = 6;            // Starting offset of the processed range.
+    int64 length = 7;            // Length of the processed range.
+    int64 limit = 8;             // Maximum number of matches requested.
+    bool front_to_back = 9;      // Whether replacements were applied from low offsets to high offsets.
+    bool overwrite_only = 10;    // Whether replacement bytes were applied as raw overwrites.
+    int64 replacement_count = 11;// Number of matches selected for replacement.
+    int64 delete_count = 12;     // Number of lowered delete ops applied.
+    int64 insert_count = 13;     // Number of lowered insert ops applied.
+    int64 overwrite_count = 14;  // Number of lowered overwrite ops applied.
 }
 
 // Request to replace all non-overlapping matches by checkpointed streaming.
 message ReplaceSessionCheckpointedRequest {
-  string session_id = 1;                 // Session to edit.
-  bytes pattern = 2;                     // Byte pattern to replace.
-  bytes replacement = 3;                 // Replacement bytes.
-  optional bool is_case_insensitive = 4; // When true, perform case-insensitive matching.
-  optional int64 offset = 5;             // Starting byte offset of the replace-all range.
-  optional int64 length = 6;             // Number of bytes to process within the session.
+    string session_id = 1;                // Session to edit.
+    bytes pattern = 2;                    // Byte pattern to replace.
+    bytes replacement = 3;                // Replacement bytes.
+    optional bool is_case_insensitive = 4;// When true, perform case-insensitive matching.
+    optional int64 offset = 5;            // Starting byte offset of the replace-all range.
+    optional int64 length = 6;            // Number of bytes to process within the session.
 }
 
 // Result of a checkpointed replace-all operation.
 message ReplaceSessionCheckpointedResponse {
-  string session_id = 1;         // Session that was edited.
-  bytes pattern = 2;             // The pattern that was replaced.
-  bytes replacement = 3;         // The replacement bytes that were written.
-  bool is_case_insensitive = 4;  // Whether the match was case-insensitive.
-  int64 offset = 5;              // Starting offset of the processed range.
-  int64 length = 6;              // Length of the processed range.
-  int64 replacement_count = 7;   // Number of replacements performed.
+    string session_id = 1;       // Session that was edited.
+    bytes pattern = 2;           // The pattern that was replaced.
+    bytes replacement = 3;       // The replacement bytes that were written.
+    bool is_case_insensitive = 4;// Whether the match was case-insensitive.
+    int64 offset = 5;            // Starting offset of the processed range.
+    int64 length = 6;            // Length of the processed range.
+    int64 replacement_count = 7; // Number of replacements performed.
 }
 
 // Request to create a checkpoint from the current session content.
 message CreateCheckpointRequest {
-  string session_id = 1; // Session to checkpoint.
+    string session_id = 1;// Session to checkpoint.
 }
 
 // Result of creating a checkpoint model.
 message CreateCheckpointResponse {
-  string session_id = 1;           // Session that was checkpointed.
-  int64 checkpoint_count = 2;      // Checkpoint count after creation.
+    string session_id = 1;     // Session that was checkpointed.
+    int64 checkpoint_count = 2;// Checkpoint count after creation.
 }
 
 // Request to remove the most recent checkpoint model from a session.
 message DestroyLastCheckpointRequest {
-  string session_id = 1; // Session to revert.
+    string session_id = 1;// Session to revert.
 }
 
 // Result of removing the most recent checkpoint model.
 message DestroyLastCheckpointResponse {
-  string session_id = 1;             // Session that was reverted.
-  int64 remaining_checkpoints = 2;   // Remaining checkpoint count after revert.
+    string session_id = 1;          // Session that was reverted.
+    int64 remaining_checkpoints = 2;// Remaining checkpoint count after revert.
 }
 
 // Request to restore the most recent checkpoint snapshot without discarding it.
 message RestoreLastCheckpointRequest {
-  string session_id = 1; // Session to restore.
+    string session_id = 1;// Session to restore.
 }
 
 // Result of restoring the most recent checkpoint snapshot.
 message RestoreLastCheckpointResponse {
-  string session_id = 1;                // Session that was restored.
-  int64 checkpoint_count = 2;           // Checkpoint count after restore.
-  int64 change_count = 3;               // Session change count after restore.
-  int64 discarded_change_count = 4;     // Number of active changes discarded.
+    string session_id = 1;           // Session that was restored.
+    int64 checkpoint_count = 2;      // Checkpoint count after restore.
+    int64 change_count = 3;          // Session change count after restore.
+    int64 discarded_change_count = 4;// Number of active changes discarded.
 }
 
 // Transform plugin operation mode.
 enum TransformPluginOperation {
-  TRANSFORM_PLUGIN_OPERATION_UNSPECIFIED = 0;
-  TRANSFORM_PLUGIN_OPERATION_REPLACE = 1;
-  TRANSFORM_PLUGIN_OPERATION_INSPECT = 2;
-  TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT = 3;
+    TRANSFORM_PLUGIN_OPERATION_UNSPECIFIED = 0;
+    TRANSFORM_PLUGIN_OPERATION_REPLACE = 1;
+    TRANSFORM_PLUGIN_OPERATION_INSPECT = 2;
+    TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT = 3;
 }
 
 // Metadata advertised by a registered transform plugin.
 message TransformPluginInfo {
-  string id = 1;
-  string name = 2;
-  string description = 3;
-  TransformPluginOperation operation = 4;
-  uint32 flags = 5;
-  uint32 abi_version = 6;
-  string help = 7;          // Human-readable help for plugin-specific JSON arguments.
-  string example = 8;       // Example JSON arguments.
-  string default_args = 9;  // Default JSON arguments.
-  string args_schema = 10;  // JSON Schema for validating options_json before apply.
+    string id = 1;
+    string name = 2;
+    string description = 3;
+    TransformPluginOperation operation = 4;
+    uint32 flags = 5;
+    uint32 abi_version = 6;
+    string help = 7;        // Human-readable help for plugin-specific JSON arguments.
+    string example = 8;     // Example JSON arguments.
+    string default_args = 9;// Default JSON arguments.
+    string args_schema = 10;// JSON Schema for validating options_json before apply.
 }
 
 // Request registered transform plugin metadata.
 message ListTransformPluginsRequest {}
 
 // Registered transform plugin metadata.
-message ListTransformPluginsResponse {
-  repeated TransformPluginInfo plugins = 1;
-}
+message ListTransformPluginsResponse { repeated TransformPluginInfo plugins = 1; }
 
 // Request applying a transform plugin to a session range.
 message ApplyTransformPluginRequest {
-  string session_id = 1;             // Session to transform.
-  string plugin_id = 2;              // Registered plugin identifier.
-  optional int64 offset = 3;         // Starting byte offset (default: 0).
-  optional int64 length = 4;         // Number of bytes to transform (0/default = through EOF).
-  optional string options_json = 5;  // Plugin-specific options.
+    string session_id = 1;           // Session to transform.
+    string plugin_id = 2;            // Registered plugin identifier.
+    optional int64 offset = 3;       // Starting byte offset (default: 0).
+    optional int64 length = 4;       // Number of bytes to transform (0/default = through EOF).
+    optional string options_json = 5;// Plugin-specific options.
 }
 
 // Result of applying a transform plugin.
 message ApplyTransformPluginResponse {
-  string session_id = 1;                     // Session that was transformed.
-  string plugin_id = 2;                      // Plugin that was applied.
-  int64 offset = 3;                          // Starting offset of the processed range.
-  int64 length = 4;                          // Length of the processed range.
-  TransformPluginOperation operation = 5;    // Plugin operation mode.
-  bool content_changed = 6;                  // True when the plugin replaced content.
-  int64 computed_file_size = 7;              // Session size after the transform.
-  int64 replacement_length = 8;              // Replacement bytes produced by the plugin.
-  optional string result_label = 9;          // Plugin-provided result label.
-  optional string result_mime_type = 10;     // Plugin-provided result MIME type.
-  bytes result = 11;                         // Plugin-provided inspection bytes.
-  optional int64 serial = 12;                // Transform change serial when content changed.
+    string session_id = 1;                 // Session that was transformed.
+    string plugin_id = 2;                  // Plugin that was applied.
+    int64 offset = 3;                      // Starting offset of the processed range.
+    int64 length = 4;                      // Length of the processed range.
+    TransformPluginOperation operation = 5;// Plugin operation mode.
+    bool content_changed = 6;              // True when the plugin replaced content.
+    int64 computed_file_size = 7;          // Session size after the transform.
+    int64 replacement_length = 8;          // Replacement bytes produced by the plugin.
+    optional string result_label = 9;      // Plugin-provided result label.
+    optional string result_mime_type = 10; // Plugin-provided result MIME type.
+    bytes result = 11;                     // Plugin-provided inspection bytes.
+    optional int64 serial = 12;            // Transform change serial when content changed.
 }
 
 // Progress reported by a session-level transform event.
 message TransformProgress {
-  string plugin_id = 1;              // Plugin currently running.
-  string operation_id = 2;           // Server-generated ID for this transform run.
-  optional int64 processed_bytes = 3; // Bytes processed when known.
-  optional int64 total_bytes = 4;     // Total bytes when known.
-  optional double percent = 5;        // Completion percentage when known.
-  string phase = 6;                  // Machine-readable phase label.
-  string message = 7;                // Human-readable progress message.
-  bool indeterminate = 8;            // True when determinate progress is unavailable.
-  optional int64 serial = 9;         // Transform change serial when available.
+    string plugin_id = 1;              // Plugin currently running.
+    string operation_id = 2;           // Server-generated ID for this transform run.
+    optional int64 processed_bytes = 3;// Bytes processed when known.
+    optional int64 total_bytes = 4;    // Total bytes when known.
+    optional double percent = 5;       // Completion percentage when known.
+    string phase = 6;                  // Machine-readable phase label.
+    string message = 7;                // Human-readable progress message.
+    bool indeterminate = 8;            // True when determinate progress is unavailable.
+    optional int64 serial = 9;         // Transform change serial when available.
 }
 
 // Request to compute a byte-frequency histogram.
 message GetByteFrequencyProfileRequest {
-  string session_id = 1; // Session ID.
-  int64 offset = 2;      // Range start.
-  int64 length = 3;      // Range length.
+    string session_id = 1;// Session ID.
+    int64 offset = 2;     // Range start.
+    int64 length = 3;     // Range length.
 }
 
 // Byte-frequency histogram over a range of session data.
 message GetByteFrequencyProfileResponse {
-  string session_id = 1;        // Session ID.
-  int64 offset = 2;             // Range start.
-  int64 length = 3;             // Range length.
-  repeated int64 frequency = 4; // 257 entries: frequency[0..255] = count of each byte value; frequency[256] = count of DOS-style CR+LF line endings.
+    string session_id = 1;// Session ID.
+    int64 offset = 2;     // Range start.
+    int64 length = 3;     // Range length.
+    repeated int64 frequency =
+            4;// 257 entries: frequency[0..255] = count of each byte value; frequency[256] = count of DOS-style CR+LF line endings.
 }
 
 // Request to count characters by byte-width.
 message GetCharacterCountsRequest {
-  string session_id = 1;      // Session ID.
-  int64 offset = 2;           // Starting byte offset.
-  int64 length = 3;           // Number of bytes to read.
-  string byte_order_mark = 4; // Encoding hint.
+    string session_id = 1;     // Session ID.
+    int64 offset = 2;          // Starting byte offset.
+    int64 length = 3;          // Number of bytes to read.
+    string byte_order_mark = 4;// Encoding hint.
 }
 
 // Character-width breakdown for a UTF-encoded text segment.
 message GetCharacterCountsResponse {
-  string session_id = 1;          // Session ID.
-  int64 offset = 2;               // Range start.
-  int64 length = 3;               // Range length.
-  string byte_order_mark = 4;     // Encoding used for decoding.
-  int64 byte_order_mark_bytes = 5; // BOM length in bytes (0, 2, 3, or 4).
-  int64 single_byte_chars = 6;    // Count of 1-byte characters.
-  int64 double_byte_chars = 7;    // Count of 2-byte characters.
-  int64 triple_byte_chars = 8;    // Count of 3-byte characters.
-  int64 quad_byte_chars = 9;      // Count of 4-byte characters.
-  int64 invalid_bytes = 10;       // Count of bytes that don't form valid characters.
+    string session_id = 1;          // Session ID.
+    int64 offset = 2;               // Range start.
+    int64 length = 3;               // Range length.
+    string byte_order_mark = 4;     // Encoding used for decoding.
+    int64 byte_order_mark_bytes = 5;// BOM length in bytes (0, 2, 3, or 4).
+    int64 single_byte_chars = 6;    // Count of 1-byte characters.
+    int64 double_byte_chars = 7;    // Count of 2-byte characters.
+    int64 triple_byte_chars = 8;    // Count of 3-byte characters.
+    int64 quad_byte_chars = 9;      // Count of 4-byte characters.
+    int64 invalid_bytes = 10;       // Count of bytes that don't form valid characters.
 }
 
 // ===========================================================================
@@ -1141,59 +1147,59 @@ message GetCharacterCountsResponse {
 
 // Request to subscribe to session or viewport events.
 message SubscribeToSessionEventsRequest {
-  // The session ID to subscribe to.
-  string id = 1;
-  // Bitmask of event kinds to receive.  When omitted, all events are
-  // delivered.  Use the SessionEventKind enum values OR'd together.
-  optional int32 interest = 2;
+    // The session ID to subscribe to.
+    string id = 1;
+    // Bitmask of event kinds to receive.  When omitted, all events are
+    // delivered.  Use the SessionEventKind enum values OR'd together.
+    optional int32 interest = 2;
 }
 
 // A session-level event delivered via SubscribeToSessionEvents.
 message SubscribeToSessionEventsResponse {
-  string session_id = 1;                       // Originating session.
-  SessionEventKind session_event_kind = 2;     // What happened.
-  int64 computed_file_size = 3;                // Computed file size after this event.
-  int64 change_count = 4;                      // Number of applied changes after this event.
-  int64 undo_count = 5;                        // Number of undone changes after this event.
-  optional int64 serial = 6;                   // Serial number of the change (if applicable).
-  optional TransformProgress transform_progress = 7; // Transform lifecycle/progress details.
+    string session_id = 1;                            // Originating session.
+    SessionEventKind session_event_kind = 2;          // What happened.
+    int64 computed_file_size = 3;                     // Computed file size after this event.
+    int64 change_count = 4;                           // Number of applied changes after this event.
+    int64 undo_count = 5;                             // Number of undone changes after this event.
+    optional int64 serial = 6;                        // Serial number of the change (if applicable).
+    optional TransformProgress transform_progress = 7;// Transform lifecycle/progress details.
 }
 
 // Request to subscribe to viewport events.
 message SubscribeToViewportEventsRequest {
-  // The viewport ID to subscribe to.
-  string id = 1;
-  // Bitmask of event kinds to receive.
-  optional int32 interest = 2;
+    // The viewport ID to subscribe to.
+    string id = 1;
+    // Bitmask of event kinds to receive.
+    optional int32 interest = 2;
 }
 
 // A viewport-level event delivered via SubscribeToViewportEvents.
 message SubscribeToViewportEventsResponse {
-  string session_id = 1;                        // Session the viewport belongs to.
-  string viewport_id = 2;                       // Viewport that changed.
-  ViewportEventKind viewport_event_kind = 3;    // What happened.
-  optional int64 serial = 4;                    // Change serial (if triggered by an edit).
-  optional int64 offset = 5;                    // Updated viewport offset.
-  optional int64 length = 6;                    // Updated data length.
-  optional bytes data = 7;                      // Updated viewport content.
+    string session_id = 1;                    // Session the viewport belongs to.
+    string viewport_id = 2;                   // Viewport that changed.
+    ViewportEventKind viewport_event_kind = 3;// What happened.
+    optional int64 serial = 4;                // Change serial (if triggered by an edit).
+    optional int64 offset = 5;                // Updated viewport offset.
+    optional int64 length = 6;                // Updated data length.
+    optional bytes data = 7;                  // Updated viewport content.
 }
 
 // Request to cancel a session-event subscription.
 message UnsubscribeToSessionEventsRequest {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Response after cancelling a session-event subscription.
 message UnsubscribeToSessionEventsResponse {
-  string id = 1; // Session ID.
+    string id = 1;// Session ID.
 }
 
 // Request to cancel a viewport-event subscription.
 message UnsubscribeToViewportEventsRequest {
-  string id = 1; // Viewport ID.
+    string id = 1;// Viewport ID.
 }
 
 // Response after cancelling a viewport-event subscription.
 message UnsubscribeToViewportEventsResponse {
-  string id = 1; // Viewport ID.
+    string id = 1;// Viewport ID.
 }

--- a/scripts/check-clang-format.sh
+++ b/scripts/check-clang-format.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 Concurrent Technologies Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software is distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing permissions and limitations under the License.
+
+set -euo pipefail
+
+SOURCE_GLOBS=(
+    '*.c'
+    '*.cc'
+    '*.cpp'
+    '*.cxx'
+    '*.h'
+    '*.hh'
+    '*.hpp'
+    '*.hxx'
+    '*.proto'
+)
+readonly SOURCE_GLOBS
+
+if ! command -v clang-format >/dev/null 2>&1; then
+    echo "clang-format is required to check C/C++ source formatting." >&2
+    exit 127
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "scripts/check-clang-format.sh must be run from inside the git repository." >&2
+    exit 1
+fi
+
+tracked_sources="$(mktemp)"
+trap 'rm -f "${tracked_sources}"' EXIT
+
+git ls-files -z -- "${SOURCE_GLOBS[@]}" > "${tracked_sources}"
+if [[ ! -s "${tracked_sources}" ]]; then
+    echo "No tracked C/C++ or proto sources found."
+    exit 0
+fi
+
+if ! xargs -0 -r clang-format --dry-run --Werror < "${tracked_sources}"; then
+    echo >&2
+    echo "C/C++ source formatting check failed." >&2
+    echo "Run the following command from the repository root and commit the result:" >&2
+    echo "  git ls-files -z -- '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' '*.proto' | xargs -0 -r clang-format -i" >&2
+    exit 1
+fi

--- a/server/cpp/src/cld3_language_detector.cpp
+++ b/server/cpp/src/cld3_language_detector.cpp
@@ -14,157 +14,143 @@
 
 #include "content_detection.h"
 
-#include <cld3/nnet_language_identifier.h>
 #include <algorithm>
+#include <cld3/nnet_language_identifier.h>
 #include <cstring>
 #include <unordered_map>
 
 namespace omega_edit {
-namespace grpc_server {
+    namespace grpc_server {
 
-// ── CLD3-backed language detector ────────────────────────────────────────────
+        // ── CLD3-backed language detector ────────────────────────────────────────────
 
-/// Maps CLD3's BCP-47 codes to the short codes expected by the test suite
-/// (which historically used Tika/Optimaize style codes).
-static const std::unordered_map<std::string, std::string> &bcp47_to_short() {
-    static const std::unordered_map<std::string, std::string> table = {
-        {"en", "en"}, {"fr", "fr"}, {"de", "de"}, {"es", "es"}, {"pt", "pt"}, {"it", "it"},
-        {"nl", "nl"}, {"sv", "sv"}, {"ru", "ru"}, {"ar", "ar"}, {"hi", "hi"}, {"el", "el"},
-        {"ja", "ja"}, {"ko", "ko"}, {"zh", "zh-CN"}, {"zh-Latn", "zh-CN"},
-    };
-    return table;
-}
-
-/// Convert CLD3 language code to the codes expected by downstream clients.
-static std::string normalize_language_code(const std::string &cld3_code) {
-    // CLD3 returns "und" for undetermined
-    if (cld3_code == chrome_lang_id::NNetLanguageIdentifier::kUnknown) {
-        return "unknown";
-    }
-    // Try exact match first
-    auto &table = bcp47_to_short();
-    auto it = table.find(cld3_code);
-    if (it != table.end()) {
-        return it->second;
-    }
-    // Split on '-' and try the base tag (e.g. "zh-Hant" → "zh")
-    auto dash = cld3_code.find('-');
-    if (dash != std::string::npos) {
-        auto base = cld3_code.substr(0, dash);
-        it = table.find(base);
-        if (it != table.end()) {
-            return it->second;
-        }
-        return base;
-    }
-    return cld3_code;
-}
-
-/// Convert data from a BOM encoding to a UTF-8 std::string for analysis.
-static std::string convert_to_utf8(const uint8_t *data, int64_t length, const std::string &bom) {
-    if (bom == "none" || bom == "unknown" || bom == "UTF-8") {
-        // Skip UTF-8 BOM if present
-        if (length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) {
-            return std::string(reinterpret_cast<const char *>(data + 3), length - 3);
-        }
-        return std::string(reinterpret_cast<const char *>(data), length);
-    }
-
-    // Simplified UTF-16/32 → UTF-8 for BMP characters
-    std::string result;
-
-    auto push_codepoint = [&](uint32_t cp) {
-        if (cp < 0x80) {
-            result += static_cast<char>(cp);
-        } else if (cp < 0x800) {
-            result += static_cast<char>(0xC0 | (cp >> 6));
-            result += static_cast<char>(0x80 | (cp & 0x3F));
-        } else if (cp < 0x10000) {
-            result += static_cast<char>(0xE0 | (cp >> 12));
-            result += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-            result += static_cast<char>(0x80 | (cp & 0x3F));
-        } else if (cp < 0x110000) {
-            result += static_cast<char>(0xF0 | (cp >> 18));
-            result += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
-            result += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-            result += static_cast<char>(0x80 | (cp & 0x3F));
-        }
-    };
-
-    if (bom == "UTF-16LE") {
-        int64_t start = (length >= 2 && data[0] == 0xFF && data[1] == 0xFE) ? 2 : 0;
-        for (int64_t i = start; i + 1 < length; i += 2) {
-            push_codepoint(static_cast<uint16_t>(data[i]) | (static_cast<uint16_t>(data[i + 1]) << 8));
-        }
-    } else if (bom == "UTF-16BE") {
-        int64_t start = (length >= 2 && data[0] == 0xFE && data[1] == 0xFF) ? 2 : 0;
-        for (int64_t i = start; i + 1 < length; i += 2) {
-            push_codepoint((static_cast<uint16_t>(data[i]) << 8) | static_cast<uint16_t>(data[i + 1]));
-        }
-    } else if (bom == "UTF-32LE") {
-        int64_t start = (length >= 4 && data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00)
-                            ? 4
-                            : 0;
-        for (int64_t i = start; i + 3 < length; i += 4) {
-            push_codepoint(static_cast<uint32_t>(data[i]) | (static_cast<uint32_t>(data[i + 1]) << 8) |
-                           (static_cast<uint32_t>(data[i + 2]) << 16) | (static_cast<uint32_t>(data[i + 3]) << 24));
-        }
-    } else if (bom == "UTF-32BE") {
-        int64_t start = (length >= 4 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF)
-                            ? 4
-                            : 0;
-        for (int64_t i = start; i + 3 < length; i += 4) {
-            push_codepoint((static_cast<uint32_t>(data[i]) << 24) | (static_cast<uint32_t>(data[i + 1]) << 16) |
-                           (static_cast<uint32_t>(data[i + 2]) << 8) | static_cast<uint32_t>(data[i + 3]));
-        }
-    } else {
-        return std::string(reinterpret_cast<const char *>(data), length);
-    }
-
-    return result;
-}
-
-class Cld3LanguageDetector final : public ILanguageDetector {
-public:
-    Cld3LanguageDetector() : identifier_(0, 4096) {}
-
-    std::string detect(const uint8_t *data, int64_t length, const std::string &bom) override {
-        if (!data || length <= 0) {
-            return "unknown";
+        /// Maps CLD3's BCP-47 codes to the short codes expected by the test suite
+        /// (which historically used Tika/Optimaize style codes).
+        static const std::unordered_map<std::string, std::string> &bcp47_to_short() {
+            static const std::unordered_map<std::string, std::string> table = {
+                    {"en", "en"}, {"fr", "fr"}, {"de", "de"},    {"es", "es"},         {"pt", "pt"}, {"it", "it"},
+                    {"nl", "nl"}, {"sv", "sv"}, {"ru", "ru"},    {"ar", "ar"},         {"hi", "hi"}, {"el", "el"},
+                    {"ja", "ja"}, {"ko", "ko"}, {"zh", "zh-CN"}, {"zh-Latn", "zh-CN"},
+            };
+            return table;
         }
 
-        std::string text = convert_to_utf8(data, length, bom);
-        if (text.size() < 10) {
-            return "unknown";
+        /// Convert CLD3 language code to the codes expected by downstream clients.
+        static std::string normalize_language_code(const std::string &cld3_code) {
+            // CLD3 returns "und" for undetermined
+            if (cld3_code == chrome_lang_id::NNetLanguageIdentifier::kUnknown) { return "unknown"; }
+            // Try exact match first
+            auto &table = bcp47_to_short();
+            auto it = table.find(cld3_code);
+            if (it != table.end()) { return it->second; }
+            // Split on '-' and try the base tag (e.g. "zh-Hant" → "zh")
+            auto dash = cld3_code.find('-');
+            if (dash != std::string::npos) {
+                auto base = cld3_code.substr(0, dash);
+                it = table.find(base);
+                if (it != table.end()) { return it->second; }
+                return base;
+            }
+            return cld3_code;
         }
 
-        auto result = identifier_.FindLanguage(text);
-        if (result.language == chrome_lang_id::NNetLanguageIdentifier::kUnknown) {
-            return "unknown";
+        /// Convert data from a BOM encoding to a UTF-8 std::string for analysis.
+        static std::string convert_to_utf8(const uint8_t *data, int64_t length, const std::string &bom) {
+            if (bom == "none" || bom == "unknown" || bom == "UTF-8") {
+                // Skip UTF-8 BOM if present
+                if (length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) {
+                    return std::string(reinterpret_cast<const char *>(data + 3), length - 3);
+                }
+                return std::string(reinterpret_cast<const char *>(data), length);
+            }
+
+            // Simplified UTF-16/32 → UTF-8 for BMP characters
+            std::string result;
+
+            auto push_codepoint = [&](uint32_t cp) {
+                if (cp < 0x80) {
+                    result += static_cast<char>(cp);
+                } else if (cp < 0x800) {
+                    result += static_cast<char>(0xC0 | (cp >> 6));
+                    result += static_cast<char>(0x80 | (cp & 0x3F));
+                } else if (cp < 0x10000) {
+                    result += static_cast<char>(0xE0 | (cp >> 12));
+                    result += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+                    result += static_cast<char>(0x80 | (cp & 0x3F));
+                } else if (cp < 0x110000) {
+                    result += static_cast<char>(0xF0 | (cp >> 18));
+                    result += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+                    result += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+                    result += static_cast<char>(0x80 | (cp & 0x3F));
+                }
+            };
+
+            if (bom == "UTF-16LE") {
+                int64_t start = (length >= 2 && data[0] == 0xFF && data[1] == 0xFE) ? 2 : 0;
+                for (int64_t i = start; i + 1 < length; i += 2) {
+                    push_codepoint(static_cast<uint16_t>(data[i]) | (static_cast<uint16_t>(data[i + 1]) << 8));
+                }
+            } else if (bom == "UTF-16BE") {
+                int64_t start = (length >= 2 && data[0] == 0xFE && data[1] == 0xFF) ? 2 : 0;
+                for (int64_t i = start; i + 1 < length; i += 2) {
+                    push_codepoint((static_cast<uint16_t>(data[i]) << 8) | static_cast<uint16_t>(data[i + 1]));
+                }
+            } else if (bom == "UTF-32LE") {
+                int64_t start =
+                        (length >= 4 && data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00) ? 4
+                                                                                                                  : 0;
+                for (int64_t i = start; i + 3 < length; i += 4) {
+                    push_codepoint(static_cast<uint32_t>(data[i]) | (static_cast<uint32_t>(data[i + 1]) << 8) |
+                                   (static_cast<uint32_t>(data[i + 2]) << 16) |
+                                   (static_cast<uint32_t>(data[i + 3]) << 24));
+                }
+            } else if (bom == "UTF-32BE") {
+                int64_t start =
+                        (length >= 4 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF) ? 4
+                                                                                                                  : 0;
+                for (int64_t i = start; i + 3 < length; i += 4) {
+                    push_codepoint((static_cast<uint32_t>(data[i]) << 24) | (static_cast<uint32_t>(data[i + 1]) << 16) |
+                                   (static_cast<uint32_t>(data[i + 2]) << 8) | static_cast<uint32_t>(data[i + 3]));
+                }
+            } else {
+                return std::string(reinterpret_cast<const char *>(data), length);
+            }
+
+            return result;
         }
 
-        std::string lang = normalize_language_code(result.language);
+        class Cld3LanguageDetector final : public ILanguageDetector {
+        public:
+            Cld3LanguageDetector() : identifier_(0, 4096) {}
 
-        // CLD3 detects Japanese aggressively due to its distinctive script
-        // mixture (kanji + kana).  For parity with the previous server's
-        // Tika/Optimaize backend (which needed more text for Japanese),
-        // require a minimum UTF-8 byte count for Japanese detection only.
-        static constexpr size_t MIN_JA_DETECT_BYTES = 100;
-        if (lang == "ja" && text.size() < MIN_JA_DETECT_BYTES) {
-            return "unknown";
+            std::string detect(const uint8_t *data, int64_t length, const std::string &bom) override {
+                if (!data || length <= 0) { return "unknown"; }
+
+                std::string text = convert_to_utf8(data, length, bom);
+                if (text.size() < 10) { return "unknown"; }
+
+                auto result = identifier_.FindLanguage(text);
+                if (result.language == chrome_lang_id::NNetLanguageIdentifier::kUnknown) { return "unknown"; }
+
+                std::string lang = normalize_language_code(result.language);
+
+                // CLD3 detects Japanese aggressively due to its distinctive script
+                // mixture (kanji + kana).  For parity with the previous server's
+                // Tika/Optimaize backend (which needed more text for Japanese),
+                // require a minimum UTF-8 byte count for Japanese detection only.
+                static constexpr size_t MIN_JA_DETECT_BYTES = 100;
+                if (lang == "ja" && text.size() < MIN_JA_DETECT_BYTES) { return "unknown"; }
+
+                return lang;
+            }
+
+        private:
+            chrome_lang_id::NNetLanguageIdentifier identifier_;
+        };
+
+        std::unique_ptr<ILanguageDetector> create_default_language_detector() {
+            return std::make_unique<Cld3LanguageDetector>();
         }
 
-        return lang;
-    }
-
-private:
-    chrome_lang_id::NNetLanguageIdentifier identifier_;
-};
-
-std::unique_ptr<ILanguageDetector> create_default_language_detector() {
-    return std::make_unique<Cld3LanguageDetector>();
-}
-
-} // namespace grpc_server
-} // namespace omega_edit
-
+    }// namespace grpc_server
+}// namespace omega_edit

--- a/server/cpp/src/content_detection.cpp
+++ b/server/cpp/src/content_detection.cpp
@@ -20,180 +20,170 @@
 #include <string>
 
 namespace omega_edit {
-namespace grpc_server {
-namespace {
+    namespace grpc_server {
+        namespace {
 
-bool starts_with(const uint8_t *data, int64_t length, const char *signature, size_t signature_length) {
-    return data != nullptr && length >= static_cast<int64_t>(signature_length) &&
-           std::memcmp(data, signature, signature_length) == 0;
-}
+            bool starts_with(const uint8_t *data, int64_t length, const char *signature, size_t signature_length) {
+                return data != nullptr && length >= static_cast<int64_t>(signature_length) &&
+                       std::memcmp(data, signature, signature_length) == 0;
+            }
 
-bool starts_with_bytes(const uint8_t *data, int64_t length, const uint8_t *signature, size_t signature_length) {
-    return data != nullptr && length >= static_cast<int64_t>(signature_length) &&
-           std::memcmp(data, signature, signature_length) == 0;
-}
+            bool starts_with_bytes(const uint8_t *data, int64_t length, const uint8_t *signature,
+                                   size_t signature_length) {
+                return data != nullptr && length >= static_cast<int64_t>(signature_length) &&
+                       std::memcmp(data, signature, signature_length) == 0;
+            }
 
-std::string lower_extension(const std::string &file_path) {
-    const auto slash = file_path.find_last_of("\\/");
-    const auto dot = file_path.find_last_of('.');
-    if (dot == std::string::npos || (slash != std::string::npos && dot < slash)) {
-        return "";
-    }
+            std::string lower_extension(const std::string &file_path) {
+                const auto slash = file_path.find_last_of("\\/");
+                const auto dot = file_path.find_last_of('.');
+                if (dot == std::string::npos || (slash != std::string::npos && dot < slash)) { return ""; }
 
-    std::string ext = file_path.substr(dot);
-    std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) {
-        return static_cast<char>(std::tolower(ch));
-    });
-    return ext;
-}
+                std::string ext = file_path.substr(dot);
+                std::transform(ext.begin(), ext.end(), ext.begin(),
+                               [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+                return ext;
+            }
 
-bool has_utf16_bom(const uint8_t *data, int64_t length) {
-    return length >= 2 &&
-           ((data[0] == 0xff && data[1] == 0xfe) ||
-            (data[0] == 0xfe && data[1] == 0xff));
-}
+            bool has_utf16_bom(const uint8_t *data, int64_t length) {
+                return length >= 2 && ((data[0] == 0xff && data[1] == 0xfe) || (data[0] == 0xfe && data[1] == 0xff));
+            }
 
-bool has_utf8_bom(const uint8_t *data, int64_t length) {
-    return length >= 3 && data[0] == 0xef && data[1] == 0xbb && data[2] == 0xbf;
-}
+            bool has_utf8_bom(const uint8_t *data, int64_t length) {
+                return length >= 3 && data[0] == 0xef && data[1] == 0xbb && data[2] == 0xbf;
+            }
 
-bool is_valid_utf8(const uint8_t *data, int64_t length) {
-    for (int64_t i = 0; i < length;) {
-        const uint8_t byte = data[i];
-        if (byte < 0x80) {
-            ++i;
-            continue;
+            bool is_valid_utf8(const uint8_t *data, int64_t length) {
+                for (int64_t i = 0; i < length;) {
+                    const uint8_t byte = data[i];
+                    if (byte < 0x80) {
+                        ++i;
+                        continue;
+                    }
+
+                    int extra = 0;
+                    if ((byte & 0xe0) == 0xc0) {
+                        extra = 1;
+                        if (byte < 0xc2) return false;
+                    } else if ((byte & 0xf0) == 0xe0) {
+                        extra = 2;
+                    } else if ((byte & 0xf8) == 0xf0) {
+                        extra = 3;
+                        if (byte > 0xf4) return false;
+                    } else {
+                        return false;
+                    }
+
+                    if (i + extra >= length) return false;
+                    for (int j = 1; j <= extra; ++j) {
+                        if ((data[i + j] & 0xc0) != 0x80) return false;
+                    }
+
+                    i += extra + 1;
+                }
+                return true;
+            }
+
+            bool is_likely_text(const uint8_t *data, int64_t length) {
+                if (!data || length <= 0) return false;
+                if (has_utf16_bom(data, length) || has_utf8_bom(data, length)) return true;
+                if (!is_valid_utf8(data, length)) return false;
+
+                int64_t control_count = 0;
+                for (int64_t i = 0; i < length; ++i) {
+                    const uint8_t byte = data[i];
+                    if (byte == 0) return false;
+                    if (byte < 0x20 && byte != '\t' && byte != '\r' && byte != '\n' && byte != '\f' && byte != '\b') {
+                        ++control_count;
+                    }
+                }
+
+                return control_count <= std::max<int64_t>(1, length / 50);
+            }
+
+            std::string ascii_prefix(const uint8_t *data, int64_t length) {
+                const int64_t limit = std::min<int64_t>(length, 4096);
+                std::string text;
+                text.reserve(static_cast<size_t>(limit));
+                for (int64_t i = 0; i < limit; ++i) {
+                    const uint8_t byte = data[i];
+                    text.push_back(byte < 0x80 ? static_cast<char>(byte) : ' ');
+                }
+                std::transform(text.begin(), text.end(), text.begin(),
+                               [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+                return text;
+            }
+
+            bool extension_is_markdown(const std::string &ext) {
+                return ext == ".md" || ext == ".markdown" || ext == ".mdown" || ext == ".mkd";
+            }
+
+            bool extension_is_plain_text(const std::string &ext) {
+                return ext == ".txt" || ext == ".log" || ext == ".csv" || ext == ".tsv" || ext == ".yaml" ||
+                       ext == ".yml" || ext == ".toml" || ext == ".ini" || ext == ".css" || ext == ".js" ||
+                       ext == ".ts" || ext == ".tsx" || ext == ".jsx" || ext == ".py" || ext == ".sh" ||
+                       ext == ".ps1" || ext == ".c" || ext == ".cc" || ext == ".cpp" || ext == ".h" || ext == ".hpp" ||
+                       ext == ".java" || ext == ".rs" || ext == ".go" || ext == ".sql";
+            }
+
+            bool looks_like_markdown(const std::string &text) {
+                int score = 0;
+                if (text.find("\n# ") != std::string::npos || text.rfind("# ", 0) == 0) ++score;
+                if (text.find("\n##") != std::string::npos || text.rfind("##", 0) == 0) ++score;
+                if (text.find("\n- ") != std::string::npos || text.find("\n* ") != std::string::npos) ++score;
+                if (text.find("](") != std::string::npos) ++score;
+                if (text.find("\n```") != std::string::npos || text.rfind("```", 0) == 0) ++score;
+                if (text.find("\n|") != std::string::npos && text.find("|") != std::string::npos) ++score;
+                if (text.find("<h1") != std::string::npos || text.find("<div") != std::string::npos) ++score;
+                return score >= 2;
+            }
+
+            std::string detect_text_type(const uint8_t *data, int64_t length, const std::string &ext) {
+                const std::string text = ascii_prefix(data, length);
+                const size_t first = text.find_first_not_of(" \t\r\n");
+                const std::string leading = first == std::string::npos ? "" : text.substr(first, 32);
+
+                if (extension_is_markdown(ext) || looks_like_markdown(text)) return "text/markdown";
+                if (ext == ".json" || leading.rfind("{", 0) == 0 || leading.rfind("[", 0) == 0)
+                    return "application/json";
+                if (ext == ".xml" || leading.rfind("<?xml", 0) == 0) return "application/xml";
+                if (ext == ".html" || ext == ".htm" || leading.rfind("<!doctype html", 0) == 0 ||
+                    leading.rfind("<html", 0) == 0) {
+                    return "text/html";
+                }
+                if (extension_is_plain_text(ext)) return "text/plain";
+                return "text/plain";
+            }
+
+        }// namespace
+
+        std::string detect_builtin_content_type(const uint8_t *data, int64_t length, const std::string &file_path) {
+            if (!data || length <= 0) { return "application/octet-stream"; }
+
+            static constexpr uint8_t png_signature[] = {0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a};
+            static constexpr uint8_t jpg_signature[] = {0xff, 0xd8, 0xff};
+            static constexpr uint8_t gzip_signature[] = {0x1f, 0x8b};
+            static constexpr uint8_t elf_signature[] = {0x7f, 'E', 'L', 'F'};
+
+            if (starts_with_bytes(data, length, png_signature, sizeof(png_signature))) return "image/png";
+            if (starts_with_bytes(data, length, jpg_signature, sizeof(jpg_signature))) return "image/jpeg";
+            if (starts_with(data, length, "GIF87a", 6) || starts_with(data, length, "GIF89a", 6)) return "image/gif";
+            if (starts_with(data, length, "%PDF-", 5)) return "application/pdf";
+            if (starts_with(data, length, "PK\003\004", 4) || starts_with(data, length, "PK\005\006", 4) ||
+                starts_with(data, length, "PK\007\010", 4)) {
+                return "application/zip";
+            }
+            if (starts_with_bytes(data, length, gzip_signature, sizeof(gzip_signature))) return "application/gzip";
+            if (starts_with(data, length, "BM", 2)) return "image/bmp";
+            if (starts_with_bytes(data, length, elf_signature, sizeof(elf_signature))) return "application/x-elf";
+            if (length >= 12 && starts_with(data, length, "RIFF", 4) && std::memcmp(data + 8, "WEBP", 4) == 0) {
+                return "image/webp";
+            }
+
+            if (is_likely_text(data, length)) { return detect_text_type(data, length, lower_extension(file_path)); }
+
+            return "application/octet-stream";
         }
 
-        int extra = 0;
-        if ((byte & 0xe0) == 0xc0) {
-            extra = 1;
-            if (byte < 0xc2) return false;
-        } else if ((byte & 0xf0) == 0xe0) {
-            extra = 2;
-        } else if ((byte & 0xf8) == 0xf0) {
-            extra = 3;
-            if (byte > 0xf4) return false;
-        } else {
-            return false;
-        }
-
-        if (i + extra >= length) return false;
-        for (int j = 1; j <= extra; ++j) {
-            if ((data[i + j] & 0xc0) != 0x80) return false;
-        }
-
-        i += extra + 1;
-    }
-    return true;
-}
-
-bool is_likely_text(const uint8_t *data, int64_t length) {
-    if (!data || length <= 0) return false;
-    if (has_utf16_bom(data, length) || has_utf8_bom(data, length)) return true;
-    if (!is_valid_utf8(data, length)) return false;
-
-    int64_t control_count = 0;
-    for (int64_t i = 0; i < length; ++i) {
-        const uint8_t byte = data[i];
-        if (byte == 0) return false;
-        if (byte < 0x20 && byte != '\t' && byte != '\r' && byte != '\n' && byte != '\f' && byte != '\b') {
-            ++control_count;
-        }
-    }
-
-    return control_count <= std::max<int64_t>(1, length / 50);
-}
-
-std::string ascii_prefix(const uint8_t *data, int64_t length) {
-    const int64_t limit = std::min<int64_t>(length, 4096);
-    std::string text;
-    text.reserve(static_cast<size_t>(limit));
-    for (int64_t i = 0; i < limit; ++i) {
-        const uint8_t byte = data[i];
-        text.push_back(byte < 0x80 ? static_cast<char>(byte) : ' ');
-    }
-    std::transform(text.begin(), text.end(), text.begin(), [](unsigned char ch) {
-        return static_cast<char>(std::tolower(ch));
-    });
-    return text;
-}
-
-bool extension_is_markdown(const std::string &ext) {
-    return ext == ".md" || ext == ".markdown" || ext == ".mdown" || ext == ".mkd";
-}
-
-bool extension_is_plain_text(const std::string &ext) {
-    return ext == ".txt" || ext == ".log" || ext == ".csv" || ext == ".tsv" ||
-           ext == ".yaml" || ext == ".yml" || ext == ".toml" || ext == ".ini" ||
-           ext == ".css" || ext == ".js" || ext == ".ts" || ext == ".tsx" ||
-           ext == ".jsx" || ext == ".py" || ext == ".sh" || ext == ".ps1" ||
-           ext == ".c" || ext == ".cc" || ext == ".cpp" || ext == ".h" ||
-           ext == ".hpp" || ext == ".java" || ext == ".rs" || ext == ".go" ||
-           ext == ".sql";
-}
-
-bool looks_like_markdown(const std::string &text) {
-    int score = 0;
-    if (text.find("\n# ") != std::string::npos || text.rfind("# ", 0) == 0) ++score;
-    if (text.find("\n##") != std::string::npos || text.rfind("##", 0) == 0) ++score;
-    if (text.find("\n- ") != std::string::npos || text.find("\n* ") != std::string::npos) ++score;
-    if (text.find("](") != std::string::npos) ++score;
-    if (text.find("\n```") != std::string::npos || text.rfind("```", 0) == 0) ++score;
-    if (text.find("\n|") != std::string::npos && text.find("|") != std::string::npos) ++score;
-    if (text.find("<h1") != std::string::npos || text.find("<div") != std::string::npos) ++score;
-    return score >= 2;
-}
-
-std::string detect_text_type(const uint8_t *data, int64_t length, const std::string &ext) {
-    const std::string text = ascii_prefix(data, length);
-    const size_t first = text.find_first_not_of(" \t\r\n");
-    const std::string leading = first == std::string::npos ? "" : text.substr(first, 32);
-
-    if (extension_is_markdown(ext) || looks_like_markdown(text)) return "text/markdown";
-    if (ext == ".json" || leading.rfind("{", 0) == 0 || leading.rfind("[", 0) == 0) return "application/json";
-    if (ext == ".xml" || leading.rfind("<?xml", 0) == 0) return "application/xml";
-    if (ext == ".html" || ext == ".htm" || leading.rfind("<!doctype html", 0) == 0 || leading.rfind("<html", 0) == 0) {
-        return "text/html";
-    }
-    if (extension_is_plain_text(ext)) return "text/plain";
-    return "text/plain";
-}
-
-} // namespace
-
-std::string detect_builtin_content_type(const uint8_t *data, int64_t length, const std::string &file_path) {
-    if (!data || length <= 0) {
-        return "application/octet-stream";
-    }
-
-    static constexpr uint8_t png_signature[] = {0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a};
-    static constexpr uint8_t jpg_signature[] = {0xff, 0xd8, 0xff};
-    static constexpr uint8_t gzip_signature[] = {0x1f, 0x8b};
-    static constexpr uint8_t elf_signature[] = {0x7f, 'E', 'L', 'F'};
-
-    if (starts_with_bytes(data, length, png_signature, sizeof(png_signature))) return "image/png";
-    if (starts_with_bytes(data, length, jpg_signature, sizeof(jpg_signature))) return "image/jpeg";
-    if (starts_with(data, length, "GIF87a", 6) || starts_with(data, length, "GIF89a", 6)) return "image/gif";
-    if (starts_with(data, length, "%PDF-", 5)) return "application/pdf";
-    if (starts_with(data, length, "PK\003\004", 4) ||
-        starts_with(data, length, "PK\005\006", 4) ||
-        starts_with(data, length, "PK\007\010", 4)) {
-        return "application/zip";
-    }
-    if (starts_with_bytes(data, length, gzip_signature, sizeof(gzip_signature))) return "application/gzip";
-    if (starts_with(data, length, "BM", 2)) return "image/bmp";
-    if (starts_with_bytes(data, length, elf_signature, sizeof(elf_signature))) return "application/x-elf";
-    if (length >= 12 && starts_with(data, length, "RIFF", 4) && std::memcmp(data + 8, "WEBP", 4) == 0) {
-        return "image/webp";
-    }
-
-    if (is_likely_text(data, length)) {
-        return detect_text_type(data, length, lower_extension(file_path));
-    }
-
-    return "application/octet-stream";
-}
-
-} // namespace grpc_server
-} // namespace omega_edit
+    }// namespace grpc_server
+}// namespace omega_edit

--- a/server/cpp/src/content_detection.h
+++ b/server/cpp/src/content_detection.h
@@ -20,51 +20,51 @@
 #include <string>
 
 namespace omega_edit {
-namespace grpc_server {
+    namespace grpc_server {
 
-// ── Pluggable interfaces ─────────────────────────────────────────────────────
+        // ── Pluggable interfaces ─────────────────────────────────────────────────────
 
-/// Abstract interface for content/MIME type detection.
-/// Implementations may use libmagic, heuristics, or any other backend.
-class IContentTypeDetector {
-public:
-    virtual ~IContentTypeDetector() = default;
+        /// Abstract interface for content/MIME type detection.
+        /// Implementations may use libmagic, heuristics, or any other backend.
+        class IContentTypeDetector {
+        public:
+            virtual ~IContentTypeDetector() = default;
 
-    /// Detect the MIME type of a data buffer.
-    /// @param data pointer to the raw bytes
-    /// @param length number of bytes
-    /// @param file_path optional source path hint for extension-aware fallback detection
-    /// @return MIME type string (e.g. "text/plain", "application/pdf")
-    virtual std::string detect(const uint8_t *data, int64_t length, const std::string &file_path) = 0;
-};
+            /// Detect the MIME type of a data buffer.
+            /// @param data pointer to the raw bytes
+            /// @param length number of bytes
+            /// @param file_path optional source path hint for extension-aware fallback detection
+            /// @return MIME type string (e.g. "text/plain", "application/pdf")
+            virtual std::string detect(const uint8_t *data, int64_t length, const std::string &file_path) = 0;
+        };
 
-/// Abstract interface for language detection.
-/// Implementations may use CLD3, trigrams, or any other backend.
-class ILanguageDetector {
-public:
-    virtual ~ILanguageDetector() = default;
+        /// Abstract interface for language detection.
+        /// Implementations may use CLD3, trigrams, or any other backend.
+        class ILanguageDetector {
+        public:
+            virtual ~ILanguageDetector() = default;
 
-    /// Detect the language of a text buffer.
-    /// @param data pointer to the raw bytes (expected to be text)
-    /// @param length number of bytes
-    /// @param bom byte-order mark hint (e.g. "UTF-8", "UTF-16LE", "none")
-    /// @return ISO 639-1 language code (e.g. "en", "ja") or "unknown"
-    virtual std::string detect(const uint8_t *data, int64_t length, const std::string &bom) = 0;
-};
+            /// Detect the language of a text buffer.
+            /// @param data pointer to the raw bytes (expected to be text)
+            /// @param length number of bytes
+            /// @param bom byte-order mark hint (e.g. "UTF-8", "UTF-16LE", "none")
+            /// @return ISO 639-1 language code (e.g. "en", "ja") or "unknown"
+            virtual std::string detect(const uint8_t *data, int64_t length, const std::string &bom) = 0;
+        };
 
-// ── Factory functions ────────────────────────────────────────────────────────
+        // ── Factory functions ────────────────────────────────────────────────────────
 
-/// Create the default content-type detector (libmagic-backed).
-std::unique_ptr<IContentTypeDetector> create_default_content_type_detector();
+        /// Create the default content-type detector (libmagic-backed).
+        std::unique_ptr<IContentTypeDetector> create_default_content_type_detector();
 
-/// Lightweight built-in content-type detector used as a fallback when libmagic is unavailable
-/// or returns a generic result.
-std::string detect_builtin_content_type(const uint8_t *data, int64_t length, const std::string &file_path);
+        /// Lightweight built-in content-type detector used as a fallback when libmagic is unavailable
+        /// or returns a generic result.
+        std::string detect_builtin_content_type(const uint8_t *data, int64_t length, const std::string &file_path);
 
-/// Create the default language detector (CLD3-backed).
-std::unique_ptr<ILanguageDetector> create_default_language_detector();
+        /// Create the default language detector (CLD3-backed).
+        std::unique_ptr<ILanguageDetector> create_default_language_detector();
 
-} // namespace grpc_server
-} // namespace omega_edit
+    }// namespace grpc_server
+}// namespace omega_edit
 
-#endif // OMEGA_EDIT_CONTENT_DETECTION_H
+#endif// OMEGA_EDIT_CONTENT_DETECTION_H

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -22,8 +22,8 @@
 
 #include <algorithm>
 #include <atomic>
-#include <chrono>
 #include <cctype>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
@@ -48,2168 +48,2261 @@
 #endif
 
 namespace omega_edit {
-namespace grpc_server {
+    namespace grpc_server {
 
-static const std::string &get_hostname() {
-    static const std::string value = []() -> std::string {
-        char buf[256] = {};
+        static const std::string &get_hostname() {
+            static const std::string value = []() -> std::string {
+                char buf[256] = {};
 #ifdef _WIN32
-        DWORD size = sizeof(buf);
-        if (GetComputerNameA(buf, &size)) return std::string(buf, size);
+                DWORD size = sizeof(buf);
+                if (GetComputerNameA(buf, &size)) return std::string(buf, size);
 #else
-        if (gethostname(buf, sizeof(buf)) == 0) return std::string(buf);
+                if (gethostname(buf, sizeof(buf)) == 0) return std::string(buf);
 #endif
-        return "unknown";
-    }();
-    return value;
-}
+                return "unknown";
+            }();
+            return value;
+        }
 
-static int get_pid() {
+        static int get_pid() {
 #ifdef _WIN32
-    return static_cast<int>(GetCurrentProcessId());
+            return static_cast<int>(GetCurrentProcessId());
 #else
-    return static_cast<int>(getpid());
+            return static_cast<int>(getpid());
 #endif
-}
+        }
 
-static int get_cpu_count() {
-    auto n = std::thread::hardware_concurrency();
-    return n > 0 ? static_cast<int>(n) : 1;
-}
+        static int get_cpu_count() {
+            auto n = std::thread::hardware_concurrency();
+            return n > 0 ? static_cast<int>(n) : 1;
+        }
 
-static constexpr char SESSION_FINGERPRINT_DIGEST_PLUGIN_ID[] = "omega.example.openssl_digests";
-static constexpr char DEFAULT_SESSION_FINGERPRINT_ALGORITHM[] = "sha256";
-static constexpr int64_t SESSION_FINGERPRINT_CHUNK_SIZE = 1024 * 1024;
+        static constexpr char SESSION_FINGERPRINT_DIGEST_PLUGIN_ID[] = "omega.example.openssl_digests";
+        static constexpr char DEFAULT_SESSION_FINGERPRINT_ALGORITHM[] = "sha256";
+        static constexpr int64_t SESSION_FINGERPRINT_CHUNK_SIZE = 1024 * 1024;
 
-static bool path_argument_is_safe_for_core(const std::string &path) {
-    return path.size() < FILENAME_MAX &&
-           std::none_of(path.begin(), path.end(), [](unsigned char ch) {
-               return ch == '\0' || ch < 0x20U || ch == 0x7FU;
-           });
-}
+        static bool path_argument_is_safe_for_core(const std::string &path) {
+            return path.size() < FILENAME_MAX && std::none_of(path.begin(), path.end(), [](unsigned char ch) {
+                       return ch == '\0' || ch < 0x20U || ch == 0x7FU;
+                   });
+        }
 
-static grpc::Status validate_path_argument(const std::string &path, const char *field_name) {
-    if (path.empty() || path_argument_is_safe_for_core(path)) { return grpc::Status::OK; }
-    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                        std::string(field_name) +
-                                " must be shorter than FILENAME_MAX and contain no NUL or control characters");
-}
+        static grpc::Status validate_path_argument(const std::string &path, const char *field_name) {
+            if (path.empty() || path_argument_is_safe_for_core(path)) { return grpc::Status::OK; }
+            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                std::string(field_name) +
+                                        " must be shorter than FILENAME_MAX and contain no NUL or control characters");
+        }
 
-static std::string normalize_digest_algorithm(std::string algorithm) {
-    if (algorithm.empty()) { return DEFAULT_SESSION_FINGERPRINT_ALGORITHM; }
-    std::transform(algorithm.begin(), algorithm.end(), algorithm.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-    return algorithm;
-}
+        static std::string normalize_digest_algorithm(std::string algorithm) {
+            if (algorithm.empty()) { return DEFAULT_SESSION_FINGERPRINT_ALGORITHM; }
+            std::transform(algorithm.begin(), algorithm.end(), algorithm.begin(),
+                           [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            return algorithm;
+        }
 
-static bool digest_algorithm_is_json_safe(const std::string &algorithm) {
-    return !algorithm.empty() &&
-           std::all_of(algorithm.begin(), algorithm.end(),
-                       [](unsigned char c) { return std::isalnum(c) != 0 || c == '-'; });
-}
+        static bool digest_algorithm_is_json_safe(const std::string &algorithm) {
+            return !algorithm.empty() && std::all_of(algorithm.begin(), algorithm.end(),
+                                                     [](unsigned char c) { return std::isalnum(c) != 0 || c == '-'; });
+        }
 
-static std::string make_digest_options_json(const std::string &algorithm) {
-    return "{\"algorithm\":\"" + algorithm + "\"}";
-}
+        static std::string make_digest_options_json(const std::string &algorithm) {
+            return "{\"algorithm\":\"" + algorithm + "\"}";
+        }
 
-using session_fingerprint_content = ::omega_edit::v1::SessionFingerprintContent;
+        using session_fingerprint_content = ::omega_edit::v1::SessionFingerprintContent;
 
-static int64_t get_session_fingerprint_byte_length(omega_session_t *session, session_fingerprint_content content) {
-    switch (content) {
-    case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL:
-        return omega_session_get_original_file_size(session);
-    case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED:
-        return omega_session_get_computed_file_size(session);
-    default:
-        return -1;
-    }
-}
+        static int64_t get_session_fingerprint_byte_length(omega_session_t *session,
+                                                           session_fingerprint_content content) {
+            switch (content) {
+                case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL:
+                    return omega_session_get_original_file_size(session);
+                case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED:
+                    return omega_session_get_computed_file_size(session);
+                default:
+                    return -1;
+            }
+        }
 
-static int read_session_fingerprint_segment(const omega_session_t *session, session_fingerprint_content content,
-                                            omega_segment_t *segment, int64_t offset) {
-    switch (content) {
-    case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL:
-        return omega_session_get_original_segment(session, segment, offset);
-    case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED:
-        return omega_session_get_segment(session, segment, offset);
-    default:
-        return -1;
-    }
-}
+        static int read_session_fingerprint_segment(const omega_session_t *session, session_fingerprint_content content,
+                                                    omega_segment_t *segment, int64_t offset) {
+            switch (content) {
+                case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL:
+                    return omega_session_get_original_segment(session, segment, offset);
+                case ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED:
+                    return omega_session_get_segment(session, segment, offset);
+                default:
+                    return -1;
+            }
+        }
 
-struct session_fingerprint_reader {
-    const omega_session_t *session{};
-    session_fingerprint_content content{};
-    int64_t byte_length{};
-};
+        struct session_fingerprint_reader {
+            const omega_session_t *session{};
+            session_fingerprint_content content{};
+            int64_t byte_length{};
+        };
 
-static int64_t read_session_fingerprint_chunk(int64_t relative_offset, omega_byte_t *buffer, int64_t length,
-                                              void *user_data_ptr) {
-    auto *reader = static_cast<session_fingerprint_reader *>(user_data_ptr);
-    if (!reader || !reader->session || !buffer || relative_offset < 0 || length < 0 ||
-        relative_offset > reader->byte_length) {
-        return -1;
-    }
+        static int64_t read_session_fingerprint_chunk(int64_t relative_offset, omega_byte_t *buffer, int64_t length,
+                                                      void *user_data_ptr) {
+            auto *reader = static_cast<session_fingerprint_reader *>(user_data_ptr);
+            if (!reader || !reader->session || !buffer || relative_offset < 0 || length < 0 ||
+                relative_offset > reader->byte_length) {
+                return -1;
+            }
 
-    const auto remaining = reader->byte_length - relative_offset;
-    const auto read_length = std::min(std::min(length, remaining), SESSION_FINGERPRINT_CHUNK_SIZE);
-    if (read_length == 0) { return 0; }
+            const auto remaining = reader->byte_length - relative_offset;
+            const auto read_length = std::min(std::min(length, remaining), SESSION_FINGERPRINT_CHUNK_SIZE);
+            if (read_length == 0) { return 0; }
 
-    auto *segment = omega_segment_create(read_length);
-    if (!segment) { return -1; }
-    const auto rc = read_session_fingerprint_segment(reader->session, reader->content, segment, relative_offset);
-    if (rc != 0) {
-        omega_segment_destroy(segment);
-        return -1;
-    }
+            auto *segment = omega_segment_create(read_length);
+            if (!segment) { return -1; }
+            const auto rc =
+                    read_session_fingerprint_segment(reader->session, reader->content, segment, relative_offset);
+            if (rc != 0) {
+                omega_segment_destroy(segment);
+                return -1;
+            }
 
-    const auto segment_length = std::min(read_length, omega_segment_get_length(segment));
-    auto *data = omega_segment_get_data(segment);
-    if (segment_length <= 0 || !data) {
-        omega_segment_destroy(segment);
-        return -1;
-    }
-    std::memcpy(buffer, data, static_cast<size_t>(segment_length));
-    omega_segment_destroy(segment);
-    return segment_length;
-}
+            const auto segment_length = std::min(read_length, omega_segment_get_length(segment));
+            auto *data = omega_segment_get_data(segment);
+            if (segment_length <= 0 || !data) {
+                omega_segment_destroy(segment);
+                return -1;
+            }
+            std::memcpy(buffer, data, static_cast<size_t>(segment_length));
+            omega_segment_destroy(segment);
+            return segment_length;
+        }
 
-struct process_memory_metrics {
-    std::optional<int64_t> resident_memory_bytes;
-    std::optional<int64_t> virtual_memory_bytes;
-    std::optional<int64_t> peak_resident_memory_bytes;
-};
+        struct process_memory_metrics {
+            std::optional<int64_t> resident_memory_bytes;
+            std::optional<int64_t> virtual_memory_bytes;
+            std::optional<int64_t> peak_resident_memory_bytes;
+        };
 
-struct transform_plugin_response_guard {
-    omega_transform_plugin_response_t response{};
+        struct transform_plugin_response_guard {
+            omega_transform_plugin_response_t response{};
 
-    transform_plugin_response_guard() = default;
-    transform_plugin_response_guard(const transform_plugin_response_guard &) = delete;
-    auto operator=(const transform_plugin_response_guard &) -> transform_plugin_response_guard & = delete;
-    ~transform_plugin_response_guard() { omega_transform_plugin_response_clear(&response); }
-};
+            transform_plugin_response_guard() = default;
+            transform_plugin_response_guard(const transform_plugin_response_guard &) = delete;
+            auto operator=(const transform_plugin_response_guard &) -> transform_plugin_response_guard & = delete;
+            ~transform_plugin_response_guard() { omega_transform_plugin_response_clear(&response); }
+        };
 
-struct transform_progress_context {
-    SessionManager *session_manager{};
-    std::string session_id;
-    std::string plugin_id;
-    std::string operation_id;
-    std::chrono::steady_clock::time_point last_emit{};
-};
+        struct transform_progress_context {
+            SessionManager *session_manager{};
+            std::string session_id;
+            std::string plugin_id;
+            std::string operation_id;
+            std::chrono::steady_clock::time_point last_emit{};
+        };
 
-static std::atomic<uint64_t> g_transform_operation_counter{0};
+        static std::atomic<uint64_t> g_transform_operation_counter{0};
 
-static std::string next_transform_operation_id() {
-    return "transform_" + std::to_string(g_transform_operation_counter.fetch_add(1, std::memory_order_relaxed) + 1);
-}
+        static std::string next_transform_operation_id() {
+            return "transform_" +
+                   std::to_string(g_transform_operation_counter.fetch_add(1, std::memory_order_relaxed) + 1);
+        }
 
-static TransformProgressData make_transform_progress(const std::string &plugin_id, const std::string &operation_id,
-                                                     const char *phase, const char *message,
-                                                     bool indeterminate = true) {
-    TransformProgressData progress;
-    progress.plugin_id = plugin_id;
-    progress.operation_id = operation_id;
-    progress.phase = phase ? phase : "";
-    progress.message = message ? message : "";
-    progress.indeterminate = indeterminate;
-    return progress;
-}
+        static TransformProgressData make_transform_progress(const std::string &plugin_id,
+                                                             const std::string &operation_id, const char *phase,
+                                                             const char *message, bool indeterminate = true) {
+            TransformProgressData progress;
+            progress.plugin_id = plugin_id;
+            progress.operation_id = operation_id;
+            progress.phase = phase ? phase : "";
+            progress.message = message ? message : "";
+            progress.indeterminate = indeterminate;
+            return progress;
+        }
 
-static TransformProgressData make_transform_progress(const transform_progress_context &context,
-                                                     const omega_transform_plugin_progress_t &reported) {
-    TransformProgressData progress;
-    progress.plugin_id = context.plugin_id;
-    progress.operation_id = context.operation_id;
-    progress.phase = reported.phase ? reported.phase : "";
-    progress.message = reported.message ? reported.message : "";
-    progress.indeterminate = (reported.flags & OMEGA_TRANSFORM_PROGRESS_INDETERMINATE) != 0U;
-    progress.has_processed_bytes = (reported.flags & OMEGA_TRANSFORM_PROGRESS_HAS_PROCESSED_BYTES) != 0U;
-    progress.has_total_bytes = (reported.flags & OMEGA_TRANSFORM_PROGRESS_HAS_TOTAL_BYTES) != 0U;
-    progress.has_percent = (reported.flags & OMEGA_TRANSFORM_PROGRESS_HAS_PERCENT) != 0U;
-    progress.processed_bytes = reported.processed_bytes;
-    progress.total_bytes = reported.total_bytes;
-    progress.percent = reported.percent;
-    return progress;
-}
+        static TransformProgressData make_transform_progress(const transform_progress_context &context,
+                                                             const omega_transform_plugin_progress_t &reported) {
+            TransformProgressData progress;
+            progress.plugin_id = context.plugin_id;
+            progress.operation_id = context.operation_id;
+            progress.phase = reported.phase ? reported.phase : "";
+            progress.message = reported.message ? reported.message : "";
+            progress.indeterminate = (reported.flags & OMEGA_TRANSFORM_PROGRESS_INDETERMINATE) != 0U;
+            progress.has_processed_bytes = (reported.flags & OMEGA_TRANSFORM_PROGRESS_HAS_PROCESSED_BYTES) != 0U;
+            progress.has_total_bytes = (reported.flags & OMEGA_TRANSFORM_PROGRESS_HAS_TOTAL_BYTES) != 0U;
+            progress.has_percent = (reported.flags & OMEGA_TRANSFORM_PROGRESS_HAS_PERCENT) != 0U;
+            progress.processed_bytes = reported.processed_bytes;
+            progress.total_bytes = reported.total_bytes;
+            progress.percent = reported.percent;
+            return progress;
+        }
 
-static int transform_progress_callback(const omega_transform_plugin_progress_t *progress_ptr, void *user_data_ptr) {
-    auto *context = static_cast<transform_progress_context *>(user_data_ptr);
-    if (!context || !context->session_manager || !progress_ptr) { return -1; }
+        static int transform_progress_callback(const omega_transform_plugin_progress_t *progress_ptr,
+                                               void *user_data_ptr) {
+            auto *context = static_cast<transform_progress_context *>(user_data_ptr);
+            if (!context || !context->session_manager || !progress_ptr) { return -1; }
 
-    const auto now = std::chrono::steady_clock::now();
-    constexpr auto min_interval = std::chrono::milliseconds(250);
-    const bool complete_percent =
-            (progress_ptr->flags & OMEGA_TRANSFORM_PROGRESS_HAS_PERCENT) != 0U && progress_ptr->percent >= 100.0;
-    if (context->last_emit.time_since_epoch().count() != 0 && now - context->last_emit < min_interval &&
-        !complete_percent) {
-        return 0;
-    }
+            const auto now = std::chrono::steady_clock::now();
+            constexpr auto min_interval = std::chrono::milliseconds(250);
+            const bool complete_percent = (progress_ptr->flags & OMEGA_TRANSFORM_PROGRESS_HAS_PERCENT) != 0U &&
+                                          progress_ptr->percent >= 100.0;
+            if (context->last_emit.time_since_epoch().count() != 0 && now - context->last_emit < min_interval &&
+                !complete_percent) {
+                return 0;
+            }
 
-    context->last_emit = now;
-    const auto progress = make_transform_progress(*context, *progress_ptr);
-    context->session_manager->publish_transform_progress(
-            context->session_id, static_cast<int32_t>(SESSION_EVT_TRANSFORM_PROGRESS), progress);
-    return 0;
-}
+            context->last_emit = now;
+            const auto progress = make_transform_progress(*context, *progress_ptr);
+            context->session_manager->publish_transform_progress(
+                    context->session_id, static_cast<int32_t>(SESSION_EVT_TRANSFORM_PROGRESS), progress);
+            return 0;
+        }
 
-static grpc::Status status_for_session_operation_start(SessionOperationStartResult result,
-                                                       const std::string &operation_name,
-                                                       const std::string &session_id) {
-    switch (result) {
-    case SessionOperationStartResult::STARTED:
-        return grpc::Status::OK;
-    case SessionOperationStartResult::SESSION_NOT_FOUND:
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + session_id);
-    case SessionOperationStartResult::TRANSFORM_IN_PROGRESS:
-        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+        static grpc::Status status_for_session_operation_start(SessionOperationStartResult result,
+                                                               const std::string &operation_name,
+                                                               const std::string &session_id) {
+            switch (result) {
+                case SessionOperationStartResult::STARTED:
+                    return grpc::Status::OK;
+                case SessionOperationStartResult::SESSION_NOT_FOUND:
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + session_id);
+                case SessionOperationStartResult::TRANSFORM_IN_PROGRESS:
+                    return grpc::Status(
+                            grpc::StatusCode::FAILED_PRECONDITION,
                             operation_name + " cannot run while a transform is in progress for session: " + session_id);
-    case SessionOperationStartResult::MUTATION_IN_PROGRESS:
-        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                case SessionOperationStartResult::MUTATION_IN_PROGRESS:
+                    return grpc::Status(
+                            grpc::StatusCode::FAILED_PRECONDITION,
                             operation_name +
                                     " cannot run while a session mutation is in progress for session: " + session_id);
-    }
-    return grpc::Status(grpc::StatusCode::INTERNAL, "unknown session operation state");
-}
+            }
+            return grpc::Status(grpc::StatusCode::INTERNAL, "unknown session operation state");
+        }
 
-static const std::string &get_runtime_kind() {
-    static const std::string value = "native";
-    return value;
-}
+        static const std::string &get_runtime_kind() {
+            static const std::string value = "native";
+            return value;
+        }
 
-static const std::string &get_runtime_name() {
-    static const std::string value = "C++";
-    return value;
-}
+        static const std::string &get_runtime_name() {
+            static const std::string value = "C++";
+            return value;
+        }
 
-static const std::string &get_platform_summary() {
-    static const std::string value = []() {
+        static const std::string &get_platform_summary() {
+            static const std::string value = []() {
 #ifdef _WIN32
-        std::string os = "windows";
+                std::string os = "windows";
 #elif defined(__APPLE__)
-        std::string os = "macos";
+                std::string os = "macos";
 #elif defined(__linux__)
-        std::string os = "linux";
+                std::string os = "linux";
 #else
-        std::string os = "unknown";
+                std::string os = "unknown";
 #endif
 
 #if defined(_M_X64) || defined(__x86_64__)
-        std::string arch = "x64";
+                std::string arch = "x64";
 #elif defined(_M_ARM64) || defined(__aarch64__)
-        std::string arch = "arm64";
+                std::string arch = "arm64";
 #elif defined(_M_IX86) || defined(__i386__)
-        std::string arch = "x86";
+                std::string arch = "x86";
 #elif defined(_M_ARM) || defined(__arm__)
-        std::string arch = "arm";
+                std::string arch = "arm";
 #else
-        std::string arch = "unknown";
+                std::string arch = "unknown";
 #endif
-        return os + "-" + arch;
-    }();
-    return value;
-}
+                return os + "-" + arch;
+            }();
+            return value;
+        }
 
-static const std::string &get_compiler_info() {
-    static const std::string value =
+        static const std::string &get_compiler_info() {
+            static const std::string value =
 #if defined(__clang__)
-            "Clang " + std::to_string(__clang_major__) + "." + std::to_string(__clang_minor__) + "." +
-            std::to_string(__clang_patchlevel__);
+                    "Clang " + std::to_string(__clang_major__) + "." + std::to_string(__clang_minor__) + "." +
+                    std::to_string(__clang_patchlevel__);
 #elif defined(_MSC_FULL_VER)
-            "MSVC " + std::to_string(_MSC_FULL_VER);
+                    "MSVC " + std::to_string(_MSC_FULL_VER);
 #elif defined(_MSC_VER)
-            "MSVC " + std::to_string(_MSC_VER);
+                    "MSVC " + std::to_string(_MSC_VER);
 #elif defined(__GNUC__)
-            "GCC " + std::to_string(__GNUC__) + "." + std::to_string(__GNUC_MINOR__) + "." +
-            std::to_string(__GNUC_PATCHLEVEL__);
+                    "GCC " + std::to_string(__GNUC__) + "." + std::to_string(__GNUC_MINOR__) + "." +
+                    std::to_string(__GNUC_PATCHLEVEL__);
 #else
-            "unknown";
+                    "unknown";
 #endif
-    return value;
-}
+            return value;
+        }
 
-static const std::string &get_build_type() {
+        static const std::string &get_build_type() {
 #ifdef NDEBUG
-    static const std::string value = "Release";
+            static const std::string value = "Release";
 #else
-    static const std::string value = "Debug";
+            static const std::string value = "Debug";
 #endif
-    return value;
-}
+            return value;
+        }
 
-static const std::string &get_cpp_standard() {
-    static const std::string value = []() -> std::string {
+        static const std::string &get_cpp_standard() {
+            static const std::string value = []() -> std::string {
 #if __cplusplus >= 202302L
-        return "C++23";
+                return "C++23";
 #elif __cplusplus >= 202002L
-        return "C++20";
+                return "C++20";
 #elif __cplusplus >= 201703L
-        return "C++17";
+                return "C++17";
 #elif __cplusplus >= 201402L
-        return "C++14";
+                return "C++14";
 #elif __cplusplus >= 201103L
-        return "C++11";
+                return "C++11";
 #elif defined(_MSVC_LANG)
 #if _MSVC_LANG >= 202302L
-        return "C++23";
+                return "C++23";
 #elif _MSVC_LANG >= 202002L
-        return "C++20";
+                return "C++20";
 #elif _MSVC_LANG >= 201703L
-        return "C++17";
+                return "C++17";
 #elif _MSVC_LANG >= 201402L
-        return "C++14";
+                return "C++14";
 #else
-        return "C++11";
+                return "C++11";
 #endif
 #else
-        return "unknown";
+                return "unknown";
 #endif
-    }();
-    return value;
-}
+            }();
+            return value;
+        }
 
-static std::optional<double> get_cpu_load_average() {
+        static std::optional<double> get_cpu_load_average() {
 #ifdef _WIN32
-    return std::nullopt;
+            return std::nullopt;
 #else
-    double loadavg[1] = {0.0};
-    if (getloadavg(loadavg, 1) == 1) { return loadavg[0]; }
-    return std::nullopt;
+            double loadavg[1] = {0.0};
+            if (getloadavg(loadavg, 1) == 1) { return loadavg[0]; }
+            return std::nullopt;
 #endif
-}
+        }
 
 #if defined(__linux__)
-static std::optional<int64_t> read_proc_status_kibibytes(const char *label) {
-    std::ifstream status_file("/proc/self/status");
-    if (!status_file.is_open()) { return std::nullopt; }
+        static std::optional<int64_t> read_proc_status_kibibytes(const char *label) {
+            std::ifstream status_file("/proc/self/status");
+            if (!status_file.is_open()) { return std::nullopt; }
 
-    std::string line;
-    while (std::getline(status_file, line)) {
-        if (line.rfind(label, 0) != 0) { continue; }
+            std::string line;
+            while (std::getline(status_file, line)) {
+                if (line.rfind(label, 0) != 0) { continue; }
 
-        std::istringstream stream(line.substr(std::strlen(label)));
-        int64_t kibibytes = 0;
-        std::string unit;
-        if (stream >> kibibytes >> unit) { return kibibytes * 1024; }
-    }
+                std::istringstream stream(line.substr(std::strlen(label)));
+                int64_t kibibytes = 0;
+                std::string unit;
+                if (stream >> kibibytes >> unit) { return kibibytes * 1024; }
+            }
 
-    return std::nullopt;
-}
+            return std::nullopt;
+        }
 #endif
 
-static process_memory_metrics get_process_memory_metrics() {
-    process_memory_metrics metrics;
+        static process_memory_metrics get_process_memory_metrics() {
+            process_memory_metrics metrics;
 
 #ifdef _WIN32
-    PROCESS_MEMORY_COUNTERS_EX counters = {};
-    if (GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PROCESS_MEMORY_COUNTERS *>(&counters),
-                             sizeof(counters))) {
-        metrics.resident_memory_bytes = static_cast<int64_t>(counters.WorkingSetSize);
-        metrics.peak_resident_memory_bytes = static_cast<int64_t>(counters.PeakWorkingSetSize);
-    }
+            PROCESS_MEMORY_COUNTERS_EX counters = {};
+            if (GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PROCESS_MEMORY_COUNTERS *>(&counters),
+                                     sizeof(counters))) {
+                metrics.resident_memory_bytes = static_cast<int64_t>(counters.WorkingSetSize);
+                metrics.peak_resident_memory_bytes = static_cast<int64_t>(counters.PeakWorkingSetSize);
+            }
 #elif defined(__APPLE__)
-    mach_task_basic_info info = {};
-    mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
-    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &info_count) ==
-        KERN_SUCCESS) {
-        metrics.resident_memory_bytes = static_cast<int64_t>(info.resident_size);
-        metrics.virtual_memory_bytes = static_cast<int64_t>(info.virtual_size);
-    }
+            mach_task_basic_info info = {};
+            mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
+            if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &info_count) ==
+                KERN_SUCCESS) {
+                metrics.resident_memory_bytes = static_cast<int64_t>(info.resident_size);
+                metrics.virtual_memory_bytes = static_cast<int64_t>(info.virtual_size);
+            }
 
-    struct rusage usage = {};
-    if (getrusage(RUSAGE_SELF, &usage) == 0) {
-        metrics.peak_resident_memory_bytes = static_cast<int64_t>(usage.ru_maxrss);
-    }
+            struct rusage usage = {};
+            if (getrusage(RUSAGE_SELF, &usage) == 0) {
+                metrics.peak_resident_memory_bytes = static_cast<int64_t>(usage.ru_maxrss);
+            }
 #elif defined(__linux__)
-    metrics.resident_memory_bytes = read_proc_status_kibibytes("VmRSS:");
-    metrics.virtual_memory_bytes = read_proc_status_kibibytes("VmSize:");
-    metrics.peak_resident_memory_bytes = read_proc_status_kibibytes("VmHWM:");
+            metrics.resident_memory_bytes = read_proc_status_kibibytes("VmRSS:");
+            metrics.virtual_memory_bytes = read_proc_status_kibibytes("VmSize:");
+            metrics.peak_resident_memory_bytes = read_proc_status_kibibytes("VmHWM:");
 
-    if (!metrics.peak_resident_memory_bytes.has_value()) {
-        struct rusage usage = {};
-        if (getrusage(RUSAGE_SELF, &usage) == 0) {
-            metrics.peak_resident_memory_bytes = static_cast<int64_t>(usage.ru_maxrss) * 1024;
-        }
-    }
+            if (!metrics.peak_resident_memory_bytes.has_value()) {
+                struct rusage usage = {};
+                if (getrusage(RUSAGE_SELF, &usage) == 0) {
+                    metrics.peak_resident_memory_bytes = static_cast<int64_t>(usage.ru_maxrss) * 1024;
+                }
+            }
 #endif
 
-    return metrics;
-}
-
-static grpc::Status validate_change_payload_size(const ::omega_edit::v1::SubmitChangeRequest *request,
-                                                 int64_t max_change_bytes) {
-    if ((request->kind() != ::omega_edit::v1::CHANGE_KIND_INSERT &&
-         request->kind() != ::omega_edit::v1::CHANGE_KIND_OVERWRITE) ||
-        max_change_bytes <= 0) {
-        return grpc::Status::OK;
-    }
-
-    if (request->data().size() <= static_cast<size_t>(max_change_bytes)) { return grpc::Status::OK; }
-
-    return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
-                        "change payload exceeds configured limit of " + std::to_string(max_change_bytes) + " bytes");
-}
-
-static grpc::Status
-validate_replace_checkpointed_payload_sizes(const ::omega_edit::v1::ReplaceSessionCheckpointedRequest *request,
-                                            int64_t max_change_bytes) {
-    if (max_change_bytes <= 0) { return grpc::Status::OK; }
-
-    if (request->pattern().size() > static_cast<size_t>(max_change_bytes)) {
-        return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
-                            "checkpointed replace pattern exceeds configured limit of " +
-                                    std::to_string(max_change_bytes) + " bytes");
-    }
-
-    if (request->replacement().size() > static_cast<size_t>(max_change_bytes)) {
-        return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
-                            "checkpointed replace replacement exceeds configured limit of " +
-                                    std::to_string(max_change_bytes) + " bytes");
-    }
-
-    return grpc::Status::OK;
-}
-
-static grpc::Status validate_replace_payload_sizes(const std::string &pattern, const std::string &replacement,
-                                                   int64_t max_change_bytes, const std::string &operation_name) {
-    if (max_change_bytes <= 0) { return grpc::Status::OK; }
-
-    if (pattern.size() > static_cast<size_t>(max_change_bytes)) {
-        return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, operation_name +
-                                                                          " pattern exceeds configured limit of " +
-                                                                          std::to_string(max_change_bytes) + " bytes");
-    }
-
-    if (replacement.size() > static_cast<size_t>(max_change_bytes)) {
-        return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, operation_name +
-                                                                          " replacement exceeds configured limit of " +
-                                                                          std::to_string(max_change_bytes) + " bytes");
-    }
-
-    return grpc::Status::OK;
-}
-
-static ::omega_edit::v1::TransformPluginOperation
-to_proto_transform_plugin_operation(omega_transform_plugin_operation_t operation) {
-    switch (operation) {
-    case OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE:
-        return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_REPLACE;
-    case OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT:
-        return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_INSPECT;
-    case OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT:
-        return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT;
-    default:
-        return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_UNSPECIFIED;
-    }
-}
-
-static void fill_transform_plugin_info(const omega_transform_plugin_info_t *info,
-                                       ::omega_edit::v1::TransformPluginInfo *response) {
-    if (!info || !response) { return; }
-    response->set_id(info->id ? info->id : "");
-    response->set_name(info->name ? info->name : "");
-    response->set_description(info->description ? info->description : "");
-    response->set_operation(to_proto_transform_plugin_operation(info->operation));
-    response->set_flags(info->flags);
-    response->set_abi_version(info->abi_version);
-    response->set_help(info->help ? info->help : "");
-    response->set_example(info->example ? info->example : "");
-    response->set_default_args(info->default_args ? info->default_args : "");
-    response->set_args_schema(info->args_schema ? info->args_schema : "");
-}
-
-static grpc::Status validate_viewport_range(int64_t offset, int64_t capacity) {
-    if (offset < 0 || capacity <= 0) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "viewport offset must be non-negative and capacity must be positive");
-    }
-    if (capacity > OMEGA_VIEWPORT_CAPACITY_LIMIT || offset > (std::numeric_limits<int64_t>::max)() - capacity) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "viewport range is invalid or exceeds configured capacity limit");
-    }
-    return grpc::Status::OK;
-}
-
-EditorServiceImpl::EditorServiceImpl(HeartbeatConfig heartbeat_config, ResourceLimits resource_limits,
-                                     std::function<void()> shutdown_callback,
-                                     std::vector<std::string> transform_plugin_directories)
-    : session_manager_(resource_limits), content_type_detector_(create_default_content_type_detector()),
-      language_detector_(create_default_language_detector()),
-      transform_plugin_registry_(omega_transform_plugin_registry_create()),
-      start_time_(std::chrono::steady_clock::now()), heartbeat_config_(heartbeat_config),
-      resource_limits_(resource_limits), shutdown_callback_(std::move(shutdown_callback)) {
-    for (const auto &plugin_directory : transform_plugin_directories) {
-        if (plugin_directory.empty()) { continue; }
-        const auto loaded_count = omega_transform_plugin_registry_register_directory(transform_plugin_registry_,
-                                                                                     plugin_directory.c_str());
-        if (loaded_count < 0) {
-            std::cerr << "Warning: could not register transform plugin directory: " << plugin_directory << "\n";
-        } else {
-            std::cerr << "Registered " << loaded_count << " transform plugin(s) from " << plugin_directory << "\n";
+            return metrics;
         }
-    }
 
-    if (heartbeat_config_.session_timeout.count() > 0 && heartbeat_config_.cleanup_interval.count() > 0) {
-        reaper_thread_ = std::thread(&EditorServiceImpl::reaper_loop, this);
-    }
-}
+        static grpc::Status validate_change_payload_size(const ::omega_edit::v1::SubmitChangeRequest *request,
+                                                         int64_t max_change_bytes) {
+            if ((request->kind() != ::omega_edit::v1::CHANGE_KIND_INSERT &&
+                 request->kind() != ::omega_edit::v1::CHANGE_KIND_OVERWRITE) ||
+                max_change_bytes <= 0) {
+                return grpc::Status::OK;
+            }
 
-EditorServiceImpl::~EditorServiceImpl() {
-    {
-        std::lock_guard<std::mutex> lock(reaper_cv_mutex_);
-        reaper_stop_ = true;
-    }
-    reaper_cv_.notify_all();
-    if (reaper_thread_.joinable()) { reaper_thread_.join(); }
-    session_manager_.destroy_all();
-    omega_transform_plugin_registry_destroy(transform_plugin_registry_);
-    transform_plugin_registry_ = nullptr;
-}
+            if (request->data().size() <= static_cast<size_t>(max_change_bytes)) { return grpc::Status::OK; }
 
-void EditorServiceImpl::reaper_loop() {
-    while (!reaper_stop_) {
-        {
-            std::unique_lock<std::mutex> lock(reaper_cv_mutex_);
-            reaper_cv_.wait_for(lock, heartbeat_config_.cleanup_interval, [this] { return reaper_stop_.load(); });
+            return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED, "change payload exceeds configured limit of " +
+                                                                              std::to_string(max_change_bytes) +
+                                                                              " bytes");
         }
-        if (reaper_stop_) break;
 
-        auto idle_ids = session_manager_.get_idle_session_ids(heartbeat_config_.session_timeout);
-        for (const auto &sid : idle_ids) { session_manager_.destroy_session(sid); }
+        static grpc::Status
+        validate_replace_checkpointed_payload_sizes(const ::omega_edit::v1::ReplaceSessionCheckpointedRequest *request,
+                                                    int64_t max_change_bytes) {
+            if (max_change_bytes <= 0) { return grpc::Status::OK; }
 
-        if (heartbeat_config_.shutdown_when_no_sessions && session_manager_.session_count() == 0 && !idle_ids.empty()) {
-            // We just reaped sessions and now there are none left
-            request_shutdown();
-            break;
+            if (request->pattern().size() > static_cast<size_t>(max_change_bytes)) {
+                return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                    "checkpointed replace pattern exceeds configured limit of " +
+                                            std::to_string(max_change_bytes) + " bytes");
+            }
+
+            if (request->replacement().size() > static_cast<size_t>(max_change_bytes)) {
+                return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                    "checkpointed replace replacement exceeds configured limit of " +
+                                            std::to_string(max_change_bytes) + " bytes");
+            }
+
+            return grpc::Status::OK;
         }
-    }
-}
 
-bool EditorServiceImpl::parse_viewport_id(const std::string &fqid, std::string &session_id, std::string &viewport_id) {
-    auto pos = fqid.find(':');
-    if (pos == std::string::npos) return false;
-    session_id = fqid.substr(0, pos);
-    viewport_id = fqid.substr(pos + 1);
-    return !session_id.empty() && !viewport_id.empty();
-}
+        static grpc::Status validate_replace_payload_sizes(const std::string &pattern, const std::string &replacement,
+                                                           int64_t max_change_bytes,
+                                                           const std::string &operation_name) {
+            if (max_change_bytes <= 0) { return grpc::Status::OK; }
 
-std::string EditorServiceImpl::make_viewport_fqid(const std::string &session_id, const std::string &viewport_id) {
-    std::string fqid;
-    fqid.reserve(session_id.size() + 1 + viewport_id.size());
-    fqid.append(session_id);
-    fqid.push_back(':');
-    fqid.append(viewport_id);
-    return fqid;
-}
+            if (pattern.size() > static_cast<size_t>(max_change_bytes)) {
+                return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                    operation_name + " pattern exceeds configured limit of " +
+                                            std::to_string(max_change_bytes) + " bytes");
+            }
 
-void EditorServiceImpl::request_shutdown() {
-    if (!shutdown_callback_) { return; }
+            if (replacement.size() > static_cast<size_t>(max_change_bytes)) {
+                return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                    operation_name + " replacement exceeds configured limit of " +
+                                            std::to_string(max_change_bytes) + " bytes");
+            }
 
-    std::call_once(shutdown_once_, [callback = shutdown_callback_]() {
-        std::thread([callback]() {
-            // Let the active unary RPC return before the shutdown monitor calls
-            // grpc::Server::Shutdown(); Windows can otherwise strand the client
-            // call until an external cleanup kills the process.
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            callback();
-        }).detach();
-    });
-}
-
-template <typename T>
-void EditorServiceImpl::fill_change_details(const omega_change_t *change, const std::string &session_id, T *response) {
-    response->set_session_id(session_id);
-    response->set_serial(omega_change_get_serial(change));
-
-    char kind_char = omega_change_get_kind_as_char(change);
-    switch (kind_char) {
-    case 'D':
-        response->set_kind(::omega_edit::v1::CHANGE_KIND_DELETE);
-        break;
-    case 'I':
-        response->set_kind(::omega_edit::v1::CHANGE_KIND_INSERT);
-        break;
-    case 'O':
-        response->set_kind(::omega_edit::v1::CHANGE_KIND_OVERWRITE);
-        break;
-    case 'T':
-        response->set_kind(::omega_edit::v1::CHANGE_KIND_TRANSFORM);
-        break;
-    default:
-        response->set_kind(::omega_edit::v1::CHANGE_KIND_UNSPECIFIED);
-        break;
-    }
-
-    response->set_offset(omega_change_get_offset(change));
-    response->set_length(omega_change_get_length(change));
-
-    const auto *bytes = omega_change_get_bytes(change);
-    if (bytes && omega_change_get_length(change) > 0) {
-        response->set_data(bytes, static_cast<size_t>(omega_change_get_length(change)));
-    }
-
-    if (omega_change_is_transform(change)) {
-        auto *transform = response->mutable_transform();
-        if (const auto *transform_id = omega_change_get_transform_id(change)) {
-            transform->set_transform_id(transform_id);
+            return grpc::Status::OK;
         }
-        if (const auto *options_json = omega_change_get_transform_options_json(change)) {
-            transform->set_options_json(options_json);
+
+        static ::omega_edit::v1::TransformPluginOperation
+        to_proto_transform_plugin_operation(omega_transform_plugin_operation_t operation) {
+            switch (operation) {
+                case OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE:
+                    return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_REPLACE;
+                case OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT:
+                    return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_INSPECT;
+                case OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT:
+                    return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT;
+                default:
+                    return ::omega_edit::v1::TRANSFORM_PLUGIN_OPERATION_UNSPECIFIED;
+            }
         }
-        transform->set_replacement_length(omega_change_get_transform_replacement_length(change));
-        transform->set_computed_file_size_before(omega_change_get_transform_computed_file_size_before(change));
-        transform->set_computed_file_size_after(omega_change_get_transform_computed_file_size_after(change));
-    }
-}
 
-template <typename T>
-grpc::Status EditorServiceImpl::fill_viewport_data(const std::string &session_id, const std::string &viewport_id,
-                                                   const std::string &fqid, T *response) {
-    auto locked_viewport = session_manager_.lock_viewport(session_id, viewport_id);
-    if (!locked_viewport) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + fqid); }
-    auto *vp = locked_viewport.viewport();
-    const auto *data = omega_viewport_get_data(vp);
-    auto length = omega_viewport_get_length(vp);
-
-    response->set_viewport_id(fqid);
-    response->set_offset(omega_viewport_get_offset(vp));
-    response->set_length(length);
-    if (data && length > 0) { response->set_data(data, static_cast<size_t>(length)); }
-    response->set_following_byte_count(omega_viewport_get_following_byte_count(vp));
-    return grpc::Status::OK;
-}
-
-// ---------- Server Info ----------
-
-grpc::Status EditorServiceImpl::GetServerInfo(grpc::ServerContext * /*context*/,
-                                              const ::omega_edit::v1::GetServerInfoRequest * /*request*/,
-                                              ::omega_edit::v1::GetServerInfoResponse *response) {
-    response->set_hostname(get_hostname());
-    response->set_process_id(get_pid());
-    response->set_server_version(SERVER_VERSION);
-    response->set_runtime_kind(get_runtime_kind());
-    response->set_runtime_name(get_runtime_name());
-    response->set_platform(get_platform_summary());
-    response->set_available_processors(get_cpu_count());
-    response->set_compiler(get_compiler_info());
-    response->set_build_type(get_build_type());
-    response->set_cpp_standard(get_cpp_standard());
-    return grpc::Status::OK;
-}
-
-// ---------- Session Lifecycle ----------
-
-grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
-                                              const ::omega_edit::v1::CreateSessionRequest *request,
-                                              ::omega_edit::v1::CreateSessionResponse *response) {
-    if (graceful_shutdown_.load()) { return grpc::Status(grpc::StatusCode::UNAVAILABLE, "server is shutting down"); }
-
-    std::string file_path;
-    if (request->has_file_path()) { file_path = request->file_path(); }
-    const auto file_path_status = validate_path_argument(file_path, "file_path");
-    if (!file_path_status.ok()) { return file_path_status; }
-
-    const auto has_initial_data = request->has_initial_data();
-    if (!file_path.empty() && has_initial_data) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "create session accepts either file_path or initial_data, not both");
-    }
-
-    // Validate file path exists if provided (match previous server behavior)
-    if (!file_path.empty()) {
-        std::error_code ec;
-        if (!std::filesystem::exists(file_path, ec) || ec) {
-            return grpc::Status(grpc::StatusCode::INTERNAL,
-                                std::string("Failed to create session: file does not exist: ") + file_path);
+        static void fill_transform_plugin_info(const omega_transform_plugin_info_t *info,
+                                               ::omega_edit::v1::TransformPluginInfo *response) {
+            if (!info || !response) { return; }
+            response->set_id(info->id ? info->id : "");
+            response->set_name(info->name ? info->name : "");
+            response->set_description(info->description ? info->description : "");
+            response->set_operation(to_proto_transform_plugin_operation(info->operation));
+            response->set_flags(info->flags);
+            response->set_abi_version(info->abi_version);
+            response->set_help(info->help ? info->help : "");
+            response->set_example(info->example ? info->example : "");
+            response->set_default_args(info->default_args ? info->default_args : "");
+            response->set_args_schema(info->args_schema ? info->args_schema : "");
         }
-    }
 
-    std::string desired_id;
-    if (request->has_session_id_desired()) { desired_id = request->session_id_desired(); }
+        static grpc::Status validate_viewport_range(int64_t offset, int64_t capacity) {
+            if (offset < 0 || capacity <= 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "viewport offset must be non-negative and capacity must be positive");
+            }
+            if (capacity > OMEGA_VIEWPORT_CAPACITY_LIMIT || offset > (std::numeric_limits<int64_t>::max)() - capacity) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "viewport range is invalid or exceeds configured capacity limit");
+            }
+            return grpc::Status::OK;
+        }
 
-    std::string checkpoint_dir;
-    if (request->has_checkpoint_directory()) { checkpoint_dir = request->checkpoint_directory(); }
-    const auto checkpoint_dir_status = validate_path_argument(checkpoint_dir, "checkpoint_directory");
-    if (!checkpoint_dir_status.ok()) { return checkpoint_dir_status; }
+        EditorServiceImpl::EditorServiceImpl(HeartbeatConfig heartbeat_config, ResourceLimits resource_limits,
+                                             std::function<void()> shutdown_callback,
+                                             std::vector<std::string> transform_plugin_directories)
+            : session_manager_(resource_limits), content_type_detector_(create_default_content_type_detector()),
+              language_detector_(create_default_language_detector()),
+              transform_plugin_registry_(omega_transform_plugin_registry_create()),
+              start_time_(std::chrono::steady_clock::now()), heartbeat_config_(heartbeat_config),
+              resource_limits_(resource_limits), shutdown_callback_(std::move(shutdown_callback)) {
+            for (const auto &plugin_directory : transform_plugin_directories) {
+                if (plugin_directory.empty()) { continue; }
+                const auto loaded_count = omega_transform_plugin_registry_register_directory(transform_plugin_registry_,
+                                                                                             plugin_directory.c_str());
+                if (loaded_count < 0) {
+                    std::cerr << "Warning: could not register transform plugin directory: " << plugin_directory << "\n";
+                } else {
+                    std::cerr << "Registered " << loaded_count << " transform plugin(s) from " << plugin_directory
+                              << "\n";
+                }
+            }
 
-    int64_t file_size = 0;
-    std::string checkpoint_dir_out;
-    std::string session_id;
-    SessionCreateError create_error = SessionCreateError::SUCCESS;
-    std::string initial_data;
-    if (has_initial_data) { initial_data = request->initial_data(); }
-    const std::string *initial_data_ptr = has_initial_data ? &initial_data : nullptr;
-    try {
-        session_id = session_manager_.create_session(file_path, desired_id, checkpoint_dir, initial_data_ptr, file_size,
-                                                     checkpoint_dir_out, &create_error);
-    } catch (const std::exception &e) {
-        return grpc::Status(grpc::StatusCode::INTERNAL, std::string("Failed to create session: ") + e.what());
-    }
+            if (heartbeat_config_.session_timeout.count() > 0 && heartbeat_config_.cleanup_interval.count() > 0) {
+                reaper_thread_ = std::thread(&EditorServiceImpl::reaper_loop, this);
+            }
+        }
 
-    if (session_id.empty()) {
-        switch (create_error) {
-        case SessionCreateError::INVALID_ID:
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+        EditorServiceImpl::~EditorServiceImpl() {
+            {
+                std::lock_guard<std::mutex> lock(reaper_cv_mutex_);
+                reaper_stop_ = true;
+            }
+            reaper_cv_.notify_all();
+            if (reaper_thread_.joinable()) { reaper_thread_.join(); }
+            session_manager_.destroy_all();
+            omega_transform_plugin_registry_destroy(transform_plugin_registry_);
+            transform_plugin_registry_ = nullptr;
+        }
+
+        void EditorServiceImpl::reaper_loop() {
+            while (!reaper_stop_) {
+                {
+                    std::unique_lock<std::mutex> lock(reaper_cv_mutex_);
+                    reaper_cv_.wait_for(lock, heartbeat_config_.cleanup_interval,
+                                        [this] { return reaper_stop_.load(); });
+                }
+                if (reaper_stop_) break;
+
+                auto idle_ids = session_manager_.get_idle_session_ids(heartbeat_config_.session_timeout);
+                for (const auto &sid : idle_ids) { session_manager_.destroy_session(sid); }
+
+                if (heartbeat_config_.shutdown_when_no_sessions && session_manager_.session_count() == 0 &&
+                    !idle_ids.empty()) {
+                    // We just reaped sessions and now there are none left
+                    request_shutdown();
+                    break;
+                }
+            }
+        }
+
+        bool EditorServiceImpl::parse_viewport_id(const std::string &fqid, std::string &session_id,
+                                                  std::string &viewport_id) {
+            auto pos = fqid.find(':');
+            if (pos == std::string::npos) return false;
+            session_id = fqid.substr(0, pos);
+            viewport_id = fqid.substr(pos + 1);
+            return !session_id.empty() && !viewport_id.empty();
+        }
+
+        std::string EditorServiceImpl::make_viewport_fqid(const std::string &session_id,
+                                                          const std::string &viewport_id) {
+            std::string fqid;
+            fqid.reserve(session_id.size() + 1 + viewport_id.size());
+            fqid.append(session_id);
+            fqid.push_back(':');
+            fqid.append(viewport_id);
+            return fqid;
+        }
+
+        void EditorServiceImpl::request_shutdown() {
+            if (!shutdown_callback_) { return; }
+
+            std::call_once(shutdown_once_, [callback = shutdown_callback_]() {
+                std::thread([callback]() {
+                    // Let the active unary RPC return before the shutdown monitor calls
+                    // grpc::Server::Shutdown(); Windows can otherwise strand the client
+                    // call until an external cleanup kills the process.
+                    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                    callback();
+                }).detach();
+            });
+        }
+
+        template<typename T>
+        void EditorServiceImpl::fill_change_details(const omega_change_t *change, const std::string &session_id,
+                                                    T *response) {
+            response->set_session_id(session_id);
+            response->set_serial(omega_change_get_serial(change));
+
+            char kind_char = omega_change_get_kind_as_char(change);
+            switch (kind_char) {
+                case 'D':
+                    response->set_kind(::omega_edit::v1::CHANGE_KIND_DELETE);
+                    break;
+                case 'I':
+                    response->set_kind(::omega_edit::v1::CHANGE_KIND_INSERT);
+                    break;
+                case 'O':
+                    response->set_kind(::omega_edit::v1::CHANGE_KIND_OVERWRITE);
+                    break;
+                case 'T':
+                    response->set_kind(::omega_edit::v1::CHANGE_KIND_TRANSFORM);
+                    break;
+                default:
+                    response->set_kind(::omega_edit::v1::CHANGE_KIND_UNSPECIFIED);
+                    break;
+            }
+
+            response->set_offset(omega_change_get_offset(change));
+            response->set_length(omega_change_get_length(change));
+
+            const auto *bytes = omega_change_get_bytes(change);
+            if (bytes && omega_change_get_length(change) > 0) {
+                response->set_data(bytes, static_cast<size_t>(omega_change_get_length(change)));
+            }
+
+            if (omega_change_is_transform(change)) {
+                auto *transform = response->mutable_transform();
+                if (const auto *transform_id = omega_change_get_transform_id(change)) {
+                    transform->set_transform_id(transform_id);
+                }
+                if (const auto *options_json = omega_change_get_transform_options_json(change)) {
+                    transform->set_options_json(options_json);
+                }
+                transform->set_replacement_length(omega_change_get_transform_replacement_length(change));
+                transform->set_computed_file_size_before(omega_change_get_transform_computed_file_size_before(change));
+                transform->set_computed_file_size_after(omega_change_get_transform_computed_file_size_after(change));
+            }
+        }
+
+        template<typename T>
+        grpc::Status EditorServiceImpl::fill_viewport_data(const std::string &session_id,
+                                                           const std::string &viewport_id, const std::string &fqid,
+                                                           T *response) {
+            auto locked_viewport = session_manager_.lock_viewport(session_id, viewport_id);
+            if (!locked_viewport) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + fqid); }
+            auto *vp = locked_viewport.viewport();
+            const auto *data = omega_viewport_get_data(vp);
+            auto length = omega_viewport_get_length(vp);
+
+            response->set_viewport_id(fqid);
+            response->set_offset(omega_viewport_get_offset(vp));
+            response->set_length(length);
+            if (data && length > 0) { response->set_data(data, static_cast<size_t>(length)); }
+            response->set_following_byte_count(omega_viewport_get_following_byte_count(vp));
+            return grpc::Status::OK;
+        }
+
+        // ---------- Server Info ----------
+
+        grpc::Status EditorServiceImpl::GetServerInfo(grpc::ServerContext * /*context*/,
+                                                      const ::omega_edit::v1::GetServerInfoRequest * /*request*/,
+                                                      ::omega_edit::v1::GetServerInfoResponse *response) {
+            response->set_hostname(get_hostname());
+            response->set_process_id(get_pid());
+            response->set_server_version(SERVER_VERSION);
+            response->set_runtime_kind(get_runtime_kind());
+            response->set_runtime_name(get_runtime_name());
+            response->set_platform(get_platform_summary());
+            response->set_available_processors(get_cpu_count());
+            response->set_compiler(get_compiler_info());
+            response->set_build_type(get_build_type());
+            response->set_cpp_standard(get_cpp_standard());
+            return grpc::Status::OK;
+        }
+
+        // ---------- Session Lifecycle ----------
+
+        grpc::Status EditorServiceImpl::CreateSession(grpc::ServerContext * /*context*/,
+                                                      const ::omega_edit::v1::CreateSessionRequest *request,
+                                                      ::omega_edit::v1::CreateSessionResponse *response) {
+            if (graceful_shutdown_.load()) {
+                return grpc::Status(grpc::StatusCode::UNAVAILABLE, "server is shutting down");
+            }
+
+            std::string file_path;
+            if (request->has_file_path()) { file_path = request->file_path(); }
+            const auto file_path_status = validate_path_argument(file_path, "file_path");
+            if (!file_path_status.ok()) { return file_path_status; }
+
+            const auto has_initial_data = request->has_initial_data();
+            if (!file_path.empty() && has_initial_data) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "create session accepts either file_path or initial_data, not both");
+            }
+
+            // Validate file path exists if provided (match previous server behavior)
+            if (!file_path.empty()) {
+                std::error_code ec;
+                if (!std::filesystem::exists(file_path, ec) || ec) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        std::string("Failed to create session: file does not exist: ") + file_path);
+                }
+            }
+
+            std::string desired_id;
+            if (request->has_session_id_desired()) { desired_id = request->session_id_desired(); }
+
+            std::string checkpoint_dir;
+            if (request->has_checkpoint_directory()) { checkpoint_dir = request->checkpoint_directory(); }
+            const auto checkpoint_dir_status = validate_path_argument(checkpoint_dir, "checkpoint_directory");
+            if (!checkpoint_dir_status.ok()) { return checkpoint_dir_status; }
+
+            int64_t file_size = 0;
+            std::string checkpoint_dir_out;
+            std::string session_id;
+            SessionCreateError create_error = SessionCreateError::SUCCESS;
+            std::string initial_data;
+            if (has_initial_data) { initial_data = request->initial_data(); }
+            const std::string *initial_data_ptr = has_initial_data ? &initial_data : nullptr;
+            try {
+                session_id = session_manager_.create_session(file_path, desired_id, checkpoint_dir, initial_data_ptr,
+                                                             file_size, checkpoint_dir_out, &create_error);
+            } catch (const std::exception &e) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, std::string("Failed to create session: ") + e.what());
+            }
+
+            if (session_id.empty()) {
+                switch (create_error) {
+                    case SessionCreateError::INVALID_ID:
+                        return grpc::Status(
+                                grpc::StatusCode::INVALID_ARGUMENT,
                                 "session id must be 1-128 bytes and contain only letters, digits, '_', '.', or '-'");
-        case SessionCreateError::INVALID_FILE_PATH:
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                    case SessionCreateError::INVALID_FILE_PATH:
+                        return grpc::Status(
+                                grpc::StatusCode::INVALID_ARGUMENT,
                                 "file_path must be shorter than FILENAME_MAX and contain no NUL or control characters");
-        case SessionCreateError::INVALID_CHECKPOINT_DIRECTORY:
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                    case SessionCreateError::INVALID_CHECKPOINT_DIRECTORY:
+                        return grpc::Status(
+                                grpc::StatusCode::INVALID_ARGUMENT,
                                 "checkpoint_directory must be shorter than FILENAME_MAX and contain no NUL or "
                                 "control characters");
-        case SessionCreateError::ALREADY_EXISTS:
-            return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, "session already exists: " + desired_id);
-        default:
-            return grpc::Status(grpc::StatusCode::INTERNAL, "Failed to create session");
-        }
-    }
-
-    response->set_session_id(session_id);
-    response->set_checkpoint_directory(checkpoint_dir_out);
-    if (!file_path.empty() || has_initial_data) { response->set_file_size(file_size); }
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::SaveSession(grpc::ServerContext * /*context*/,
-                                            const ::omega_edit::v1::SaveSessionRequest *request,
-                                            ::omega_edit::v1::SaveSessionResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    char saved_file_path[FILENAME_MAX] = {};
-    int64_t offset = request->has_offset() ? request->offset() : 0;
-    int64_t length = request->has_length() ? request->length() : 0;
-
-    int result;
-    if (offset != 0 || length != 0) {
-        result = omega_edit_save_segment(session, request->file_path().c_str(), request->io_flags(), saved_file_path,
-                                         offset, length);
-    } else {
-        result = omega_edit_save(session, request->file_path().c_str(), request->io_flags(), saved_file_path);
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_save_status(result);
-    if (result == 0) {
-        // Only set file_path on success
-        std::string actual_path = (saved_file_path[0] != '\0') ? std::string(saved_file_path) : request->file_path();
-        response->set_file_path(actual_path);
-    }
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::DestroySession(grpc::ServerContext * /*context*/,
-                                               const ::omega_edit::v1::DestroySessionRequest *request,
-                                               ::omega_edit::v1::DestroySessionResponse *response) {
-    if (!session_manager_.detach_session(request->id())) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
-    }
-    response->set_id(request->id());
-
-    // If graceful shutdown is pending and no sessions remain, trigger shutdown
-    if (graceful_shutdown_.load() && session_manager_.session_count() == 0) { request_shutdown(); }
-
-    return grpc::Status::OK;
-}
-
-// ---------- Edit Operations ----------
-
-grpc::Status EditorServiceImpl::SubmitChange(grpc::ServerContext * /*context*/,
-                                             const ::omega_edit::v1::SubmitChangeRequest *request,
-                                             ::omega_edit::v1::SubmitChangeResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "change", request->session_id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    const grpc::Status payload_status = validate_change_payload_size(request, resource_limits_.max_change_bytes);
-    if (!payload_status.ok()) { return payload_status; }
-
-    if (request->offset() < 0 || request->length() < 0) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "invalid change arguments");
-    }
-
-    int64_t serial = 0;
-    switch (request->kind()) {
-    case ::omega_edit::v1::CHANGE_KIND_DELETE:
-        serial = omega_edit_delete(session, request->offset(), request->length());
-        break;
-    case ::omega_edit::v1::CHANGE_KIND_INSERT:
-        if (request->has_data()) {
-            serial = omega_edit_insert_bytes(session, request->offset(),
-                                             reinterpret_cast<const omega_byte_t *>(request->data().data()),
-                                             static_cast<int64_t>(request->data().size()));
-        } else {
-            serial = omega_edit_insert_bytes(session, request->offset(), nullptr, 0);
-        }
-        break;
-    case ::omega_edit::v1::CHANGE_KIND_OVERWRITE:
-        if (request->has_data()) {
-            serial = omega_edit_overwrite_bytes(session, request->offset(),
-                                                reinterpret_cast<const omega_byte_t *>(request->data().data()),
-                                                static_cast<int64_t>(request->data().size()));
-        } else {
-            serial = omega_edit_overwrite_bytes(session, request->offset(), nullptr, 0);
-        }
-        break;
-    default:
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "undefined change kind");
-    }
-
-    if (serial < 0) { return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "invalid change arguments"); }
-
-    if (serial == 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "change operation failed"); }
-
-    response->set_session_id(request->session_id());
-    response->set_serial(serial);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::UndoLastChange(grpc::ServerContext * /*context*/,
-                                               const ::omega_edit::v1::UndoLastChangeRequest *request,
-                                               ::omega_edit::v1::UndoLastChangeResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->id());
-    if (!mutation_guard) { return status_for_session_operation_start(mutation_guard.result(), "undo", request->id()); }
-
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    int64_t serial = omega_edit_undo_last_change(session);
-    if (serial == 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "undo failed or nothing to undo"); }
-
-    response->set_session_id(request->id());
-    response->set_serial(serial);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::RedoLastUndo(grpc::ServerContext * /*context*/,
-                                             const ::omega_edit::v1::RedoLastUndoRequest *request,
-                                             ::omega_edit::v1::RedoLastUndoResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->id());
-    if (!mutation_guard) { return status_for_session_operation_start(mutation_guard.result(), "redo", request->id()); }
-
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    int64_t serial = omega_edit_redo_last_undo(session);
-    if (serial == 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "redo failed or nothing to redo"); }
-
-    response->set_session_id(request->id());
-    response->set_serial(serial);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::ClearChanges(grpc::ServerContext * /*context*/,
-                                             const ::omega_edit::v1::ClearChangesRequest *request,
-                                             ::omega_edit::v1::ClearChangesResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "clear changes", request->id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    int result = omega_edit_clear_changes(session);
-    if (result != 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "clear changes failed"); }
-
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
-
-// ---------- Session Control ----------
-
-grpc::Status EditorServiceImpl::PauseSessionChanges(grpc::ServerContext * /*context*/,
-                                                    const ::omega_edit::v1::PauseSessionChangesRequest *request,
-                                                    ::omega_edit::v1::PauseSessionChangesResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "pause changes", request->id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    omega_session_pause_changes(session);
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::ResumeSessionChanges(grpc::ServerContext * /*context*/,
-                                                     const ::omega_edit::v1::ResumeSessionChangesRequest *request,
-                                                     ::omega_edit::v1::ResumeSessionChangesResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "resume changes", request->id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    omega_session_resume_changes(session);
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::PauseViewportEvents(grpc::ServerContext * /*context*/,
-                                                    const ::omega_edit::v1::PauseViewportEventsRequest *request,
-                                                    ::omega_edit::v1::PauseViewportEventsResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    omega_session_pause_viewport_event_callbacks(session);
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::ResumeViewportEvents(grpc::ServerContext * /*context*/,
-                                                     const ::omega_edit::v1::ResumeViewportEventsRequest *request,
-                                                     ::omega_edit::v1::ResumeViewportEventsResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    omega_session_resume_viewport_event_callbacks(session);
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::SessionBeginTransaction(grpc::ServerContext * /*context*/,
-                                                        const ::omega_edit::v1::SessionBeginTransactionRequest *request,
-                                                        ::omega_edit::v1::SessionBeginTransactionResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "begin transaction", request->id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    // Tolerate nested begin-transaction calls (no-op if already in a transaction)
-    // to match the server behaviour used by the TypeScript client's
-    // replace helper which wraps delete+insert in a transaction even when an
-    // outer transaction is already open.
-    omega_session_begin_transaction(session);
-
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::SessionEndTransaction(grpc::ServerContext * /*context*/,
-                                                      const ::omega_edit::v1::SessionEndTransactionRequest *request,
-                                                      ::omega_edit::v1::SessionEndTransactionResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "end transaction", request->id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    // Tolerate end-transaction when no transaction is open (no-op).
-    omega_session_end_transaction(session);
-
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::NotifyChangedViewports(grpc::ServerContext * /*context*/,
-                                                       const ::omega_edit::v1::NotifyChangedViewportsRequest *request,
-                                                       ::omega_edit::v1::NotifyChangedViewportsResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    int count = omega_session_notify_changed_viewports(session);
-    response->set_count(count);
-    return grpc::Status::OK;
-}
-
-// ---------- Viewport Operations ----------
-
-grpc::Status EditorServiceImpl::CreateViewport(grpc::ServerContext * /*context*/,
-                                               const ::omega_edit::v1::CreateViewportRequest *request,
-                                               ::omega_edit::v1::CreateViewportResponse *response) {
-    auto viewport_status = validate_viewport_range(request->offset(), request->capacity());
-    if (!viewport_status.ok()) { return viewport_status; }
-
-    std::string desired_vp_id;
-    if (request->has_viewport_id_desired()) { desired_vp_id = request->viewport_id_desired(); }
-
-    ViewportCreateError vp_error = ViewportCreateError::SUCCESS;
-    std::string fqid = session_manager_.create_viewport(request->session_id(), request->offset(), request->capacity(),
-                                                        request->is_floating(), desired_vp_id, &vp_error);
-    if (fqid.empty()) {
-        switch (vp_error) {
-        case ViewportCreateError::SESSION_NOT_FOUND:
-            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-        case ViewportCreateError::INVALID_VIEWPORT_ID:
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                "viewport id must be 1-128 bytes and contain only letters, digits, '_', '.', or '-'");
-        case ViewportCreateError::DUPLICATE_VIEWPORT_ID:
-            return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, "viewport already exists: " + desired_vp_id);
-        case ViewportCreateError::TOO_MANY_VIEWPORTS:
-            return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
-                                "session reached configured viewport limit of " +
-                                        std::to_string(resource_limits_.max_viewports_per_session));
-        default:
-            return grpc::Status(grpc::StatusCode::INTERNAL, "failed to create viewport");
-        }
-    }
-
-    std::string sid, vid;
-    if (!parse_viewport_id(fqid, sid, vid)) {
-        return grpc::Status(grpc::StatusCode::INTERNAL, "malformed viewport id: " + fqid);
-    }
-
-    session_manager_.touch_session(request->session_id());
-    return fill_viewport_data(sid, vid, fqid, response);
-}
-
-grpc::Status EditorServiceImpl::ModifyViewport(grpc::ServerContext * /*context*/,
-                                               const ::omega_edit::v1::ModifyViewportRequest *request,
-                                               ::omega_edit::v1::ModifyViewportResponse *response) {
-    auto viewport_status = validate_viewport_range(request->offset(), request->capacity());
-    if (!viewport_status.ok()) { return viewport_status; }
-
-    std::string sid, vid;
-    if (!parse_viewport_id(request->viewport_id(), sid, vid)) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->viewport_id());
-    }
-
-    auto locked_viewport = session_manager_.lock_viewport(sid, vid);
-    if (!locked_viewport) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->viewport_id());
-    }
-    auto *vp = locked_viewport.viewport();
-
-    int result = omega_viewport_modify(vp, request->offset(), request->capacity(), request->is_floating() ? 1 : 0);
-    if (result != 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "modify viewport failed"); }
-
-    // Keep the existing core lock while returning the refreshed viewport data. Calling fill_viewport_data here would
-    // attempt to acquire the same per-session lock again.
-    const auto *data = omega_viewport_get_data(vp);
-    auto length = omega_viewport_get_length(vp);
-    response->set_viewport_id(request->viewport_id());
-    response->set_offset(omega_viewport_get_offset(vp));
-    response->set_length(length);
-    if (data && length > 0) { response->set_data(data, static_cast<size_t>(length)); }
-    response->set_following_byte_count(omega_viewport_get_following_byte_count(vp));
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::ViewportHasChanges(grpc::ServerContext * /*context*/,
-                                                   const ::omega_edit::v1::ViewportHasChangesRequest *request,
-                                                   ::omega_edit::v1::ViewportHasChangesResponse *response) {
-    std::string sid, vid;
-    if (!parse_viewport_id(request->id(), sid, vid)) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
-    }
-
-    auto locked_viewport = session_manager_.lock_viewport(sid, vid);
-    if (!locked_viewport) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->id()); }
-    auto *vp = locked_viewport.viewport();
-
-    response->set_result(omega_viewport_has_changes(vp) != 0);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::GetViewportData(grpc::ServerContext * /*context*/,
-                                                const ::omega_edit::v1::GetViewportDataRequest *request,
-                                                ::omega_edit::v1::GetViewportDataResponse *response) {
-    std::string sid, vid;
-    if (!parse_viewport_id(request->viewport_id(), sid, vid)) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->viewport_id());
-    }
-
-    return fill_viewport_data(sid, vid, request->viewport_id(), response);
-}
-
-grpc::Status EditorServiceImpl::DestroyViewport(grpc::ServerContext * /*context*/,
-                                                const ::omega_edit::v1::DestroyViewportRequest *request,
-                                                ::omega_edit::v1::DestroyViewportResponse *response) {
-    std::string sid, vid;
-    if (!parse_viewport_id(request->id(), sid, vid)) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
-    }
-
-    if (!session_manager_.destroy_viewport(sid, vid)) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->id());
-    }
-
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
-
-// ---------- Change Details ----------
-
-grpc::Status EditorServiceImpl::GetChangeDetails(grpc::ServerContext * /*context*/,
-                                                 const ::omega_edit::v1::GetChangeDetailsRequest *request,
-                                                 ::omega_edit::v1::GetChangeDetailsResponse *response) {
-    if (!request->has_serial()) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "change serial id required");
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    const auto *change = omega_session_get_change(session, request->serial());
-    if (!change) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "change not found"); }
-
-    fill_change_details(change, request->session_id(), response);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::GetLastChange(grpc::ServerContext * /*context*/,
-                                              const ::omega_edit::v1::GetLastChangeRequest *request,
-                                              ::omega_edit::v1::GetLastChangeResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    const auto *change = omega_session_get_last_change(session);
-    if (!change) { return grpc::Status(grpc::StatusCode::UNKNOWN, "no changes available"); }
-
-    fill_change_details(change, request->id(), response);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::GetLastUndo(grpc::ServerContext * /*context*/,
-                                            const ::omega_edit::v1::GetLastUndoRequest *request,
-                                            ::omega_edit::v1::GetLastUndoResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    const auto *change = omega_session_get_last_undo(session);
-    if (!change) { return grpc::Status(grpc::StatusCode::UNKNOWN, "no undone changes available"); }
-
-    fill_change_details(change, request->id(), response);
-    return grpc::Status::OK;
-}
-
-// ---------- Computed File Size ----------
-
-grpc::Status EditorServiceImpl::GetComputedFileSize(grpc::ServerContext * /*context*/,
-                                                    const ::omega_edit::v1::GetComputedFileSizeRequest *request,
-                                                    ::omega_edit::v1::GetComputedFileSizeResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->id());
-    if (!locked_session) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-    auto *session = locked_session.session();
-
-    const auto computed_file_size = omega_session_get_computed_file_size(session);
-    if (computed_file_size < 0) { return grpc::Status(grpc::StatusCode::INTERNAL, "computed file size overflow"); }
-    response->set_session_id(request->id());
-    response->set_computed_file_size(computed_file_size);
-    return grpc::Status::OK;
-}
-
-// ---------- BOM / Content Type / Language ----------
-
-grpc::Status EditorServiceImpl::GetByteOrderMark(grpc::ServerContext * /*context*/,
-                                                 const ::omega_edit::v1::GetByteOrderMarkRequest *request,
-                                                 ::omega_edit::v1::GetByteOrderMarkResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    omega_bom_t bom = omega_session_detect_BOM(session, request->offset());
-    const char *bom_str = omega_util_BOM_to_cstring(bom);
-    auto bom_size = static_cast<int64_t>(omega_util_BOM_size(bom));
-
-    response->set_session_id(request->session_id());
-    response->set_offset(request->offset());
-    response->set_length(bom_size);
-    response->set_byte_order_mark(bom_str);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::GetContentType(grpc::ServerContext * /*context*/,
-                                               const ::omega_edit::v1::GetContentTypeRequest *request,
-                                               ::omega_edit::v1::GetContentTypeResponse *response) {
-    if (request->offset() < 0) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    if (request->length() <= 0) {
-        response->set_session_id(request->session_id());
-        response->set_offset(request->offset());
-        response->set_length(0);
-        response->set_content_type("application/octet-stream");
-        return grpc::Status::OK;
-    }
-    auto segment = std::unique_ptr<omega_segment_t, decltype(&omega_segment_destroy)>(
-            omega_segment_create(request->length()), omega_segment_destroy);
-    if (!segment) { return grpc::Status(grpc::StatusCode::INTERNAL, "failed to allocate segment"); }
-
-    int result = omega_session_get_segment(session, segment.get(), request->offset());
-    std::string content_type;
-    int64_t actual_length = 0;
-    if (result == 0) {
-        auto *data = omega_segment_get_data(segment.get());
-        actual_length = omega_segment_get_length(segment.get());
-        content_type = content_type_detector_->detect(data, actual_length, locked_session.info->canonical_file_path);
-    } else {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "couldn't get segment");
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_offset(request->offset());
-    response->set_length(actual_length);
-    response->set_content_type(content_type);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::GetLanguage(grpc::ServerContext * /*context*/,
-                                            const ::omega_edit::v1::GetLanguageRequest *request,
-                                            ::omega_edit::v1::GetLanguageResponse *response) {
-    if (request->offset() < 0) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    if (request->length() <= 0) {
-        response->set_session_id(request->session_id());
-        response->set_offset(request->offset());
-        response->set_length(0);
-        response->set_language("unknown");
-        return grpc::Status::OK;
-    }
-    auto segment = std::unique_ptr<omega_segment_t, decltype(&omega_segment_destroy)>(
-            omega_segment_create(request->length()), omega_segment_destroy);
-    if (!segment) { return grpc::Status(grpc::StatusCode::INTERNAL, "failed to allocate segment"); }
-
-    int result = omega_session_get_segment(session, segment.get(), request->offset());
-    std::string language;
-    int64_t actual_length = 0;
-    if (result == 0) {
-        auto *data = omega_segment_get_data(segment.get());
-        actual_length = omega_segment_get_length(segment.get());
-        std::string bom_str = request->byte_order_mark();
-        language = language_detector_->detect(data, actual_length, bom_str);
-    } else {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "couldn't get segment");
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_offset(request->offset());
-    response->set_length(actual_length);
-    response->set_language(language);
-    return grpc::Status::OK;
-}
-
-// ---------- Counts ----------
-
-grpc::Status EditorServiceImpl::GetCount(grpc::ServerContext * /*context*/,
-                                         const ::omega_edit::v1::GetCountRequest *request,
-                                         ::omega_edit::v1::GetCountResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    response->set_session_id(request->session_id());
-
-    for (int i = 0; i < request->kind_size(); ++i) {
-        auto kind = request->kind(i);
-        int64_t count_value = 0;
-        switch (kind) {
-        case ::omega_edit::v1::COUNT_KIND_COMPUTED_FILE_SIZE:
-            count_value = omega_session_get_computed_file_size(session);
-            if (count_value < 0) { return grpc::Status(grpc::StatusCode::INTERNAL, "computed file size overflow"); }
-            break;
-        case ::omega_edit::v1::COUNT_KIND_CHANGES:
-            count_value = omega_session_get_num_changes(session);
-            break;
-        case ::omega_edit::v1::COUNT_KIND_UNDOS:
-            count_value = omega_session_get_num_undone_changes(session);
-            break;
-        case ::omega_edit::v1::COUNT_KIND_VIEWPORTS:
-            count_value = omega_session_get_num_viewports(session);
-            break;
-        case ::omega_edit::v1::COUNT_KIND_CHECKPOINTS:
-            count_value = omega_session_get_num_checkpoints(session);
-            break;
-        case ::omega_edit::v1::COUNT_KIND_SEARCH_CONTEXTS:
-            count_value = omega_session_get_num_search_contexts(session);
-            break;
-        case ::omega_edit::v1::COUNT_KIND_CHANGE_TRANSACTIONS:
-            count_value = omega_session_get_num_change_transactions(session);
-            break;
-        case ::omega_edit::v1::COUNT_KIND_UNDO_TRANSACTIONS:
-            count_value = omega_session_get_num_undone_change_transactions(session);
-            break;
-        default:
-            return grpc::Status(grpc::StatusCode::UNKNOWN, "undefined count kind");
-        }
-        auto *single = response->add_counts();
-        single->set_kind(kind);
-        single->set_count(count_value);
-    }
-
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::CheckSessionModel(grpc::ServerContext * /*context*/,
-                                                  const ::omega_edit::v1::CheckSessionModelRequest *request,
-                                                  ::omega_edit::v1::CheckSessionModelResponse *response) {
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-
-    const auto status = omega_check_model(locked_session.session());
-    response->set_session_id(request->session_id());
-    response->set_valid(status == 0);
-    response->set_status(status);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::GetSessionFingerprint(
-        grpc::ServerContext * /*context*/, const ::omega_edit::v1::GetSessionFingerprintRequest *request,
-        ::omega_edit::v1::GetSessionFingerprintResponse *response) {
-    const auto content = request->content();
-    if (content != ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL &&
-        content != ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "fingerprint content must be original or computed");
-    }
-
-    auto algorithm = normalize_digest_algorithm(request->has_algorithm() ? request->algorithm() : "");
-    if (!digest_algorithm_is_json_safe(algorithm)) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "unsupported fingerprint digest algorithm: " + algorithm);
-    }
-    const auto options_json = make_digest_options_json(algorithm);
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    const auto byte_length = get_session_fingerprint_byte_length(session, content);
-    if (byte_length < 0) {
-        return grpc::Status(grpc::StatusCode::INTERNAL, "session content length unavailable for fingerprint");
-    }
-
-    transform_plugin_response_guard plugin_response;
-    {
-        std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
-        const auto *plugin_info = omega_transform_plugin_registry_find_info(transform_plugin_registry_,
-                                                                           SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
-        if (!plugin_info) {
-            return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                "session fingerprint digest plugin is not registered: " +
-                                        std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-        }
-        if (plugin_info->operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-            (plugin_info->flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-            return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                "session fingerprint digest plugin must be a streaming inspect plugin");
-        }
-        if (0 != omega_transform_plugin_options_match_args_schema(options_json.c_str(), plugin_info->args_schema)) {
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                "unsupported fingerprint digest algorithm: " + algorithm);
-        }
-
-        session_fingerprint_reader reader{session, content, byte_length};
-        if (0 != omega_transform_plugin_registry_inspect_reader(
-                         transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
-                         options_json.c_str(), omega_session_get_checkpoint_directory(session),
-                         read_session_fingerprint_chunk, &reader, SESSION_FINGERPRINT_CHUNK_SIZE, nullptr, nullptr,
-                         &plugin_response.response)) {
-            return grpc::Status(grpc::StatusCode::INTERNAL,
-                                "session fingerprint digest plugin failed: " +
-                                        std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-        }
-    }
-
-    if (plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
-        return grpc::Status(grpc::StatusCode::INTERNAL,
-                            "session fingerprint digest plugin returned an empty digest");
-    }
-
-    std::string digest_value(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
-                             static_cast<size_t>(plugin_response.response.result_length));
-    if (plugin_response.response.result_label && *plugin_response.response.result_label) {
-        algorithm = normalize_digest_algorithm(plugin_response.response.result_label);
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_content(content);
-    auto *fingerprint = response->mutable_fingerprint();
-    fingerprint->set_byte_length(byte_length);
-    auto *digest_response = fingerprint->mutable_digest();
-    digest_response->set_algorithm(algorithm);
-    digest_response->set_value(digest_value);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::GetSessionCount(grpc::ServerContext * /*context*/,
-                                                const ::omega_edit::v1::GetSessionCountRequest * /*request*/,
-                                                ::omega_edit::v1::GetSessionCountResponse *response) {
-    response->set_count(session_manager_.session_count());
-    return grpc::Status::OK;
-}
-
-// ---------- Segment ----------
-
-grpc::Status EditorServiceImpl::GetSegment(grpc::ServerContext * /*context*/,
-                                           const ::omega_edit::v1::GetSegmentRequest *request,
-                                           ::omega_edit::v1::GetSegmentResponse *response) {
-    if (request->offset() < 0) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    if (request->length() <= 0) {
-        response->set_session_id(request->session_id());
-        response->set_offset(request->offset());
-        return grpc::Status::OK;
-    }
-    auto *segment = omega_segment_create(request->length());
-    if (!segment) { return grpc::Status(grpc::StatusCode::INTERNAL, "failed to allocate segment"); }
-
-    int result = omega_session_get_segment(session, segment, request->offset());
-    if (result != 0) {
-        omega_segment_destroy(segment);
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "couldn't find segment");
-    }
-
-    auto *data = omega_segment_get_data(segment);
-    auto segment_length = omega_segment_get_length(segment);
-
-    response->set_session_id(request->session_id());
-    response->set_offset(omega_segment_get_offset(segment));
-    if (data && segment_length > 0) { response->set_data(data, static_cast<size_t>(segment_length)); }
-
-    omega_segment_destroy(segment);
-    return grpc::Status::OK;
-}
-
-// ---------- Search ----------
-
-grpc::Status EditorServiceImpl::SearchSession(grpc::ServerContext * /*context*/,
-                                              const ::omega_edit::v1::SearchSessionRequest *request,
-                                              ::omega_edit::v1::SearchSessionResponse *response) {
-    bool case_insensitive = request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
-    bool is_reverse = request->has_is_reverse() ? request->is_reverse() : false;
-    int64_t offset = request->has_offset() ? request->offset() : 0;
-    int64_t length = request->has_length() ? request->length() : 0;
-    int64_t limit = request->has_limit() ? request->limit() : 0; // 0 = no limit
-    std::vector<int64_t> match_offsets;
-
-    {
-        auto locked_session = session_manager_.lock_session(request->session_id());
-        if (!locked_session) {
-            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-        }
-        auto *session = locked_session.session();
-
-        auto *ctx = omega_search_create_context_bytes(session,
-                                                      reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
-                                                      static_cast<int64_t>(request->pattern().size()), offset, length,
-                                                      case_insensitive ? 1 : 0, is_reverse ? 1 : 0);
-
-        if (ctx) {
-            int64_t num_matches = 0;
-            while ((limit <= 0 || num_matches < limit) && omega_search_next_match(ctx, 1) > 0) {
-                match_offsets.push_back(omega_search_context_get_match_offset(ctx));
-                ++num_matches;
+                    case SessionCreateError::ALREADY_EXISTS:
+                        return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, "session already exists: " + desired_id);
+                    default:
+                        return grpc::Status(grpc::StatusCode::INTERNAL, "Failed to create session");
+                }
             }
-            omega_search_destroy_context(ctx);
-        }
-    }
 
-    response->set_session_id(request->session_id());
-    response->set_pattern(request->pattern());
-    response->set_is_case_insensitive(case_insensitive);
-    response->set_is_reverse(is_reverse);
-    response->set_offset(offset);
-    response->set_length(length);
-    for (const auto match_offset : match_offsets) { response->add_match_offset(match_offset); }
-
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::ReplaceSession(grpc::ServerContext * /*context*/,
-                                               const ::omega_edit::v1::ReplaceSessionRequest *request,
-                                               ::omega_edit::v1::ReplaceSessionResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "replace", request->session_id());
-    }
-    // Session operation guard held intentionally: validation runs without holding core_mutex to avoid blocking other
-    // handlers during potentially long payload and size checks, while still preventing transforms from starting until
-    // the mutation attempt has completed.
-
-    const bool case_insensitive = request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
-    const bool is_reverse = request->has_is_reverse() ? request->is_reverse() : false;
-    const int64_t offset = request->has_offset() ? request->offset() : 0;
-    const int64_t length = request->has_length() ? request->length() : 0;
-    const int64_t limit = request->has_limit() ? request->limit() : 0;
-    const bool front_to_back = request->has_front_to_back() ? request->front_to_back() : true;
-    const bool overwrite_only = request->has_overwrite_only() ? request->overwrite_only() : false;
-
-    if (offset < 0 || length < 0 || limit < 0) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "replace offset, length, and limit must be non-negative");
-    }
-
-    const auto payload_status = validate_replace_payload_sizes(request->pattern(), request->replacement(),
-                                                               resource_limits_.max_change_bytes, "replace");
-    if (!payload_status.ok()) { return payload_status; }
-
-    response->set_session_id(request->session_id());
-    response->set_pattern(request->pattern());
-    response->set_replacement(request->replacement());
-    response->set_is_case_insensitive(case_insensitive);
-    response->set_is_reverse(is_reverse);
-    response->set_offset(offset);
-    response->set_length(length);
-    response->set_limit(limit);
-    response->set_front_to_back(front_to_back);
-    response->set_overwrite_only(overwrite_only);
-
-    if (request->pattern().empty()) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "replace pattern must not be empty for session: " + request->session_id());
-    }
-
-    int64_t replacement_count = 0;
-    int64_t delete_count = 0;
-    int64_t insert_count = 0;
-    int64_t overwrite_count = 0;
-
-    {
-        auto locked_session = session_manager_.lock_session(request->session_id());
-        if (!locked_session) {
-            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-        }
-        auto *session = locked_session.session();
-
-        const auto session_size = omega_session_get_computed_file_size(session);
-        if (session_size < 0) {
-            return grpc::Status(grpc::StatusCode::INTERNAL,
-                                "failed to compute session size for session: " + request->session_id());
-        }
-        if (offset > session_size) {
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                "replace offset " + std::to_string(offset) + " exceeds session size " +
-                                        std::to_string(session_size) + " for session: " + request->session_id());
+            response->set_session_id(session_id);
+            response->set_checkpoint_directory(checkpoint_dir_out);
+            if (!file_path.empty() || has_initial_data) { response->set_file_size(file_size); }
+            return grpc::Status::OK;
         }
 
-        if (omega_session_changes_paused(session) != 0) {
-            return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                "replace requires active session changes for session: " + request->session_id());
+        grpc::Status EditorServiceImpl::SaveSession(grpc::ServerContext * /*context*/,
+                                                    const ::omega_edit::v1::SaveSessionRequest *request,
+                                                    ::omega_edit::v1::SaveSessionResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            char saved_file_path[FILENAME_MAX] = {};
+            int64_t offset = request->has_offset() ? request->offset() : 0;
+            int64_t length = request->has_length() ? request->length() : 0;
+
+            int result;
+            if (offset != 0 || length != 0) {
+                result = omega_edit_save_segment(session, request->file_path().c_str(), request->io_flags(),
+                                                 saved_file_path, offset, length);
+            } else {
+                result = omega_edit_save(session, request->file_path().c_str(), request->io_flags(), saved_file_path);
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_save_status(result);
+            if (result == 0) {
+                // Only set file_path on success
+                std::string actual_path =
+                        (saved_file_path[0] != '\0') ? std::string(saved_file_path) : request->file_path();
+                response->set_file_path(actual_path);
+            }
+            return grpc::Status::OK;
         }
 
-        const auto rc = omega_edit_replace_matches_bytes(
-                session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
-                static_cast<int64_t>(request->pattern().size()),
-                reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
-                static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0, is_reverse ? 1 : 0,
-                offset, length, limit, front_to_back ? 1 : 0, overwrite_only ? 1 : 0, &replacement_count, &delete_count,
-                &insert_count, &overwrite_count);
-        if (rc != 0) {
-            return grpc::Status(grpc::StatusCode::INTERNAL, "replace failed for session: " + request->session_id());
-        }
-    }
+        grpc::Status EditorServiceImpl::DestroySession(grpc::ServerContext * /*context*/,
+                                                       const ::omega_edit::v1::DestroySessionRequest *request,
+                                                       ::omega_edit::v1::DestroySessionResponse *response) {
+            if (!session_manager_.detach_session(request->id())) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            response->set_id(request->id());
 
-    response->set_replacement_count(replacement_count);
-    response->set_delete_count(delete_count);
-    response->set_insert_count(insert_count);
-    response->set_overwrite_count(overwrite_count);
-    return grpc::Status::OK;
-}
+            // If graceful shutdown is pending and no sessions remain, trigger shutdown
+            if (graceful_shutdown_.load() && session_manager_.session_count() == 0) { request_shutdown(); }
 
-grpc::Status
-EditorServiceImpl::ReplaceSessionCheckpointed(grpc::ServerContext * /*context*/,
-                                              const ::omega_edit::v1::ReplaceSessionCheckpointedRequest *request,
-                                              ::omega_edit::v1::ReplaceSessionCheckpointedResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "checkpointed replace",
-                                                  request->session_id());
-    }
-    // Session operation guard held intentionally: validation runs without holding core_mutex to avoid blocking other
-    // handlers during potentially long payload and size checks, while still preventing transforms from starting until
-    // the mutation attempt has completed.
-
-    const bool case_insensitive = request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
-    const int64_t offset = request->has_offset() ? request->offset() : 0;
-    const int64_t length = request->has_length() ? request->length() : 0;
-
-    if (offset < 0 || length < 0) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                            "checkpointed replace offset and length must be non-negative");
-    }
-
-    const auto payload_status = validate_replace_checkpointed_payload_sizes(request, resource_limits_.max_change_bytes);
-    if (!payload_status.ok()) { return payload_status; }
-
-    int64_t replacement_count = 0;
-    {
-        auto locked_session = session_manager_.lock_session(request->session_id());
-        if (!locked_session) {
-            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-        }
-        auto *session = locked_session.session();
-
-        const auto session_size = omega_session_get_computed_file_size(session);
-        if (session_size < 0) {
-            return grpc::Status(grpc::StatusCode::INTERNAL,
-                                "failed to compute session size for session: " + request->session_id());
-        }
-        if (offset > session_size) {
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                "checkpointed replace offset " + std::to_string(offset) + " exceeds session size " +
-                                        std::to_string(session_size) + " for session: " + request->session_id());
+            return grpc::Status::OK;
         }
 
-        if (request->pattern().empty()) {
+        // ---------- Edit Operations ----------
+
+        grpc::Status EditorServiceImpl::SubmitChange(grpc::ServerContext * /*context*/,
+                                                     const ::omega_edit::v1::SubmitChangeRequest *request,
+                                                     ::omega_edit::v1::SubmitChangeResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "change", request->session_id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            const grpc::Status payload_status =
+                    validate_change_payload_size(request, resource_limits_.max_change_bytes);
+            if (!payload_status.ok()) { return payload_status; }
+
+            if (request->offset() < 0 || request->length() < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "invalid change arguments");
+            }
+
+            int64_t serial = 0;
+            switch (request->kind()) {
+                case ::omega_edit::v1::CHANGE_KIND_DELETE:
+                    serial = omega_edit_delete(session, request->offset(), request->length());
+                    break;
+                case ::omega_edit::v1::CHANGE_KIND_INSERT:
+                    if (request->has_data()) {
+                        serial = omega_edit_insert_bytes(session, request->offset(),
+                                                         reinterpret_cast<const omega_byte_t *>(request->data().data()),
+                                                         static_cast<int64_t>(request->data().size()));
+                    } else {
+                        serial = omega_edit_insert_bytes(session, request->offset(), nullptr, 0);
+                    }
+                    break;
+                case ::omega_edit::v1::CHANGE_KIND_OVERWRITE:
+                    if (request->has_data()) {
+                        serial = omega_edit_overwrite_bytes(
+                                session, request->offset(),
+                                reinterpret_cast<const omega_byte_t *>(request->data().data()),
+                                static_cast<int64_t>(request->data().size()));
+                    } else {
+                        serial = omega_edit_overwrite_bytes(session, request->offset(), nullptr, 0);
+                    }
+                    break;
+                default:
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "undefined change kind");
+            }
+
+            if (serial < 0) { return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "invalid change arguments"); }
+
+            if (serial == 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "change operation failed"); }
+
+            response->set_session_id(request->session_id());
+            response->set_serial(serial);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::UndoLastChange(grpc::ServerContext * /*context*/,
+                                                       const ::omega_edit::v1::UndoLastChangeRequest *request,
+                                                       ::omega_edit::v1::UndoLastChangeResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "undo", request->id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            int64_t serial = omega_edit_undo_last_change(session);
+            if (serial == 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "undo failed or nothing to undo"); }
+
+            response->set_session_id(request->id());
+            response->set_serial(serial);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::RedoLastUndo(grpc::ServerContext * /*context*/,
+                                                     const ::omega_edit::v1::RedoLastUndoRequest *request,
+                                                     ::omega_edit::v1::RedoLastUndoResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "redo", request->id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            int64_t serial = omega_edit_redo_last_undo(session);
+            if (serial == 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "redo failed or nothing to redo"); }
+
+            response->set_session_id(request->id());
+            response->set_serial(serial);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::ClearChanges(grpc::ServerContext * /*context*/,
+                                                     const ::omega_edit::v1::ClearChangesRequest *request,
+                                                     ::omega_edit::v1::ClearChangesResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "clear changes", request->id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            int result = omega_edit_clear_changes(session);
+            if (result != 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "clear changes failed"); }
+
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        // ---------- Session Control ----------
+
+        grpc::Status EditorServiceImpl::PauseSessionChanges(grpc::ServerContext * /*context*/,
+                                                            const ::omega_edit::v1::PauseSessionChangesRequest *request,
+                                                            ::omega_edit::v1::PauseSessionChangesResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "pause changes", request->id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            omega_session_pause_changes(session);
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        grpc::Status
+        EditorServiceImpl::ResumeSessionChanges(grpc::ServerContext * /*context*/,
+                                                const ::omega_edit::v1::ResumeSessionChangesRequest *request,
+                                                ::omega_edit::v1::ResumeSessionChangesResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "resume changes", request->id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            omega_session_resume_changes(session);
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::PauseViewportEvents(grpc::ServerContext * /*context*/,
+                                                            const ::omega_edit::v1::PauseViewportEventsRequest *request,
+                                                            ::omega_edit::v1::PauseViewportEventsResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            omega_session_pause_viewport_event_callbacks(session);
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        grpc::Status
+        EditorServiceImpl::ResumeViewportEvents(grpc::ServerContext * /*context*/,
+                                                const ::omega_edit::v1::ResumeViewportEventsRequest *request,
+                                                ::omega_edit::v1::ResumeViewportEventsResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            omega_session_resume_viewport_event_callbacks(session);
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        grpc::Status
+        EditorServiceImpl::SessionBeginTransaction(grpc::ServerContext * /*context*/,
+                                                   const ::omega_edit::v1::SessionBeginTransactionRequest *request,
+                                                   ::omega_edit::v1::SessionBeginTransactionResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "begin transaction", request->id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            // Tolerate nested begin-transaction calls (no-op if already in a transaction)
+            // to match the server behaviour used by the TypeScript client's
+            // replace helper which wraps delete+insert in a transaction even when an
+            // outer transaction is already open.
+            omega_session_begin_transaction(session);
+
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        grpc::Status
+        EditorServiceImpl::SessionEndTransaction(grpc::ServerContext * /*context*/,
+                                                 const ::omega_edit::v1::SessionEndTransactionRequest *request,
+                                                 ::omega_edit::v1::SessionEndTransactionResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "end transaction", request->id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            // Tolerate end-transaction when no transaction is open (no-op).
+            omega_session_end_transaction(session);
+
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        grpc::Status
+        EditorServiceImpl::NotifyChangedViewports(grpc::ServerContext * /*context*/,
+                                                  const ::omega_edit::v1::NotifyChangedViewportsRequest *request,
+                                                  ::omega_edit::v1::NotifyChangedViewportsResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            int count = omega_session_notify_changed_viewports(session);
+            response->set_count(count);
+            return grpc::Status::OK;
+        }
+
+        // ---------- Viewport Operations ----------
+
+        grpc::Status EditorServiceImpl::CreateViewport(grpc::ServerContext * /*context*/,
+                                                       const ::omega_edit::v1::CreateViewportRequest *request,
+                                                       ::omega_edit::v1::CreateViewportResponse *response) {
+            auto viewport_status = validate_viewport_range(request->offset(), request->capacity());
+            if (!viewport_status.ok()) { return viewport_status; }
+
+            std::string desired_vp_id;
+            if (request->has_viewport_id_desired()) { desired_vp_id = request->viewport_id_desired(); }
+
+            ViewportCreateError vp_error = ViewportCreateError::SUCCESS;
+            std::string fqid =
+                    session_manager_.create_viewport(request->session_id(), request->offset(), request->capacity(),
+                                                     request->is_floating(), desired_vp_id, &vp_error);
+            if (fqid.empty()) {
+                switch (vp_error) {
+                    case ViewportCreateError::SESSION_NOT_FOUND:
+                        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+                    case ViewportCreateError::INVALID_VIEWPORT_ID:
+                        return grpc::Status(
+                                grpc::StatusCode::INVALID_ARGUMENT,
+                                "viewport id must be 1-128 bytes and contain only letters, digits, '_', '.', or '-'");
+                    case ViewportCreateError::DUPLICATE_VIEWPORT_ID:
+                        return grpc::Status(grpc::StatusCode::ALREADY_EXISTS,
+                                            "viewport already exists: " + desired_vp_id);
+                    case ViewportCreateError::TOO_MANY_VIEWPORTS:
+                        return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                            "session reached configured viewport limit of " +
+                                                    std::to_string(resource_limits_.max_viewports_per_session));
+                    default:
+                        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to create viewport");
+                }
+            }
+
+            std::string sid, vid;
+            if (!parse_viewport_id(fqid, sid, vid)) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "malformed viewport id: " + fqid);
+            }
+
+            session_manager_.touch_session(request->session_id());
+            return fill_viewport_data(sid, vid, fqid, response);
+        }
+
+        grpc::Status EditorServiceImpl::ModifyViewport(grpc::ServerContext * /*context*/,
+                                                       const ::omega_edit::v1::ModifyViewportRequest *request,
+                                                       ::omega_edit::v1::ModifyViewportResponse *response) {
+            auto viewport_status = validate_viewport_range(request->offset(), request->capacity());
+            if (!viewport_status.ok()) { return viewport_status; }
+
+            std::string sid, vid;
+            if (!parse_viewport_id(request->viewport_id(), sid, vid)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "malformed viewport id: " + request->viewport_id());
+            }
+
+            auto locked_viewport = session_manager_.lock_viewport(sid, vid);
+            if (!locked_viewport) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->viewport_id());
+            }
+            auto *vp = locked_viewport.viewport();
+
+            int result =
+                    omega_viewport_modify(vp, request->offset(), request->capacity(), request->is_floating() ? 1 : 0);
+            if (result != 0) { return grpc::Status(grpc::StatusCode::UNKNOWN, "modify viewport failed"); }
+
+            // Keep the existing core lock while returning the refreshed viewport data. Calling fill_viewport_data here would
+            // attempt to acquire the same per-session lock again.
+            const auto *data = omega_viewport_get_data(vp);
+            auto length = omega_viewport_get_length(vp);
+            response->set_viewport_id(request->viewport_id());
+            response->set_offset(omega_viewport_get_offset(vp));
+            response->set_length(length);
+            if (data && length > 0) { response->set_data(data, static_cast<size_t>(length)); }
+            response->set_following_byte_count(omega_viewport_get_following_byte_count(vp));
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::ViewportHasChanges(grpc::ServerContext * /*context*/,
+                                                           const ::omega_edit::v1::ViewportHasChangesRequest *request,
+                                                           ::omega_edit::v1::ViewportHasChangesResponse *response) {
+            std::string sid, vid;
+            if (!parse_viewport_id(request->id(), sid, vid)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
+            }
+
+            auto locked_viewport = session_manager_.lock_viewport(sid, vid);
+            if (!locked_viewport) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->id());
+            }
+            auto *vp = locked_viewport.viewport();
+
+            response->set_result(omega_viewport_has_changes(vp) != 0);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::GetViewportData(grpc::ServerContext * /*context*/,
+                                                        const ::omega_edit::v1::GetViewportDataRequest *request,
+                                                        ::omega_edit::v1::GetViewportDataResponse *response) {
+            std::string sid, vid;
+            if (!parse_viewport_id(request->viewport_id(), sid, vid)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "malformed viewport id: " + request->viewport_id());
+            }
+
+            return fill_viewport_data(sid, vid, request->viewport_id(), response);
+        }
+
+        grpc::Status EditorServiceImpl::DestroyViewport(grpc::ServerContext * /*context*/,
+                                                        const ::omega_edit::v1::DestroyViewportRequest *request,
+                                                        ::omega_edit::v1::DestroyViewportResponse *response) {
+            std::string sid, vid;
+            if (!parse_viewport_id(request->id(), sid, vid)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
+            }
+
+            if (!session_manager_.destroy_viewport(sid, vid)) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->id());
+            }
+
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        // ---------- Change Details ----------
+
+        grpc::Status EditorServiceImpl::GetChangeDetails(grpc::ServerContext * /*context*/,
+                                                         const ::omega_edit::v1::GetChangeDetailsRequest *request,
+                                                         ::omega_edit::v1::GetChangeDetailsResponse *response) {
+            if (!request->has_serial()) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "change serial id required");
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            const auto *change = omega_session_get_change(session, request->serial());
+            if (!change) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "change not found"); }
+
+            fill_change_details(change, request->session_id(), response);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::GetLastChange(grpc::ServerContext * /*context*/,
+                                                      const ::omega_edit::v1::GetLastChangeRequest *request,
+                                                      ::omega_edit::v1::GetLastChangeResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            const auto *change = omega_session_get_last_change(session);
+            if (!change) { return grpc::Status(grpc::StatusCode::UNKNOWN, "no changes available"); }
+
+            fill_change_details(change, request->id(), response);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::GetLastUndo(grpc::ServerContext * /*context*/,
+                                                    const ::omega_edit::v1::GetLastUndoRequest *request,
+                                                    ::omega_edit::v1::GetLastUndoResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            const auto *change = omega_session_get_last_undo(session);
+            if (!change) { return grpc::Status(grpc::StatusCode::UNKNOWN, "no undone changes available"); }
+
+            fill_change_details(change, request->id(), response);
+            return grpc::Status::OK;
+        }
+
+        // ---------- Computed File Size ----------
+
+        grpc::Status EditorServiceImpl::GetComputedFileSize(grpc::ServerContext * /*context*/,
+                                                            const ::omega_edit::v1::GetComputedFileSizeRequest *request,
+                                                            ::omega_edit::v1::GetComputedFileSizeResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id());
+            }
+            auto *session = locked_session.session();
+
+            const auto computed_file_size = omega_session_get_computed_file_size(session);
+            if (computed_file_size < 0) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "computed file size overflow");
+            }
+            response->set_session_id(request->id());
+            response->set_computed_file_size(computed_file_size);
+            return grpc::Status::OK;
+        }
+
+        // ---------- BOM / Content Type / Language ----------
+
+        grpc::Status EditorServiceImpl::GetByteOrderMark(grpc::ServerContext * /*context*/,
+                                                         const ::omega_edit::v1::GetByteOrderMarkRequest *request,
+                                                         ::omega_edit::v1::GetByteOrderMarkResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            omega_bom_t bom = omega_session_detect_BOM(session, request->offset());
+            const char *bom_str = omega_util_BOM_to_cstring(bom);
+            auto bom_size = static_cast<int64_t>(omega_util_BOM_size(bom));
+
+            response->set_session_id(request->session_id());
+            response->set_offset(request->offset());
+            response->set_length(bom_size);
+            response->set_byte_order_mark(bom_str);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::GetContentType(grpc::ServerContext * /*context*/,
+                                                       const ::omega_edit::v1::GetContentTypeRequest *request,
+                                                       ::omega_edit::v1::GetContentTypeResponse *response) {
+            if (request->offset() < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            if (request->length() <= 0) {
+                response->set_session_id(request->session_id());
+                response->set_offset(request->offset());
+                response->set_length(0);
+                response->set_content_type("application/octet-stream");
+                return grpc::Status::OK;
+            }
+            auto segment = std::unique_ptr<omega_segment_t, decltype(&omega_segment_destroy)>(
+                    omega_segment_create(request->length()), omega_segment_destroy);
+            if (!segment) { return grpc::Status(grpc::StatusCode::INTERNAL, "failed to allocate segment"); }
+
+            int result = omega_session_get_segment(session, segment.get(), request->offset());
+            std::string content_type;
+            int64_t actual_length = 0;
+            if (result == 0) {
+                auto *data = omega_segment_get_data(segment.get());
+                actual_length = omega_segment_get_length(segment.get());
+                content_type =
+                        content_type_detector_->detect(data, actual_length, locked_session.info->canonical_file_path);
+            } else {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "couldn't get segment");
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_offset(request->offset());
+            response->set_length(actual_length);
+            response->set_content_type(content_type);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::GetLanguage(grpc::ServerContext * /*context*/,
+                                                    const ::omega_edit::v1::GetLanguageRequest *request,
+                                                    ::omega_edit::v1::GetLanguageResponse *response) {
+            if (request->offset() < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            if (request->length() <= 0) {
+                response->set_session_id(request->session_id());
+                response->set_offset(request->offset());
+                response->set_length(0);
+                response->set_language("unknown");
+                return grpc::Status::OK;
+            }
+            auto segment = std::unique_ptr<omega_segment_t, decltype(&omega_segment_destroy)>(
+                    omega_segment_create(request->length()), omega_segment_destroy);
+            if (!segment) { return grpc::Status(grpc::StatusCode::INTERNAL, "failed to allocate segment"); }
+
+            int result = omega_session_get_segment(session, segment.get(), request->offset());
+            std::string language;
+            int64_t actual_length = 0;
+            if (result == 0) {
+                auto *data = omega_segment_get_data(segment.get());
+                actual_length = omega_segment_get_length(segment.get());
+                std::string bom_str = request->byte_order_mark();
+                language = language_detector_->detect(data, actual_length, bom_str);
+            } else {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "couldn't get segment");
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_offset(request->offset());
+            response->set_length(actual_length);
+            response->set_language(language);
+            return grpc::Status::OK;
+        }
+
+        // ---------- Counts ----------
+
+        grpc::Status EditorServiceImpl::GetCount(grpc::ServerContext * /*context*/,
+                                                 const ::omega_edit::v1::GetCountRequest *request,
+                                                 ::omega_edit::v1::GetCountResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            response->set_session_id(request->session_id());
+
+            for (int i = 0; i < request->kind_size(); ++i) {
+                auto kind = request->kind(i);
+                int64_t count_value = 0;
+                switch (kind) {
+                    case ::omega_edit::v1::COUNT_KIND_COMPUTED_FILE_SIZE:
+                        count_value = omega_session_get_computed_file_size(session);
+                        if (count_value < 0) {
+                            return grpc::Status(grpc::StatusCode::INTERNAL, "computed file size overflow");
+                        }
+                        break;
+                    case ::omega_edit::v1::COUNT_KIND_CHANGES:
+                        count_value = omega_session_get_num_changes(session);
+                        break;
+                    case ::omega_edit::v1::COUNT_KIND_UNDOS:
+                        count_value = omega_session_get_num_undone_changes(session);
+                        break;
+                    case ::omega_edit::v1::COUNT_KIND_VIEWPORTS:
+                        count_value = omega_session_get_num_viewports(session);
+                        break;
+                    case ::omega_edit::v1::COUNT_KIND_CHECKPOINTS:
+                        count_value = omega_session_get_num_checkpoints(session);
+                        break;
+                    case ::omega_edit::v1::COUNT_KIND_SEARCH_CONTEXTS:
+                        count_value = omega_session_get_num_search_contexts(session);
+                        break;
+                    case ::omega_edit::v1::COUNT_KIND_CHANGE_TRANSACTIONS:
+                        count_value = omega_session_get_num_change_transactions(session);
+                        break;
+                    case ::omega_edit::v1::COUNT_KIND_UNDO_TRANSACTIONS:
+                        count_value = omega_session_get_num_undone_change_transactions(session);
+                        break;
+                    default:
+                        return grpc::Status(grpc::StatusCode::UNKNOWN, "undefined count kind");
+                }
+                auto *single = response->add_counts();
+                single->set_kind(kind);
+                single->set_count(count_value);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::CheckSessionModel(grpc::ServerContext * /*context*/,
+                                                          const ::omega_edit::v1::CheckSessionModelRequest *request,
+                                                          ::omega_edit::v1::CheckSessionModelResponse *response) {
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+
+            const auto status = omega_check_model(locked_session.session());
+            response->set_session_id(request->session_id());
+            response->set_valid(status == 0);
+            response->set_status(status);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status
+        EditorServiceImpl::GetSessionFingerprint(grpc::ServerContext * /*context*/,
+                                                 const ::omega_edit::v1::GetSessionFingerprintRequest *request,
+                                                 ::omega_edit::v1::GetSessionFingerprintResponse *response) {
+            const auto content = request->content();
+            if (content != ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_ORIGINAL &&
+                content != ::omega_edit::v1::SESSION_FINGERPRINT_CONTENT_COMPUTED) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "fingerprint content must be original or computed");
+            }
+
+            auto algorithm = normalize_digest_algorithm(request->has_algorithm() ? request->algorithm() : "");
+            if (!digest_algorithm_is_json_safe(algorithm)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "unsupported fingerprint digest algorithm: " + algorithm);
+            }
+            const auto options_json = make_digest_options_json(algorithm);
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            const auto byte_length = get_session_fingerprint_byte_length(session, content);
+            if (byte_length < 0) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "session content length unavailable for fingerprint");
+            }
+
+            transform_plugin_response_guard plugin_response;
+            {
+                std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
+                const auto *plugin_info = omega_transform_plugin_registry_find_info(
+                        transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
+                if (!plugin_info) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "session fingerprint digest plugin is not registered: " +
+                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
+                }
+                if (plugin_info->operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
+                    (plugin_info->flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "session fingerprint digest plugin must be a streaming inspect plugin");
+                }
+                if (0 !=
+                    omega_transform_plugin_options_match_args_schema(options_json.c_str(), plugin_info->args_schema)) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "unsupported fingerprint digest algorithm: " + algorithm);
+                }
+
+                session_fingerprint_reader reader{session, content, byte_length};
+                if (0 != omega_transform_plugin_registry_inspect_reader(
+                                 transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
+                                 options_json.c_str(), omega_session_get_checkpoint_directory(session),
+                                 read_session_fingerprint_chunk, &reader, SESSION_FINGERPRINT_CHUNK_SIZE, nullptr,
+                                 nullptr, &plugin_response.response)) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        "session fingerprint digest plugin failed: " +
+                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
+                }
+            }
+
+            if (plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
+                return grpc::Status(grpc::StatusCode::INTERNAL,
+                                    "session fingerprint digest plugin returned an empty digest");
+            }
+
+            std::string digest_value(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
+                                     static_cast<size_t>(plugin_response.response.result_length));
+            if (plugin_response.response.result_label && *plugin_response.response.result_label) {
+                algorithm = normalize_digest_algorithm(plugin_response.response.result_label);
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_content(content);
+            auto *fingerprint = response->mutable_fingerprint();
+            fingerprint->set_byte_length(byte_length);
+            auto *digest_response = fingerprint->mutable_digest();
+            digest_response->set_algorithm(algorithm);
+            digest_response->set_value(digest_value);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::GetSessionCount(grpc::ServerContext * /*context*/,
+                                                        const ::omega_edit::v1::GetSessionCountRequest * /*request*/,
+                                                        ::omega_edit::v1::GetSessionCountResponse *response) {
+            response->set_count(session_manager_.session_count());
+            return grpc::Status::OK;
+        }
+
+        // ---------- Segment ----------
+
+        grpc::Status EditorServiceImpl::GetSegment(grpc::ServerContext * /*context*/,
+                                                   const ::omega_edit::v1::GetSegmentRequest *request,
+                                                   ::omega_edit::v1::GetSegmentResponse *response) {
+            if (request->offset() < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            if (request->length() <= 0) {
+                response->set_session_id(request->session_id());
+                response->set_offset(request->offset());
+                return grpc::Status::OK;
+            }
+            auto *segment = omega_segment_create(request->length());
+            if (!segment) { return grpc::Status(grpc::StatusCode::INTERNAL, "failed to allocate segment"); }
+
+            int result = omega_session_get_segment(session, segment, request->offset());
+            if (result != 0) {
+                omega_segment_destroy(segment);
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "couldn't find segment");
+            }
+
+            auto *data = omega_segment_get_data(segment);
+            auto segment_length = omega_segment_get_length(segment);
+
+            response->set_session_id(request->session_id());
+            response->set_offset(omega_segment_get_offset(segment));
+            if (data && segment_length > 0) { response->set_data(data, static_cast<size_t>(segment_length)); }
+
+            omega_segment_destroy(segment);
+            return grpc::Status::OK;
+        }
+
+        // ---------- Search ----------
+
+        grpc::Status EditorServiceImpl::SearchSession(grpc::ServerContext * /*context*/,
+                                                      const ::omega_edit::v1::SearchSessionRequest *request,
+                                                      ::omega_edit::v1::SearchSessionResponse *response) {
+            bool case_insensitive = request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
+            bool is_reverse = request->has_is_reverse() ? request->is_reverse() : false;
+            int64_t offset = request->has_offset() ? request->offset() : 0;
+            int64_t length = request->has_length() ? request->length() : 0;
+            int64_t limit = request->has_limit() ? request->limit() : 0;// 0 = no limit
+            std::vector<int64_t> match_offsets;
+
+            {
+                auto locked_session = session_manager_.lock_session(request->session_id());
+                if (!locked_session) {
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+                }
+                auto *session = locked_session.session();
+
+                auto *ctx = omega_search_create_context_bytes(
+                        session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+                        static_cast<int64_t>(request->pattern().size()), offset, length, case_insensitive ? 1 : 0,
+                        is_reverse ? 1 : 0);
+
+                if (ctx) {
+                    int64_t num_matches = 0;
+                    while ((limit <= 0 || num_matches < limit) && omega_search_next_match(ctx, 1) > 0) {
+                        match_offsets.push_back(omega_search_context_get_match_offset(ctx));
+                        ++num_matches;
+                    }
+                    omega_search_destroy_context(ctx);
+                }
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_pattern(request->pattern());
+            response->set_is_case_insensitive(case_insensitive);
+            response->set_is_reverse(is_reverse);
+            response->set_offset(offset);
+            response->set_length(length);
+            for (const auto match_offset : match_offsets) { response->add_match_offset(match_offset); }
+
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::ReplaceSession(grpc::ServerContext * /*context*/,
+                                                       const ::omega_edit::v1::ReplaceSessionRequest *request,
+                                                       ::omega_edit::v1::ReplaceSessionResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "replace", request->session_id());
+            }
+            // Session operation guard held intentionally: validation runs without holding core_mutex to avoid blocking other
+            // handlers during potentially long payload and size checks, while still preventing transforms from starting until
+            // the mutation attempt has completed.
+
+            const bool case_insensitive = request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
+            const bool is_reverse = request->has_is_reverse() ? request->is_reverse() : false;
+            const int64_t offset = request->has_offset() ? request->offset() : 0;
+            const int64_t length = request->has_length() ? request->length() : 0;
+            const int64_t limit = request->has_limit() ? request->limit() : 0;
+            const bool front_to_back = request->has_front_to_back() ? request->front_to_back() : true;
+            const bool overwrite_only = request->has_overwrite_only() ? request->overwrite_only() : false;
+
+            if (offset < 0 || length < 0 || limit < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "replace offset, length, and limit must be non-negative");
+            }
+
+            const auto payload_status = validate_replace_payload_sizes(request->pattern(), request->replacement(),
+                                                                       resource_limits_.max_change_bytes, "replace");
+            if (!payload_status.ok()) { return payload_status; }
+
+            response->set_session_id(request->session_id());
+            response->set_pattern(request->pattern());
+            response->set_replacement(request->replacement());
+            response->set_is_case_insensitive(case_insensitive);
+            response->set_is_reverse(is_reverse);
+            response->set_offset(offset);
+            response->set_length(length);
+            response->set_limit(limit);
+            response->set_front_to_back(front_to_back);
+            response->set_overwrite_only(overwrite_only);
+
+            if (request->pattern().empty()) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "replace pattern must not be empty for session: " + request->session_id());
+            }
+
+            int64_t replacement_count = 0;
+            int64_t delete_count = 0;
+            int64_t insert_count = 0;
+            int64_t overwrite_count = 0;
+
+            {
+                auto locked_session = session_manager_.lock_session(request->session_id());
+                if (!locked_session) {
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+                }
+                auto *session = locked_session.session();
+
+                const auto session_size = omega_session_get_computed_file_size(session);
+                if (session_size < 0) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        "failed to compute session size for session: " + request->session_id());
+                }
+                if (offset > session_size) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "replace offset " + std::to_string(offset) + " exceeds session size " +
+                                                std::to_string(session_size) +
+                                                " for session: " + request->session_id());
+                }
+
+                if (omega_session_changes_paused(session) != 0) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "replace requires active session changes for session: " +
+                                                request->session_id());
+                }
+
+                const auto rc = omega_edit_replace_matches_bytes(
+                        session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+                        static_cast<int64_t>(request->pattern().size()),
+                        reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
+                        static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0,
+                        is_reverse ? 1 : 0, offset, length, limit, front_to_back ? 1 : 0, overwrite_only ? 1 : 0,
+                        &replacement_count, &delete_count, &insert_count, &overwrite_count);
+                if (rc != 0) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        "replace failed for session: " + request->session_id());
+                }
+            }
+
+            response->set_replacement_count(replacement_count);
+            response->set_delete_count(delete_count);
+            response->set_insert_count(insert_count);
+            response->set_overwrite_count(overwrite_count);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::ReplaceSessionCheckpointed(
+                grpc::ServerContext * /*context*/, const ::omega_edit::v1::ReplaceSessionCheckpointedRequest *request,
+                ::omega_edit::v1::ReplaceSessionCheckpointedResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "checkpointed replace",
+                                                          request->session_id());
+            }
+            // Session operation guard held intentionally: validation runs without holding core_mutex to avoid blocking other
+            // handlers during potentially long payload and size checks, while still preventing transforms from starting until
+            // the mutation attempt has completed.
+
+            const bool case_insensitive = request->has_is_case_insensitive() ? request->is_case_insensitive() : false;
+            const int64_t offset = request->has_offset() ? request->offset() : 0;
+            const int64_t length = request->has_length() ? request->length() : 0;
+
+            if (offset < 0 || length < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "checkpointed replace offset and length must be non-negative");
+            }
+
+            const auto payload_status =
+                    validate_replace_checkpointed_payload_sizes(request, resource_limits_.max_change_bytes);
+            if (!payload_status.ok()) { return payload_status; }
+
+            int64_t replacement_count = 0;
+            {
+                auto locked_session = session_manager_.lock_session(request->session_id());
+                if (!locked_session) {
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+                }
+                auto *session = locked_session.session();
+
+                const auto session_size = omega_session_get_computed_file_size(session);
+                if (session_size < 0) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        "failed to compute session size for session: " + request->session_id());
+                }
+                if (offset > session_size) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "checkpointed replace offset " + std::to_string(offset) +
+                                                " exceeds session size " + std::to_string(session_size) +
+                                                " for session: " + request->session_id());
+                }
+
+                if (request->pattern().empty()) {
+                    response->set_session_id(request->session_id());
+                    response->set_pattern(request->pattern());
+                    response->set_replacement(request->replacement());
+                    response->set_is_case_insensitive(case_insensitive);
+                    response->set_offset(offset);
+                    response->set_length(length);
+                    response->set_replacement_count(0);
+                    return grpc::Status::OK;
+                }
+
+                if (omega_session_changes_paused(session) != 0) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "checkpointed replace requires active session changes for session: " +
+                                                request->session_id());
+                }
+
+                const auto rc = omega_edit_replace_all_bytes(
+                        session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+                        static_cast<int64_t>(request->pattern().size()),
+                        reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
+                        static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0, offset, length,
+                        &replacement_count);
+                if (rc != 0) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        "checkpointed replace failed for session: " + request->session_id());
+                }
+            }
+
             response->set_session_id(request->session_id());
             response->set_pattern(request->pattern());
             response->set_replacement(request->replacement());
             response->set_is_case_insensitive(case_insensitive);
             response->set_offset(offset);
             response->set_length(length);
-            response->set_replacement_count(0);
+            response->set_replacement_count(replacement_count);
             return grpc::Status::OK;
         }
 
-        if (omega_session_changes_paused(session) != 0) {
-            return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                "checkpointed replace requires active session changes for session: " +
-                                        request->session_id());
-        }
-
-        const auto rc =
-                omega_edit_replace_all_bytes(session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
-                                             static_cast<int64_t>(request->pattern().size()),
-                                             reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
-                                             static_cast<int64_t>(request->replacement().size()),
-                                             case_insensitive ? 1 : 0, offset, length, &replacement_count);
-        if (rc != 0) {
-            return grpc::Status(grpc::StatusCode::INTERNAL,
-                                "checkpointed replace failed for session: " + request->session_id());
-        }
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_pattern(request->pattern());
-    response->set_replacement(request->replacement());
-    response->set_is_case_insensitive(case_insensitive);
-    response->set_offset(offset);
-    response->set_length(length);
-    response->set_replacement_count(replacement_count);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::DestroyLastCheckpoint(grpc::ServerContext * /*context*/,
-                                                      const ::omega_edit::v1::DestroyLastCheckpointRequest *request,
-                                                      ::omega_edit::v1::DestroyLastCheckpointResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "destroy checkpoint", request->session_id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    if (0 != omega_edit_destroy_last_checkpoint(session)) {
-        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "no checkpoint available to destroy");
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_remaining_checkpoints(omega_session_get_num_checkpoints(session));
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::RestoreLastCheckpoint(grpc::ServerContext * /*context*/,
-                                                      const ::omega_edit::v1::RestoreLastCheckpointRequest *request,
-                                                      ::omega_edit::v1::RestoreLastCheckpointResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "restore checkpoint", request->session_id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    const auto before_change_count = omega_session_get_num_changes(session);
-    if (0 != omega_edit_restore_last_checkpoint(session)) {
-        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "no checkpoint available to restore");
-    }
-
-    const auto after_change_count = omega_session_get_num_changes(session);
-    response->set_session_id(request->session_id());
-    response->set_checkpoint_count(omega_session_get_num_checkpoints(session));
-    response->set_change_count(after_change_count);
-    response->set_discarded_change_count(
-            before_change_count > after_change_count ? before_change_count - after_change_count : 0);
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::CreateCheckpoint(grpc::ServerContext * /*context*/,
-                                                 const ::omega_edit::v1::CreateCheckpointRequest *request,
-                                                 ::omega_edit::v1::CreateCheckpointResponse *response) {
-    auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
-    if (!mutation_guard) {
-        return status_for_session_operation_start(mutation_guard.result(), "create checkpoint", request->session_id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    if (0 != omega_edit_create_checkpoint(session)) {
-        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to create checkpoint");
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_checkpoint_count(omega_session_get_num_checkpoints(session));
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::ListTransformPlugins(grpc::ServerContext * /*context*/,
-                                                     const ::omega_edit::v1::ListTransformPluginsRequest * /*request*/,
-                                                     ::omega_edit::v1::ListTransformPluginsResponse *response) {
-    std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
-    const auto count = omega_transform_plugin_registry_get_count(transform_plugin_registry_);
-    for (int64_t i = 0; i < count; ++i) {
-        fill_transform_plugin_info(omega_transform_plugin_registry_get_info(transform_plugin_registry_, i),
-                                   response->add_plugins());
-    }
-    return grpc::Status::OK;
-}
-
-grpc::Status EditorServiceImpl::ApplyTransformPlugin(grpc::ServerContext * /*context*/,
-                                                     const ::omega_edit::v1::ApplyTransformPluginRequest *request,
-                                                     ::omega_edit::v1::ApplyTransformPluginResponse *response) {
-    if (request->plugin_id().empty()) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "plugin_id is required");
-    }
-
-    const int64_t offset = request->has_offset() ? request->offset() : 0;
-    const int64_t length = request->has_length() ? request->length() : 0;
-    if (offset < 0 || length < 0) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "transform offset and length must be non-negative");
-    }
-
-    auto transform_guard = session_manager_.try_begin_transform(request->session_id());
-    if (!transform_guard) {
-        return status_for_session_operation_start(transform_guard.result(), "transform", request->session_id());
-    }
-
-    auto locked_session = session_manager_.lock_session(request->session_id());
-    if (!locked_session) {
-        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-    }
-    auto *session = locked_session.session();
-
-    if (omega_session_get_transaction_state(session) != 0) {
-        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                            "transform cannot run while a session transaction is open for session: " +
-                                    request->session_id());
-    }
-
-    const auto file_size_before = omega_session_get_computed_file_size(session);
-    if (file_size_before < 0 || offset > file_size_before) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "transform range offset is outside the session");
-    }
-    const auto remaining = file_size_before - offset;
-    const auto effective_length = (length == 0 || length > remaining) ? remaining : length;
-
-    omega_transform_plugin_operation_t operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
-    const std::string operation_id = next_transform_operation_id();
-    transform_progress_context progress_context{
-            &session_manager_, request->session_id(), request->plugin_id(), operation_id, {},
-    };
-    session_manager_.publish_transform_progress(
-            request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_STARTED),
-            make_transform_progress(request->plugin_id(), operation_id, "starting", "Transform started"));
-    transform_plugin_response_guard plugin_response;
-    int64_t transform_serial = 0;
-    {
-        // Serializes registry/plugin-library access while the session lock above serializes
-        // access to the non-thread-safe omega_session_t.
-        std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
-        const auto *plugin_info =
-                omega_transform_plugin_registry_find_info(transform_plugin_registry_, request->plugin_id().c_str());
-        if (!plugin_info) {
-            session_manager_.publish_transform_progress(
-                    request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
-                    make_transform_progress(request->plugin_id(), operation_id, "failed",
-                                            "Transform plugin not found"));
-            return grpc::Status(grpc::StatusCode::NOT_FOUND, "transform plugin not found: " + request->plugin_id());
-        }
-
-        operation = plugin_info->operation;
-        const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
-        if (0 != omega_transform_plugin_options_match_args_schema(options_json, plugin_info->args_schema)) {
-            session_manager_.publish_transform_progress(
-                    request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
-                    make_transform_progress(request->plugin_id(), operation_id, "failed",
-                                            "Transform options do not match schema"));
-            return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                "transform options do not match schema: " + request->plugin_id());
-        }
-        if (0 != omega_transform_plugin_registry_apply_to_session_with_progress_and_serial(
-                         transform_plugin_registry_, request->plugin_id().c_str(), session, offset, length,
-                         options_json, transform_progress_callback, &progress_context, &plugin_response.response,
-                         &transform_serial)) {
-            session_manager_.publish_transform_progress(
-                    request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
-                    make_transform_progress(request->plugin_id(), operation_id, "failed", "Transform plugin failed"));
-            return grpc::Status(grpc::StatusCode::INTERNAL, "transform plugin failed: " + request->plugin_id());
-        }
-    }
-
-    if (plugin_response.response.result_length < 0 ||
-        (plugin_response.response.result_length > 0 && plugin_response.response.result_bytes == nullptr)) {
-        session_manager_.publish_transform_progress(
-                request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
-                make_transform_progress(request->plugin_id(), operation_id, "failed",
-                                        "Transform plugin returned an invalid inspection result"));
-        return grpc::Status(grpc::StatusCode::INTERNAL, "transform plugin returned an invalid inspection result");
-    }
-
-    const bool operation_replaces = operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE ||
-                                    operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT;
-    const auto computed_file_size_after = omega_session_get_computed_file_size(session);
-    response->set_session_id(request->session_id());
-    response->set_plugin_id(request->plugin_id());
-    response->set_offset(offset);
-    response->set_length(effective_length);
-    response->set_operation(to_proto_transform_plugin_operation(operation));
-    response->set_content_changed(operation_replaces && transform_serial > 0);
-    response->set_computed_file_size(computed_file_size_after);
-    response->set_replacement_length(plugin_response.response.replacement_length);
-    if (transform_serial > 0) { response->set_serial(transform_serial); }
-    if (plugin_response.response.result_label) { response->set_result_label(plugin_response.response.result_label); }
-    if (plugin_response.response.result_mime_type) {
-        response->set_result_mime_type(plugin_response.response.result_mime_type);
-    }
-    if (plugin_response.response.result_length > 0) {
-        response->set_result(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
-                             static_cast<size_t>(plugin_response.response.result_length));
-    }
-    TransformProgressData completed =
-            make_transform_progress(request->plugin_id(), operation_id, "completed", "Transform completed", false);
-    completed.processed_bytes = effective_length;
-    completed.total_bytes = effective_length;
-    completed.percent = 100.0;
-    completed.has_processed_bytes = true;
-    completed.has_total_bytes = true;
-    completed.has_percent = true;
-    if (transform_serial > 0) {
-        completed.serial = transform_serial;
-        completed.has_serial = true;
-    }
-    session_manager_.publish_transform_progress(request->session_id(),
-                                                static_cast<int32_t>(SESSION_EVT_TRANSFORM_COMPLETED), completed);
-    return grpc::Status::OK;
-}
-
-// ---------- Byte Frequency Profile ----------
-
-grpc::Status EditorServiceImpl::GetByteFrequencyProfile(grpc::ServerContext * /*context*/,
-                                                        const ::omega_edit::v1::GetByteFrequencyProfileRequest *request,
-                                                        ::omega_edit::v1::GetByteFrequencyProfileResponse *response) {
-    omega_byte_frequency_profile_t profile;
-    std::memset(profile, 0, sizeof(profile));
-
-    {
-        auto locked_session = session_manager_.lock_session(request->session_id());
-        if (!locked_session) {
-            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-        }
-        auto *session = locked_session.session();
-
-        int result = omega_session_byte_frequency_profile(session, &profile, request->offset(), request->length());
-        if (result != 0) {
-            return grpc::Status(grpc::StatusCode::UNKNOWN,
-                                "Profile function failed with error code: " + std::to_string(result));
-        }
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_offset(request->offset());
-    response->set_length(request->length());
-
-    for (int i = 0; i < OMEGA_EDIT_BYTE_FREQUENCY_PROFILE_SIZE; ++i) { response->add_frequency(profile[i]); }
-
-    return grpc::Status::OK;
-}
-
-// ---------- Character Counts ----------
-
-grpc::Status EditorServiceImpl::GetCharacterCounts(grpc::ServerContext * /*context*/,
-                                                   const ::omega_edit::v1::GetCharacterCountsRequest *request,
-                                                   ::omega_edit::v1::GetCharacterCountsResponse *response) {
-    omega_bom_t bom = omega_util_cstring_to_BOM(request->byte_order_mark().c_str());
-    auto *counts = omega_character_counts_create();
-    omega_character_counts_set_BOM(counts, bom);
-
-    {
-        auto locked_session = session_manager_.lock_session(request->session_id());
-        if (!locked_session) {
-            omega_character_counts_destroy(counts);
-            return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-        }
-        auto *session = locked_session.session();
-
-        int result = omega_session_character_counts(session, counts, request->offset(), request->length(), bom);
-        if (result != 0) {
-            omega_character_counts_destroy(counts);
-            return grpc::Status(grpc::StatusCode::UNKNOWN,
-                                "CharCount function failed with error code: " + std::to_string(result));
-        }
-    }
-
-    response->set_session_id(request->session_id());
-    response->set_offset(request->offset());
-    response->set_length(request->length());
-    response->set_byte_order_mark(omega_util_BOM_to_cstring(omega_character_counts_get_BOM(counts)));
-    response->set_byte_order_mark_bytes(omega_character_counts_bom_bytes(counts));
-    response->set_single_byte_chars(omega_character_counts_single_byte_chars(counts));
-    response->set_double_byte_chars(omega_character_counts_double_byte_chars(counts));
-    response->set_triple_byte_chars(omega_character_counts_triple_byte_chars(counts));
-    response->set_quad_byte_chars(omega_character_counts_quad_byte_chars(counts));
-    response->set_invalid_bytes(omega_character_counts_invalid_bytes(counts));
-
-    omega_character_counts_destroy(counts);
-    return grpc::Status::OK;
-}
-
-// ---------- Server Control ----------
-
-grpc::Status EditorServiceImpl::ServerControl(grpc::ServerContext * /*context*/,
-                                              const ::omega_edit::v1::ServerControlRequest *request,
-                                              ::omega_edit::v1::ServerControlResponse *response) {
-    response->set_kind(request->kind());
-    response->set_pid(get_pid());
-
-    switch (request->kind()) {
-    case ::omega_edit::v1::SERVER_CONTROL_KIND_GRACEFUL_SHUTDOWN:
-        graceful_shutdown_.store(true);
-        // Check if no sessions remain - if so, we can stop immediately
-        if (session_manager_.session_count() == 0) {
-            response->set_response_code(0);
-            response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_COMPLETED);
-            request_shutdown();
-        } else {
-            response->set_response_code(0);
-            response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_DRAINING);
-        }
-        break;
-
-    case ::omega_edit::v1::SERVER_CONTROL_KIND_IMMEDIATE_SHUTDOWN:
-        graceful_shutdown_.store(true);
-        session_manager_.destroy_all();
-        response->set_response_code(0);
-        response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_COMPLETED);
-        request_shutdown();
-        break;
-
-    default:
-        return grpc::Status(grpc::StatusCode::UNKNOWN, "undefined server control kind");
-    }
-
-    return grpc::Status::OK;
-}
-
-// ---------- Heartbeat ----------
-
-grpc::Status EditorServiceImpl::GetHeartbeat(grpc::ServerContext * /*context*/,
-                                             const ::omega_edit::v1::GetHeartbeatRequest *request,
-                                             ::omega_edit::v1::GetHeartbeatResponse *response) {
-    // Touch sessions referenced in the heartbeat to keep them alive
-    if (request->session_ids_size() > 0) { session_manager_.touch_sessions(request->session_ids()); }
-
-    auto now = std::chrono::system_clock::now();
-    auto uptime = std::chrono::steady_clock::now() - start_time_;
-
-    response->set_session_count(static_cast<int32_t>(session_manager_.session_count()));
-    response->set_timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
-    response->set_uptime(std::chrono::duration_cast<std::chrono::milliseconds>(uptime).count());
-    response->set_cpu_count(get_cpu_count());
-
-    if (const auto load_average = get_cpu_load_average(); load_average.has_value()) {
-        response->set_cpu_load_average(*load_average);
-        response->set_load_average(*load_average);
-    }
-
-    const process_memory_metrics memory = get_process_memory_metrics();
-    if (memory.resident_memory_bytes.has_value()) {
-        response->set_resident_memory_bytes(*memory.resident_memory_bytes);
-    }
-    if (memory.virtual_memory_bytes.has_value()) { response->set_virtual_memory_bytes(*memory.virtual_memory_bytes); }
-    if (memory.peak_resident_memory_bytes.has_value()) {
-        response->set_peak_resident_memory_bytes(*memory.peak_resident_memory_bytes);
-    }
-
-    return grpc::Status::OK;
-}
-
-// ---------- Event Streams ----------
-
-grpc::Status EditorServiceImpl::SubscribeToSessionEvents(
-        grpc::ServerContext *context, const ::omega_edit::v1::SubscribeToSessionEventsRequest *request,
-        grpc::ServerWriter<::omega_edit::v1::SubscribeToSessionEventsResponse> *writer) {
-
-    auto queue = session_manager_.subscribe_session_events(request->id(),
-                                                           request->has_interest() ? request->interest() : -1);
-    if (!queue) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
-
-    SessionEventData event_data;
-    while (!context->IsCancelled()) {
-        if (queue->pop(event_data, std::chrono::milliseconds(500))) {
-            ::omega_edit::v1::SubscribeToSessionEventsResponse event;
-            event.set_session_id(event_data.session_id);
-            event.set_session_event_kind(
-                    static_cast<::omega_edit::v1::SessionEventKind>(event_data.session_event_kind));
-            event.set_computed_file_size(event_data.computed_file_size);
-            event.set_change_count(event_data.change_count);
-            event.set_undo_count(event_data.undo_count);
-            if (event_data.serial != 0) { event.set_serial(event_data.serial); }
-            if (event_data.has_transform_progress) {
-                auto *progress = event.mutable_transform_progress();
-                progress->set_plugin_id(event_data.transform_progress.plugin_id);
-                progress->set_operation_id(event_data.transform_progress.operation_id);
-                if (event_data.transform_progress.has_processed_bytes) {
-                    progress->set_processed_bytes(event_data.transform_progress.processed_bytes);
-                }
-                if (event_data.transform_progress.has_total_bytes) {
-                    progress->set_total_bytes(event_data.transform_progress.total_bytes);
-                }
-                if (event_data.transform_progress.has_percent) {
-                    progress->set_percent(event_data.transform_progress.percent);
-                }
-                if (event_data.transform_progress.has_serial) {
-                    progress->set_serial(event_data.transform_progress.serial);
-                }
-                progress->set_phase(event_data.transform_progress.phase);
-                progress->set_message(event_data.transform_progress.message);
-                progress->set_indeterminate(event_data.transform_progress.indeterminate);
+        grpc::Status
+        EditorServiceImpl::DestroyLastCheckpoint(grpc::ServerContext * /*context*/,
+                                                 const ::omega_edit::v1::DestroyLastCheckpointRequest *request,
+                                                 ::omega_edit::v1::DestroyLastCheckpointResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "destroy checkpoint",
+                                                          request->session_id());
             }
-            if (!writer->Write(event)) { break; }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            if (0 != omega_edit_destroy_last_checkpoint(session)) {
+                return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "no checkpoint available to destroy");
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_remaining_checkpoints(omega_session_get_num_checkpoints(session));
+            return grpc::Status::OK;
         }
-        if (queue->is_closed()) break;
-    }
 
-    // Unsubscribe so the event queue stops accumulating events after the
-    // client disconnects (prevents unbounded memory growth).
-    session_manager_.unsubscribe_session_events(request->id(), queue);
-    return grpc::Status::OK;
-}
+        grpc::Status
+        EditorServiceImpl::RestoreLastCheckpoint(grpc::ServerContext * /*context*/,
+                                                 const ::omega_edit::v1::RestoreLastCheckpointRequest *request,
+                                                 ::omega_edit::v1::RestoreLastCheckpointResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "restore checkpoint",
+                                                          request->session_id());
+            }
 
-grpc::Status EditorServiceImpl::SubscribeToViewportEvents(
-        grpc::ServerContext *context, const ::omega_edit::v1::SubscribeToViewportEventsRequest *request,
-        grpc::ServerWriter<::omega_edit::v1::SubscribeToViewportEventsResponse> *writer) {
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
 
-    std::string sid, vid;
-    if (!parse_viewport_id(request->id(), sid, vid)) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
-    }
+            const auto before_change_count = omega_session_get_num_changes(session);
+            if (0 != omega_edit_restore_last_checkpoint(session)) {
+                return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "no checkpoint available to restore");
+            }
 
-    auto queue =
-            session_manager_.subscribe_viewport_events(sid, vid, request->has_interest() ? request->interest() : -1);
-    if (!queue) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->id()); }
-
-    ViewportEventData event_data;
-    while (!context->IsCancelled()) {
-        if (queue->pop(event_data, std::chrono::milliseconds(500))) {
-            ::omega_edit::v1::SubscribeToViewportEventsResponse event;
-            event.set_session_id(event_data.session_id);
-            event.set_viewport_id(make_viewport_fqid(event_data.session_id, event_data.viewport_id));
-            event.set_viewport_event_kind(
-                    static_cast<::omega_edit::v1::ViewportEventKind>(event_data.viewport_event_kind));
-            if (event_data.serial != 0) { event.set_serial(event_data.serial); }
-            if (event_data.offset >= 0) { event.set_offset(event_data.offset); }
-            if (event_data.length >= 0) { event.set_length(event_data.length); }
-            if (!event_data.data.empty()) { event.set_data(event_data.data.data(), event_data.data.size()); }
-            if (!writer->Write(event)) { break; }
+            const auto after_change_count = omega_session_get_num_changes(session);
+            response->set_session_id(request->session_id());
+            response->set_checkpoint_count(omega_session_get_num_checkpoints(session));
+            response->set_change_count(after_change_count);
+            response->set_discarded_change_count(
+                    before_change_count > after_change_count ? before_change_count - after_change_count : 0);
+            return grpc::Status::OK;
         }
-        if (queue->is_closed()) break;
-    }
 
-    // Unsubscribe so the event queue stops accumulating events after the
-    // client disconnects (prevents unbounded memory growth).
-    session_manager_.unsubscribe_viewport_events(sid, vid, queue);
-    return grpc::Status::OK;
-}
+        grpc::Status EditorServiceImpl::CreateCheckpoint(grpc::ServerContext * /*context*/,
+                                                         const ::omega_edit::v1::CreateCheckpointRequest *request,
+                                                         ::omega_edit::v1::CreateCheckpointResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "create checkpoint",
+                                                          request->session_id());
+            }
 
-grpc::Status
-EditorServiceImpl::UnsubscribeToSessionEvents(grpc::ServerContext * /*context*/,
-                                              const ::omega_edit::v1::UnsubscribeToSessionEventsRequest *request,
-                                              ::omega_edit::v1::UnsubscribeToSessionEventsResponse *response) {
-    session_manager_.unsubscribe_session_events(request->id());
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
 
-grpc::Status
-EditorServiceImpl::UnsubscribeToViewportEvents(grpc::ServerContext * /*context*/,
-                                               const ::omega_edit::v1::UnsubscribeToViewportEventsRequest *request,
-                                               ::omega_edit::v1::UnsubscribeToViewportEventsResponse *response) {
-    std::string sid, vid;
-    if (!parse_viewport_id(request->id(), sid, vid)) {
-        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
-    }
+            if (0 != omega_edit_create_checkpoint(session)) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "failed to create checkpoint");
+            }
 
-    session_manager_.unsubscribe_viewport_events(sid, vid);
-    response->set_id(request->id());
-    return grpc::Status::OK;
-}
+            response->set_session_id(request->session_id());
+            response->set_checkpoint_count(omega_session_get_num_checkpoints(session));
+            return grpc::Status::OK;
+        }
 
-} // namespace grpc_server
-} // namespace omega_edit
+        grpc::Status
+        EditorServiceImpl::ListTransformPlugins(grpc::ServerContext * /*context*/,
+                                                const ::omega_edit::v1::ListTransformPluginsRequest * /*request*/,
+                                                ::omega_edit::v1::ListTransformPluginsResponse *response) {
+            std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
+            const auto count = omega_transform_plugin_registry_get_count(transform_plugin_registry_);
+            for (int64_t i = 0; i < count; ++i) {
+                fill_transform_plugin_info(omega_transform_plugin_registry_get_info(transform_plugin_registry_, i),
+                                           response->add_plugins());
+            }
+            return grpc::Status::OK;
+        }
+
+        grpc::Status
+        EditorServiceImpl::ApplyTransformPlugin(grpc::ServerContext * /*context*/,
+                                                const ::omega_edit::v1::ApplyTransformPluginRequest *request,
+                                                ::omega_edit::v1::ApplyTransformPluginResponse *response) {
+            if (request->plugin_id().empty()) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "plugin_id is required");
+            }
+
+            const int64_t offset = request->has_offset() ? request->offset() : 0;
+            const int64_t length = request->has_length() ? request->length() : 0;
+            if (offset < 0 || length < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "transform offset and length must be non-negative");
+            }
+
+            auto transform_guard = session_manager_.try_begin_transform(request->session_id());
+            if (!transform_guard) {
+                return status_for_session_operation_start(transform_guard.result(), "transform", request->session_id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            if (omega_session_get_transaction_state(session) != 0) {
+                return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                    "transform cannot run while a session transaction is open for session: " +
+                                            request->session_id());
+            }
+
+            const auto file_size_before = omega_session_get_computed_file_size(session);
+            if (file_size_before < 0 || offset > file_size_before) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "transform range offset is outside the session");
+            }
+            const auto remaining = file_size_before - offset;
+            const auto effective_length = (length == 0 || length > remaining) ? remaining : length;
+
+            omega_transform_plugin_operation_t operation = OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT;
+            const std::string operation_id = next_transform_operation_id();
+            transform_progress_context progress_context{
+                    &session_manager_, request->session_id(), request->plugin_id(), operation_id, {},
+            };
+            session_manager_.publish_transform_progress(
+                    request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_STARTED),
+                    make_transform_progress(request->plugin_id(), operation_id, "starting", "Transform started"));
+            transform_plugin_response_guard plugin_response;
+            int64_t transform_serial = 0;
+            {
+                // Serializes registry/plugin-library access while the session lock above serializes
+                // access to the non-thread-safe omega_session_t.
+                std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
+                const auto *plugin_info = omega_transform_plugin_registry_find_info(transform_plugin_registry_,
+                                                                                    request->plugin_id().c_str());
+                if (!plugin_info) {
+                    session_manager_.publish_transform_progress(
+                            request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
+                            make_transform_progress(request->plugin_id(), operation_id, "failed",
+                                                    "Transform plugin not found"));
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND,
+                                        "transform plugin not found: " + request->plugin_id());
+                }
+
+                operation = plugin_info->operation;
+                const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
+                if (0 != omega_transform_plugin_options_match_args_schema(options_json, plugin_info->args_schema)) {
+                    session_manager_.publish_transform_progress(
+                            request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
+                            make_transform_progress(request->plugin_id(), operation_id, "failed",
+                                                    "Transform options do not match schema"));
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "transform options do not match schema: " + request->plugin_id());
+                }
+                if (0 != omega_transform_plugin_registry_apply_to_session_with_progress_and_serial(
+                                 transform_plugin_registry_, request->plugin_id().c_str(), session, offset, length,
+                                 options_json, transform_progress_callback, &progress_context,
+                                 &plugin_response.response, &transform_serial)) {
+                    session_manager_.publish_transform_progress(
+                            request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
+                            make_transform_progress(request->plugin_id(), operation_id, "failed",
+                                                    "Transform plugin failed"));
+                    return grpc::Status(grpc::StatusCode::INTERNAL, "transform plugin failed: " + request->plugin_id());
+                }
+            }
+
+            if (plugin_response.response.result_length < 0 ||
+                (plugin_response.response.result_length > 0 && plugin_response.response.result_bytes == nullptr)) {
+                session_manager_.publish_transform_progress(
+                        request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
+                        make_transform_progress(request->plugin_id(), operation_id, "failed",
+                                                "Transform plugin returned an invalid inspection result"));
+                return grpc::Status(grpc::StatusCode::INTERNAL,
+                                    "transform plugin returned an invalid inspection result");
+            }
+
+            const bool operation_replaces = operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE ||
+                                            operation == OMEGA_TRANSFORM_PLUGIN_OPERATION_REPLACE_AND_INSPECT;
+            const auto computed_file_size_after = omega_session_get_computed_file_size(session);
+            response->set_session_id(request->session_id());
+            response->set_plugin_id(request->plugin_id());
+            response->set_offset(offset);
+            response->set_length(effective_length);
+            response->set_operation(to_proto_transform_plugin_operation(operation));
+            response->set_content_changed(operation_replaces && transform_serial > 0);
+            response->set_computed_file_size(computed_file_size_after);
+            response->set_replacement_length(plugin_response.response.replacement_length);
+            if (transform_serial > 0) { response->set_serial(transform_serial); }
+            if (plugin_response.response.result_label) {
+                response->set_result_label(plugin_response.response.result_label);
+            }
+            if (plugin_response.response.result_mime_type) {
+                response->set_result_mime_type(plugin_response.response.result_mime_type);
+            }
+            if (plugin_response.response.result_length > 0) {
+                response->set_result(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
+                                     static_cast<size_t>(plugin_response.response.result_length));
+            }
+            TransformProgressData completed = make_transform_progress(request->plugin_id(), operation_id, "completed",
+                                                                      "Transform completed", false);
+            completed.processed_bytes = effective_length;
+            completed.total_bytes = effective_length;
+            completed.percent = 100.0;
+            completed.has_processed_bytes = true;
+            completed.has_total_bytes = true;
+            completed.has_percent = true;
+            if (transform_serial > 0) {
+                completed.serial = transform_serial;
+                completed.has_serial = true;
+            }
+            session_manager_.publish_transform_progress(
+                    request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_COMPLETED), completed);
+            return grpc::Status::OK;
+        }
+
+        // ---------- Byte Frequency Profile ----------
+
+        grpc::Status
+        EditorServiceImpl::GetByteFrequencyProfile(grpc::ServerContext * /*context*/,
+                                                   const ::omega_edit::v1::GetByteFrequencyProfileRequest *request,
+                                                   ::omega_edit::v1::GetByteFrequencyProfileResponse *response) {
+            omega_byte_frequency_profile_t profile;
+            std::memset(profile, 0, sizeof(profile));
+
+            {
+                auto locked_session = session_manager_.lock_session(request->session_id());
+                if (!locked_session) {
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+                }
+                auto *session = locked_session.session();
+
+                int result =
+                        omega_session_byte_frequency_profile(session, &profile, request->offset(), request->length());
+                if (result != 0) {
+                    return grpc::Status(grpc::StatusCode::UNKNOWN,
+                                        "Profile function failed with error code: " + std::to_string(result));
+                }
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_offset(request->offset());
+            response->set_length(request->length());
+
+            for (int i = 0; i < OMEGA_EDIT_BYTE_FREQUENCY_PROFILE_SIZE; ++i) { response->add_frequency(profile[i]); }
+
+            return grpc::Status::OK;
+        }
+
+        // ---------- Character Counts ----------
+
+        grpc::Status EditorServiceImpl::GetCharacterCounts(grpc::ServerContext * /*context*/,
+                                                           const ::omega_edit::v1::GetCharacterCountsRequest *request,
+                                                           ::omega_edit::v1::GetCharacterCountsResponse *response) {
+            omega_bom_t bom = omega_util_cstring_to_BOM(request->byte_order_mark().c_str());
+            auto *counts = omega_character_counts_create();
+            omega_character_counts_set_BOM(counts, bom);
+
+            {
+                auto locked_session = session_manager_.lock_session(request->session_id());
+                if (!locked_session) {
+                    omega_character_counts_destroy(counts);
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+                }
+                auto *session = locked_session.session();
+
+                int result = omega_session_character_counts(session, counts, request->offset(), request->length(), bom);
+                if (result != 0) {
+                    omega_character_counts_destroy(counts);
+                    return grpc::Status(grpc::StatusCode::UNKNOWN,
+                                        "CharCount function failed with error code: " + std::to_string(result));
+                }
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_offset(request->offset());
+            response->set_length(request->length());
+            response->set_byte_order_mark(omega_util_BOM_to_cstring(omega_character_counts_get_BOM(counts)));
+            response->set_byte_order_mark_bytes(omega_character_counts_bom_bytes(counts));
+            response->set_single_byte_chars(omega_character_counts_single_byte_chars(counts));
+            response->set_double_byte_chars(omega_character_counts_double_byte_chars(counts));
+            response->set_triple_byte_chars(omega_character_counts_triple_byte_chars(counts));
+            response->set_quad_byte_chars(omega_character_counts_quad_byte_chars(counts));
+            response->set_invalid_bytes(omega_character_counts_invalid_bytes(counts));
+
+            omega_character_counts_destroy(counts);
+            return grpc::Status::OK;
+        }
+
+        // ---------- Server Control ----------
+
+        grpc::Status EditorServiceImpl::ServerControl(grpc::ServerContext * /*context*/,
+                                                      const ::omega_edit::v1::ServerControlRequest *request,
+                                                      ::omega_edit::v1::ServerControlResponse *response) {
+            response->set_kind(request->kind());
+            response->set_pid(get_pid());
+
+            switch (request->kind()) {
+                case ::omega_edit::v1::SERVER_CONTROL_KIND_GRACEFUL_SHUTDOWN:
+                    graceful_shutdown_.store(true);
+                    // Check if no sessions remain - if so, we can stop immediately
+                    if (session_manager_.session_count() == 0) {
+                        response->set_response_code(0);
+                        response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_COMPLETED);
+                        request_shutdown();
+                    } else {
+                        response->set_response_code(0);
+                        response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_DRAINING);
+                    }
+                    break;
+
+                case ::omega_edit::v1::SERVER_CONTROL_KIND_IMMEDIATE_SHUTDOWN:
+                    graceful_shutdown_.store(true);
+                    session_manager_.destroy_all();
+                    response->set_response_code(0);
+                    response->set_status(::omega_edit::v1::SERVER_CONTROL_STATUS_COMPLETED);
+                    request_shutdown();
+                    break;
+
+                default:
+                    return grpc::Status(grpc::StatusCode::UNKNOWN, "undefined server control kind");
+            }
+
+            return grpc::Status::OK;
+        }
+
+        // ---------- Heartbeat ----------
+
+        grpc::Status EditorServiceImpl::GetHeartbeat(grpc::ServerContext * /*context*/,
+                                                     const ::omega_edit::v1::GetHeartbeatRequest *request,
+                                                     ::omega_edit::v1::GetHeartbeatResponse *response) {
+            // Touch sessions referenced in the heartbeat to keep them alive
+            if (request->session_ids_size() > 0) { session_manager_.touch_sessions(request->session_ids()); }
+
+            auto now = std::chrono::system_clock::now();
+            auto uptime = std::chrono::steady_clock::now() - start_time_;
+
+            response->set_session_count(static_cast<int32_t>(session_manager_.session_count()));
+            response->set_timestamp(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
+            response->set_uptime(std::chrono::duration_cast<std::chrono::milliseconds>(uptime).count());
+            response->set_cpu_count(get_cpu_count());
+
+            if (const auto load_average = get_cpu_load_average(); load_average.has_value()) {
+                response->set_cpu_load_average(*load_average);
+                response->set_load_average(*load_average);
+            }
+
+            const process_memory_metrics memory = get_process_memory_metrics();
+            if (memory.resident_memory_bytes.has_value()) {
+                response->set_resident_memory_bytes(*memory.resident_memory_bytes);
+            }
+            if (memory.virtual_memory_bytes.has_value()) {
+                response->set_virtual_memory_bytes(*memory.virtual_memory_bytes);
+            }
+            if (memory.peak_resident_memory_bytes.has_value()) {
+                response->set_peak_resident_memory_bytes(*memory.peak_resident_memory_bytes);
+            }
+
+            return grpc::Status::OK;
+        }
+
+        // ---------- Event Streams ----------
+
+        grpc::Status EditorServiceImpl::SubscribeToSessionEvents(
+                grpc::ServerContext *context, const ::omega_edit::v1::SubscribeToSessionEventsRequest *request,
+                grpc::ServerWriter<::omega_edit::v1::SubscribeToSessionEventsResponse> *writer) {
+
+            auto queue = session_manager_.subscribe_session_events(request->id(),
+                                                                   request->has_interest() ? request->interest() : -1);
+            if (!queue) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->id()); }
+
+            SessionEventData event_data;
+            while (!context->IsCancelled()) {
+                if (queue->pop(event_data, std::chrono::milliseconds(500))) {
+                    ::omega_edit::v1::SubscribeToSessionEventsResponse event;
+                    event.set_session_id(event_data.session_id);
+                    event.set_session_event_kind(
+                            static_cast<::omega_edit::v1::SessionEventKind>(event_data.session_event_kind));
+                    event.set_computed_file_size(event_data.computed_file_size);
+                    event.set_change_count(event_data.change_count);
+                    event.set_undo_count(event_data.undo_count);
+                    if (event_data.serial != 0) { event.set_serial(event_data.serial); }
+                    if (event_data.has_transform_progress) {
+                        auto *progress = event.mutable_transform_progress();
+                        progress->set_plugin_id(event_data.transform_progress.plugin_id);
+                        progress->set_operation_id(event_data.transform_progress.operation_id);
+                        if (event_data.transform_progress.has_processed_bytes) {
+                            progress->set_processed_bytes(event_data.transform_progress.processed_bytes);
+                        }
+                        if (event_data.transform_progress.has_total_bytes) {
+                            progress->set_total_bytes(event_data.transform_progress.total_bytes);
+                        }
+                        if (event_data.transform_progress.has_percent) {
+                            progress->set_percent(event_data.transform_progress.percent);
+                        }
+                        if (event_data.transform_progress.has_serial) {
+                            progress->set_serial(event_data.transform_progress.serial);
+                        }
+                        progress->set_phase(event_data.transform_progress.phase);
+                        progress->set_message(event_data.transform_progress.message);
+                        progress->set_indeterminate(event_data.transform_progress.indeterminate);
+                    }
+                    if (!writer->Write(event)) { break; }
+                }
+                if (queue->is_closed()) break;
+            }
+
+            // Unsubscribe so the event queue stops accumulating events after the
+            // client disconnects (prevents unbounded memory growth).
+            session_manager_.unsubscribe_session_events(request->id(), queue);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::SubscribeToViewportEvents(
+                grpc::ServerContext *context, const ::omega_edit::v1::SubscribeToViewportEventsRequest *request,
+                grpc::ServerWriter<::omega_edit::v1::SubscribeToViewportEventsResponse> *writer) {
+
+            std::string sid, vid;
+            if (!parse_viewport_id(request->id(), sid, vid)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
+            }
+
+            auto queue = session_manager_.subscribe_viewport_events(sid, vid,
+                                                                    request->has_interest() ? request->interest() : -1);
+            if (!queue) { return grpc::Status(grpc::StatusCode::NOT_FOUND, "viewport not found: " + request->id()); }
+
+            ViewportEventData event_data;
+            while (!context->IsCancelled()) {
+                if (queue->pop(event_data, std::chrono::milliseconds(500))) {
+                    ::omega_edit::v1::SubscribeToViewportEventsResponse event;
+                    event.set_session_id(event_data.session_id);
+                    event.set_viewport_id(make_viewport_fqid(event_data.session_id, event_data.viewport_id));
+                    event.set_viewport_event_kind(
+                            static_cast<::omega_edit::v1::ViewportEventKind>(event_data.viewport_event_kind));
+                    if (event_data.serial != 0) { event.set_serial(event_data.serial); }
+                    if (event_data.offset >= 0) { event.set_offset(event_data.offset); }
+                    if (event_data.length >= 0) { event.set_length(event_data.length); }
+                    if (!event_data.data.empty()) { event.set_data(event_data.data.data(), event_data.data.size()); }
+                    if (!writer->Write(event)) { break; }
+                }
+                if (queue->is_closed()) break;
+            }
+
+            // Unsubscribe so the event queue stops accumulating events after the
+            // client disconnects (prevents unbounded memory growth).
+            session_manager_.unsubscribe_viewport_events(sid, vid, queue);
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::UnsubscribeToSessionEvents(
+                grpc::ServerContext * /*context*/, const ::omega_edit::v1::UnsubscribeToSessionEventsRequest *request,
+                ::omega_edit::v1::UnsubscribeToSessionEventsResponse *response) {
+            session_manager_.unsubscribe_session_events(request->id());
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+        grpc::Status EditorServiceImpl::UnsubscribeToViewportEvents(
+                grpc::ServerContext * /*context*/, const ::omega_edit::v1::UnsubscribeToViewportEventsRequest *request,
+                ::omega_edit::v1::UnsubscribeToViewportEventsResponse *response) {
+            std::string sid, vid;
+            if (!parse_viewport_id(request->id(), sid, vid)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "malformed viewport id: " + request->id());
+            }
+
+            session_manager_.unsubscribe_viewport_events(sid, vid);
+            response->set_id(request->id());
+            return grpc::Status::OK;
+        }
+
+    }// namespace grpc_server
+}// namespace omega_edit

--- a/server/cpp/src/editor_service.h
+++ b/server/cpp/src/editor_service.h
@@ -19,9 +19,9 @@
 #include "session_manager.h"
 
 #include <grpcpp/grpcpp.h>
-#include <omega_edit/v1/omega_edit.grpc.pb.h>
 #include <omega_edit/fwd_defs.h>
 #include <omega_edit/transform.h>
+#include <omega_edit/v1/omega_edit.grpc.pb.h>
 
 #include <atomic>
 #include <chrono>
@@ -34,233 +34,245 @@
 #include <vector>
 
 namespace omega_edit {
-namespace grpc_server {
+    namespace grpc_server {
 
-/// Heartbeat / session-reaping configuration
-struct HeartbeatConfig {
-    std::chrono::milliseconds session_timeout{0};   ///< 0 = disabled
-    std::chrono::milliseconds cleanup_interval{0};  ///< 0 = disabled
-    bool shutdown_when_no_sessions{false};
-};
+        /// Heartbeat / session-reaping configuration
+        struct HeartbeatConfig {
+            std::chrono::milliseconds session_timeout{0}; ///< 0 = disabled
+            std::chrono::milliseconds cleanup_interval{0};///< 0 = disabled
+            bool shutdown_when_no_sessions{false};
+        };
 
-class EditorServiceImpl final : public ::omega_edit::v1::EditorService::Service {
-public:
-    /// Construct with optional heartbeat config, resource limits, and shutdown callback
-    explicit EditorServiceImpl(HeartbeatConfig heartbeat_config = {}, ResourceLimits resource_limits = {},
-                               std::function<void()> shutdown_callback = nullptr,
-                               std::vector<std::string> transform_plugin_directories = {});
-    ~EditorServiceImpl() override;
+        class EditorServiceImpl final : public ::omega_edit::v1::EditorService::Service {
+        public:
+            /// Construct with optional heartbeat config, resource limits, and shutdown callback
+            explicit EditorServiceImpl(HeartbeatConfig heartbeat_config = {}, ResourceLimits resource_limits = {},
+                                       std::function<void()> shutdown_callback = nullptr,
+                                       std::vector<std::string> transform_plugin_directories = {});
+            ~EditorServiceImpl() override;
 
-    grpc::Status GetServerInfo(grpc::ServerContext *context, const ::omega_edit::v1::GetServerInfoRequest *request,
-                               ::omega_edit::v1::GetServerInfoResponse *response) override;
+            grpc::Status GetServerInfo(grpc::ServerContext *context,
+                                       const ::omega_edit::v1::GetServerInfoRequest *request,
+                                       ::omega_edit::v1::GetServerInfoResponse *response) override;
 
-    grpc::Status CreateSession(grpc::ServerContext *context, const ::omega_edit::v1::CreateSessionRequest *request,
-                               ::omega_edit::v1::CreateSessionResponse *response) override;
+            grpc::Status CreateSession(grpc::ServerContext *context,
+                                       const ::omega_edit::v1::CreateSessionRequest *request,
+                                       ::omega_edit::v1::CreateSessionResponse *response) override;
 
-    grpc::Status SaveSession(grpc::ServerContext *context, const ::omega_edit::v1::SaveSessionRequest *request,
-                             ::omega_edit::v1::SaveSessionResponse *response) override;
+            grpc::Status SaveSession(grpc::ServerContext *context, const ::omega_edit::v1::SaveSessionRequest *request,
+                                     ::omega_edit::v1::SaveSessionResponse *response) override;
 
-    grpc::Status DestroySession(grpc::ServerContext *context, const ::omega_edit::v1::DestroySessionRequest *request,
-                                ::omega_edit::v1::DestroySessionResponse *response) override;
+            grpc::Status DestroySession(grpc::ServerContext *context,
+                                        const ::omega_edit::v1::DestroySessionRequest *request,
+                                        ::omega_edit::v1::DestroySessionResponse *response) override;
 
-    grpc::Status SubmitChange(grpc::ServerContext *context, const ::omega_edit::v1::SubmitChangeRequest *request,
-                              ::omega_edit::v1::SubmitChangeResponse *response) override;
+            grpc::Status SubmitChange(grpc::ServerContext *context,
+                                      const ::omega_edit::v1::SubmitChangeRequest *request,
+                                      ::omega_edit::v1::SubmitChangeResponse *response) override;
 
-    grpc::Status UndoLastChange(grpc::ServerContext *context, const ::omega_edit::v1::UndoLastChangeRequest *request,
-                                ::omega_edit::v1::UndoLastChangeResponse *response) override;
+            grpc::Status UndoLastChange(grpc::ServerContext *context,
+                                        const ::omega_edit::v1::UndoLastChangeRequest *request,
+                                        ::omega_edit::v1::UndoLastChangeResponse *response) override;
 
-    grpc::Status RedoLastUndo(grpc::ServerContext *context, const ::omega_edit::v1::RedoLastUndoRequest *request,
-                              ::omega_edit::v1::RedoLastUndoResponse *response) override;
+            grpc::Status RedoLastUndo(grpc::ServerContext *context,
+                                      const ::omega_edit::v1::RedoLastUndoRequest *request,
+                                      ::omega_edit::v1::RedoLastUndoResponse *response) override;
 
-    grpc::Status ClearChanges(grpc::ServerContext *context, const ::omega_edit::v1::ClearChangesRequest *request,
-                              ::omega_edit::v1::ClearChangesResponse *response) override;
+            grpc::Status ClearChanges(grpc::ServerContext *context,
+                                      const ::omega_edit::v1::ClearChangesRequest *request,
+                                      ::omega_edit::v1::ClearChangesResponse *response) override;
 
-    grpc::Status PauseSessionChanges(grpc::ServerContext *context,
-                                     const ::omega_edit::v1::PauseSessionChangesRequest *request,
-                                     ::omega_edit::v1::PauseSessionChangesResponse *response) override;
+            grpc::Status PauseSessionChanges(grpc::ServerContext *context,
+                                             const ::omega_edit::v1::PauseSessionChangesRequest *request,
+                                             ::omega_edit::v1::PauseSessionChangesResponse *response) override;
 
-    grpc::Status ResumeSessionChanges(grpc::ServerContext *context,
-                                      const ::omega_edit::v1::ResumeSessionChangesRequest *request,
-                                      ::omega_edit::v1::ResumeSessionChangesResponse *response) override;
+            grpc::Status ResumeSessionChanges(grpc::ServerContext *context,
+                                              const ::omega_edit::v1::ResumeSessionChangesRequest *request,
+                                              ::omega_edit::v1::ResumeSessionChangesResponse *response) override;
 
-    grpc::Status PauseViewportEvents(grpc::ServerContext *context,
-                                     const ::omega_edit::v1::PauseViewportEventsRequest *request,
-                                     ::omega_edit::v1::PauseViewportEventsResponse *response) override;
+            grpc::Status PauseViewportEvents(grpc::ServerContext *context,
+                                             const ::omega_edit::v1::PauseViewportEventsRequest *request,
+                                             ::omega_edit::v1::PauseViewportEventsResponse *response) override;
 
-    grpc::Status ResumeViewportEvents(grpc::ServerContext *context,
-                                      const ::omega_edit::v1::ResumeViewportEventsRequest *request,
-                                      ::omega_edit::v1::ResumeViewportEventsResponse *response) override;
+            grpc::Status ResumeViewportEvents(grpc::ServerContext *context,
+                                              const ::omega_edit::v1::ResumeViewportEventsRequest *request,
+                                              ::omega_edit::v1::ResumeViewportEventsResponse *response) override;
 
-    grpc::Status SessionBeginTransaction(grpc::ServerContext *context,
-                                         const ::omega_edit::v1::SessionBeginTransactionRequest *request,
-                                         ::omega_edit::v1::SessionBeginTransactionResponse *response) override;
+            grpc::Status SessionBeginTransaction(grpc::ServerContext *context,
+                                                 const ::omega_edit::v1::SessionBeginTransactionRequest *request,
+                                                 ::omega_edit::v1::SessionBeginTransactionResponse *response) override;
 
-    grpc::Status SessionEndTransaction(grpc::ServerContext *context,
-                                       const ::omega_edit::v1::SessionEndTransactionRequest *request,
-                                       ::omega_edit::v1::SessionEndTransactionResponse *response) override;
+            grpc::Status SessionEndTransaction(grpc::ServerContext *context,
+                                               const ::omega_edit::v1::SessionEndTransactionRequest *request,
+                                               ::omega_edit::v1::SessionEndTransactionResponse *response) override;
 
-    grpc::Status NotifyChangedViewports(grpc::ServerContext *context,
-                                        const ::omega_edit::v1::NotifyChangedViewportsRequest *request,
-                                        ::omega_edit::v1::NotifyChangedViewportsResponse *response) override;
+            grpc::Status NotifyChangedViewports(grpc::ServerContext *context,
+                                                const ::omega_edit::v1::NotifyChangedViewportsRequest *request,
+                                                ::omega_edit::v1::NotifyChangedViewportsResponse *response) override;
 
-    grpc::Status CreateViewport(grpc::ServerContext *context, const ::omega_edit::v1::CreateViewportRequest *request,
-                                ::omega_edit::v1::CreateViewportResponse *response) override;
+            grpc::Status CreateViewport(grpc::ServerContext *context,
+                                        const ::omega_edit::v1::CreateViewportRequest *request,
+                                        ::omega_edit::v1::CreateViewportResponse *response) override;
 
-    grpc::Status ModifyViewport(grpc::ServerContext *context, const ::omega_edit::v1::ModifyViewportRequest *request,
-                                ::omega_edit::v1::ModifyViewportResponse *response) override;
+            grpc::Status ModifyViewport(grpc::ServerContext *context,
+                                        const ::omega_edit::v1::ModifyViewportRequest *request,
+                                        ::omega_edit::v1::ModifyViewportResponse *response) override;
 
-    grpc::Status ViewportHasChanges(grpc::ServerContext *context,
-                                    const ::omega_edit::v1::ViewportHasChangesRequest *request,
-                                    ::omega_edit::v1::ViewportHasChangesResponse *response) override;
+            grpc::Status ViewportHasChanges(grpc::ServerContext *context,
+                                            const ::omega_edit::v1::ViewportHasChangesRequest *request,
+                                            ::omega_edit::v1::ViewportHasChangesResponse *response) override;
 
-    grpc::Status GetViewportData(grpc::ServerContext *context,
-                                 const ::omega_edit::v1::GetViewportDataRequest *request,
-                                 ::omega_edit::v1::GetViewportDataResponse *response) override;
+            grpc::Status GetViewportData(grpc::ServerContext *context,
+                                         const ::omega_edit::v1::GetViewportDataRequest *request,
+                                         ::omega_edit::v1::GetViewportDataResponse *response) override;
 
-    grpc::Status DestroyViewport(grpc::ServerContext *context,
-                                 const ::omega_edit::v1::DestroyViewportRequest *request,
-                                 ::omega_edit::v1::DestroyViewportResponse *response) override;
+            grpc::Status DestroyViewport(grpc::ServerContext *context,
+                                         const ::omega_edit::v1::DestroyViewportRequest *request,
+                                         ::omega_edit::v1::DestroyViewportResponse *response) override;
 
-    grpc::Status GetChangeDetails(grpc::ServerContext *context,
-                                  const ::omega_edit::v1::GetChangeDetailsRequest *request,
-                                  ::omega_edit::v1::GetChangeDetailsResponse *response) override;
+            grpc::Status GetChangeDetails(grpc::ServerContext *context,
+                                          const ::omega_edit::v1::GetChangeDetailsRequest *request,
+                                          ::omega_edit::v1::GetChangeDetailsResponse *response) override;
 
-    grpc::Status GetLastChange(grpc::ServerContext *context, const ::omega_edit::v1::GetLastChangeRequest *request,
-                               ::omega_edit::v1::GetLastChangeResponse *response) override;
+            grpc::Status GetLastChange(grpc::ServerContext *context,
+                                       const ::omega_edit::v1::GetLastChangeRequest *request,
+                                       ::omega_edit::v1::GetLastChangeResponse *response) override;
 
-    grpc::Status GetLastUndo(grpc::ServerContext *context, const ::omega_edit::v1::GetLastUndoRequest *request,
-                             ::omega_edit::v1::GetLastUndoResponse *response) override;
+            grpc::Status GetLastUndo(grpc::ServerContext *context, const ::omega_edit::v1::GetLastUndoRequest *request,
+                                     ::omega_edit::v1::GetLastUndoResponse *response) override;
 
-    grpc::Status GetComputedFileSize(grpc::ServerContext *context,
-                                     const ::omega_edit::v1::GetComputedFileSizeRequest *request,
-                                     ::omega_edit::v1::GetComputedFileSizeResponse *response) override;
+            grpc::Status GetComputedFileSize(grpc::ServerContext *context,
+                                             const ::omega_edit::v1::GetComputedFileSizeRequest *request,
+                                             ::omega_edit::v1::GetComputedFileSizeResponse *response) override;
 
-    grpc::Status GetByteOrderMark(grpc::ServerContext *context,
-                                  const ::omega_edit::v1::GetByteOrderMarkRequest *request,
-                                  ::omega_edit::v1::GetByteOrderMarkResponse *response) override;
+            grpc::Status GetByteOrderMark(grpc::ServerContext *context,
+                                          const ::omega_edit::v1::GetByteOrderMarkRequest *request,
+                                          ::omega_edit::v1::GetByteOrderMarkResponse *response) override;
 
-    grpc::Status GetContentType(grpc::ServerContext *context,
-                                const ::omega_edit::v1::GetContentTypeRequest *request,
-                                ::omega_edit::v1::GetContentTypeResponse *response) override;
+            grpc::Status GetContentType(grpc::ServerContext *context,
+                                        const ::omega_edit::v1::GetContentTypeRequest *request,
+                                        ::omega_edit::v1::GetContentTypeResponse *response) override;
 
-    grpc::Status GetLanguage(grpc::ServerContext *context, const ::omega_edit::v1::GetLanguageRequest *request,
-                             ::omega_edit::v1::GetLanguageResponse *response) override;
+            grpc::Status GetLanguage(grpc::ServerContext *context, const ::omega_edit::v1::GetLanguageRequest *request,
+                                     ::omega_edit::v1::GetLanguageResponse *response) override;
 
-    grpc::Status GetCount(grpc::ServerContext *context, const ::omega_edit::v1::GetCountRequest *request,
-                          ::omega_edit::v1::GetCountResponse *response) override;
+            grpc::Status GetCount(grpc::ServerContext *context, const ::omega_edit::v1::GetCountRequest *request,
+                                  ::omega_edit::v1::GetCountResponse *response) override;
 
-    grpc::Status CheckSessionModel(grpc::ServerContext *context,
-                                   const ::omega_edit::v1::CheckSessionModelRequest *request,
-                                   ::omega_edit::v1::CheckSessionModelResponse *response) override;
+            grpc::Status CheckSessionModel(grpc::ServerContext *context,
+                                           const ::omega_edit::v1::CheckSessionModelRequest *request,
+                                           ::omega_edit::v1::CheckSessionModelResponse *response) override;
 
-    grpc::Status GetSessionFingerprint(grpc::ServerContext *context,
-                                       const ::omega_edit::v1::GetSessionFingerprintRequest *request,
-                                       ::omega_edit::v1::GetSessionFingerprintResponse *response) override;
+            grpc::Status GetSessionFingerprint(grpc::ServerContext *context,
+                                               const ::omega_edit::v1::GetSessionFingerprintRequest *request,
+                                               ::omega_edit::v1::GetSessionFingerprintResponse *response) override;
 
-    grpc::Status GetSessionCount(grpc::ServerContext *context,
-                                 const ::omega_edit::v1::GetSessionCountRequest *request,
-                                 ::omega_edit::v1::GetSessionCountResponse *response) override;
+            grpc::Status GetSessionCount(grpc::ServerContext *context,
+                                         const ::omega_edit::v1::GetSessionCountRequest *request,
+                                         ::omega_edit::v1::GetSessionCountResponse *response) override;
 
-    grpc::Status GetSegment(grpc::ServerContext *context, const ::omega_edit::v1::GetSegmentRequest *request,
-                            ::omega_edit::v1::GetSegmentResponse *response) override;
+            grpc::Status GetSegment(grpc::ServerContext *context, const ::omega_edit::v1::GetSegmentRequest *request,
+                                    ::omega_edit::v1::GetSegmentResponse *response) override;
 
-    grpc::Status SearchSession(grpc::ServerContext *context,
-                               const ::omega_edit::v1::SearchSessionRequest *request,
-                               ::omega_edit::v1::SearchSessionResponse *response) override;
+            grpc::Status SearchSession(grpc::ServerContext *context,
+                                       const ::omega_edit::v1::SearchSessionRequest *request,
+                                       ::omega_edit::v1::SearchSessionResponse *response) override;
 
-    grpc::Status ReplaceSession(grpc::ServerContext *context,
-                                const ::omega_edit::v1::ReplaceSessionRequest *request,
-                                ::omega_edit::v1::ReplaceSessionResponse *response) override;
+            grpc::Status ReplaceSession(grpc::ServerContext *context,
+                                        const ::omega_edit::v1::ReplaceSessionRequest *request,
+                                        ::omega_edit::v1::ReplaceSessionResponse *response) override;
 
-    grpc::Status ReplaceSessionCheckpointed(
-        grpc::ServerContext *context,
-        const ::omega_edit::v1::ReplaceSessionCheckpointedRequest *request,
-        ::omega_edit::v1::ReplaceSessionCheckpointedResponse *response) override;
+            grpc::Status
+            ReplaceSessionCheckpointed(grpc::ServerContext *context,
+                                       const ::omega_edit::v1::ReplaceSessionCheckpointedRequest *request,
+                                       ::omega_edit::v1::ReplaceSessionCheckpointedResponse *response) override;
 
-    grpc::Status CreateCheckpoint(grpc::ServerContext *context,
-                                  const ::omega_edit::v1::CreateCheckpointRequest *request,
-                                  ::omega_edit::v1::CreateCheckpointResponse *response) override;
+            grpc::Status CreateCheckpoint(grpc::ServerContext *context,
+                                          const ::omega_edit::v1::CreateCheckpointRequest *request,
+                                          ::omega_edit::v1::CreateCheckpointResponse *response) override;
 
-    grpc::Status DestroyLastCheckpoint(
-        grpc::ServerContext *context,
-        const ::omega_edit::v1::DestroyLastCheckpointRequest *request,
-        ::omega_edit::v1::DestroyLastCheckpointResponse *response) override;
+            grpc::Status DestroyLastCheckpoint(grpc::ServerContext *context,
+                                               const ::omega_edit::v1::DestroyLastCheckpointRequest *request,
+                                               ::omega_edit::v1::DestroyLastCheckpointResponse *response) override;
 
-    grpc::Status RestoreLastCheckpoint(
-        grpc::ServerContext *context,
-        const ::omega_edit::v1::RestoreLastCheckpointRequest *request,
-        ::omega_edit::v1::RestoreLastCheckpointResponse *response) override;
+            grpc::Status RestoreLastCheckpoint(grpc::ServerContext *context,
+                                               const ::omega_edit::v1::RestoreLastCheckpointRequest *request,
+                                               ::omega_edit::v1::RestoreLastCheckpointResponse *response) override;
 
-    grpc::Status ListTransformPlugins(grpc::ServerContext *context,
-                                      const ::omega_edit::v1::ListTransformPluginsRequest *request,
-                                      ::omega_edit::v1::ListTransformPluginsResponse *response) override;
+            grpc::Status ListTransformPlugins(grpc::ServerContext *context,
+                                              const ::omega_edit::v1::ListTransformPluginsRequest *request,
+                                              ::omega_edit::v1::ListTransformPluginsResponse *response) override;
 
-    grpc::Status ApplyTransformPlugin(grpc::ServerContext *context,
-                                      const ::omega_edit::v1::ApplyTransformPluginRequest *request,
-                                      ::omega_edit::v1::ApplyTransformPluginResponse *response) override;
+            grpc::Status ApplyTransformPlugin(grpc::ServerContext *context,
+                                              const ::omega_edit::v1::ApplyTransformPluginRequest *request,
+                                              ::omega_edit::v1::ApplyTransformPluginResponse *response) override;
 
-    grpc::Status GetByteFrequencyProfile(grpc::ServerContext *context,
-                                         const ::omega_edit::v1::GetByteFrequencyProfileRequest *request,
-                                         ::omega_edit::v1::GetByteFrequencyProfileResponse *response) override;
+            grpc::Status GetByteFrequencyProfile(grpc::ServerContext *context,
+                                                 const ::omega_edit::v1::GetByteFrequencyProfileRequest *request,
+                                                 ::omega_edit::v1::GetByteFrequencyProfileResponse *response) override;
 
-    grpc::Status GetCharacterCounts(grpc::ServerContext *context,
-                                    const ::omega_edit::v1::GetCharacterCountsRequest *request,
-                                    ::omega_edit::v1::GetCharacterCountsResponse *response) override;
+            grpc::Status GetCharacterCounts(grpc::ServerContext *context,
+                                            const ::omega_edit::v1::GetCharacterCountsRequest *request,
+                                            ::omega_edit::v1::GetCharacterCountsResponse *response) override;
 
-    grpc::Status ServerControl(grpc::ServerContext *context, const ::omega_edit::v1::ServerControlRequest *request,
-                               ::omega_edit::v1::ServerControlResponse *response) override;
+            grpc::Status ServerControl(grpc::ServerContext *context,
+                                       const ::omega_edit::v1::ServerControlRequest *request,
+                                       ::omega_edit::v1::ServerControlResponse *response) override;
 
-    grpc::Status GetHeartbeat(grpc::ServerContext *context, const ::omega_edit::v1::GetHeartbeatRequest *request,
-                              ::omega_edit::v1::GetHeartbeatResponse *response) override;
+            grpc::Status GetHeartbeat(grpc::ServerContext *context,
+                                      const ::omega_edit::v1::GetHeartbeatRequest *request,
+                                      ::omega_edit::v1::GetHeartbeatResponse *response) override;
 
-    grpc::Status SubscribeToSessionEvents(
-        grpc::ServerContext *context, const ::omega_edit::v1::SubscribeToSessionEventsRequest *request,
-        grpc::ServerWriter<::omega_edit::v1::SubscribeToSessionEventsResponse> *writer) override;
+            grpc::Status SubscribeToSessionEvents(
+                    grpc::ServerContext *context, const ::omega_edit::v1::SubscribeToSessionEventsRequest *request,
+                    grpc::ServerWriter<::omega_edit::v1::SubscribeToSessionEventsResponse> *writer) override;
 
-    grpc::Status SubscribeToViewportEvents(
-        grpc::ServerContext *context, const ::omega_edit::v1::SubscribeToViewportEventsRequest *request,
-        grpc::ServerWriter<::omega_edit::v1::SubscribeToViewportEventsResponse> *writer) override;
+            grpc::Status SubscribeToViewportEvents(
+                    grpc::ServerContext *context, const ::omega_edit::v1::SubscribeToViewportEventsRequest *request,
+                    grpc::ServerWriter<::omega_edit::v1::SubscribeToViewportEventsResponse> *writer) override;
 
-    grpc::Status UnsubscribeToSessionEvents(
-        grpc::ServerContext *context, const ::omega_edit::v1::UnsubscribeToSessionEventsRequest *request,
-        ::omega_edit::v1::UnsubscribeToSessionEventsResponse *response) override;
+            grpc::Status
+            UnsubscribeToSessionEvents(grpc::ServerContext *context,
+                                       const ::omega_edit::v1::UnsubscribeToSessionEventsRequest *request,
+                                       ::omega_edit::v1::UnsubscribeToSessionEventsResponse *response) override;
 
-    grpc::Status UnsubscribeToViewportEvents(
-        grpc::ServerContext *context, const ::omega_edit::v1::UnsubscribeToViewportEventsRequest *request,
-        ::omega_edit::v1::UnsubscribeToViewportEventsResponse *response) override;
+            grpc::Status
+            UnsubscribeToViewportEvents(grpc::ServerContext *context,
+                                        const ::omega_edit::v1::UnsubscribeToViewportEventsRequest *request,
+                                        ::omega_edit::v1::UnsubscribeToViewportEventsResponse *response) override;
 
-private:
-    // Parse "sessionId:viewportId" format
-    static bool parse_viewport_id(const std::string &fqid, std::string &session_id, std::string &viewport_id);
-    static std::string make_viewport_fqid(const std::string &session_id, const std::string &viewport_id);
-    template <typename T>
-    grpc::Status fill_viewport_data(const std::string &session_id, const std::string &viewport_id,
-                                    const std::string &fqid, T *response);
-    template <typename T>
-    void fill_change_details(const omega_change_t *change, const std::string &session_id, T *response);
-    void request_shutdown();
+        private:
+            // Parse "sessionId:viewportId" format
+            static bool parse_viewport_id(const std::string &fqid, std::string &session_id, std::string &viewport_id);
+            static std::string make_viewport_fqid(const std::string &session_id, const std::string &viewport_id);
+            template<typename T>
+            grpc::Status fill_viewport_data(const std::string &session_id, const std::string &viewport_id,
+                                            const std::string &fqid, T *response);
+            template<typename T>
+            void fill_change_details(const omega_change_t *change, const std::string &session_id, T *response);
+            void request_shutdown();
 
-    SessionManager session_manager_;
-    std::unique_ptr<IContentTypeDetector> content_type_detector_;
-    std::unique_ptr<ILanguageDetector> language_detector_;
-    omega_transform_plugin_registry_t *transform_plugin_registry_{nullptr};
-    std::mutex transform_plugin_mutex_;
-    std::chrono::steady_clock::time_point start_time_;
-    std::atomic<bool> graceful_shutdown_{false};
+            SessionManager session_manager_;
+            std::unique_ptr<IContentTypeDetector> content_type_detector_;
+            std::unique_ptr<ILanguageDetector> language_detector_;
+            omega_transform_plugin_registry_t *transform_plugin_registry_{nullptr};
+            std::mutex transform_plugin_mutex_;
+            std::chrono::steady_clock::time_point start_time_;
+            std::atomic<bool> graceful_shutdown_{false};
 
-    // Session reaping
-    HeartbeatConfig heartbeat_config_;
-    ResourceLimits resource_limits_;
-    std::function<void()> shutdown_callback_;
-    std::once_flag shutdown_once_;
-    std::thread reaper_thread_;
-    std::atomic<bool> reaper_stop_{false};
-    std::mutex reaper_cv_mutex_;
-    std::condition_variable reaper_cv_;
-    void reaper_loop();
-};
+            // Session reaping
+            HeartbeatConfig heartbeat_config_;
+            ResourceLimits resource_limits_;
+            std::function<void()> shutdown_callback_;
+            std::once_flag shutdown_once_;
+            std::thread reaper_thread_;
+            std::atomic<bool> reaper_stop_{false};
+            std::mutex reaper_cv_mutex_;
+            std::condition_variable reaper_cv_;
+            void reaper_loop();
+        };
 
-} // namespace grpc_server
-} // namespace omega_edit
+    }// namespace grpc_server
+}// namespace omega_edit
 
-#endif // OMEGA_EDIT_EDITOR_SERVICE_H
+#endif// OMEGA_EDIT_EDITOR_SERVICE_H

--- a/server/cpp/src/libmagic_content_detector.cpp
+++ b/server/cpp/src/libmagic_content_detector.cpp
@@ -14,146 +14,136 @@
 
 #include "content_detection.h"
 
-#include <magic.h>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <magic.h>
 #include <mutex>
 
 #ifdef _WIN32
 #include <windows.h>
 #else
-#include <unistd.h>
 #include <climits>
+#include <unistd.h>
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
 #endif
 
 namespace omega_edit {
-namespace grpc_server {
+    namespace grpc_server {
 
-// ── libmagic-backed content-type detector ────────────────────────────────────
+        // ── libmagic-backed content-type detector ────────────────────────────────────
 
-/// Get the directory containing the running executable.
-static std::string get_executable_dir() {
+        /// Get the directory containing the running executable.
+        static std::string get_executable_dir() {
 #ifdef _WIN32
-    char buf[MAX_PATH] = {0};
-    DWORD len = GetModuleFileNameA(nullptr, buf, MAX_PATH);
-    if (len > 0 && len < MAX_PATH) {
-        std::string path(buf, len);
-        auto pos = path.find_last_of("\\/");
-        if (pos != std::string::npos) return path.substr(0, pos);
-    }
+            char buf[MAX_PATH] = {0};
+            DWORD len = GetModuleFileNameA(nullptr, buf, MAX_PATH);
+            if (len > 0 && len < MAX_PATH) {
+                std::string path(buf, len);
+                auto pos = path.find_last_of("\\/");
+                if (pos != std::string::npos) return path.substr(0, pos);
+            }
 #elif defined(__APPLE__)
-    char buf[PATH_MAX] = {0};
-    uint32_t size = sizeof(buf);
-    if (_NSGetExecutablePath(buf, &size) == 0) {
-        // _NSGetExecutablePath may return a relative or symlinked path; resolve it
-        char resolved[PATH_MAX] = {0};
-        if (realpath(buf, resolved)) {
-            std::string path(resolved);
-            auto pos = path.find_last_of('/');
-            if (pos != std::string::npos) return path.substr(0, pos);
-        }
-    }
-#else
-    char buf[PATH_MAX] = {0};
-    ssize_t len = readlink("/proc/self/exe", buf, PATH_MAX - 1);
-    if (len > 0) {
-        std::string path(buf, len);
-        auto pos = path.find_last_of('/');
-        if (pos != std::string::npos) return path.substr(0, pos);
-    }
-#endif
-    return {};
-}
-
-class LibmagicContentTypeDetector final : public IContentTypeDetector {
-public:
-    LibmagicContentTypeDetector() {
-        cookie_ = magic_open(MAGIC_MIME_TYPE | MAGIC_ERROR);
-        if (!cookie_) {
-            std::cerr << "warning: magic_open() failed, content detection will fall back to octet-stream\n";
-            return;
-        }
-
-        // Try to load the magic database in order of preference:
-        // 1. MAGIC_FILE env var (for custom deployments)
-        // 2. magic.mgc adjacent to the executable (for bundled distributions)
-        // 3. Compile-time path from vcpkg (MAGIC_MGC_PATH define)
-        // 4. System default (nullptr)
-        const char *magic_file = std::getenv("MAGIC_FILE");
-        std::string adjacent_path;
-        if (!magic_file) {
-            auto dir = get_executable_dir();
-            if (!dir.empty()) {
-                adjacent_path = dir + "/magic.mgc";
-                // Check if the file exists
-                FILE *f = std::fopen(adjacent_path.c_str(), "rb");
-                if (f) {
-                    std::fclose(f);
-                    magic_file = adjacent_path.c_str();
+            char buf[PATH_MAX] = {0};
+            uint32_t size = sizeof(buf);
+            if (_NSGetExecutablePath(buf, &size) == 0) {
+                // _NSGetExecutablePath may return a relative or symlinked path; resolve it
+                char resolved[PATH_MAX] = {0};
+                if (realpath(buf, resolved)) {
+                    std::string path(resolved);
+                    auto pos = path.find_last_of('/');
+                    if (pos != std::string::npos) return path.substr(0, pos);
                 }
             }
-        }
-#ifdef MAGIC_MGC_PATH
-        if (!magic_file) {
-            magic_file = MAGIC_MGC_PATH;
-        }
-#endif
-        if (magic_load(cookie_, magic_file) != 0) {
-            // Try without a path (system default)
-            if (magic_load(cookie_, nullptr) != 0) {
-                std::cerr << "warning: magic_load() failed: " << magic_error(cookie_)
-                          << " — content detection will fall back to octet-stream\n";
-                magic_close(cookie_);
-                cookie_ = nullptr;
+#else
+            char buf[PATH_MAX] = {0};
+            ssize_t len = readlink("/proc/self/exe", buf, PATH_MAX - 1);
+            if (len > 0) {
+                std::string path(buf, len);
+                auto pos = path.find_last_of('/');
+                if (pos != std::string::npos) return path.substr(0, pos);
             }
-        }
-    }
-
-    ~LibmagicContentTypeDetector() override {
-        if (cookie_) {
-            magic_close(cookie_);
-        }
-    }
-
-    // Disallow copy
-    LibmagicContentTypeDetector(const LibmagicContentTypeDetector &) = delete;
-    LibmagicContentTypeDetector &operator=(const LibmagicContentTypeDetector &) = delete;
-
-    std::string detect(const uint8_t *data, int64_t length, const std::string &file_path) override {
-        if (!data || length <= 0) {
-            return "application/octet-stream";
-        }
-        const std::string builtin = detect_builtin_content_type(data, length, file_path);
-        if (!cookie_) {
-            return builtin;
+#endif
+            return {};
         }
 
-        // libmagic is not thread-safe for a single cookie, so serialize access
-        std::lock_guard<std::mutex> lock(mutex_);
-        const char *mime = magic_buffer(cookie_, data, static_cast<size_t>(length));
-        if (!mime) {
-            return builtin;
+        class LibmagicContentTypeDetector final : public IContentTypeDetector {
+        public:
+            LibmagicContentTypeDetector() {
+                cookie_ = magic_open(MAGIC_MIME_TYPE | MAGIC_ERROR);
+                if (!cookie_) {
+                    std::cerr << "warning: magic_open() failed, content detection will fall back to octet-stream\n";
+                    return;
+                }
+
+                // Try to load the magic database in order of preference:
+                // 1. MAGIC_FILE env var (for custom deployments)
+                // 2. magic.mgc adjacent to the executable (for bundled distributions)
+                // 3. Compile-time path from vcpkg (MAGIC_MGC_PATH define)
+                // 4. System default (nullptr)
+                const char *magic_file = std::getenv("MAGIC_FILE");
+                std::string adjacent_path;
+                if (!magic_file) {
+                    auto dir = get_executable_dir();
+                    if (!dir.empty()) {
+                        adjacent_path = dir + "/magic.mgc";
+                        // Check if the file exists
+                        FILE *f = std::fopen(adjacent_path.c_str(), "rb");
+                        if (f) {
+                            std::fclose(f);
+                            magic_file = adjacent_path.c_str();
+                        }
+                    }
+                }
+#ifdef MAGIC_MGC_PATH
+                if (!magic_file) { magic_file = MAGIC_MGC_PATH; }
+#endif
+                if (magic_load(cookie_, magic_file) != 0) {
+                    // Try without a path (system default)
+                    if (magic_load(cookie_, nullptr) != 0) {
+                        std::cerr << "warning: magic_load() failed: " << magic_error(cookie_)
+                                  << " — content detection will fall back to octet-stream\n";
+                        magic_close(cookie_);
+                        cookie_ = nullptr;
+                    }
+                }
+            }
+
+            ~LibmagicContentTypeDetector() override {
+                if (cookie_) { magic_close(cookie_); }
+            }
+
+            // Disallow copy
+            LibmagicContentTypeDetector(const LibmagicContentTypeDetector &) = delete;
+            LibmagicContentTypeDetector &operator=(const LibmagicContentTypeDetector &) = delete;
+
+            std::string detect(const uint8_t *data, int64_t length, const std::string &file_path) override {
+                if (!data || length <= 0) { return "application/octet-stream"; }
+                const std::string builtin = detect_builtin_content_type(data, length, file_path);
+                if (!cookie_) { return builtin; }
+
+                // libmagic is not thread-safe for a single cookie, so serialize access
+                std::lock_guard<std::mutex> lock(mutex_);
+                const char *mime = magic_buffer(cookie_, data, static_cast<size_t>(length));
+                if (!mime) { return builtin; }
+                std::string detected(mime);
+                if ((detected == "application/octet-stream" || detected == "text/plain") &&
+                    builtin != "application/octet-stream" && builtin != detected) {
+                    return builtin;
+                }
+                return detected;
+            }
+
+        private:
+            magic_t cookie_ = nullptr;
+            std::mutex mutex_;
+        };
+
+        std::unique_ptr<IContentTypeDetector> create_default_content_type_detector() {
+            return std::make_unique<LibmagicContentTypeDetector>();
         }
-        std::string detected(mime);
-        if ((detected == "application/octet-stream" || detected == "text/plain") &&
-            builtin != "application/octet-stream" && builtin != detected) {
-            return builtin;
-        }
-        return detected;
-    }
 
-private:
-    magic_t cookie_ = nullptr;
-    std::mutex mutex_;
-};
-
-std::unique_ptr<IContentTypeDetector> create_default_content_type_detector() {
-    return std::make_unique<LibmagicContentTypeDetector>();
-}
-
-} // namespace grpc_server
-} // namespace omega_edit
+    }// namespace grpc_server
+}// namespace omega_edit

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -20,13 +20,13 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 
-#include <csignal>
+#include <atomic>
+#include <cctype>
+#include <chrono>
 #include <climits>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
-#include <atomic>
-#include <chrono>
-#include <cctype>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
@@ -69,10 +69,14 @@ static void signal_handler(int /*signum*/) { g_shutdown_requested.store(true, st
 
 static const char *log_level_name(LogLevel level) {
     switch (level) {
-        case LogLevel::Debug: return "DEBUG";
-        case LogLevel::Info: return "INFO";
-        case LogLevel::Warn: return "WARN";
-        case LogLevel::Error: return "ERROR";
+        case LogLevel::Debug:
+            return "DEBUG";
+        case LogLevel::Info:
+            return "INFO";
+        case LogLevel::Warn:
+            return "WARN";
+        case LogLevel::Error:
+            return "ERROR";
     }
     return "INFO";
 }
@@ -80,9 +84,7 @@ static const char *log_level_name(LogLevel level) {
 static bool try_parse_log_level(const std::string &value, LogLevel &out) {
     std::string normalized;
     normalized.reserve(value.size());
-    for (char ch : value) {
-        normalized.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
-    }
+    for (char ch : value) { normalized.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch)))); }
     if (normalized == "trace" || normalized == "debug") {
         out = LogLevel::Debug;
         return true;
@@ -105,8 +107,8 @@ static bool try_parse_log_level(const std::string &value, LogLevel &out) {
 static bool parse_log_level(const std::string &value, const std::string &name, LogLevel &out) {
     if (!try_parse_log_level(value, out)) {
         std::cerr << "Error: " << name
-                  << " must be one of trace, debug, info, warn, warning, error, fatal, critical; got: "
-                  << value << "\n";
+                  << " must be one of trace, debug, info, warn, warning, error, fatal, critical; got: " << value
+                  << "\n";
         return false;
     }
     return true;
@@ -127,14 +129,11 @@ static std::string current_timestamp() {
 }
 
 static void log_message(LogLevel level, const std::string &message) {
-    if (static_cast<int>(level) < static_cast<int>(g_log_level)) {
-        return;
-    }
+    if (static_cast<int>(level) < static_cast<int>(g_log_level)) { return; }
 
     std::lock_guard<std::mutex> lock(g_log_mutex);
-    (*g_log_stream) << "[" << current_timestamp() << "] "
-                    << "[" << log_level_name(level) << "] "
-                    << message << std::endl;
+    (*g_log_stream) << "[" << current_timestamp() << "] " << "[" << log_level_name(level) << "] " << message
+                    << std::endl;
 }
 
 static bool configure_log_output(const std::string &log_file) {
@@ -167,14 +166,10 @@ static bool apply_log_config_file(const std::string &config_path, std::string &l
     const std::regex root_level_regex(R"OMEGA(<root[^>]*level\s*=\s*"([^"]+)")OMEGA", std::regex::icase);
     std::smatch match;
 
-    if (std::regex_search(contents, match, file_regex)) {
-        log_file = match[1].str();
-    }
+    if (std::regex_search(contents, match, file_regex)) { log_file = match[1].str(); }
     if (std::regex_search(contents, match, root_level_regex)) {
         LogLevel parsed_level;
-        if (!parse_log_level(match[1].str(), "--log-config root level", parsed_level)) {
-            return false;
-        }
+        if (!parse_log_level(match[1].str(), "--log-config root level", parsed_level)) { return false; }
         log_level = parsed_level;
     }
 
@@ -192,8 +187,8 @@ static bool parse_int(const std::string &str, const std::string &name, long min_
             return false;
         }
         if (v < min_val || v > max_val) {
-            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val
-                      << ", got: " << v << "\n";
+            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val << ", got: " << v
+                      << "\n";
             return false;
         }
         out = static_cast<int>(v);
@@ -216,8 +211,8 @@ static bool parse_int64(const std::string &str, const std::string &name, int64_t
             return false;
         }
         if (v < min_val || v > max_val) {
-            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val
-                      << ", got: " << v << "\n";
+            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val << ", got: " << v
+                      << "\n";
             return false;
         }
         out = static_cast<int64_t>(v);
@@ -230,8 +225,7 @@ static bool parse_int64(const std::string &str, const std::string &name, int64_t
 
 /// Parse a string as a size_t in [min_val, max_val], writing the result to out.
 /// Returns true on success; on failure prints a message to stderr and returns false.
-static bool parse_size_t(const std::string &str, const std::string &name, size_t min_val, size_t max_val,
-                         size_t &out) {
+static bool parse_size_t(const std::string &str, const std::string &name, size_t min_val, size_t max_val, size_t &out) {
     try {
         size_t pos = 0;
         unsigned long long v = std::stoull(str, &pos);
@@ -240,8 +234,8 @@ static bool parse_size_t(const std::string &str, const std::string &name, size_t
             return false;
         }
         if (v < min_val || v > max_val) {
-            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val
-                      << ", got: " << v << "\n";
+            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val << ", got: " << v
+                      << "\n";
             return false;
         }
         out = static_cast<size_t>(v);
@@ -262,9 +256,7 @@ static void append_transform_plugin_directories(const std::string &directories, 
     std::stringstream stream(directories);
     std::string directory;
     while (std::getline(stream, directory, delimiter)) {
-        if (!directory.empty()) {
-            out.push_back(directory);
-        }
+        if (!directory.empty()) { out.push_back(directory); }
     }
 }
 
@@ -322,31 +314,21 @@ int main(int argc, char **argv) {
     size_t max_viewports_per_session = resource_limits.max_viewports_per_session;
     std::vector<std::string> transform_plugin_directories;
     // Environment variable defaults
-    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_HOST")) {
-        interface_addr = env;
-    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_HOST")) { interface_addr = env; }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_PORT")) {
         if (!parse_int(env, "OMEGA_EDIT_SERVER_PORT", 1, 65535, port)) return 1;
     }
-    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_UNIX_SOCKET")) {
-        unix_socket = env;
-    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_UNIX_SOCKET")) { unix_socket = env; }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_UNIX_SOCKET_ONLY")) {
         std::string val(env);
-        if (val == "true" || val == "1") {
-            unix_socket_only = true;
-        }
+        if (val == "true" || val == "1") { unix_socket_only = true; }
     }
-    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_PIDFILE")) {
-        pidfile = env;
-    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_PIDFILE")) { pidfile = env; }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_CONFIG")) {
         log_config_file = env;
         if (!apply_log_config_file(log_config_file, log_file, log_level)) return 1;
     }
-    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_FILE")) {
-        log_file = env;
-    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_FILE")) { log_file = env; }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_LEVEL")) {
         if (!parse_log_level(env, "OMEGA_EDIT_SERVER_LOG_LEVEL", log_level)) return 1;
     } else if (const char *env = std::getenv("OMEGA_EDIT_LOG_LEVEL")) {
@@ -366,19 +348,22 @@ int main(int argc, char **argv) {
     }
     if (const char *env = std::getenv("OMEGA_EDIT_SESSION_EVENT_QUEUE_CAPACITY")) {
         if (!parse_size_t(env, "OMEGA_EDIT_SESSION_EVENT_QUEUE_CAPACITY", 0, std::numeric_limits<size_t>::max(),
-                       session_event_queue_capacity)) return 1;
+                          session_event_queue_capacity))
+            return 1;
     }
     if (const char *env = std::getenv("OMEGA_EDIT_VIEWPORT_EVENT_QUEUE_CAPACITY")) {
         if (!parse_size_t(env, "OMEGA_EDIT_VIEWPORT_EVENT_QUEUE_CAPACITY", 0, std::numeric_limits<size_t>::max(),
-                       viewport_event_queue_capacity)) return 1;
+                          viewport_event_queue_capacity))
+            return 1;
     }
     if (const char *env = std::getenv("OMEGA_EDIT_MAX_CHANGE_BYTES")) {
-        if (!parse_int64(env, "OMEGA_EDIT_MAX_CHANGE_BYTES", 0, std::numeric_limits<int64_t>::max(),
-                         max_change_bytes)) return 1;
+        if (!parse_int64(env, "OMEGA_EDIT_MAX_CHANGE_BYTES", 0, std::numeric_limits<int64_t>::max(), max_change_bytes))
+            return 1;
     }
     if (const char *env = std::getenv("OMEGA_EDIT_MAX_VIEWPORTS_PER_SESSION")) {
         if (!parse_size_t(env, "OMEGA_EDIT_MAX_VIEWPORTS_PER_SESSION", 0, std::numeric_limits<size_t>::max(),
-                       max_viewports_per_session)) return 1;
+                          max_viewports_per_session))
+            return 1;
     }
     if (const char *env = std::getenv("OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS")) {
         append_transform_plugin_directories(env, transform_plugin_directories);
@@ -408,9 +393,7 @@ int main(int argc, char **argv) {
             } else {
                 key = arg;
                 // Only consume the next argument as a value if it exists and doesn't look like a flag
-                if (i + 1 < argc && argv[i + 1][0] != '-') {
-                    value = argv[++i];
-                }
+                if (i + 1 < argc && argv[i + 1][0] != '-') { value = argv[++i]; }
             }
 
             if (key == "-i" || key == "--interface") {
@@ -470,12 +453,8 @@ int main(int argc, char **argv) {
                 std::string config_log_file = log_file;
                 LogLevel config_log_level = log_level;
                 if (!apply_log_config_file(log_config_file, config_log_file, config_log_level)) return 1;
-                if (!has_explicit_log_file) {
-                    log_file = config_log_file;
-                }
-                if (!has_explicit_log_level) {
-                    log_level = config_log_level;
-                }
+                if (!has_explicit_log_file) { log_file = config_log_file; }
+                if (!has_explicit_log_level) { log_level = config_log_level; }
             } else if (key == "--session-timeout") {
                 if (value.empty()) {
                     std::cerr << "Error: " << key << " requires a value\n";
@@ -494,28 +473,31 @@ int main(int argc, char **argv) {
                     return 1;
                 }
                 if (!parse_size_t(value, "--session-event-queue-capacity", 0, std::numeric_limits<size_t>::max(),
-                               session_event_queue_capacity)) return 1;
+                                  session_event_queue_capacity))
+                    return 1;
             } else if (key == "--viewport-event-queue-capacity") {
                 if (value.empty()) {
                     std::cerr << "Error: " << key << " requires a value\n";
                     return 1;
                 }
                 if (!parse_size_t(value, "--viewport-event-queue-capacity", 0, std::numeric_limits<size_t>::max(),
-                               viewport_event_queue_capacity)) return 1;
+                                  viewport_event_queue_capacity))
+                    return 1;
             } else if (key == "--max-change-bytes") {
                 if (value.empty()) {
                     std::cerr << "Error: " << key << " requires a value\n";
                     return 1;
                 }
-                if (!parse_int64(value, "--max-change-bytes", 0, std::numeric_limits<int64_t>::max(),
-                                 max_change_bytes)) return 1;
+                if (!parse_int64(value, "--max-change-bytes", 0, std::numeric_limits<int64_t>::max(), max_change_bytes))
+                    return 1;
             } else if (key == "--max-viewports-per-session") {
                 if (value.empty()) {
                     std::cerr << "Error: " << key << " requires a value\n";
                     return 1;
                 }
                 if (!parse_size_t(value, "--max-viewports-per-session", 0, std::numeric_limits<size_t>::max(),
-                               max_viewports_per_session)) return 1;
+                                  max_viewports_per_session))
+                    return 1;
             } else if (key == "--transform-plugin-dir") {
                 if (value.empty()) {
                     std::cerr << "Error: " << key << " requires a value\n";
@@ -529,9 +511,7 @@ int main(int argc, char **argv) {
 
     g_log_level = log_level;
     if (!configure_log_output(log_file)) return 1;
-    if (!log_file.empty()) {
-        log_message(LogLevel::Info, "native server logging redirected to " + log_file);
-    }
+    if (!log_file.empty()) { log_message(LogLevel::Info, "native server logging redirected to " + log_file); }
 
     // Write PID file
     int pid = getpid();
@@ -586,13 +566,13 @@ int main(int argc, char **argv) {
         std::string unix_addr = "unix:" + unix_socket;
         builder.AddListeningPort(unix_addr, grpc::InsecureServerCredentials());
         log_message(LogLevel::Info, std::string("Ωedit gRPC server (v") + SERVER_VERSION + ") with PID " +
-                                         std::to_string(pid) + " bound to " + unix_addr + ": ready...");
+                                            std::to_string(pid) + " bound to " + unix_addr + ": ready...");
 #endif
     } else {
         std::string server_address = interface_addr + ":" + std::to_string(port);
         builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
         log_message(LogLevel::Info, std::string("Ωedit gRPC server (v") + SERVER_VERSION + ") with PID " +
-                                         std::to_string(pid) + " bound to " + server_address + ": ready...");
+                                            std::to_string(pid) + " bound to " + server_address + ": ready...");
 
 #ifndef _WIN32
         if (!unix_socket.empty()) {
@@ -619,9 +599,7 @@ int main(int argc, char **argv) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
         std::cerr << "Received shutdown signal, shutting down..." << std::endl;
-        if (g_server) {
-            g_server->Shutdown();
-        }
+        if (g_server) { g_server->Shutdown(); }
     });
 
     g_server->Wait();
@@ -630,9 +608,7 @@ int main(int argc, char **argv) {
     std::cerr << "Ωedit gRPC server (v" << SERVER_VERSION << ") with PID " << pid << ": exiting..." << std::endl;
 
     // Cleanup PID file
-    if (!pidfile.empty()) {
-        std::remove(pidfile.c_str());
-    }
+    if (!pidfile.empty()) { std::remove(pidfile.c_str()); }
 
     return 0;
 }

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -49,1128 +49,1149 @@
 #endif
 
 namespace omega_edit {
-namespace grpc_server {
-namespace fs = std::filesystem;
+    namespace grpc_server {
+        namespace fs = std::filesystem;
 
-namespace {
+        namespace {
 
-constexpr char kManagedTempRootName[] = "omega-edit-grpc-server";
-constexpr char kManagedServerPrefix[] = "server-";
-constexpr char kManagedSessionPrefix[] = "session-";
-constexpr char kSessionIdPrefix[] = "sess_";
-constexpr char kViewportIdPrefix[] = "vp_";
-constexpr char kSubscriptionIdPrefix[] = "sub_";
-constexpr size_t kMaxCallerIdBytes = 128;
+            constexpr char kManagedTempRootName[] = "omega-edit-grpc-server";
+            constexpr char kManagedServerPrefix[] = "server-";
+            constexpr char kManagedSessionPrefix[] = "session-";
+            constexpr char kSessionIdPrefix[] = "sess_";
+            constexpr char kViewportIdPrefix[] = "vp_";
+            constexpr char kSubscriptionIdPrefix[] = "sub_";
+            constexpr size_t kMaxCallerIdBytes = 128;
 
-bool is_valid_external_id_char(unsigned char ch) {
-    return std::isalnum(ch) != 0 || ch == '_' || ch == '-' || ch == '.';
-}
+            bool is_valid_external_id_char(unsigned char ch) {
+                return std::isalnum(ch) != 0 || ch == '_' || ch == '-' || ch == '.';
+            }
 
-bool is_valid_external_id(const std::string &id) {
-    return !id.empty() && id.size() <= kMaxCallerIdBytes &&
-           std::all_of(id.begin(), id.end(),
-                       [](unsigned char ch) { return is_valid_external_id_char(ch); });
-}
+            bool is_valid_external_id(const std::string &id) {
+                return !id.empty() && id.size() <= kMaxCallerIdBytes &&
+                       std::all_of(id.begin(), id.end(),
+                                   [](unsigned char ch) { return is_valid_external_id_char(ch); });
+            }
 
-bool is_control_or_nul_byte(unsigned char ch) {
-    return ch == '\0' || ch < 0x20U || ch == 0x7FU;
-}
+            bool is_control_or_nul_byte(unsigned char ch) { return ch == '\0' || ch < 0x20U || ch == 0x7FU; }
 
-bool is_valid_external_path(const std::string &path) {
-    return path.size() < FILENAME_MAX &&
-           std::none_of(path.begin(), path.end(), [](unsigned char ch) { return is_control_or_nul_byte(ch); });
-}
+            bool is_valid_external_path(const std::string &path) {
+                return path.size() < FILENAME_MAX && std::none_of(path.begin(), path.end(), [](unsigned char ch) {
+                           return is_control_or_nul_byte(ch);
+                       });
+            }
 
-int get_current_process_id() {
+            int get_current_process_id() {
 #ifdef _WIN32
-    return static_cast<int>(GetCurrentProcessId());
+                return static_cast<int>(GetCurrentProcessId());
 #else
-    return static_cast<int>(getpid());
+                return static_cast<int>(getpid());
 #endif
-}
+            }
 
-std::string get_managed_temp_root_path() {
-    char *temp_dir = omega_util_get_temp_directory();
-    if (temp_dir == nullptr) { return ""; }
+            std::string get_managed_temp_root_path() {
+                char *temp_dir = omega_util_get_temp_directory();
+                if (temp_dir == nullptr) { return ""; }
 
-    const std::string root_path = (fs::path(temp_dir) / kManagedTempRootName).string();
-    free(temp_dir);
-    return root_path;
-}
+                const std::string root_path = (fs::path(temp_dir) / kManagedTempRootName).string();
+                free(temp_dir);
+                return root_path;
+            }
 
-bool parse_managed_server_root_pid(const std::string &name, int &pid_out) {
-    if (name.rfind(kManagedServerPrefix, 0) != 0) { return false; }
+            bool parse_managed_server_root_pid(const std::string &name, int &pid_out) {
+                if (name.rfind(kManagedServerPrefix, 0) != 0) { return false; }
 
-    const size_t pid_start = std::strlen(kManagedServerPrefix);
-    const size_t pid_end = name.find('-', pid_start);
-    if (pid_end == std::string::npos || pid_end == pid_start) { return false; }
+                const size_t pid_start = std::strlen(kManagedServerPrefix);
+                const size_t pid_end = name.find('-', pid_start);
+                if (pid_end == std::string::npos || pid_end == pid_start) { return false; }
 
-    const std::string pid_str = name.substr(pid_start, pid_end - pid_start);
-    if (!std::all_of(pid_str.begin(), pid_str.end(), [](unsigned char ch) { return std::isdigit(ch) != 0; })) {
-        return false;
-    }
+                const std::string pid_str = name.substr(pid_start, pid_end - pid_start);
+                if (!std::all_of(pid_str.begin(), pid_str.end(),
+                                 [](unsigned char ch) { return std::isdigit(ch) != 0; })) {
+                    return false;
+                }
 
-    try {
-        pid_out = std::stoi(pid_str);
-    } catch (...) { return false; }
+                try {
+                    pid_out = std::stoi(pid_str);
+                } catch (...) { return false; }
 
-    return pid_out > 0;
-}
+                return pid_out > 0;
+            }
 
-bool is_process_alive(int pid) {
-    if (pid <= 0) { return false; }
+            bool is_process_alive(int pid) {
+                if (pid <= 0) { return false; }
 
 #ifdef _WIN32
-    HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(pid));
-    if (process == nullptr) { return false; }
+                HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(pid));
+                if (process == nullptr) { return false; }
 
-    DWORD exit_code = 0;
-    const BOOL ok = GetExitCodeProcess(process, &exit_code);
-    CloseHandle(process);
-    return ok != FALSE && exit_code == STILL_ACTIVE;
+                DWORD exit_code = 0;
+                const BOOL ok = GetExitCodeProcess(process, &exit_code);
+                CloseHandle(process);
+                return ok != FALSE && exit_code == STILL_ACTIVE;
 #else
-    if (kill(static_cast<pid_t>(pid), 0) == 0) { return true; }
+                if (kill(static_cast<pid_t>(pid), 0) == 0) { return true; }
 
-    return errno == EPERM;
+                return errno == EPERM;
 #endif
-}
+            }
 
-int32_t combine_session_event_interest(const std::vector<SessionEventSubscriptionInfo> &subscriptions) {
-    uint32_t combined = 0;
-    for (const auto &subscription : subscriptions) { combined |= static_cast<uint32_t>(subscription.interest); }
-    return static_cast<int32_t>(combined);
-}
+            int32_t combine_session_event_interest(const std::vector<SessionEventSubscriptionInfo> &subscriptions) {
+                uint32_t combined = 0;
+                for (const auto &subscription : subscriptions) {
+                    combined |= static_cast<uint32_t>(subscription.interest);
+                }
+                return static_cast<int32_t>(combined);
+            }
 
-int32_t combine_viewport_event_interest(const std::vector<ViewportEventSubscriptionInfo> &subscriptions) {
-    uint32_t combined = 0;
-    for (const auto &subscription : subscriptions) { combined |= static_cast<uint32_t>(subscription.interest); }
-    return static_cast<int32_t>(combined);
-}
+            int32_t combine_viewport_event_interest(const std::vector<ViewportEventSubscriptionInfo> &subscriptions) {
+                uint32_t combined = 0;
+                for (const auto &subscription : subscriptions) {
+                    combined |= static_cast<uint32_t>(subscription.interest);
+                }
+                return static_cast<int32_t>(combined);
+            }
 
-bool normalize_existing_file_path(const std::string &file_path, std::string &normalized_path_out) {
-    char normalized_path[FILENAME_MAX] = {};
-    char *result = omega_util_normalize_path(file_path.c_str(), normalized_path);
-    if (result == nullptr) { return false; }
+            bool normalize_existing_file_path(const std::string &file_path, std::string &normalized_path_out) {
+                char normalized_path[FILENAME_MAX] = {};
+                char *result = omega_util_normalize_path(file_path.c_str(), normalized_path);
+                if (result == nullptr) { return false; }
 
-    normalized_path_out = result;
-    return !normalized_path_out.empty();
-}
+                normalized_path_out = result;
+                return !normalized_path_out.empty();
+            }
 
-uint64_t random_u64(std::mt19937_64 &rng) {
-    std::uniform_int_distribution<uint64_t> dis;
-    return dis(rng);
-}
+            uint64_t random_u64(std::mt19937_64 &rng) {
+                std::uniform_int_distribution<uint64_t> dis;
+                return dis(rng);
+            }
 
-std::mt19937_64 create_seeded_rng() {
-    std::random_device rd;
-    std::seed_seq seed{
-            rd(),
-            rd(),
-            rd(),
-            rd(),
-            static_cast<unsigned int>(std::chrono::steady_clock::now().time_since_epoch().count()),
-    };
-    return std::mt19937_64(seed);
-}
+            std::mt19937_64 create_seeded_rng() {
+                std::random_device rd;
+                std::seed_seq seed{
+                        rd(),
+                        rd(),
+                        rd(),
+                        rd(),
+                        static_cast<unsigned int>(std::chrono::steady_clock::now().time_since_epoch().count()),
+                };
+                return std::mt19937_64(seed);
+            }
 
-std::string format_uuid(uint64_t hi, uint64_t lo) {
-    char buf[37];
-    std::snprintf(buf, sizeof(buf), "%08" PRIx32 "-%04" PRIx16 "-%04" PRIx16 "-%04" PRIx16 "-%012" PRIx64,
-                  static_cast<uint32_t>(hi >> 32), static_cast<uint16_t>(hi >> 16), static_cast<uint16_t>(hi),
-                  static_cast<uint16_t>(lo >> 48), static_cast<uint64_t>(lo & 0x0000FFFFFFFFFFFFULL));
-    return std::string(buf);
-}
+            std::string format_uuid(uint64_t hi, uint64_t lo) {
+                char buf[37];
+                std::snprintf(buf, sizeof(buf), "%08" PRIx32 "-%04" PRIx16 "-%04" PRIx16 "-%04" PRIx16 "-%012" PRIx64,
+                              static_cast<uint32_t>(hi >> 32), static_cast<uint16_t>(hi >> 16),
+                              static_cast<uint16_t>(hi), static_cast<uint16_t>(lo >> 48),
+                              static_cast<uint64_t>(lo & 0x0000FFFFFFFFFFFFULL));
+                return std::string(buf);
+            }
 
-} // namespace
+        }// namespace
 
-SessionOperationGuard::SessionOperationGuard(SessionManager *manager, std::string session_id, SessionOperationKind kind,
-                                             SessionOperationStartResult result)
-    : manager_(manager), session_id_(std::move(session_id)), kind_(kind), result_(result) {}
+        SessionOperationGuard::SessionOperationGuard(SessionManager *manager, std::string session_id,
+                                                     SessionOperationKind kind, SessionOperationStartResult result)
+            : manager_(manager), session_id_(std::move(session_id)), kind_(kind), result_(result) {}
 
-SessionOperationGuard::SessionOperationGuard(SessionOperationGuard &&other) noexcept
-    : manager_(other.manager_), session_id_(std::move(other.session_id_)), kind_(other.kind_), result_(other.result_) {
-    other.manager_ = nullptr;
-    other.result_ = SessionOperationStartResult::SESSION_NOT_FOUND;
-}
+        SessionOperationGuard::SessionOperationGuard(SessionOperationGuard &&other) noexcept
+            : manager_(other.manager_), session_id_(std::move(other.session_id_)), kind_(other.kind_),
+              result_(other.result_) {
+            other.manager_ = nullptr;
+            other.result_ = SessionOperationStartResult::SESSION_NOT_FOUND;
+        }
 
-auto SessionOperationGuard::operator=(SessionOperationGuard &&other) noexcept -> SessionOperationGuard & {
-    if (this != &other) {
-        release();
-        manager_ = other.manager_;
-        session_id_ = std::move(other.session_id_);
-        kind_ = other.kind_;
-        result_ = other.result_;
-        other.manager_ = nullptr;
-        other.result_ = SessionOperationStartResult::SESSION_NOT_FOUND;
-    }
-    return *this;
-}
+        auto SessionOperationGuard::operator=(SessionOperationGuard &&other) noexcept -> SessionOperationGuard & {
+            if (this != &other) {
+                release();
+                manager_ = other.manager_;
+                session_id_ = std::move(other.session_id_);
+                kind_ = other.kind_;
+                result_ = other.result_;
+                other.manager_ = nullptr;
+                other.result_ = SessionOperationStartResult::SESSION_NOT_FOUND;
+            }
+            return *this;
+        }
 
-SessionOperationGuard::~SessionOperationGuard() { release(); }
+        SessionOperationGuard::~SessionOperationGuard() { release(); }
 
-void SessionOperationGuard::release() {
-    if (manager_ && result_ == SessionOperationStartResult::STARTED) { manager_->finish_operation(session_id_, kind_); }
-    manager_ = nullptr;
-    result_ = SessionOperationStartResult::SESSION_NOT_FOUND;
-}
+        void SessionOperationGuard::release() {
+            if (manager_ && result_ == SessionOperationStartResult::STARTED) {
+                manager_->finish_operation(session_id_, kind_);
+            }
+            manager_ = nullptr;
+            result_ = SessionOperationStartResult::SESSION_NOT_FOUND;
+        }
 
-// ── UUID generation ──────────────────────────────────────────────────────────
-static std::string generate_random_uuid_fallback() {
-    static thread_local std::mt19937_64 rng = create_seeded_rng();
-    uint64_t hi = random_u64(rng);
-    uint64_t lo = random_u64(rng);
-    // Set version 4 and variant bits per RFC 4122
-    hi = (hi & 0xFFFFFFFFFFFF0FFFULL) | 0x0000000000004000ULL;
-    lo = (lo & 0x3FFFFFFFFFFFFFFFULL) | 0x8000000000000000ULL;
-    return format_uuid(hi, lo);
-}
+        // ── UUID generation ──────────────────────────────────────────────────────────
+        static std::string generate_random_uuid_fallback() {
+            static thread_local std::mt19937_64 rng = create_seeded_rng();
+            uint64_t hi = random_u64(rng);
+            uint64_t lo = random_u64(rng);
+            // Set version 4 and variant bits per RFC 4122
+            hi = (hi & 0xFFFFFFFFFFFF0FFFULL) | 0x0000000000004000ULL;
+            lo = (lo & 0x3FFFFFFFFFFFFFFFULL) | 0x8000000000000000ULL;
+            return format_uuid(hi, lo);
+        }
 
-std::string SessionManager::generate_uuid_v4() {
+        std::string SessionManager::generate_uuid_v4() {
 #ifdef _WIN32
-    UUID uuid;
-    if (UuidCreate(&uuid) != RPC_S_OK) { return generate_random_uuid_fallback(); }
-    RPC_CSTR str = nullptr;
-    if (UuidToStringA(&uuid, &str) != RPC_S_OK) {
-        if (str != nullptr) RpcStringFreeA(&str);
-        return generate_random_uuid_fallback();
-    }
-    if (str == nullptr) { return generate_random_uuid_fallback(); }
-    std::string result(reinterpret_cast<char *>(str));
-    RpcStringFreeA(&str);
-    return result;
+            UUID uuid;
+            if (UuidCreate(&uuid) != RPC_S_OK) { return generate_random_uuid_fallback(); }
+            RPC_CSTR str = nullptr;
+            if (UuidToStringA(&uuid, &str) != RPC_S_OK) {
+                if (str != nullptr) RpcStringFreeA(&str);
+                return generate_random_uuid_fallback();
+            }
+            if (str == nullptr) { return generate_random_uuid_fallback(); }
+            std::string result(reinterpret_cast<char *>(str));
+            RpcStringFreeA(&str);
+            return result;
 #else
 #ifdef OMEGA_EDIT_HAS_LIBUUID
-    uuid_t uuid;
-    char str[37];
-    uuid_generate(uuid);
-    uuid_unparse_lower(uuid, str);
-    return std::string(str);
+            uuid_t uuid;
+            char str[37];
+            uuid_generate(uuid);
+            uuid_unparse_lower(uuid, str);
+            return std::string(str);
 #else
-    return generate_random_uuid_fallback();
+            return generate_random_uuid_fallback();
 #endif
 #endif
-}
+        }
 
-std::string SessionManager::generate_uuid_v7() {
-    struct UuidV7State {
-        std::mutex mutex;
-        uint64_t last_timestamp_ms{0};
-        uint16_t rand_a{0};
-        uint64_t rand_b{0};
-        std::mt19937_64 rng{create_seeded_rng()};
-    };
+        std::string SessionManager::generate_uuid_v7() {
+            struct UuidV7State {
+                std::mutex mutex;
+                uint64_t last_timestamp_ms{0};
+                uint16_t rand_a{0};
+                uint64_t rand_b{0};
+                std::mt19937_64 rng{create_seeded_rng()};
+            };
 
-    static UuidV7State state;
+            static UuidV7State state;
 
-    const auto now_ms = static_cast<uint64_t>(
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
-                    .count());
+            const auto now_ms = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                                              std::chrono::system_clock::now().time_since_epoch())
+                                                              .count());
 
-    std::lock_guard<std::mutex> lock(state.mutex);
+            std::lock_guard<std::mutex> lock(state.mutex);
 
-    uint64_t timestamp_ms = now_ms;
-    if (timestamp_ms > state.last_timestamp_ms) {
-        state.last_timestamp_ms = timestamp_ms;
-        state.rand_a = static_cast<uint16_t>(random_u64(state.rng) & 0x0FFFU);
-        state.rand_b = random_u64(state.rng) & 0x3FFFFFFFFFFFFFFFULL;
-    } else {
-        timestamp_ms = state.last_timestamp_ms;
-        if (state.rand_b == 0x3FFFFFFFFFFFFFFFULL) {
-            state.rand_b = 0;
-            state.rand_a = static_cast<uint16_t>((state.rand_a + 1U) & 0x0FFFU);
-            if (state.rand_a == 0) {
-                ++state.last_timestamp_ms;
+            uint64_t timestamp_ms = now_ms;
+            if (timestamp_ms > state.last_timestamp_ms) {
+                state.last_timestamp_ms = timestamp_ms;
+                state.rand_a = static_cast<uint16_t>(random_u64(state.rng) & 0x0FFFU);
+                state.rand_b = random_u64(state.rng) & 0x3FFFFFFFFFFFFFFFULL;
+            } else {
                 timestamp_ms = state.last_timestamp_ms;
+                if (state.rand_b == 0x3FFFFFFFFFFFFFFFULL) {
+                    state.rand_b = 0;
+                    state.rand_a = static_cast<uint16_t>((state.rand_a + 1U) & 0x0FFFU);
+                    if (state.rand_a == 0) {
+                        ++state.last_timestamp_ms;
+                        timestamp_ms = state.last_timestamp_ms;
+                    }
+                } else {
+                    ++state.rand_b;
+                }
             }
-        } else {
-            ++state.rand_b;
+
+            const uint64_t hi = ((timestamp_ms & 0x0000FFFFFFFFFFFFULL) << 16) | (0x7ULL << 12) |
+                                static_cast<uint64_t>(state.rand_a & 0x0FFFU);
+            const uint64_t lo = 0x8000000000000000ULL | (state.rand_b & 0x3FFFFFFFFFFFFFFFULL);
+            return format_uuid(hi, lo);
         }
-    }
 
-    const uint64_t hi = ((timestamp_ms & 0x0000FFFFFFFFFFFFULL) << 16) | (0x7ULL << 12) |
-                        static_cast<uint64_t>(state.rand_a & 0x0FFFU);
-    const uint64_t lo = 0x8000000000000000ULL | (state.rand_b & 0x3FFFFFFFFFFFFFFFULL);
-    return format_uuid(hi, lo);
-}
-
-std::string SessionManager::generate_prefixed_id(const char *prefix) {
-    return std::string(prefix) + generate_uuid_v7();
-}
-
-std::string SessionManager::generate_session_id() { return generate_prefixed_id(kSessionIdPrefix); }
-
-std::string SessionManager::generate_viewport_id() { return generate_prefixed_id(kViewportIdPrefix); }
-
-std::string SessionManager::generate_subscription_id() { return generate_prefixed_id(kSubscriptionIdPrefix); }
-
-std::string SessionManager::make_viewport_fqid(const std::string &session_id, const std::string &viewport_id) {
-    return session_id + ":" + viewport_id;
-}
-
-void SessionManager::cleanup_directory_best_effort(const std::string &directory_path) {
-    if (directory_path.empty()) { return; }
-
-    std::error_code ec;
-    fs::remove_all(fs::path(directory_path), ec);
-}
-
-void SessionManager::cleanup_stale_server_roots_best_effort(const std::string &root_path) {
-    if (root_path.empty()) { return; }
-
-    std::error_code ec;
-    const fs::path managed_root(root_path);
-    if (!fs::exists(managed_root, ec) || !fs::is_directory(managed_root, ec)) { return; }
-
-    for (fs::directory_iterator it(managed_root, ec), end; !ec && it != end; it.increment(ec)) {
-        std::error_code entry_ec;
-        if (!it->is_directory(entry_ec)) { continue; }
-
-        const std::string name = it->path().filename().string();
-        if (!is_managed_server_root_name(name)) { continue; }
-
-        int pid = 0;
-        if (!parse_managed_server_root_pid(name, pid) || is_process_alive(pid)) { continue; }
-
-        std::error_code remove_ec;
-        fs::remove_all(it->path(), remove_ec);
-    }
-}
-
-bool SessionManager::is_managed_server_root_name(const std::string &name) {
-    int pid = 0;
-    return parse_managed_server_root_pid(name, pid);
-}
-
-std::string SessionManager::create_server_root_name() {
-    return std::string(kManagedServerPrefix) + std::to_string(get_current_process_id()) + "-" + generate_uuid_v4();
-}
-
-std::string SessionManager::create_managed_checkpoint_directory() {
-    if (managed_server_root_.empty()) {
-        const std::string managed_root_parent = get_managed_temp_root_path();
-        if (managed_root_parent.empty()) { return ""; }
-
-        std::error_code ec;
-        const fs::path managed_root_parent_path(managed_root_parent);
-        fs::create_directories(managed_root_parent_path, ec);
-        if (ec) { return ""; }
-
-        cleanup_stale_server_roots_best_effort(managed_root_parent);
-
-        const fs::path server_root = managed_root_parent_path / create_server_root_name();
-        ec.clear();
-        fs::create_directories(server_root, ec);
-        if (ec) { return ""; }
-
-        managed_server_root_ = server_root.string();
-    }
-
-    std::error_code ec;
-    const fs::path checkpoint_directory =
-            fs::path(managed_server_root_) / (std::string(kManagedSessionPrefix) + generate_uuid_v4());
-    fs::create_directories(checkpoint_directory, ec);
-    if (ec) { return ""; }
-
-    return checkpoint_directory.string();
-}
-
-void SessionManager::cleanup_managed_server_root_if_empty() {
-    if (managed_server_root_.empty() || !sessions_.empty()) { return; }
-
-    std::error_code ec;
-    const fs::path server_root(managed_server_root_);
-    if (fs::exists(server_root, ec) && fs::is_directory(server_root, ec) && fs::is_empty(server_root, ec)) {
-        ec.clear();
-        fs::remove(server_root, ec);
-    }
-
-    ec.clear();
-    if (!fs::exists(server_root, ec)) { managed_server_root_.clear(); }
-}
-
-// ── Callbacks ────────────────────────────────────────────────────────────────
-void SessionManager::session_event_callback(const omega_session_t *session, omega_session_event_t event,
-                                            const void *ptr) {
-    auto *info = static_cast<SessionInfo *>(const_cast<void *>(omega_session_get_user_data_ptr(session)));
-    if (!info) return;
-
-    SessionEventData evt;
-    evt.session_id = info->session_id;
-    evt.session_event_kind = static_cast<int32_t>(event);
-    evt.computed_file_size = omega_session_get_computed_file_size(session);
-    evt.change_count = omega_session_get_num_changes(session);
-    evt.undo_count = omega_session_get_num_undone_changes(session);
-
-    // EDIT, UNDO, and content-changing TRANSFORM events provide an omega_change_t* payload.
-    // CLEAR is notified with nullptr; other events pass different types
-    // (e.g., viewport pointer for CREATE_VIEWPORT/DESTROY_VIEWPORT, char* for SAVE).
-    evt.serial = 0;
-    switch (event) {
-    case SESSION_EVT_EDIT:
-    case SESSION_EVT_UNDO:
-    case SESSION_EVT_TRANSFORM:
-        if (ptr) {
-            auto *change = static_cast<const omega_change_t *>(ptr);
-            evt.serial = omega_change_get_serial(change);
+        std::string SessionManager::generate_prefixed_id(const char *prefix) {
+            return std::string(prefix) + generate_uuid_v7();
         }
-        break;
-    default:
-        break;
-    }
 
-    const auto event_kind = static_cast<int32_t>(event);
-    const auto event_mask = static_cast<uint32_t>(event_kind);
-    std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
-    {
-        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-        subscribers.reserve(info->session_subscriptions.size());
-        for (const auto &subscription : info->session_subscriptions) {
-            if (subscription.event_queue && ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
-                subscribers.push_back(subscription.event_queue);
+        std::string SessionManager::generate_session_id() { return generate_prefixed_id(kSessionIdPrefix); }
+
+        std::string SessionManager::generate_viewport_id() { return generate_prefixed_id(kViewportIdPrefix); }
+
+        std::string SessionManager::generate_subscription_id() { return generate_prefixed_id(kSubscriptionIdPrefix); }
+
+        std::string SessionManager::make_viewport_fqid(const std::string &session_id, const std::string &viewport_id) {
+            return session_id + ":" + viewport_id;
+        }
+
+        void SessionManager::cleanup_directory_best_effort(const std::string &directory_path) {
+            if (directory_path.empty()) { return; }
+
+            std::error_code ec;
+            fs::remove_all(fs::path(directory_path), ec);
+        }
+
+        void SessionManager::cleanup_stale_server_roots_best_effort(const std::string &root_path) {
+            if (root_path.empty()) { return; }
+
+            std::error_code ec;
+            const fs::path managed_root(root_path);
+            if (!fs::exists(managed_root, ec) || !fs::is_directory(managed_root, ec)) { return; }
+
+            for (fs::directory_iterator it(managed_root, ec), end; !ec && it != end; it.increment(ec)) {
+                std::error_code entry_ec;
+                if (!it->is_directory(entry_ec)) { continue; }
+
+                const std::string name = it->path().filename().string();
+                if (!is_managed_server_root_name(name)) { continue; }
+
+                int pid = 0;
+                if (!parse_managed_server_root_pid(name, pid) || is_process_alive(pid)) { continue; }
+
+                std::error_code remove_ec;
+                fs::remove_all(it->path(), remove_ec);
             }
         }
-    }
 
-    for (const auto &subscriber : subscribers) { subscriber->push(evt); }
-}
-
-void SessionManager::viewport_event_callback(const omega_viewport_t *viewport, omega_viewport_event_t event,
-                                             const void *ptr) {
-    auto *info = static_cast<ViewportInfo *>(const_cast<void *>(omega_viewport_get_user_data_ptr(viewport)));
-    if (!info) return;
-
-    ViewportEventData evt;
-    evt.session_id = info->session_id;
-    evt.viewport_id = info->viewport_id;
-    evt.viewport_event_kind = static_cast<int32_t>(event);
-
-    // EDIT, UNDO, and content-changing TRANSFORM events provide an omega_change_t* payload.
-    // CLEAR is notified with nullptr; CREATE passes a viewport pointer.
-    evt.serial = 0;
-    switch (event) {
-    case VIEWPORT_EVT_EDIT:
-    case VIEWPORT_EVT_UNDO:
-    case VIEWPORT_EVT_TRANSFORM:
-        if (ptr) {
-            auto *change = static_cast<const omega_change_t *>(ptr);
-            evt.serial = omega_change_get_serial(change);
+        bool SessionManager::is_managed_server_root_name(const std::string &name) {
+            int pid = 0;
+            return parse_managed_server_root_pid(name, pid);
         }
-        break;
-    default:
-        break;
-    }
 
-    evt.offset = omega_viewport_get_offset(viewport);
-    auto length = omega_viewport_get_length(viewport);
-    evt.length = length;
-    const auto *data = omega_viewport_get_data(viewport);
-    if (data && length > 0) { evt.data.assign(data, data + length); }
+        std::string SessionManager::create_server_root_name() {
+            return std::string(kManagedServerPrefix) + std::to_string(get_current_process_id()) + "-" +
+                   generate_uuid_v4();
+        }
 
-    const auto event_kind = static_cast<int32_t>(event);
-    const auto event_mask = static_cast<uint32_t>(event_kind);
-    std::vector<std::shared_ptr<EventQueue<ViewportEventData>>> subscribers;
-    {
-        std::lock_guard<std::mutex> subscription_lock(info->viewport_subscription_mutex);
-        subscribers.reserve(info->viewport_subscriptions.size());
-        for (const auto &subscription : info->viewport_subscriptions) {
-            if (subscription.event_queue && ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
-                subscribers.push_back(subscription.event_queue);
+        std::string SessionManager::create_managed_checkpoint_directory() {
+            if (managed_server_root_.empty()) {
+                const std::string managed_root_parent = get_managed_temp_root_path();
+                if (managed_root_parent.empty()) { return ""; }
+
+                std::error_code ec;
+                const fs::path managed_root_parent_path(managed_root_parent);
+                fs::create_directories(managed_root_parent_path, ec);
+                if (ec) { return ""; }
+
+                cleanup_stale_server_roots_best_effort(managed_root_parent);
+
+                const fs::path server_root = managed_root_parent_path / create_server_root_name();
+                ec.clear();
+                fs::create_directories(server_root, ec);
+                if (ec) { return ""; }
+
+                managed_server_root_ = server_root.string();
             }
+
+            std::error_code ec;
+            const fs::path checkpoint_directory =
+                    fs::path(managed_server_root_) / (std::string(kManagedSessionPrefix) + generate_uuid_v4());
+            fs::create_directories(checkpoint_directory, ec);
+            if (ec) { return ""; }
+
+            return checkpoint_directory.string();
         }
-    }
 
-    for (const auto &subscriber : subscribers) { subscriber->push(evt); }
-}
+        void SessionManager::cleanup_managed_server_root_if_empty() {
+            if (managed_server_root_.empty() || !sessions_.empty()) { return; }
 
-// ── Constructor / Destructor ─────────────────────────────────────────────────
-SessionManager::SessionManager(ResourceLimits limits) : limits_(limits) {
-    cleanup_stale_server_roots_best_effort(get_managed_temp_root_path());
-}
+            std::error_code ec;
+            const fs::path server_root(managed_server_root_);
+            if (fs::exists(server_root, ec) && fs::is_directory(server_root, ec) && fs::is_empty(server_root, ec)) {
+                ec.clear();
+                fs::remove(server_root, ec);
+            }
 
-SessionManager::~SessionManager() { destroy_all(); }
+            ec.clear();
+            if (!fs::exists(server_root, ec)) { managed_server_root_.clear(); }
+        }
 
-// ── Session lifecycle ────────────────────────────────────────────────────────
-std::string SessionManager::create_session(const std::string &file_path, const std::string &desired_id,
-                                           const std::string &checkpoint_directory, const std::string *initial_data,
-                                           int64_t &file_size_out, std::string &checkpoint_dir_out,
-                                           SessionCreateError *error_out) {
-    std::lock_guard<std::mutex> lock(mutex_);
+        // ── Callbacks ────────────────────────────────────────────────────────────────
+        void SessionManager::session_event_callback(const omega_session_t *session, omega_session_event_t event,
+                                                    const void *ptr) {
+            auto *info = static_cast<SessionInfo *>(const_cast<void *>(omega_session_get_user_data_ptr(session)));
+            if (!info) return;
 
-    if (error_out) { *error_out = SessionCreateError::SUCCESS; }
+            SessionEventData evt;
+            evt.session_id = info->session_id;
+            evt.session_event_kind = static_cast<int32_t>(event);
+            evt.computed_file_size = omega_session_get_computed_file_size(session);
+            evt.change_count = omega_session_get_num_changes(session);
+            evt.undo_count = omega_session_get_num_undone_changes(session);
 
-    if (!file_path.empty() && !is_valid_external_path(file_path)) {
-        if (error_out) { *error_out = SessionCreateError::INVALID_FILE_PATH; }
-        return "";
-    }
-    if (!checkpoint_directory.empty() && !is_valid_external_path(checkpoint_directory)) {
-        if (error_out) { *error_out = SessionCreateError::INVALID_CHECKPOINT_DIRECTORY; }
-        return "";
-    }
+            // EDIT, UNDO, and content-changing TRANSFORM events provide an omega_change_t* payload.
+            // CLEAR is notified with nullptr; other events pass different types
+            // (e.g., viewport pointer for CREATE_VIEWPORT/DESTROY_VIEWPORT, char* for SAVE).
+            evt.serial = 0;
+            switch (event) {
+                case SESSION_EVT_EDIT:
+                case SESSION_EVT_UNDO:
+                case SESSION_EVT_TRANSFORM:
+                    if (ptr) {
+                        auto *change = static_cast<const omega_change_t *>(ptr);
+                        evt.serial = omega_change_get_serial(change);
+                    }
+                    break;
+                default:
+                    break;
+            }
 
-    const bool has_file_backing = !file_path.empty() && initial_data == nullptr;
-    std::string canonical_file_path;
-    if (has_file_backing && !normalize_existing_file_path(file_path, canonical_file_path)) {
-        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
-        return "";
-    }
+            const auto event_kind = static_cast<int32_t>(event);
+            const auto event_mask = static_cast<uint32_t>(event_kind);
+            std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
+            {
+                std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+                subscribers.reserve(info->session_subscriptions.size());
+                for (const auto &subscription : info->session_subscriptions) {
+                    if (subscription.event_queue &&
+                        ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
+                        subscribers.push_back(subscription.event_queue);
+                    }
+                }
+            }
 
-    const bool share_existing_file_session = desired_id.empty() && has_file_backing;
+            for (const auto &subscriber : subscribers) { subscriber->push(evt); }
+        }
 
-    if (share_existing_file_session) {
-        auto existing_file_session = file_sessions_by_path_.find(canonical_file_path);
-        if (existing_file_session != file_sessions_by_path_.end()) {
-            auto existing = sessions_.find(existing_file_session->second);
-            if (existing == sessions_.end()) {
-                file_sessions_by_path_.erase(existing_file_session);
-            } else if (checkpoint_directory.empty() || checkpoint_directory == existing->second->checkpoint_directory) {
-                auto &info = existing->second;
-                std::lock_guard<std::mutex> core_lock(info->core_mutex);
-                const auto computed_size = info->session ? omega_session_get_computed_file_size(info->session) : 0;
-                if (computed_size < 0) {
+        void SessionManager::viewport_event_callback(const omega_viewport_t *viewport, omega_viewport_event_t event,
+                                                     const void *ptr) {
+            auto *info = static_cast<ViewportInfo *>(const_cast<void *>(omega_viewport_get_user_data_ptr(viewport)));
+            if (!info) return;
+
+            ViewportEventData evt;
+            evt.session_id = info->session_id;
+            evt.viewport_id = info->viewport_id;
+            evt.viewport_event_kind = static_cast<int32_t>(event);
+
+            // EDIT, UNDO, and content-changing TRANSFORM events provide an omega_change_t* payload.
+            // CLEAR is notified with nullptr; CREATE passes a viewport pointer.
+            evt.serial = 0;
+            switch (event) {
+                case VIEWPORT_EVT_EDIT:
+                case VIEWPORT_EVT_UNDO:
+                case VIEWPORT_EVT_TRANSFORM:
+                    if (ptr) {
+                        auto *change = static_cast<const omega_change_t *>(ptr);
+                        evt.serial = omega_change_get_serial(change);
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            evt.offset = omega_viewport_get_offset(viewport);
+            auto length = omega_viewport_get_length(viewport);
+            evt.length = length;
+            const auto *data = omega_viewport_get_data(viewport);
+            if (data && length > 0) { evt.data.assign(data, data + length); }
+
+            const auto event_kind = static_cast<int32_t>(event);
+            const auto event_mask = static_cast<uint32_t>(event_kind);
+            std::vector<std::shared_ptr<EventQueue<ViewportEventData>>> subscribers;
+            {
+                std::lock_guard<std::mutex> subscription_lock(info->viewport_subscription_mutex);
+                subscribers.reserve(info->viewport_subscriptions.size());
+                for (const auto &subscription : info->viewport_subscriptions) {
+                    if (subscription.event_queue &&
+                        ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
+                        subscribers.push_back(subscription.event_queue);
+                    }
+                }
+            }
+
+            for (const auto &subscriber : subscribers) { subscriber->push(evt); }
+        }
+
+        // ── Constructor / Destructor ─────────────────────────────────────────────────
+        SessionManager::SessionManager(ResourceLimits limits) : limits_(limits) {
+            cleanup_stale_server_roots_best_effort(get_managed_temp_root_path());
+        }
+
+        SessionManager::~SessionManager() { destroy_all(); }
+
+        // ── Session lifecycle ────────────────────────────────────────────────────────
+        std::string SessionManager::create_session(const std::string &file_path, const std::string &desired_id,
+                                                   const std::string &checkpoint_directory,
+                                                   const std::string *initial_data, int64_t &file_size_out,
+                                                   std::string &checkpoint_dir_out, SessionCreateError *error_out) {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            if (error_out) { *error_out = SessionCreateError::SUCCESS; }
+
+            if (!file_path.empty() && !is_valid_external_path(file_path)) {
+                if (error_out) { *error_out = SessionCreateError::INVALID_FILE_PATH; }
+                return "";
+            }
+            if (!checkpoint_directory.empty() && !is_valid_external_path(checkpoint_directory)) {
+                if (error_out) { *error_out = SessionCreateError::INVALID_CHECKPOINT_DIRECTORY; }
+                return "";
+            }
+
+            const bool has_file_backing = !file_path.empty() && initial_data == nullptr;
+            std::string canonical_file_path;
+            if (has_file_backing && !normalize_existing_file_path(file_path, canonical_file_path)) {
+                if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                return "";
+            }
+
+            const bool share_existing_file_session = desired_id.empty() && has_file_backing;
+
+            if (share_existing_file_session) {
+                auto existing_file_session = file_sessions_by_path_.find(canonical_file_path);
+                if (existing_file_session != file_sessions_by_path_.end()) {
+                    auto existing = sessions_.find(existing_file_session->second);
+                    if (existing == sessions_.end()) {
+                        file_sessions_by_path_.erase(existing_file_session);
+                    } else if (checkpoint_directory.empty() ||
+                               checkpoint_directory == existing->second->checkpoint_directory) {
+                        auto &info = existing->second;
+                        std::lock_guard<std::mutex> core_lock(info->core_mutex);
+                        const auto computed_size =
+                                info->session ? omega_session_get_computed_file_size(info->session) : 0;
+                        if (computed_size < 0) {
+                            if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                            return "";
+                        }
+                        ++info->attachment_count;
+                        info->last_activity = std::chrono::steady_clock::now();
+                        file_size_out = computed_size;
+                        checkpoint_dir_out = info->checkpoint_directory;
+                        return info->session_id;
+                    } else {
+                        if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
+                        return "";
+                    }
+                }
+            }
+
+            // Session ID priority: desired_id > generated opaque session ID
+            std::string session_id;
+            if (!desired_id.empty()) {
+                if (!is_valid_external_id(desired_id)) {
+                    if (error_out) { *error_out = SessionCreateError::INVALID_ID; }
+                    return "";
+                }
+                session_id = desired_id;
+                if (sessions_.count(session_id) != 0) {
+                    if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
+                    return "";// Already exists
+                }
+            } else {
+                do { session_id = generate_session_id(); } while (sessions_.count(session_id) != 0);
+            }
+
+            auto info = std::make_shared<SessionInfo>();
+            info->session_id = session_id;
+            info->canonical_file_path = canonical_file_path;
+            info->attachment_count = 1;
+            info->last_activity = std::chrono::steady_clock::now();
+
+            // Store info first so the callback can find it
+            sessions_[session_id] = info;
+
+            std::string effective_checkpoint_directory = checkpoint_directory;
+            if (effective_checkpoint_directory.empty()) {
+                effective_checkpoint_directory = create_managed_checkpoint_directory();
+                if (effective_checkpoint_directory.empty()) {
+                    sessions_.erase(session_id);
+                    cleanup_managed_server_root_if_empty();
                     if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
                     return "";
                 }
-                ++info->attachment_count;
-                info->last_activity = std::chrono::steady_clock::now();
-                file_size_out = computed_size;
-                checkpoint_dir_out = info->checkpoint_directory;
-                return info->session_id;
+                info->owns_checkpoint_directory = true;
+            }
+
+            info->checkpoint_directory = effective_checkpoint_directory;
+            const char *chkpt_dir =
+                    effective_checkpoint_directory.empty() ? nullptr : effective_checkpoint_directory.c_str();
+
+            omega_session_t *session = nullptr;
+            if (initial_data != nullptr) {
+                session = omega_edit_create_session_from_bytes(
+                        reinterpret_cast<const omega_byte_t *>(initial_data->data()),
+                        static_cast<int64_t>(initial_data->size()), session_event_callback, info.get(), 0, chkpt_dir);
             } else {
-                if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
+                const char *path = canonical_file_path.empty() ? nullptr : canonical_file_path.c_str();
+                session = omega_edit_create_session(path, session_event_callback, info.get(), 0, chkpt_dir);
+            }
+
+            if (!session) {
+                if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
+                sessions_.erase(session_id);
+                cleanup_managed_server_root_if_empty();
+                if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                return "";// Failed to create
+            }
+
+            info->session = session;
+            file_size_out = omega_session_get_computed_file_size(session);
+            if (file_size_out < 0) {
+                omega_edit_destroy_session(session);
+                info->session = nullptr;
+                if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
+                sessions_.erase(session_id);
+                cleanup_managed_server_root_if_empty();
+                if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
                 return "";
             }
+
+            const char *chkpt = omega_session_get_checkpoint_directory(session);
+            checkpoint_dir_out = chkpt ? chkpt : "";
+            if (!checkpoint_dir_out.empty()) { info->checkpoint_directory = checkpoint_dir_out; }
+
+            if (share_existing_file_session) { file_sessions_by_path_[canonical_file_path] = session_id; }
+
+            return session_id;
         }
-    }
 
-    // Session ID priority: desired_id > generated opaque session ID
-    std::string session_id;
-    if (!desired_id.empty()) {
-        if (!is_valid_external_id(desired_id)) {
-            if (error_out) { *error_out = SessionCreateError::INVALID_ID; }
-            return "";
-        }
-        session_id = desired_id;
-        if (sessions_.count(session_id) != 0) {
-            if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
-            return ""; // Already exists
-        }
-    } else {
-        do { session_id = generate_session_id(); } while (sessions_.count(session_id) != 0);
-    }
+        bool SessionManager::destroy_session_locked(
+                const std::map<std::string, std::shared_ptr<SessionInfo>>::iterator &it) {
+            auto info = it->second;
+            std::lock_guard<std::mutex> core_lock(info->core_mutex);
 
-    auto info = std::make_shared<SessionInfo>();
-    info->session_id = session_id;
-    info->canonical_file_path = canonical_file_path;
-    info->attachment_count = 1;
-    info->last_activity = std::chrono::steady_clock::now();
+            // Close event queues
+            {
+                std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+                for (auto &subscription : info->session_subscriptions) {
+                    if (subscription.event_queue) { subscription.event_queue->close(); }
+                }
+                info->session_subscriptions.clear();
+            }
 
-    // Store info first so the callback can find it
-    sessions_[session_id] = info;
+            // Destroy all viewports first
+            for (auto &vp : info->viewports) {
+                {
+                    std::lock_guard<std::mutex> subscription_lock(vp.second->viewport_subscription_mutex);
+                    for (auto &subscription : vp.second->viewport_subscriptions) {
+                        if (subscription.event_queue) { subscription.event_queue->close(); }
+                    }
+                    vp.second->viewport_subscriptions.clear();
+                }
+                vp.second->viewport = nullptr;
+                // Viewports are destroyed when session is destroyed
+            }
 
-    std::string effective_checkpoint_directory = checkpoint_directory;
-    if (effective_checkpoint_directory.empty()) {
-        effective_checkpoint_directory = create_managed_checkpoint_directory();
-        if (effective_checkpoint_directory.empty()) {
-            sessions_.erase(session_id);
+            // Destroy the session (this also destroys all viewports)
+            if (info->session) {
+                omega_edit_destroy_session(info->session);
+                info->session = nullptr;
+            }
+            if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
+
+            if (!info->canonical_file_path.empty()) {
+                auto canonical_it = file_sessions_by_path_.find(info->canonical_file_path);
+                if (canonical_it != file_sessions_by_path_.end() && canonical_it->second == info->session_id) {
+                    file_sessions_by_path_.erase(canonical_it);
+                }
+            }
+
+            sessions_.erase(it);
             cleanup_managed_server_root_if_empty();
-            if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
-            return "";
+            return true;
         }
-        info->owns_checkpoint_directory = true;
-    }
 
-    info->checkpoint_directory = effective_checkpoint_directory;
-    const char *chkpt_dir = effective_checkpoint_directory.empty() ? nullptr : effective_checkpoint_directory.c_str();
+        bool SessionManager::destroy_session(const std::string &session_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
 
-    omega_session_t *session = nullptr;
-    if (initial_data != nullptr) {
-        session = omega_edit_create_session_from_bytes(reinterpret_cast<const omega_byte_t *>(initial_data->data()),
-                                                       static_cast<int64_t>(initial_data->size()),
-                                                       session_event_callback, info.get(), 0, chkpt_dir);
-    } else {
-        const char *path = canonical_file_path.empty() ? nullptr : canonical_file_path.c_str();
-        session = omega_edit_create_session(path, session_event_callback, info.get(), 0, chkpt_dir);
-    }
+            auto it = sessions_.find(session_id);
+            if (it == sessions_.end()) return false;
 
-    if (!session) {
-        if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
-        sessions_.erase(session_id);
-        cleanup_managed_server_root_if_empty();
-        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
-        return ""; // Failed to create
-    }
-
-    info->session = session;
-    file_size_out = omega_session_get_computed_file_size(session);
-    if (file_size_out < 0) {
-        omega_edit_destroy_session(session);
-        info->session = nullptr;
-        if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
-        sessions_.erase(session_id);
-        cleanup_managed_server_root_if_empty();
-        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
-        return "";
-    }
-
-    const char *chkpt = omega_session_get_checkpoint_directory(session);
-    checkpoint_dir_out = chkpt ? chkpt : "";
-    if (!checkpoint_dir_out.empty()) { info->checkpoint_directory = checkpoint_dir_out; }
-
-    if (share_existing_file_session) { file_sessions_by_path_[canonical_file_path] = session_id; }
-
-    return session_id;
-}
-
-bool SessionManager::destroy_session_locked(const std::map<std::string, std::shared_ptr<SessionInfo>>::iterator &it) {
-    auto info = it->second;
-    std::lock_guard<std::mutex> core_lock(info->core_mutex);
-
-    // Close event queues
-    {
-        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-        for (auto &subscription : info->session_subscriptions) {
-            if (subscription.event_queue) { subscription.event_queue->close(); }
+            return destroy_session_locked(it);
         }
-        info->session_subscriptions.clear();
-    }
 
-    // Destroy all viewports first
-    for (auto &vp : info->viewports) {
-        {
-            std::lock_guard<std::mutex> subscription_lock(vp.second->viewport_subscription_mutex);
-            for (auto &subscription : vp.second->viewport_subscriptions) {
-                if (subscription.event_queue) { subscription.event_queue->close(); }
+        bool SessionManager::detach_session(const std::string &session_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            auto it = sessions_.find(session_id);
+            if (it == sessions_.end()) return false;
+
+            auto &info = it->second;
+            if (info->attachment_count > 1) {
+                --info->attachment_count;
+                return true;
             }
-            vp.second->viewport_subscriptions.clear();
+
+            return destroy_session_locked(it);
         }
-        vp.second->viewport = nullptr;
-        // Viewports are destroyed when session is destroyed
-    }
 
-    // Destroy the session (this also destroys all viewports)
-    if (info->session) {
-        omega_edit_destroy_session(info->session);
-        info->session = nullptr;
-    }
-    if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
-
-    if (!info->canonical_file_path.empty()) {
-        auto canonical_it = file_sessions_by_path_.find(info->canonical_file_path);
-        if (canonical_it != file_sessions_by_path_.end() && canonical_it->second == info->session_id) {
-            file_sessions_by_path_.erase(canonical_it);
+        omega_session_t *SessionManager::get_session(const std::string &session_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = sessions_.find(session_id);
+            return (it != sessions_.end()) ? it->second->session : nullptr;
         }
-    }
 
-    sessions_.erase(it);
-    cleanup_managed_server_root_if_empty();
-    return true;
-}
+        LockedSession SessionManager::lock_session(const std::string &session_id) {
+            std::shared_ptr<SessionInfo> info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                auto it = sessions_.find(session_id);
+                if (it == sessions_.end()) { return {}; }
+                info = it->second;
+                info->last_activity = std::chrono::steady_clock::now();
+            }
 
-bool SessionManager::destroy_session(const std::string &session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
+            std::unique_lock<std::mutex> core_lock(info->core_mutex);
+            if (info->session == nullptr) { return {}; }
+            return LockedSession{std::move(info), std::move(core_lock)};
+        }
 
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end()) return false;
+        SessionOperationGuard SessionManager::try_begin_mutation(const std::string &session_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = sessions_.find(session_id);
+            if (it == sessions_.end() || it->second->session == nullptr) {
+                return SessionOperationGuard(this, session_id, SessionOperationKind::MUTATION,
+                                             SessionOperationStartResult::SESSION_NOT_FOUND);
+            }
+            auto &info = it->second;
+            if (info->transform_in_progress) {
+                return SessionOperationGuard(this, session_id, SessionOperationKind::MUTATION,
+                                             SessionOperationStartResult::TRANSFORM_IN_PROGRESS);
+            }
+            ++info->active_mutations;
+            info->last_activity = std::chrono::steady_clock::now();
+            return SessionOperationGuard(this, session_id, SessionOperationKind::MUTATION,
+                                         SessionOperationStartResult::STARTED);
+        }
 
-    return destroy_session_locked(it);
-}
+        SessionOperationGuard SessionManager::try_begin_transform(const std::string &session_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = sessions_.find(session_id);
+            if (it == sessions_.end() || it->second->session == nullptr) {
+                return SessionOperationGuard(this, session_id, SessionOperationKind::TRANSFORM,
+                                             SessionOperationStartResult::SESSION_NOT_FOUND);
+            }
+            auto &info = it->second;
+            if (info->transform_in_progress) {
+                return SessionOperationGuard(this, session_id, SessionOperationKind::TRANSFORM,
+                                             SessionOperationStartResult::TRANSFORM_IN_PROGRESS);
+            }
+            if (info->active_mutations > 0) {
+                return SessionOperationGuard(this, session_id, SessionOperationKind::TRANSFORM,
+                                             SessionOperationStartResult::MUTATION_IN_PROGRESS);
+            }
+            info->transform_in_progress = true;
+            info->last_activity = std::chrono::steady_clock::now();
+            return SessionOperationGuard(this, session_id, SessionOperationKind::TRANSFORM,
+                                         SessionOperationStartResult::STARTED);
+        }
 
-bool SessionManager::detach_session(const std::string &session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
+        bool SessionManager::session_transform_in_progress(const std::string &session_id) const {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = sessions_.find(session_id);
+            return it != sessions_.end() && it->second->transform_in_progress;
+        }
 
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end()) return false;
+        bool SessionManager::publish_transform_progress(const std::string &session_id, int32_t event_kind,
+                                                        const TransformProgressData &progress) {
+            std::shared_ptr<SessionInfo> info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                auto it = sessions_.find(session_id);
+                if (it == sessions_.end() || it->second->session == nullptr) { return false; }
+                info = it->second;
+            }
 
-    auto &info = it->second;
-    if (info->attachment_count > 1) {
-        --info->attachment_count;
-        return true;
-    }
+            SessionEventData evt;
+            evt.session_id = info->session_id;
+            evt.session_event_kind = event_kind;
+            // Transform progress callbacks run while the non-thread-safe core session is
+            // usually already locked by the mutating RPC. Progress events are lifecycle
+            // notifications; authoritative session size/change counters are delivered by
+            // normal core session events.
+            evt.computed_file_size = 0;
+            evt.change_count = 0;
+            evt.undo_count = 0;
+            evt.serial = 0;
+            evt.transform_progress = progress;
+            evt.has_transform_progress = true;
 
-    return destroy_session_locked(it);
-}
+            const auto event_mask = static_cast<uint32_t>(event_kind);
+            std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
+            {
+                std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+                subscribers.reserve(info->session_subscriptions.size());
+                for (const auto &subscription : info->session_subscriptions) {
+                    if (subscription.event_queue &&
+                        ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
+                        subscribers.push_back(subscription.event_queue);
+                    }
+                }
+            }
 
-omega_session_t *SessionManager::get_session(const std::string &session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = sessions_.find(session_id);
-    return (it != sessions_.end()) ? it->second->session : nullptr;
-}
+            for (const auto &subscriber : subscribers) { subscriber->push(evt); }
+            return true;
+        }
 
-LockedSession SessionManager::lock_session(const std::string &session_id) {
-    std::shared_ptr<SessionInfo> info;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        auto it = sessions_.find(session_id);
-        if (it == sessions_.end()) { return {}; }
-        info = it->second;
-        info->last_activity = std::chrono::steady_clock::now();
-    }
-
-    std::unique_lock<std::mutex> core_lock(info->core_mutex);
-    if (info->session == nullptr) { return {}; }
-    return LockedSession{std::move(info), std::move(core_lock)};
-}
-
-SessionOperationGuard SessionManager::try_begin_mutation(const std::string &session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end() || it->second->session == nullptr) {
-        return SessionOperationGuard(this, session_id, SessionOperationKind::MUTATION,
-                                     SessionOperationStartResult::SESSION_NOT_FOUND);
-    }
-    auto &info = it->second;
-    if (info->transform_in_progress) {
-        return SessionOperationGuard(this, session_id, SessionOperationKind::MUTATION,
-                                     SessionOperationStartResult::TRANSFORM_IN_PROGRESS);
-    }
-    ++info->active_mutations;
-    info->last_activity = std::chrono::steady_clock::now();
-    return SessionOperationGuard(this, session_id, SessionOperationKind::MUTATION,
-                                 SessionOperationStartResult::STARTED);
-}
-
-SessionOperationGuard SessionManager::try_begin_transform(const std::string &session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end() || it->second->session == nullptr) {
-        return SessionOperationGuard(this, session_id, SessionOperationKind::TRANSFORM,
-                                     SessionOperationStartResult::SESSION_NOT_FOUND);
-    }
-    auto &info = it->second;
-    if (info->transform_in_progress) {
-        return SessionOperationGuard(this, session_id, SessionOperationKind::TRANSFORM,
-                                     SessionOperationStartResult::TRANSFORM_IN_PROGRESS);
-    }
-    if (info->active_mutations > 0) {
-        return SessionOperationGuard(this, session_id, SessionOperationKind::TRANSFORM,
-                                     SessionOperationStartResult::MUTATION_IN_PROGRESS);
-    }
-    info->transform_in_progress = true;
-    info->last_activity = std::chrono::steady_clock::now();
-    return SessionOperationGuard(this, session_id, SessionOperationKind::TRANSFORM,
-                                 SessionOperationStartResult::STARTED);
-}
-
-bool SessionManager::session_transform_in_progress(const std::string &session_id) const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = sessions_.find(session_id);
-    return it != sessions_.end() && it->second->transform_in_progress;
-}
-
-bool SessionManager::publish_transform_progress(const std::string &session_id, int32_t event_kind,
-                                                const TransformProgressData &progress) {
-    std::shared_ptr<SessionInfo> info;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        auto it = sessions_.find(session_id);
-        if (it == sessions_.end() || it->second->session == nullptr) { return false; }
-        info = it->second;
-    }
-
-    SessionEventData evt;
-    evt.session_id = info->session_id;
-    evt.session_event_kind = event_kind;
-    // Transform progress callbacks run while the non-thread-safe core session is
-    // usually already locked by the mutating RPC. Progress events are lifecycle
-    // notifications; authoritative session size/change counters are delivered by
-    // normal core session events.
-    evt.computed_file_size = 0;
-    evt.change_count = 0;
-    evt.undo_count = 0;
-    evt.serial = 0;
-    evt.transform_progress = progress;
-    evt.has_transform_progress = true;
-
-    const auto event_mask = static_cast<uint32_t>(event_kind);
-    std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
-    {
-        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-        subscribers.reserve(info->session_subscriptions.size());
-        for (const auto &subscription : info->session_subscriptions) {
-            if (subscription.event_queue && ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
-                subscribers.push_back(subscription.event_queue);
+        void SessionManager::finish_operation(const std::string &session_id, SessionOperationKind kind) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = sessions_.find(session_id);
+            if (it == sessions_.end()) { return; }
+            auto &info = it->second;
+            if (kind == SessionOperationKind::TRANSFORM) {
+                info->transform_in_progress = false;
+            } else if (info->active_mutations > 0) {
+                --info->active_mutations;
             }
         }
-    }
 
-    for (const auto &subscriber : subscribers) { subscriber->push(evt); }
-    return true;
-}
-
-void SessionManager::finish_operation(const std::string &session_id, SessionOperationKind kind) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end()) { return; }
-    auto &info = it->second;
-    if (kind == SessionOperationKind::TRANSFORM) {
-        info->transform_in_progress = false;
-    } else if (info->active_mutations > 0) {
-        --info->active_mutations;
-    }
-}
-
-int64_t SessionManager::session_count() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return static_cast<int64_t>(sessions_.size());
-}
-
-// ── Viewport lifecycle ───────────────────────────────────────────────────────
-std::string SessionManager::create_viewport(const std::string &session_id, int64_t offset, int64_t capacity,
-                                            bool is_floating, const std::string &desired_viewport_id,
-                                            ViewportCreateError *error_out) {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    auto sit = sessions_.find(session_id);
-    if (sit == sessions_.end()) {
-        if (error_out) *error_out = ViewportCreateError::SESSION_NOT_FOUND;
-        return "";
-    }
-
-    if (!desired_viewport_id.empty() && !is_valid_external_id(desired_viewport_id)) {
-        if (error_out) *error_out = ViewportCreateError::INVALID_VIEWPORT_ID;
-        return "";
-    }
-
-    auto &session_info = sit->second;
-    session_info->last_activity = std::chrono::steady_clock::now();
-    std::string viewport_id = desired_viewport_id;
-    if (viewport_id.empty()) {
-        do { viewport_id = generate_viewport_id(); } while (session_info->viewports.count(viewport_id) != 0);
-    }
-
-    // Check for duplicate viewport
-    if (session_info->viewports.count(viewport_id)) {
-        if (error_out) *error_out = ViewportCreateError::DUPLICATE_VIEWPORT_ID;
-        return "";
-    }
-
-    if (limits_.max_viewports_per_session > 0 && session_info->viewports.size() >= limits_.max_viewports_per_session) {
-        if (error_out) *error_out = ViewportCreateError::TOO_MANY_VIEWPORTS;
-        return "";
-    }
-
-    auto vp_info = std::make_shared<ViewportInfo>();
-    vp_info->session_id = session_id;
-    vp_info->viewport_id = viewport_id;
-
-    // Store first so viewport callbacks can find subscription state. lock_viewport treats a null viewport as missing
-    // until omega_edit_create_viewport publishes the core pointer below.
-    session_info->viewports[viewport_id] = vp_info;
-
-    std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
-    if (session_info->session == nullptr) {
-        session_info->viewports.erase(viewport_id);
-        if (error_out) *error_out = ViewportCreateError::SESSION_NOT_FOUND;
-        return "";
-    }
-    omega_viewport_t *viewport = omega_edit_create_viewport(
-            session_info->session, offset, capacity, is_floating ? 1 : 0, viewport_event_callback, vp_info.get(), 0);
-
-    if (!viewport) {
-        session_info->viewports.erase(viewport_id);
-        if (error_out) *error_out = ViewportCreateError::CORE_ERROR;
-        return "";
-    }
-
-    vp_info->viewport = viewport;
-    if (error_out) *error_out = ViewportCreateError::SUCCESS;
-    return make_viewport_fqid(session_id, viewport_id);
-}
-
-bool SessionManager::destroy_viewport(const std::string &session_id, const std::string &viewport_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    auto sit = sessions_.find(session_id);
-    if (sit == sessions_.end()) return false;
-
-    auto &session_info = sit->second;
-    session_info->last_activity = std::chrono::steady_clock::now();
-    auto vit = session_info->viewports.find(viewport_id);
-    if (vit == session_info->viewports.end()) return false;
-
-    auto &vp_info = vit->second;
-    std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
-    {
-        std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
-        for (auto &subscription : vp_info->viewport_subscriptions) {
-            if (subscription.event_queue) { subscription.event_queue->close(); }
+        int64_t SessionManager::session_count() const {
+            std::lock_guard<std::mutex> lock(mutex_);
+            return static_cast<int64_t>(sessions_.size());
         }
-        vp_info->viewport_subscriptions.clear();
-    }
 
-    if (vp_info->viewport) { omega_edit_destroy_viewport(vp_info->viewport); }
-    vp_info->viewport = nullptr;
-    session_info->viewports.erase(vit);
-    return true;
-}
+        // ── Viewport lifecycle ───────────────────────────────────────────────────────
+        std::string SessionManager::create_viewport(const std::string &session_id, int64_t offset, int64_t capacity,
+                                                    bool is_floating, const std::string &desired_viewport_id,
+                                                    ViewportCreateError *error_out) {
+            std::lock_guard<std::mutex> lock(mutex_);
 
-omega_viewport_t *SessionManager::get_viewport(const std::string &session_id, const std::string &viewport_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    auto sit = sessions_.find(session_id);
-    if (sit == sessions_.end()) return nullptr;
-
-    auto vit = sit->second->viewports.find(viewport_id);
-    return (vit != sit->second->viewports.end()) ? vit->second->viewport : nullptr;
-}
-
-// ── Event subscription ───────────────────────────────────────────────────────
-LockedViewport SessionManager::lock_viewport(const std::string &session_id, const std::string &viewport_id) {
-    std::shared_ptr<SessionInfo> info;
-    std::shared_ptr<ViewportInfo> viewport_info;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        auto sit = sessions_.find(session_id);
-        if (sit == sessions_.end()) { return {}; }
-
-        auto vit = sit->second->viewports.find(viewport_id);
-        if (vit == sit->second->viewports.end()) { return {}; }
-
-        info = sit->second;
-        viewport_info = vit->second;
-        info->last_activity = std::chrono::steady_clock::now();
-    }
-
-    std::unique_lock<std::mutex> core_lock(info->core_mutex);
-    if (info->session == nullptr || viewport_info->viewport == nullptr) { return {}; }
-    return LockedViewport{std::move(info), std::move(viewport_info), std::move(core_lock)};
-}
-
-std::shared_ptr<EventQueue<SessionEventData>> SessionManager::subscribe_session_events(const std::string &session_id,
-                                                                                       int32_t interest) {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end()) return nullptr;
-
-    auto &info = it->second;
-    auto queue = std::make_shared<EventQueue<SessionEventData>>(limits_.session_event_queue_capacity,
-                                                                "session subscription '" + session_id + "#" +
-                                                                        generate_subscription_id() + "'");
-    int32_t combined_interest = 0;
-    {
-        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-        info->session_subscriptions.push_back({queue, interest});
-        combined_interest = combine_session_event_interest(info->session_subscriptions);
-    }
-    std::lock_guard<std::mutex> core_lock(info->core_mutex);
-    if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
-    return queue;
-}
-
-void SessionManager::unsubscribe_session_events(const std::string &session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end()) return;
-
-    auto &info = it->second;
-    std::vector<std::shared_ptr<EventQueue<SessionEventData>>> removed_queues;
-    {
-        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-        for (const auto &subscription : info->session_subscriptions) {
-            if (subscription.event_queue) { removed_queues.push_back(subscription.event_queue); }
-        }
-        info->session_subscriptions.clear();
-    }
-    std::lock_guard<std::mutex> core_lock(info->core_mutex);
-    if (info->session) { omega_session_set_event_interest(info->session, 0); }
-
-    for (const auto &queue : removed_queues) {
-        queue->clear();
-        queue->close();
-    }
-}
-
-void SessionManager::unsubscribe_session_events(const std::string &session_id,
-                                                const std::shared_ptr<EventQueue<SessionEventData>> &queue) {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    auto it = sessions_.find(session_id);
-    if (it == sessions_.end() || !queue) return;
-
-    auto &info = it->second;
-    bool removed = false;
-    int32_t combined_interest = 0;
-    {
-        std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-        auto &subscriptions = info->session_subscriptions;
-        subscriptions.erase(std::remove_if(subscriptions.begin(), subscriptions.end(),
-                                           [&queue, &removed](const SessionEventSubscriptionInfo &subscription) {
-                                               const bool matches = subscription.event_queue == queue;
-                                               removed = removed || matches;
-                                               return matches;
-                                           }),
-                            subscriptions.end());
-        combined_interest = combine_session_event_interest(subscriptions);
-    }
-    std::lock_guard<std::mutex> core_lock(info->core_mutex);
-    if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
-
-    if (removed) {
-        queue->clear();
-        queue->close();
-    }
-}
-
-std::shared_ptr<EventQueue<ViewportEventData>> SessionManager::subscribe_viewport_events(const std::string &session_id,
-                                                                                         const std::string &viewport_id,
-                                                                                         int32_t interest) {
-    std::shared_ptr<SessionInfo> session_info;
-    std::shared_ptr<ViewportInfo> vp_info;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-
-        auto sit = sessions_.find(session_id);
-        if (sit == sessions_.end()) return nullptr;
-
-        auto vit = sit->second->viewports.find(viewport_id);
-        if (vit == sit->second->viewports.end()) return nullptr;
-
-        session_info = sit->second;
-        vp_info = vit->second;
-    }
-
-    auto queue = std::make_shared<EventQueue<ViewportEventData>>(limits_.viewport_event_queue_capacity,
-                                                                 "viewport subscription '" +
-                                                                         make_viewport_fqid(session_id, viewport_id) +
-                                                                         "#" + generate_subscription_id() + "'");
-    std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
-    if (vp_info->viewport == nullptr) { return nullptr; }
-
-    int32_t combined_interest = 0;
-    {
-        std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
-        vp_info->viewport_subscriptions.push_back({queue, interest});
-        combined_interest = combine_viewport_event_interest(vp_info->viewport_subscriptions);
-    }
-    omega_viewport_set_event_interest(vp_info->viewport, combined_interest);
-    return queue;
-}
-
-void SessionManager::unsubscribe_viewport_events(const std::string &session_id, const std::string &viewport_id) {
-    std::shared_ptr<SessionInfo> session_info;
-    std::shared_ptr<ViewportInfo> vp_info;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-
-        auto sit = sessions_.find(session_id);
-        if (sit == sessions_.end()) return;
-
-        auto vit = sit->second->viewports.find(viewport_id);
-        if (vit == sit->second->viewports.end()) return;
-
-        session_info = sit->second;
-        vp_info = vit->second;
-    }
-
-    std::vector<std::shared_ptr<EventQueue<ViewportEventData>>> removed_queues;
-    std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
-    {
-        std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
-        for (const auto &subscription : vp_info->viewport_subscriptions) {
-            if (subscription.event_queue) { removed_queues.push_back(subscription.event_queue); }
-        }
-        vp_info->viewport_subscriptions.clear();
-    }
-    if (vp_info->viewport) { omega_viewport_set_event_interest(vp_info->viewport, 0); }
-
-    for (const auto &queue : removed_queues) {
-        queue->clear();
-        queue->close();
-    }
-}
-
-void SessionManager::unsubscribe_viewport_events(const std::string &session_id, const std::string &viewport_id,
-                                                 const std::shared_ptr<EventQueue<ViewportEventData>> &queue) {
-    if (!queue) return;
-
-    std::shared_ptr<SessionInfo> session_info;
-    std::shared_ptr<ViewportInfo> vp_info;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-
-        auto sit = sessions_.find(session_id);
-        if (sit == sessions_.end()) return;
-
-        auto vit = sit->second->viewports.find(viewport_id);
-        if (vit == sit->second->viewports.end()) return;
-
-        session_info = sit->second;
-        vp_info = vit->second;
-    }
-
-    bool removed = false;
-    int32_t combined_interest = 0;
-    std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
-    {
-        std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
-        auto &subscriptions = vp_info->viewport_subscriptions;
-        subscriptions.erase(std::remove_if(subscriptions.begin(), subscriptions.end(),
-                                           [&queue, &removed](const ViewportEventSubscriptionInfo &subscription) {
-                                               const bool matches = subscription.event_queue == queue;
-                                               removed = removed || matches;
-                                               return matches;
-                                           }),
-                            subscriptions.end());
-        combined_interest = combine_viewport_event_interest(subscriptions);
-    }
-    if (vp_info->viewport) { omega_viewport_set_event_interest(vp_info->viewport, combined_interest); }
-
-    if (removed) {
-        queue->clear();
-        queue->close();
-    }
-}
-
-void SessionManager::destroy_all() {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    for (auto &pair : sessions_) {
-        auto &info = pair.second;
-        std::lock_guard<std::mutex> core_lock(info->core_mutex);
-        {
-            std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-            for (auto &subscription : info->session_subscriptions) {
-                if (subscription.event_queue) subscription.event_queue->close();
+            auto sit = sessions_.find(session_id);
+            if (sit == sessions_.end()) {
+                if (error_out) *error_out = ViewportCreateError::SESSION_NOT_FOUND;
+                return "";
             }
-            info->session_subscriptions.clear();
-        }
-        for (auto &vp : info->viewports) {
-            std::lock_guard<std::mutex> subscription_lock(vp.second->viewport_subscription_mutex);
-            for (auto &subscription : vp.second->viewport_subscriptions) {
-                if (subscription.event_queue) subscription.event_queue->close();
+
+            if (!desired_viewport_id.empty() && !is_valid_external_id(desired_viewport_id)) {
+                if (error_out) *error_out = ViewportCreateError::INVALID_VIEWPORT_ID;
+                return "";
             }
-            vp.second->viewport_subscriptions.clear();
-            vp.second->viewport = nullptr;
+
+            auto &session_info = sit->second;
+            session_info->last_activity = std::chrono::steady_clock::now();
+            std::string viewport_id = desired_viewport_id;
+            if (viewport_id.empty()) {
+                do { viewport_id = generate_viewport_id(); } while (session_info->viewports.count(viewport_id) != 0);
+            }
+
+            // Check for duplicate viewport
+            if (session_info->viewports.count(viewport_id)) {
+                if (error_out) *error_out = ViewportCreateError::DUPLICATE_VIEWPORT_ID;
+                return "";
+            }
+
+            if (limits_.max_viewports_per_session > 0 &&
+                session_info->viewports.size() >= limits_.max_viewports_per_session) {
+                if (error_out) *error_out = ViewportCreateError::TOO_MANY_VIEWPORTS;
+                return "";
+            }
+
+            auto vp_info = std::make_shared<ViewportInfo>();
+            vp_info->session_id = session_id;
+            vp_info->viewport_id = viewport_id;
+
+            // Store first so viewport callbacks can find subscription state. lock_viewport treats a null viewport as missing
+            // until omega_edit_create_viewport publishes the core pointer below.
+            session_info->viewports[viewport_id] = vp_info;
+
+            std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
+            if (session_info->session == nullptr) {
+                session_info->viewports.erase(viewport_id);
+                if (error_out) *error_out = ViewportCreateError::SESSION_NOT_FOUND;
+                return "";
+            }
+            omega_viewport_t *viewport =
+                    omega_edit_create_viewport(session_info->session, offset, capacity, is_floating ? 1 : 0,
+                                               viewport_event_callback, vp_info.get(), 0);
+
+            if (!viewport) {
+                session_info->viewports.erase(viewport_id);
+                if (error_out) *error_out = ViewportCreateError::CORE_ERROR;
+                return "";
+            }
+
+            vp_info->viewport = viewport;
+            if (error_out) *error_out = ViewportCreateError::SUCCESS;
+            return make_viewport_fqid(session_id, viewport_id);
         }
-        if (info->session) {
-            omega_edit_destroy_session(info->session);
-            info->session = nullptr;
+
+        bool SessionManager::destroy_viewport(const std::string &session_id, const std::string &viewport_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            auto sit = sessions_.find(session_id);
+            if (sit == sessions_.end()) return false;
+
+            auto &session_info = sit->second;
+            session_info->last_activity = std::chrono::steady_clock::now();
+            auto vit = session_info->viewports.find(viewport_id);
+            if (vit == session_info->viewports.end()) return false;
+
+            auto &vp_info = vit->second;
+            std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
+            {
+                std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
+                for (auto &subscription : vp_info->viewport_subscriptions) {
+                    if (subscription.event_queue) { subscription.event_queue->close(); }
+                }
+                vp_info->viewport_subscriptions.clear();
+            }
+
+            if (vp_info->viewport) { omega_edit_destroy_viewport(vp_info->viewport); }
+            vp_info->viewport = nullptr;
+            session_info->viewports.erase(vit);
+            return true;
         }
-        if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
-    }
-    sessions_.clear();
-    file_sessions_by_path_.clear();
-    cleanup_managed_server_root_if_empty();
-}
 
-void SessionManager::touch_session(const std::string &session_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = sessions_.find(session_id);
-    if (it != sessions_.end()) { it->second->last_activity = std::chrono::steady_clock::now(); }
-}
+        omega_viewport_t *SessionManager::get_viewport(const std::string &session_id, const std::string &viewport_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
 
-std::vector<std::string> SessionManager::get_idle_session_ids(std::chrono::milliseconds timeout) const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto now = std::chrono::steady_clock::now();
-    std::vector<std::string> idle;
-    for (const auto &pair : sessions_) {
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - pair.second->last_activity);
-        if (elapsed >= timeout) { idle.push_back(pair.first); }
-    }
-    return idle;
-}
+            auto sit = sessions_.find(session_id);
+            if (sit == sessions_.end()) return nullptr;
 
-} // namespace grpc_server
-} // namespace omega_edit
+            auto vit = sit->second->viewports.find(viewport_id);
+            return (vit != sit->second->viewports.end()) ? vit->second->viewport : nullptr;
+        }
+
+        // ── Event subscription ───────────────────────────────────────────────────────
+        LockedViewport SessionManager::lock_viewport(const std::string &session_id, const std::string &viewport_id) {
+            std::shared_ptr<SessionInfo> info;
+            std::shared_ptr<ViewportInfo> viewport_info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                auto sit = sessions_.find(session_id);
+                if (sit == sessions_.end()) { return {}; }
+
+                auto vit = sit->second->viewports.find(viewport_id);
+                if (vit == sit->second->viewports.end()) { return {}; }
+
+                info = sit->second;
+                viewport_info = vit->second;
+                info->last_activity = std::chrono::steady_clock::now();
+            }
+
+            std::unique_lock<std::mutex> core_lock(info->core_mutex);
+            if (info->session == nullptr || viewport_info->viewport == nullptr) { return {}; }
+            return LockedViewport{std::move(info), std::move(viewport_info), std::move(core_lock)};
+        }
+
+        std::shared_ptr<EventQueue<SessionEventData>>
+        SessionManager::subscribe_session_events(const std::string &session_id, int32_t interest) {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            auto it = sessions_.find(session_id);
+            if (it == sessions_.end()) return nullptr;
+
+            auto &info = it->second;
+            auto queue = std::make_shared<EventQueue<SessionEventData>>(limits_.session_event_queue_capacity,
+                                                                        "session subscription '" + session_id + "#" +
+                                                                                generate_subscription_id() + "'");
+            int32_t combined_interest = 0;
+            {
+                std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+                info->session_subscriptions.push_back({queue, interest});
+                combined_interest = combine_session_event_interest(info->session_subscriptions);
+            }
+            std::lock_guard<std::mutex> core_lock(info->core_mutex);
+            if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
+            return queue;
+        }
+
+        void SessionManager::unsubscribe_session_events(const std::string &session_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            auto it = sessions_.find(session_id);
+            if (it == sessions_.end()) return;
+
+            auto &info = it->second;
+            std::vector<std::shared_ptr<EventQueue<SessionEventData>>> removed_queues;
+            {
+                std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+                for (const auto &subscription : info->session_subscriptions) {
+                    if (subscription.event_queue) { removed_queues.push_back(subscription.event_queue); }
+                }
+                info->session_subscriptions.clear();
+            }
+            std::lock_guard<std::mutex> core_lock(info->core_mutex);
+            if (info->session) { omega_session_set_event_interest(info->session, 0); }
+
+            for (const auto &queue : removed_queues) {
+                queue->clear();
+                queue->close();
+            }
+        }
+
+        void SessionManager::unsubscribe_session_events(const std::string &session_id,
+                                                        const std::shared_ptr<EventQueue<SessionEventData>> &queue) {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            auto it = sessions_.find(session_id);
+            if (it == sessions_.end() || !queue) return;
+
+            auto &info = it->second;
+            bool removed = false;
+            int32_t combined_interest = 0;
+            {
+                std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+                auto &subscriptions = info->session_subscriptions;
+                subscriptions.erase(
+                        std::remove_if(subscriptions.begin(), subscriptions.end(),
+                                       [&queue, &removed](const SessionEventSubscriptionInfo &subscription) {
+                                           const bool matches = subscription.event_queue == queue;
+                                           removed = removed || matches;
+                                           return matches;
+                                       }),
+                        subscriptions.end());
+                combined_interest = combine_session_event_interest(subscriptions);
+            }
+            std::lock_guard<std::mutex> core_lock(info->core_mutex);
+            if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
+
+            if (removed) {
+                queue->clear();
+                queue->close();
+            }
+        }
+
+        std::shared_ptr<EventQueue<ViewportEventData>>
+        SessionManager::subscribe_viewport_events(const std::string &session_id, const std::string &viewport_id,
+                                                  int32_t interest) {
+            std::shared_ptr<SessionInfo> session_info;
+            std::shared_ptr<ViewportInfo> vp_info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                auto sit = sessions_.find(session_id);
+                if (sit == sessions_.end()) return nullptr;
+
+                auto vit = sit->second->viewports.find(viewport_id);
+                if (vit == sit->second->viewports.end()) return nullptr;
+
+                session_info = sit->second;
+                vp_info = vit->second;
+            }
+
+            auto queue = std::make_shared<EventQueue<ViewportEventData>>(
+                    limits_.viewport_event_queue_capacity, "viewport subscription '" +
+                                                                   make_viewport_fqid(session_id, viewport_id) + "#" +
+                                                                   generate_subscription_id() + "'");
+            std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
+            if (vp_info->viewport == nullptr) { return nullptr; }
+
+            int32_t combined_interest = 0;
+            {
+                std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
+                vp_info->viewport_subscriptions.push_back({queue, interest});
+                combined_interest = combine_viewport_event_interest(vp_info->viewport_subscriptions);
+            }
+            omega_viewport_set_event_interest(vp_info->viewport, combined_interest);
+            return queue;
+        }
+
+        void SessionManager::unsubscribe_viewport_events(const std::string &session_id,
+                                                         const std::string &viewport_id) {
+            std::shared_ptr<SessionInfo> session_info;
+            std::shared_ptr<ViewportInfo> vp_info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                auto sit = sessions_.find(session_id);
+                if (sit == sessions_.end()) return;
+
+                auto vit = sit->second->viewports.find(viewport_id);
+                if (vit == sit->second->viewports.end()) return;
+
+                session_info = sit->second;
+                vp_info = vit->second;
+            }
+
+            std::vector<std::shared_ptr<EventQueue<ViewportEventData>>> removed_queues;
+            std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
+            {
+                std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
+                for (const auto &subscription : vp_info->viewport_subscriptions) {
+                    if (subscription.event_queue) { removed_queues.push_back(subscription.event_queue); }
+                }
+                vp_info->viewport_subscriptions.clear();
+            }
+            if (vp_info->viewport) { omega_viewport_set_event_interest(vp_info->viewport, 0); }
+
+            for (const auto &queue : removed_queues) {
+                queue->clear();
+                queue->close();
+            }
+        }
+
+        void SessionManager::unsubscribe_viewport_events(const std::string &session_id, const std::string &viewport_id,
+                                                         const std::shared_ptr<EventQueue<ViewportEventData>> &queue) {
+            if (!queue) return;
+
+            std::shared_ptr<SessionInfo> session_info;
+            std::shared_ptr<ViewportInfo> vp_info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                auto sit = sessions_.find(session_id);
+                if (sit == sessions_.end()) return;
+
+                auto vit = sit->second->viewports.find(viewport_id);
+                if (vit == sit->second->viewports.end()) return;
+
+                session_info = sit->second;
+                vp_info = vit->second;
+            }
+
+            bool removed = false;
+            int32_t combined_interest = 0;
+            std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
+            {
+                std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
+                auto &subscriptions = vp_info->viewport_subscriptions;
+                subscriptions.erase(
+                        std::remove_if(subscriptions.begin(), subscriptions.end(),
+                                       [&queue, &removed](const ViewportEventSubscriptionInfo &subscription) {
+                                           const bool matches = subscription.event_queue == queue;
+                                           removed = removed || matches;
+                                           return matches;
+                                       }),
+                        subscriptions.end());
+                combined_interest = combine_viewport_event_interest(subscriptions);
+            }
+            if (vp_info->viewport) { omega_viewport_set_event_interest(vp_info->viewport, combined_interest); }
+
+            if (removed) {
+                queue->clear();
+                queue->close();
+            }
+        }
+
+        void SessionManager::destroy_all() {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            for (auto &pair : sessions_) {
+                auto &info = pair.second;
+                std::lock_guard<std::mutex> core_lock(info->core_mutex);
+                {
+                    std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+                    for (auto &subscription : info->session_subscriptions) {
+                        if (subscription.event_queue) subscription.event_queue->close();
+                    }
+                    info->session_subscriptions.clear();
+                }
+                for (auto &vp : info->viewports) {
+                    std::lock_guard<std::mutex> subscription_lock(vp.second->viewport_subscription_mutex);
+                    for (auto &subscription : vp.second->viewport_subscriptions) {
+                        if (subscription.event_queue) subscription.event_queue->close();
+                    }
+                    vp.second->viewport_subscriptions.clear();
+                    vp.second->viewport = nullptr;
+                }
+                if (info->session) {
+                    omega_edit_destroy_session(info->session);
+                    info->session = nullptr;
+                }
+                if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
+            }
+            sessions_.clear();
+            file_sessions_by_path_.clear();
+            cleanup_managed_server_root_if_empty();
+        }
+
+        void SessionManager::touch_session(const std::string &session_id) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = sessions_.find(session_id);
+            if (it != sessions_.end()) { it->second->last_activity = std::chrono::steady_clock::now(); }
+        }
+
+        std::vector<std::string> SessionManager::get_idle_session_ids(std::chrono::milliseconds timeout) const {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto now = std::chrono::steady_clock::now();
+            std::vector<std::string> idle;
+            for (const auto &pair : sessions_) {
+                auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - pair.second->last_activity);
+                if (elapsed >= timeout) { idle.push_back(pair.first); }
+            }
+            return idle;
+        }
+
+    }// namespace grpc_server
+}// namespace omega_edit

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -34,327 +34,332 @@
 #include <vector>
 
 namespace omega_edit {
-namespace grpc_server {
+    namespace grpc_server {
 
-/// Configurable service limits to bound server-side resource usage.
-struct ResourceLimits {
-    size_t session_event_queue_capacity{1024};  ///< 0 = unbounded
-    size_t viewport_event_queue_capacity{256};  ///< 0 = unbounded
-    int64_t max_change_bytes{64 * 1024 * 1024}; ///< 0 = unbounded
-    size_t max_viewports_per_session{256};      ///< 0 = unbounded
-};
+        /// Configurable service limits to bound server-side resource usage.
+        struct ResourceLimits {
+            size_t session_event_queue_capacity{1024}; ///< 0 = unbounded
+            size_t viewport_event_queue_capacity{256}; ///< 0 = unbounded
+            int64_t max_change_bytes{64 * 1024 * 1024};///< 0 = unbounded
+            size_t max_viewports_per_session{256};     ///< 0 = unbounded
+        };
 
-struct TransformProgressData {
-    std::string plugin_id;
-    std::string operation_id;
-    int64_t processed_bytes{0};
-    int64_t total_bytes{0};
-    double percent{0};
-    std::string phase;
-    std::string message;
-    bool has_processed_bytes{false};
-    bool has_total_bytes{false};
-    bool has_percent{false};
-    bool has_serial{false};
-    bool indeterminate{false};
-    int64_t serial{0};
-};
+        struct TransformProgressData {
+            std::string plugin_id;
+            std::string operation_id;
+            int64_t processed_bytes{0};
+            int64_t total_bytes{0};
+            double percent{0};
+            std::string phase;
+            std::string message;
+            bool has_processed_bytes{false};
+            bool has_total_bytes{false};
+            bool has_percent{false};
+            bool has_serial{false};
+            bool indeterminate{false};
+            int64_t serial{0};
+        };
 
-/// Session event data for streaming
-struct SessionEventData {
-    std::string session_id;
-    int32_t session_event_kind;
-    int64_t computed_file_size;
-    int64_t change_count;
-    int64_t undo_count;
-    int64_t serial; // 0 if no change serial
-    TransformProgressData transform_progress;
-    bool has_transform_progress{false};
-};
+        /// Session event data for streaming
+        struct SessionEventData {
+            std::string session_id;
+            int32_t session_event_kind;
+            int64_t computed_file_size;
+            int64_t change_count;
+            int64_t undo_count;
+            int64_t serial;// 0 if no change serial
+            TransformProgressData transform_progress;
+            bool has_transform_progress{false};
+        };
 
-/// Viewport event data for streaming
-struct ViewportEventData {
-    std::string session_id;
-    std::string viewport_id;
-    int32_t viewport_event_kind;
-    int64_t serial; // 0 if no change serial
-    int64_t offset;
-    int64_t length;
-    std::vector<uint8_t> data;
-};
+        /// Viewport event data for streaming
+        struct ViewportEventData {
+            std::string session_id;
+            std::string viewport_id;
+            int32_t viewport_event_kind;
+            int64_t serial;// 0 if no change serial
+            int64_t offset;
+            int64_t length;
+            std::vector<uint8_t> data;
+        };
 
-/// Thread-safe event queue
-template <typename T> class EventQueue {
-public:
-    explicit EventQueue(size_t max_size = 0, std::string label = "event queue")
-        : max_size_(max_size), label_(std::move(label)) {}
+        /// Thread-safe event queue
+        template<typename T>
+        class EventQueue {
+        public:
+            explicit EventQueue(size_t max_size = 0, std::string label = "event queue")
+                : max_size_(max_size), label_(std::move(label)) {}
 
-    void push(const T &event) { push_impl(event); }
+            void push(const T &event) { push_impl(event); }
 
-    void push(T &&event) { push_impl(std::move(event)); }
+            void push(T &&event) { push_impl(std::move(event)); }
 
-    bool pop(T &event, std::chrono::milliseconds timeout) {
-        std::unique_lock<std::mutex> lock(mutex_);
-        if (cv_.wait_for(lock, timeout, [this] { return !queue_.empty() || closed_; })) {
-            if (closed_ && queue_.empty()) return false;
-            event = std::move(queue_.front());
-            queue_.pop();
-            return true;
-        }
-        return false;
-    }
+            bool pop(T &event, std::chrono::milliseconds timeout) {
+                std::unique_lock<std::mutex> lock(mutex_);
+                if (cv_.wait_for(lock, timeout, [this] { return !queue_.empty() || closed_; })) {
+                    if (closed_ && queue_.empty()) return false;
+                    event = std::move(queue_.front());
+                    queue_.pop();
+                    return true;
+                }
+                return false;
+            }
 
-    void close() {
-        std::lock_guard<std::mutex> lock(mutex_);
-        closed_ = true;
-        cv_.notify_all();
-    }
+            void close() {
+                std::lock_guard<std::mutex> lock(mutex_);
+                closed_ = true;
+                cv_.notify_all();
+            }
 
-    void clear() {
-        std::lock_guard<std::mutex> lock(mutex_);
-        std::queue<T> empty;
-        queue_.swap(empty);
-        dropped_count_.store(0, std::memory_order_relaxed);
-    }
+            void clear() {
+                std::lock_guard<std::mutex> lock(mutex_);
+                std::queue<T> empty;
+                queue_.swap(empty);
+                dropped_count_.store(0, std::memory_order_relaxed);
+            }
 
-    bool is_closed() const { return closed_; }
-    size_t dropped_count() const { return dropped_count_.load(std::memory_order_relaxed); }
+            bool is_closed() const { return closed_; }
+            size_t dropped_count() const { return dropped_count_.load(std::memory_order_relaxed); }
 
-private:
-    template <typename U> void push_impl(U &&event) {
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            if (closed_) { return; }
-            if (max_size_ > 0 && queue_.size() >= max_size_) {
-                queue_.pop();
-                const size_t dropped = ++dropped_count_;
-                if (should_log_drops(dropped)) {
-                    std::cerr << "Warning: dropped " << dropped << " buffered event(s) from " << label_
-                              << " because the queue reached its capacity of " << max_size_ << std::endl;
+        private:
+            template<typename U>
+            void push_impl(U &&event) {
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    if (closed_) { return; }
+                    if (max_size_ > 0 && queue_.size() >= max_size_) {
+                        queue_.pop();
+                        const size_t dropped = ++dropped_count_;
+                        if (should_log_drops(dropped)) {
+                            std::cerr << "Warning: dropped " << dropped << " buffered event(s) from " << label_
+                                      << " because the queue reached its capacity of " << max_size_ << std::endl;
+                        }
+                    }
+                    queue_.push(std::forward<U>(event));
+                }
+                cv_.notify_one();
+            }
+
+            static bool should_log_drops(size_t dropped_count) { return (dropped_count & (dropped_count - 1)) == 0; }
+
+            size_t max_size_;
+            std::string label_;
+            std::queue<T> queue_;
+            std::mutex mutex_;
+            std::condition_variable cv_;
+            std::atomic<size_t> dropped_count_{0};
+            std::atomic<bool> closed_{false};
+        };
+
+        /// Session event subscription state
+        struct SessionEventSubscriptionInfo {
+            std::shared_ptr<EventQueue<SessionEventData>> event_queue;
+            int32_t interest;
+        };
+
+        /// Viewport event subscription state
+        struct ViewportEventSubscriptionInfo {
+            std::shared_ptr<EventQueue<ViewportEventData>> event_queue;
+            int32_t interest;
+        };
+
+        /// Information about a viewport managed by the session manager
+        struct ViewportInfo {
+            omega_viewport_t *viewport{};
+            std::string session_id;
+            std::string viewport_id;
+            std::mutex viewport_subscription_mutex;
+            std::vector<ViewportEventSubscriptionInfo> viewport_subscriptions;
+        };
+
+        /// Information about a session managed by the session manager
+        struct SessionInfo {
+            omega_session_t *session{};
+            std::string session_id;
+            std::string canonical_file_path;
+            std::string checkpoint_directory;
+            bool owns_checkpoint_directory{false};
+            // Shared sessions begin life with one attached author and are only reaped
+            // after the last attachment detaches.
+            size_t attachment_count{0};
+            std::map<std::string, std::shared_ptr<ViewportInfo>> viewports;
+            bool transform_in_progress{false};
+            size_t active_mutations{0};
+            // Serializes all access to the underlying non-thread-safe omega_session_t and its viewports.
+            std::mutex core_mutex;
+            std::mutex session_subscription_mutex;
+            std::vector<SessionEventSubscriptionInfo> session_subscriptions;
+            std::chrono::steady_clock::time_point last_activity;
+        };
+
+        struct LockedSession {
+            std::shared_ptr<SessionInfo> info;
+            std::unique_lock<std::mutex> lock;
+
+            omega_session_t *session() const { return info ? info->session : nullptr; }
+            explicit operator bool() const { return session() != nullptr; }
+        };
+
+        struct LockedViewport {
+            std::shared_ptr<SessionInfo> info;
+            std::shared_ptr<ViewportInfo> viewport_info;
+            std::unique_lock<std::mutex> lock;
+
+            omega_viewport_t *viewport() const { return viewport_info ? viewport_info->viewport : nullptr; }
+            explicit operator bool() const { return viewport() != nullptr; }
+        };
+
+        /// Error codes returned by SessionManager::create_session
+        enum class SessionCreateError {
+            SUCCESS,
+            INVALID_ID,                  ///< desired_id is not a bounded caller ID token
+            INVALID_FILE_PATH,           ///< file_path is not safe to pass to the core C API
+            INVALID_CHECKPOINT_DIRECTORY,///< checkpoint_directory is not safe to pass to the core C API
+            ALREADY_EXISTS,              ///< a session with the given id already exists
+            CORE_ERROR,                  ///< the underlying omega_edit API failed to create the session
+        };
+
+        /// Error codes returned by SessionManager::create_viewport
+        enum class ViewportCreateError {
+            SUCCESS,
+            SESSION_NOT_FOUND,
+            INVALID_VIEWPORT_ID,  ///< desired_viewport_id is not a bounded caller ID token
+            DUPLICATE_VIEWPORT_ID,///< a viewport with the given id already exists
+            TOO_MANY_VIEWPORTS,   ///< the session has reached the configured viewport limit
+            CORE_ERROR,           ///< the underlying omega_edit API failed to create the viewport
+        };
+
+        enum class SessionOperationStartResult {
+            STARTED,
+            SESSION_NOT_FOUND,
+            TRANSFORM_IN_PROGRESS,
+            MUTATION_IN_PROGRESS,
+        };
+
+        enum class SessionOperationKind {
+            MUTATION,
+            TRANSFORM,
+        };
+
+        class SessionManager;
+
+        class SessionOperationGuard {
+        public:
+            SessionOperationGuard() = default;
+            SessionOperationGuard(const SessionOperationGuard &) = delete;
+            auto operator=(const SessionOperationGuard &) -> SessionOperationGuard & = delete;
+            SessionOperationGuard(SessionOperationGuard &&other) noexcept;
+            auto operator=(SessionOperationGuard &&other) noexcept -> SessionOperationGuard &;
+            ~SessionOperationGuard();
+
+            explicit operator bool() const { return result_ == SessionOperationStartResult::STARTED; }
+            SessionOperationStartResult result() const { return result_; }
+
+        private:
+            friend class SessionManager;
+
+            SessionOperationGuard(SessionManager *manager, std::string session_id, SessionOperationKind kind,
+                                  SessionOperationStartResult result);
+
+            void release();
+
+            SessionManager *manager_{nullptr};
+            std::string session_id_;
+            SessionOperationKind kind_{SessionOperationKind::MUTATION};
+            SessionOperationStartResult result_{SessionOperationStartResult::SESSION_NOT_FOUND};
+        };
+
+        /// Manages all omega_edit sessions and viewports
+        class SessionManager {
+        public:
+            explicit SessionManager(ResourceLimits limits = {});
+            ~SessionManager();
+
+            // Session lifecycle
+            std::string create_session(const std::string &file_path, const std::string &desired_id,
+                                       const std::string &checkpoint_directory, const std::string *initial_data,
+                                       int64_t &file_size_out, std::string &checkpoint_dir_out,
+                                       SessionCreateError *error_out = nullptr);
+            bool destroy_session(const std::string &session_id);
+            bool detach_session(const std::string &session_id);
+            omega_session_t *get_session(const std::string &session_id);
+            LockedSession lock_session(const std::string &session_id);
+            SessionOperationGuard try_begin_mutation(const std::string &session_id);
+            SessionOperationGuard try_begin_transform(const std::string &session_id);
+            bool session_transform_in_progress(const std::string &session_id) const;
+            bool publish_transform_progress(const std::string &session_id, int32_t event_kind,
+                                            const TransformProgressData &progress);
+            int64_t session_count() const;
+
+            // Viewport lifecycle
+            std::string create_viewport(const std::string &session_id, int64_t offset, int64_t capacity,
+                                        bool is_floating, const std::string &desired_viewport_id,
+                                        ViewportCreateError *error_out = nullptr);
+            bool destroy_viewport(const std::string &session_id, const std::string &viewport_id);
+            omega_viewport_t *get_viewport(const std::string &session_id, const std::string &viewport_id);
+            LockedViewport lock_viewport(const std::string &session_id, const std::string &viewport_id);
+
+            // Event subscription
+            std::shared_ptr<EventQueue<SessionEventData>> subscribe_session_events(const std::string &session_id,
+                                                                                   int32_t interest);
+            void unsubscribe_session_events(const std::string &session_id);
+            void unsubscribe_session_events(const std::string &session_id,
+                                            const std::shared_ptr<EventQueue<SessionEventData>> &queue);
+            std::shared_ptr<EventQueue<ViewportEventData>>
+            subscribe_viewport_events(const std::string &session_id, const std::string &viewport_id, int32_t interest);
+            void unsubscribe_viewport_events(const std::string &session_id, const std::string &viewport_id);
+            void unsubscribe_viewport_events(const std::string &session_id, const std::string &viewport_id,
+                                             const std::shared_ptr<EventQueue<ViewportEventData>> &queue);
+
+            // Session activity tracking
+            void touch_session(const std::string &session_id);
+            template<typename SessionIdRange>
+            void touch_sessions(const SessionIdRange &session_ids) {
+                std::lock_guard<std::mutex> lock(mutex_);
+                const auto now = std::chrono::steady_clock::now();
+                for (const auto &sid : session_ids) {
+                    auto it = sessions_.find(sid);
+                    if (it != sessions_.end()) { it->second->last_activity = now; }
                 }
             }
-            queue_.push(std::forward<U>(event));
-        }
-        cv_.notify_one();
-    }
+            std::vector<std::string> get_idle_session_ids(std::chrono::milliseconds timeout) const;
 
-    static bool should_log_drops(size_t dropped_count) { return (dropped_count & (dropped_count - 1)) == 0; }
+            // Destroy all sessions (for shutdown)
+            void destroy_all();
 
-    size_t max_size_;
-    std::string label_;
-    std::queue<T> queue_;
-    std::mutex mutex_;
-    std::condition_variable cv_;
-    std::atomic<size_t> dropped_count_{0};
-    std::atomic<bool> closed_{false};
-};
+        private:
+            friend class SessionOperationGuard;
 
-/// Session event subscription state
-struct SessionEventSubscriptionInfo {
-    std::shared_ptr<EventQueue<SessionEventData>> event_queue;
-    int32_t interest;
-};
+            static std::string generate_uuid_v4();
+            static std::string generate_uuid_v7();
+            static std::string generate_prefixed_id(const char *prefix);
+            static std::string generate_session_id();
+            static std::string generate_viewport_id();
+            static std::string generate_subscription_id();
+            static std::string make_viewport_fqid(const std::string &session_id, const std::string &viewport_id);
+            static void cleanup_directory_best_effort(const std::string &directory_path);
+            static void cleanup_stale_server_roots_best_effort(const std::string &root_path);
+            static bool is_managed_server_root_name(const std::string &name);
+            static std::string create_server_root_name();
+            std::string create_managed_checkpoint_directory();
+            void cleanup_managed_server_root_if_empty();
+            bool destroy_session_locked(const std::map<std::string, std::shared_ptr<SessionInfo>>::iterator &it);
+            void finish_operation(const std::string &session_id, SessionOperationKind kind);
 
-/// Viewport event subscription state
-struct ViewportEventSubscriptionInfo {
-    std::shared_ptr<EventQueue<ViewportEventData>> event_queue;
-    int32_t interest;
-};
+            // Callbacks
+            static void session_event_callback(const omega_session_t *session, omega_session_event_t event,
+                                               const void *ptr);
+            static void viewport_event_callback(const omega_viewport_t *viewport, omega_viewport_event_t event,
+                                                const void *ptr);
 
-/// Information about a viewport managed by the session manager
-struct ViewportInfo {
-    omega_viewport_t *viewport{};
-    std::string session_id;
-    std::string viewport_id;
-    std::mutex viewport_subscription_mutex;
-    std::vector<ViewportEventSubscriptionInfo> viewport_subscriptions;
-};
+            mutable std::mutex mutex_;
+            ResourceLimits limits_;
+            std::map<std::string, std::shared_ptr<SessionInfo>> sessions_;
+            std::map<std::string, std::string> file_sessions_by_path_;
+            std::string managed_server_root_;
+        };
 
-/// Information about a session managed by the session manager
-struct SessionInfo {
-    omega_session_t *session{};
-    std::string session_id;
-    std::string canonical_file_path;
-    std::string checkpoint_directory;
-    bool owns_checkpoint_directory{false};
-    // Shared sessions begin life with one attached author and are only reaped
-    // after the last attachment detaches.
-    size_t attachment_count{0};
-    std::map<std::string, std::shared_ptr<ViewportInfo>> viewports;
-    bool transform_in_progress{false};
-    size_t active_mutations{0};
-    // Serializes all access to the underlying non-thread-safe omega_session_t and its viewports.
-    std::mutex core_mutex;
-    std::mutex session_subscription_mutex;
-    std::vector<SessionEventSubscriptionInfo> session_subscriptions;
-    std::chrono::steady_clock::time_point last_activity;
-};
+    }// namespace grpc_server
+}// namespace omega_edit
 
-struct LockedSession {
-    std::shared_ptr<SessionInfo> info;
-    std::unique_lock<std::mutex> lock;
-
-    omega_session_t *session() const { return info ? info->session : nullptr; }
-    explicit operator bool() const { return session() != nullptr; }
-};
-
-struct LockedViewport {
-    std::shared_ptr<SessionInfo> info;
-    std::shared_ptr<ViewportInfo> viewport_info;
-    std::unique_lock<std::mutex> lock;
-
-    omega_viewport_t *viewport() const { return viewport_info ? viewport_info->viewport : nullptr; }
-    explicit operator bool() const { return viewport() != nullptr; }
-};
-
-/// Error codes returned by SessionManager::create_session
-enum class SessionCreateError {
-    SUCCESS,
-    INVALID_ID,                   ///< desired_id is not a bounded caller ID token
-    INVALID_FILE_PATH,            ///< file_path is not safe to pass to the core C API
-    INVALID_CHECKPOINT_DIRECTORY, ///< checkpoint_directory is not safe to pass to the core C API
-    ALREADY_EXISTS,               ///< a session with the given id already exists
-    CORE_ERROR,                   ///< the underlying omega_edit API failed to create the session
-};
-
-/// Error codes returned by SessionManager::create_viewport
-enum class ViewportCreateError {
-    SUCCESS,
-    SESSION_NOT_FOUND,
-    INVALID_VIEWPORT_ID,   ///< desired_viewport_id is not a bounded caller ID token
-    DUPLICATE_VIEWPORT_ID, ///< a viewport with the given id already exists
-    TOO_MANY_VIEWPORTS,    ///< the session has reached the configured viewport limit
-    CORE_ERROR,            ///< the underlying omega_edit API failed to create the viewport
-};
-
-enum class SessionOperationStartResult {
-    STARTED,
-    SESSION_NOT_FOUND,
-    TRANSFORM_IN_PROGRESS,
-    MUTATION_IN_PROGRESS,
-};
-
-enum class SessionOperationKind {
-    MUTATION,
-    TRANSFORM,
-};
-
-class SessionManager;
-
-class SessionOperationGuard {
-public:
-    SessionOperationGuard() = default;
-    SessionOperationGuard(const SessionOperationGuard &) = delete;
-    auto operator=(const SessionOperationGuard &) -> SessionOperationGuard & = delete;
-    SessionOperationGuard(SessionOperationGuard &&other) noexcept;
-    auto operator=(SessionOperationGuard &&other) noexcept -> SessionOperationGuard &;
-    ~SessionOperationGuard();
-
-    explicit operator bool() const { return result_ == SessionOperationStartResult::STARTED; }
-    SessionOperationStartResult result() const { return result_; }
-
-private:
-    friend class SessionManager;
-
-    SessionOperationGuard(SessionManager *manager, std::string session_id, SessionOperationKind kind,
-                          SessionOperationStartResult result);
-
-    void release();
-
-    SessionManager *manager_{nullptr};
-    std::string session_id_;
-    SessionOperationKind kind_{SessionOperationKind::MUTATION};
-    SessionOperationStartResult result_{SessionOperationStartResult::SESSION_NOT_FOUND};
-};
-
-/// Manages all omega_edit sessions and viewports
-class SessionManager {
-public:
-    explicit SessionManager(ResourceLimits limits = {});
-    ~SessionManager();
-
-    // Session lifecycle
-    std::string create_session(const std::string &file_path, const std::string &desired_id,
-                               const std::string &checkpoint_directory, const std::string *initial_data,
-                               int64_t &file_size_out, std::string &checkpoint_dir_out,
-                               SessionCreateError *error_out = nullptr);
-    bool destroy_session(const std::string &session_id);
-    bool detach_session(const std::string &session_id);
-    omega_session_t *get_session(const std::string &session_id);
-    LockedSession lock_session(const std::string &session_id);
-    SessionOperationGuard try_begin_mutation(const std::string &session_id);
-    SessionOperationGuard try_begin_transform(const std::string &session_id);
-    bool session_transform_in_progress(const std::string &session_id) const;
-    bool publish_transform_progress(const std::string &session_id, int32_t event_kind,
-                                    const TransformProgressData &progress);
-    int64_t session_count() const;
-
-    // Viewport lifecycle
-    std::string create_viewport(const std::string &session_id, int64_t offset, int64_t capacity, bool is_floating,
-                                const std::string &desired_viewport_id, ViewportCreateError *error_out = nullptr);
-    bool destroy_viewport(const std::string &session_id, const std::string &viewport_id);
-    omega_viewport_t *get_viewport(const std::string &session_id, const std::string &viewport_id);
-    LockedViewport lock_viewport(const std::string &session_id, const std::string &viewport_id);
-
-    // Event subscription
-    std::shared_ptr<EventQueue<SessionEventData>> subscribe_session_events(const std::string &session_id,
-                                                                           int32_t interest);
-    void unsubscribe_session_events(const std::string &session_id);
-    void unsubscribe_session_events(const std::string &session_id,
-                                    const std::shared_ptr<EventQueue<SessionEventData>> &queue);
-    std::shared_ptr<EventQueue<ViewportEventData>>
-    subscribe_viewport_events(const std::string &session_id, const std::string &viewport_id, int32_t interest);
-    void unsubscribe_viewport_events(const std::string &session_id, const std::string &viewport_id);
-    void unsubscribe_viewport_events(const std::string &session_id, const std::string &viewport_id,
-                                     const std::shared_ptr<EventQueue<ViewportEventData>> &queue);
-
-    // Session activity tracking
-    void touch_session(const std::string &session_id);
-    template <typename SessionIdRange> void touch_sessions(const SessionIdRange &session_ids) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        const auto now = std::chrono::steady_clock::now();
-        for (const auto &sid : session_ids) {
-            auto it = sessions_.find(sid);
-            if (it != sessions_.end()) { it->second->last_activity = now; }
-        }
-    }
-    std::vector<std::string> get_idle_session_ids(std::chrono::milliseconds timeout) const;
-
-    // Destroy all sessions (for shutdown)
-    void destroy_all();
-
-private:
-    friend class SessionOperationGuard;
-
-    static std::string generate_uuid_v4();
-    static std::string generate_uuid_v7();
-    static std::string generate_prefixed_id(const char *prefix);
-    static std::string generate_session_id();
-    static std::string generate_viewport_id();
-    static std::string generate_subscription_id();
-    static std::string make_viewport_fqid(const std::string &session_id, const std::string &viewport_id);
-    static void cleanup_directory_best_effort(const std::string &directory_path);
-    static void cleanup_stale_server_roots_best_effort(const std::string &root_path);
-    static bool is_managed_server_root_name(const std::string &name);
-    static std::string create_server_root_name();
-    std::string create_managed_checkpoint_directory();
-    void cleanup_managed_server_root_if_empty();
-    bool destroy_session_locked(const std::map<std::string, std::shared_ptr<SessionInfo>>::iterator &it);
-    void finish_operation(const std::string &session_id, SessionOperationKind kind);
-
-    // Callbacks
-    static void session_event_callback(const omega_session_t *session, omega_session_event_t event, const void *ptr);
-    static void viewport_event_callback(const omega_viewport_t *viewport, omega_viewport_event_t event,
-                                        const void *ptr);
-
-    mutable std::mutex mutex_;
-    ResourceLimits limits_;
-    std::map<std::string, std::shared_ptr<SessionInfo>> sessions_;
-    std::map<std::string, std::string> file_sessions_by_path_;
-    std::string managed_server_root_;
-};
-
-} // namespace grpc_server
-} // namespace omega_edit
-
-#endif // OMEGA_EDIT_SESSION_MANAGER_H
+#endif// OMEGA_EDIT_SESSION_MANAGER_H

--- a/server/cpp/src/stub_content_detector.cpp
+++ b/server/cpp/src/stub_content_detector.cpp
@@ -18,18 +18,18 @@
 #include "content_detection.h"
 
 namespace omega_edit {
-namespace grpc_server {
+    namespace grpc_server {
 
-class StubContentTypeDetector final : public IContentTypeDetector {
-public:
-    std::string detect(const uint8_t *data, int64_t length, const std::string &file_path) override {
-        return detect_builtin_content_type(data, length, file_path);
-    }
-};
+        class StubContentTypeDetector final : public IContentTypeDetector {
+        public:
+            std::string detect(const uint8_t *data, int64_t length, const std::string &file_path) override {
+                return detect_builtin_content_type(data, length, file_path);
+            }
+        };
 
-std::unique_ptr<IContentTypeDetector> create_default_content_type_detector() {
-    return std::make_unique<StubContentTypeDetector>();
-}
+        std::unique_ptr<IContentTypeDetector> create_default_content_type_detector() {
+            return std::make_unique<StubContentTypeDetector>();
+        }
 
-} // namespace grpc_server
-} // namespace omega_edit
+    }// namespace grpc_server
+}// namespace omega_edit


### PR DESCRIPTION
## Summary
- Run clang-format across tracked C/C++ and proto sources.
- Add scripts/check-clang-format.sh plus a C/C++ Clang-Format Checks workflow for pushes and PRs.
- Include the new C/C++ format status in the release quality gate.

## Validation
- bash scripts/check-clang-format.sh
- yarn lint
- cmake --build .codex-tmp/wsl-root-build --target omega_edit omega_edit_transform_plugins omega_transform_plugin_tests edge_case_tests encode_tests filesystem_tests omegaEdit_tests project_info_tests session_tests utility_tests viewport_stress_tests
- .codex-tmp/wsl-root-build/plugins/tests/omega_transform_plugin_tests
- cmake --install .codex-tmp/wsl-root-build --prefix .codex-tmp/install-core
- cmake --build .codex-tmp/_build-server --target omega-edit-grpc-server
- ctest --test-dir .codex-tmp/wsl-root-build/core/src/tests --output-on-failure: 102/103 passed locally; File Copy fails on the Windows-mounted /mnt/d filesystem because chmod-style mode bits read back as 0777 instead of 0600. CI should run on a native Linux filesystem.