### PR TITLE
feat: improve hex editor row sizing

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -59,10 +59,14 @@
         "omegaEdit.bytesPerRow": {
           "type": "number",
           "default": 16,
-          "enum": [
-            8,
-            16,
-            32
+          "anyOf": [
+            {
+              "const": 0
+            },
+            {
+              "minimum": 8,
+              "maximum": 64
+            }
           ],
           "description": "%omegaEdit.configuration.bytesPerRow.description%"
         },

--- a/vscode-extension/package.nls.json
+++ b/vscode-extension/package.nls.json
@@ -5,7 +5,7 @@
   "omegaEdit.configuration.title": "Ωedit™ Data Editor",
   "omegaEdit.configuration.serverPort.description": "TCP port for the OmegaEdit gRPC server; explicitly setting it opts out of Unix socket transport on macOS/Linux",
   "omegaEdit.configuration.logLevel.description": "Log level for the OmegaEdit client",
-  "omegaEdit.configuration.bytesPerRow.description": "Number of bytes displayed per row in the hex view",
+  "omegaEdit.configuration.bytesPerRow.description": "Number of bytes displayed per row in the hex view. Use 0 to automatically fit the editor width; fixed values must be 8 through 64.",
   "omegaEdit.configuration.language.description": "Language for the Svelte data editor UI. Use auto to follow VS Code's display language.",
   "omegaEdit.configuration.transformPluginDirectories.description": "Directories containing OmegaEdit transform plugin shared libraries",
   "omegaEdit.command.openInHexEditor.title": "OmegaEdit: Open in Data Editor",

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -111,8 +111,10 @@ import {
   type ServerHealthMetricId,
   type ServerHealthMessage,
   type WebviewToHostMessage,
+  bytesPerRowFromSetting,
   normalizeExternalHighlights,
   normalizeBytesPerRow,
+  normalizeBytesPerRowSetting,
   normalizeWebviewMessage,
 } from './webviewProtocol'
 
@@ -126,6 +128,7 @@ interface EditorSession {
   bufferOffset: number
   visibleRows: number
   capacity: number
+  bytesPerRowSetting: number
   bytesPerRow: BytesPerRow
   filePath: string
   panel: vscode.WebviewPanel
@@ -1652,6 +1655,63 @@ export class HexEditorProvider
     return bufferedRows * bytesPerRow
   }
 
+  private async applySessionBytesPerRow(
+    session: EditorSession,
+    bytesPerRow: BytesPerRow
+  ): Promise<void> {
+    const normalizedBytesPerRow = normalizeBytesPerRow(bytesPerRow)
+    session.bytesPerRow = normalizedBytesPerRow
+    session.webviewState = {
+      ...session.webviewState,
+      bytesPerRow: normalizedBytesPerRow,
+    }
+    session.capacity = this.getViewportCapacity(normalizedBytesPerRow)
+    session.bufferOffset = -1
+    await this.scrollTo(session, session.offset)
+    this.postEditState(session)
+  }
+
+  private async updateBytesPerRowConfiguration(
+    session: EditorSession,
+    value: number
+  ): Promise<void> {
+    const resource = vscode.Uri.file(session.filePath)
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(resource)
+    const configuration = vscode.workspace.getConfiguration(
+      'omegaEdit',
+      resource
+    )
+    const targets = workspaceFolder
+      ? [
+          vscode.ConfigurationTarget.WorkspaceFolder,
+          vscode.ConfigurationTarget.Workspace,
+          vscode.ConfigurationTarget.Global,
+        ]
+      : vscode.workspace.workspaceFolders &&
+          vscode.workspace.workspaceFolders.length > 0
+        ? [
+            vscode.ConfigurationTarget.Workspace,
+            vscode.ConfigurationTarget.Global,
+          ]
+        : [vscode.ConfigurationTarget.Global]
+
+    let lastError: unknown
+    let updated = false
+    for (const target of targets) {
+      try {
+        await configuration.update('bytesPerRow', value, target)
+        updated = true
+        break
+      } catch (err) {
+        lastError = err
+      }
+    }
+
+    if (!updated && lastError) {
+      throw lastError
+    }
+  }
+
   public getSessionForTesting(uri: vscode.Uri): EditorSession | undefined {
     if (process.env.NODE_ENV !== 'test') {
       return undefined
@@ -1666,7 +1726,7 @@ export class HexEditorProvider
 
   private renderWebviewHtml(
     webview: vscode.Webview,
-    bytesPerRow: BytesPerRow
+    bytesPerRowSetting: number
   ): string {
     const extensionUri = this.extensionContext?.extensionUri
     if (!extensionUri) {
@@ -1676,7 +1736,7 @@ export class HexEditorProvider
       return `<!DOCTYPE html><html><body>${message}</body></html>`
     }
 
-    return getSvelteWebviewContent(webview, extensionUri, bytesPerRow)
+    return getSvelteWebviewContent(webview, extensionUri, bytesPerRowSetting)
   }
 
   public async dispatchWebviewMessageForTesting(
@@ -1804,7 +1864,10 @@ export class HexEditorProvider
 
     // --- Create Ωedit™ session for this file ---
     const config = vscode.workspace.getConfiguration('omegaEdit')
-    const bytesPerRow = normalizeBytesPerRow(config.get('bytesPerRow'))
+    const bytesPerRowSetting = normalizeBytesPerRowSetting(
+      config.get('bytesPerRow')
+    )
+    const bytesPerRow = bytesPerRowFromSetting(bytesPerRowSetting)
 
     // Keep a fixed buffered viewport so resizing the editor does not need to
     // resize the server-side viewport. Only the visible row count changes.
@@ -1819,7 +1882,7 @@ export class HexEditorProvider
     }
     webviewPanel.webview.html = this.renderWebviewHtml(
       webviewPanel.webview,
-      bytesPerRow
+      bytesPerRowSetting
     )
 
     const panelDisposables: vscode.Disposable[] = []
@@ -1892,6 +1955,7 @@ export class HexEditorProvider
       bufferOffset: 0,
       visibleRows: 32,
       capacity,
+      bytesPerRowSetting,
       bytesPerRow,
       filePath,
       panel: webviewPanel,
@@ -2188,8 +2252,12 @@ export class HexEditorProvider
   /** Re-read bytesPerRow from config and refresh all open editors */
   refreshBytesPerRow(): void {
     const config = vscode.workspace.getConfiguration('omegaEdit')
-    const bytesPerRow = normalizeBytesPerRow(config.get('bytesPerRow'))
+    const bytesPerRowSetting = normalizeBytesPerRowSetting(
+      config.get('bytesPerRow')
+    )
+    const bytesPerRow = bytesPerRowFromSetting(bytesPerRowSetting)
     for (const session of this.sessions.values()) {
+      session.bytesPerRowSetting = bytesPerRowSetting
       session.bytesPerRow = bytesPerRow
       session.webviewState = {
         ...session.webviewState,
@@ -2201,9 +2269,8 @@ export class HexEditorProvider
       }
       session.panel.webview.html = this.renderWebviewHtml(
         session.panel.webview,
-        bytesPerRow
+        bytesPerRowSetting
       )
-      session.capacity = this.getViewportCapacity(bytesPerRow)
       this.postTransformStatus(
         session,
         session.transformInFlight,
@@ -2212,8 +2279,7 @@ export class HexEditorProvider
           ? transformMutationBlockedMessage()
           : undefined
       )
-      this.sendViewportData(session)
-      this.postEditState(session)
+      void this.applySessionBytesPerRow(session, bytesPerRow)
     }
   }
 
@@ -2226,7 +2292,7 @@ export class HexEditorProvider
       }
       session.panel.webview.html = this.renderWebviewHtml(
         session.panel.webview,
-        session.bytesPerRow
+        session.bytesPerRowSetting
       )
       this.postTransformStatus(
         session,
@@ -2236,7 +2302,7 @@ export class HexEditorProvider
           ? transformMutationBlockedMessage()
           : undefined
       )
-      this.sendViewportData(session)
+      void this.sendViewportData(session)
       this.postEditState(session)
     }
   }
@@ -3558,7 +3624,9 @@ export class HexEditorProvider
       const plugin = session.transformPlugins.find(
         (entry) => entry.id === pluginId
       )
-      const inspectOnly = plugin?.operation === TransformPluginOperation.INSPECT
+      const inspectOnly =
+        plugin?.operation === TransformPluginOperation.INSPECT ||
+        contentSource !== 'computed'
       const effectiveContentSource = inspectOnly ? contentSource : 'computed'
       const contentByteLength =
         session.contentSources.find(
@@ -3587,6 +3655,7 @@ export class HexEditorProvider
           offset: response.offset,
           length: response.length,
           operation: TransformPluginOperation.INSPECT,
+          contentSource: effectiveContentSource,
           contentChanged: false,
           replacementLength: 0,
           computedFileSize: session.fileSize,
@@ -3644,6 +3713,7 @@ export class HexEditorProvider
         offset: response.offset,
         length: response.length,
         operation: response.operation,
+        contentSource: 'computed',
         contentChanged: response.contentChanged,
         replacementLength: response.replacementLength,
         computedFileSize: response.computedFileSize,
@@ -4921,40 +4991,25 @@ export class HexEditorProvider
         }
 
         case 'setBytesPerRow': {
-          const resource = vscode.Uri.file(session.filePath)
-          const workspaceFolder = vscode.workspace.getWorkspaceFolder(resource)
-          const configuration = vscode.workspace.getConfiguration(
-            'omegaEdit',
-            resource
-          )
-          const targets = workspaceFolder
-            ? [
-                vscode.ConfigurationTarget.WorkspaceFolder,
-                vscode.ConfigurationTarget.Workspace,
-                vscode.ConfigurationTarget.Global,
-              ]
-            : vscode.workspace.workspaceFolders &&
-                vscode.workspace.workspaceFolders.length > 0
-              ? [
-                  vscode.ConfigurationTarget.Workspace,
-                  vscode.ConfigurationTarget.Global,
-                ]
-              : [vscode.ConfigurationTarget.Global]
-
-          let lastError: unknown
-          let updated = false
-          for (const target of targets) {
-            try {
-              await configuration.update('bytesPerRow', msg.bytesPerRow, target)
-              updated = true
-              break
-            } catch (err) {
-              lastError = err
-            }
+          if (msg.persist === false) {
+            await this.applySessionBytesPerRow(session, msg.bytesPerRow)
+          } else {
+            session.bytesPerRowSetting = msg.bytesPerRow
+            await this.updateBytesPerRowConfiguration(session, msg.bytesPerRow)
           }
+          break
+        }
 
-          if (!updated && lastError) {
-            throw lastError
+        case 'setBytesPerRowMode': {
+          if (msg.mode === 'auto') {
+            session.bytesPerRowSetting = 0
+            await this.updateBytesPerRowConfiguration(session, 0)
+          } else {
+            session.bytesPerRowSetting = session.bytesPerRow
+            await this.updateBytesPerRowConfiguration(
+              session,
+              session.bytesPerRow
+            )
           }
           break
         }

--- a/vscode-extension/src/svelteWebview.ts
+++ b/vscode-extension/src/svelteWebview.ts
@@ -14,7 +14,11 @@
 
 import * as crypto from 'node:crypto'
 import * as vscode from 'vscode'
-import { type BytesPerRow, normalizeBytesPerRow } from './webviewProtocol'
+import {
+  AUTO_BYTES_PER_ROW_SETTING,
+  bytesPerRowFromSetting,
+  normalizeBytesPerRowSetting,
+} from './webviewProtocol'
 
 const SVELTE_WEBVIEW_OUT_DIR = ['out', 'svelte-webview'] as const
 const AUTO_WEBVIEW_LANGUAGE = 'auto'
@@ -75,7 +79,7 @@ export function getSvelteWebviewLocalResourceRoot(
 export function getSvelteWebviewContent(
   webview: vscode.Webview,
   extensionUri: vscode.Uri,
-  bytesPerRow: BytesPerRow
+  bytesPerRowSetting: number
 ): string {
   const resourceRoot = getSvelteWebviewLocalResourceRoot(extensionUri)
   const scriptUri = webview.asWebviewUri(
@@ -86,7 +90,15 @@ export function getSvelteWebviewContent(
   )
   const cspSource = escapeHtmlAttribute(webview.cspSource)
   const scriptNonce = nonce()
-  const normalizedBytesPerRow = normalizeBytesPerRow(bytesPerRow)
+  const normalizedBytesPerRowSetting =
+    normalizeBytesPerRowSetting(bytesPerRowSetting)
+  const normalizedBytesPerRow = bytesPerRowFromSetting(
+    normalizedBytesPerRowSetting
+  )
+  const bytesPerRowMode =
+    normalizedBytesPerRowSetting === AUTO_BYTES_PER_ROW_SETTING
+      ? 'auto'
+      : 'fixed'
   const language = resolveWebviewLanguage()
   const escapedLanguage = escapeHtmlAttribute(language)
   const textDirection = textDirectionForLanguage(language)
@@ -108,7 +120,7 @@ export function getSvelteWebviewContent(
   <title>${title}</title>
 </head>
 <body>
-  <div id="app" data-bytes-per-row="${normalizedBytesPerRow}" data-locale="${escapedLanguage}">
+  <div id="app" data-bytes-per-row="${normalizedBytesPerRow}" data-bytes-per-row-mode="${bytesPerRowMode}" data-locale="${escapedLanguage}">
     <p class="bootstrap-status">${loading}</p>
   </div>
   <script nonce="${scriptNonce}" type="module" src="${scriptUri.toString()}"></script>

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -18,10 +18,14 @@ export const MAX_TRANSFORM_OPTIONS_LENGTH = 256 * 1024
 export const MAX_ANALYSIS_PROFILE_BYTES = 64 * 1024
 export const MAX_LABEL_LENGTH = 128
 export const MAX_EXTERNAL_HIGHLIGHTS = 512
-export const VALID_BYTES_PER_ROW = [8, 16, 32] as const
+export const AUTO_BYTES_PER_ROW_SETTING = 0
+export const MIN_BYTES_PER_ROW = 8
+export const MAX_BYTES_PER_ROW = 64
 export const DEFAULT_BYTES_PER_ROW = 16
+export const FIXED_BYTES_PER_ROW_OPTIONS = [8, 16, 32, 64] as const
 
-export type BytesPerRow = (typeof VALID_BYTES_PER_ROW)[number]
+export type BytesPerRow = number
+export type BytesPerRowMode = 'fixed' | 'auto'
 export type OffsetRadix = 'hex' | 'dec'
 export type GridEditPane = 'hex' | 'ascii'
 export type WebviewEditMode = 'insert' | 'overwrite'
@@ -127,7 +131,8 @@ export type WebviewToHostMessage =
   | { type: 'scroll'; direction: 'up' | 'down' }
   | { type: 'scrollTo'; offset: number }
   | { type: 'setViewportMetrics'; visibleRows: number }
-  | { type: 'setBytesPerRow'; bytesPerRow: BytesPerRow }
+  | { type: 'setBytesPerRow'; bytesPerRow: BytesPerRow; persist?: boolean }
+  | { type: 'setBytesPerRowMode'; mode: BytesPerRowMode }
   | {
       type: 'requestAnalysisProfile'
       offset: number
@@ -261,6 +266,7 @@ export type HostToWebviewMessage =
       offset: number
       length: number
       operation: number
+      contentSource: WebviewSessionContentSource
       contentChanged: boolean
       replacementLength: number
       computedFileSize: number
@@ -390,9 +396,29 @@ export interface ServerHealthMessage {
 }
 
 export function normalizeBytesPerRow(value: unknown): BytesPerRow {
-  return VALID_BYTES_PER_ROW.includes(value as BytesPerRow)
-    ? (value as BytesPerRow)
+  return typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= MIN_BYTES_PER_ROW &&
+    value <= MAX_BYTES_PER_ROW
+    ? value
     : DEFAULT_BYTES_PER_ROW
+}
+
+export function normalizeBytesPerRowSetting(value: unknown): number {
+  return value === AUTO_BYTES_PER_ROW_SETTING
+    ? AUTO_BYTES_PER_ROW_SETTING
+    : normalizeBytesPerRow(value)
+}
+
+export function bytesPerRowFromSetting(value: unknown): BytesPerRow {
+  const setting = normalizeBytesPerRowSetting(value)
+  return setting === AUTO_BYTES_PER_ROW_SETTING
+    ? DEFAULT_BYTES_PER_ROW
+    : setting
+}
+
+export function normalizeBytesPerRowMode(value: unknown): BytesPerRowMode {
+  return value === 'auto' ? 'auto' : 'fixed'
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -764,8 +790,24 @@ export function normalizeWebviewMessage(
 
     case 'setBytesPerRow': {
       const bytesPerRow = normalizeBytesPerRow(raw.bytesPerRow)
-      return raw.bytesPerRow === bytesPerRow
-        ? { type: 'setBytesPerRow', bytesPerRow }
+      const persist =
+        raw.persist === undefined
+          ? undefined
+          : typeof raw.persist === 'boolean'
+            ? raw.persist
+            : null
+      return raw.bytesPerRow === bytesPerRow && persist !== null
+        ? {
+            type: 'setBytesPerRow',
+            bytesPerRow,
+            ...(persist === undefined ? {} : { persist }),
+          }
+        : undefined
+    }
+
+    case 'setBytesPerRowMode': {
+      return raw.mode === 'fixed' || raw.mode === 'auto'
+        ? { type: 'setBytesPerRowMode', mode: raw.mode }
         : undefined
     }
 

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -48,6 +48,11 @@ test('package.json matches shared extension constants', () => {
     `${packageJson.publisher}.${packageJson.name}`,
     OMEGA_EDIT_EXTENSION_ID
   )
+  assert.deepEqual(
+    packageJson.contributes.configuration.properties['omegaEdit.bytesPerRow']
+      .anyOf,
+    [{ const: 0 }, { minimum: 8, maximum: 64 }]
+  )
   assert.equal(
     packageJson.scripts['package:vsix'],
     'vsce package --out omega-edit-data-editor.vsix'
@@ -683,6 +688,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.doesNotMatch(svelteBundleCss, /\.inspector-feedback:empty/)
   assert.match(svelteBundleCss, /\.editor-main/)
   assert.match(svelteBundleCss, /\.editor-grid-shell/)
+  assert.match(svelteBundleCss, /\.editor-grid-scroller/)
   assert.match(svelteStylesSource, /\.editor-readonly-badge/)
   assert.match(svelteStylesSource, /\.editor-readonly-dot/)
   assert.match(svelteStylesSource, /\.transform-options-form/)
@@ -695,6 +701,9 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(svelteBundleCss, /\.offset-jump-input/)
   assert.match(svelteBundleCss, /\.offset-jump-status/)
   assert.match(svelteBundleCss, /--segmented-button-width/)
+  assert.match(svelteBundleCss, /\.bytes-per-row-input/)
+  assert.match(svelteBundleCss, /\.preview-grid\.bytes-64/)
+  assert.match(svelteBundleCss, /\.byte\.selected:hover/)
   assert.match(
     svelteBundleCss,
     /inline-size:\s*var\(--segmented-button-width\)/
@@ -729,11 +738,17 @@ test('compiled extension entrypoints exist after build', () => {
   }
   assert.match(svelteAppSource, /selectionAnchor/)
   assert.match(svelteAppSource, /selectedOffset/)
+  assert.match(svelteAppSource, /normalizePersistedSelection/)
+  assert.match(svelteAppSource, /selectionAnchor: number/)
+  assert.match(svelteAppSource, /selectedOffset: number/)
+  assert.match(svelteAppSource, /saveSelectionState/)
   assert.match(svelteAppSource, /const DEFAULT_VISIBLE_ROWS = 16/)
   assert.match(svelteAppSource, /pendingVisibleOffset/)
   assert.match(svelteAppSource, /pendingSearchReveal/)
   assert.match(svelteAppSource, /externalHighlights = \$state/)
   assert.match(svelteAppSource, /function currentEditorUiState/)
+  assert.match(svelteAppSource, /bytesPerRowMode/)
+  assert.match(svelteAppSource, /function applyAutoFitBytesPerRow/)
   assert.match(svelteAppSource, /type: 'editorStateChanged'/)
   assert.match(svelteAppSource, /type: 'toggleEditMode'/)
   assert.match(svelteAppSource, /case 'editMode'/)
@@ -827,6 +842,10 @@ test('compiled extension entrypoints exist after build', () => {
     /normalizeOffsetRadix\(restoredState\?\.offsetRadix\)/
   )
   assert.match(svelteAppSource, /savePreviewState\(\{ offsetRadix: radix \}\)/)
+  assert.match(
+    svelteAppSource,
+    /savePreviewState\(\{\s*\n\s*bytesPerRow: normalizedBytes,\s*\n\s*bytesPerRowMode,/
+  )
   assert.match(svelteAppSource, /case 'transformPlugins'/)
   assert.match(svelteAppSource, /transformPlugins = message\.plugins/)
   assert.match(svelteAppSource, /transformPluginsLoaded = true/)
@@ -837,8 +856,17 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(svelteAppSource, /strings\.transform\.calculationCompleted/)
   assert.match(svelteAppSource, /describeFileActionComplete/)
   assert.match(svelteAppSource, /createTransformResult\(message\)/)
+  assert.match(
+    svelteAppSource,
+    /contentSourceLabel: transformResultContentSourceLabel/
+  )
   assert.match(svelteAppSource, /rememberTransformResult/)
   assert.match(svelteAppSource, /openTransformResult/)
+  assert.match(svelteAppSource, /shouldSelectTransformResultRange/)
+  assert.match(
+    svelteAppSource,
+    /if \(shouldSelectRange && message\.offset >= 0\)/
+  )
   assert.match(
     svelteAppSource,
     /selectRange\(message\.offset, transformedLength\)/
@@ -930,6 +958,10 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(editorWorkspaceSource, /PreviewGrid/)
   assert.match(editorWorkspaceSource, /FileScrollbar/)
   assert.match(editorWorkspaceSource, /editor-grid-shell/)
+  assert.match(editorWorkspaceSource, /editor-grid-scroller/)
+  assert.match(editorWorkspaceSource, /onAutoFitBytesPerRow/)
+  assert.match(editorWorkspaceSource, /measureAutoFitBytesPerRow/)
+  assert.match(editorWorkspaceSource, /profilerExpanded !== undefined/)
   assert.match(editorWorkspaceSource, /editor-readonly-badge/)
   assert.match(editorWorkspaceSource, /editor-readonly-dot/)
   assert.match(editorWorkspaceSource, /readOnlyLabel/)
@@ -964,6 +996,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(previewGridSource, /canScrollDown/)
   assert.match(previewGridSource, /event\.stopPropagation\(\)/)
   assert.match(previewGridSource, /event\.deltaY === 0/)
+  assert.match(previewGridSource, /Math\.abs\(event\.deltaX\)/)
   assert.match(previewGridSource, /case 'Insert'/)
   assert.match(previewGridSource, /case 'Backspace'/)
   assert.match(previewGridSource, /case 'Delete'/)
@@ -1178,6 +1211,8 @@ test('compiled extension entrypoints exist after build', () => {
   assert.doesNotMatch(transformPanelSource, /refreshTransforms/)
   assert.match(transformResultPanelSource, /strings\.transform\.resultTitle/)
   assert.match(transformResultPanelSource, /navigator\.clipboard\.writeText/)
+  assert.match(transformResultPanelSource, /contentSourceLabel/)
+  assert.match(transformResultPanelSource, /strings\.transform\.contentSource/)
   assert.match(transformResultPanelSource, /class="transform-result-value"/)
   assert.match(transformResultPanelSource, /onDismiss/)
   assert.doesNotMatch(toolbarSource, /onTop/)
@@ -1397,7 +1432,9 @@ test('compiled extension entrypoints exist after build', () => {
 test('webview protocol normalizes editor commands and rejects invalid ranges', () => {
   const context = { fileSize: 10 }
 
-  assert.equal(normalizeBytesPerRow(24), 16)
+  assert.equal(normalizeBytesPerRow(24), 24)
+  assert.equal(normalizeBytesPerRow(7), 16)
+  assert.equal(normalizeBytesPerRow(65), 16)
   assert.deepEqual(
     normalizeWebviewMessage(context, {
       type: 'editorStateChanged',
@@ -1571,10 +1608,39 @@ test('webview protocol normalizes editor commands and rejects invalid ranges', (
     }),
     { type: 'setBytesPerRow', bytesPerRow: 16 }
   )
-  assert.equal(
+  assert.deepEqual(
     normalizeWebviewMessage(context, {
       type: 'setBytesPerRow',
       bytesPerRow: 24,
+    }),
+    { type: 'setBytesPerRow', bytesPerRow: 24 }
+  )
+  assert.deepEqual(
+    normalizeWebviewMessage(context, {
+      type: 'setBytesPerRow',
+      bytesPerRow: 64,
+      persist: false,
+    }),
+    { type: 'setBytesPerRow', bytesPerRow: 64, persist: false }
+  )
+  assert.deepEqual(
+    normalizeWebviewMessage(context, {
+      type: 'setBytesPerRowMode',
+      mode: 'auto',
+    }),
+    { type: 'setBytesPerRowMode', mode: 'auto' }
+  )
+  assert.equal(
+    normalizeWebviewMessage(context, {
+      type: 'setBytesPerRow',
+      bytesPerRow: 7,
+    }),
+    undefined
+  )
+  assert.equal(
+    normalizeWebviewMessage(context, {
+      type: 'setBytesPerRow',
+      bytesPerRow: 65,
     }),
     undefined
   )

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -894,6 +894,7 @@ suite('OmegaEdit VS Code extension', () => {
       'transformComplete'
     )
     assert.ok(transformComplete, 'Expected calculation action completion')
+    assert.equal(transformComplete.contentSource, 'computed')
     assert.equal(transformComplete.contentChanged, false)
     assert.equal(transformComplete.resultLabel, 'sum8')
     assert.equal(transformComplete.resultText, '0x26')
@@ -901,6 +902,64 @@ suite('OmegaEdit VS Code extension', () => {
       lastMessageOfType(panel.messages, 'editState'),
       cleanEditState
     )
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('reports calculation content source for original snapshots', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-transform-original-')
+    )
+    const samplePath = path.join(tmpDir, 'transform-original.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(
+      session,
+      'Expected a live session for the original calculation test'
+    )
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'overwrite',
+      offset: 0,
+      data: Buffer.from('z', 'utf8').toString('hex'),
+    })
+    await assertSessionText(session.sessionId, 'zbc')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'applyTransform',
+      pluginId: 'omega.example.common_checksums',
+      contentSource: 'original',
+      offset: 0,
+      length: 3,
+      optionsJson: JSON.stringify({ algorithm: 'sum8' }),
+    })
+
+    await assertSessionText(session.sessionId, 'zbc')
+    const transformComplete = lastMessageOfType(
+      panel.messages,
+      'transformComplete'
+    )
+    assert.ok(transformComplete, 'Expected original calculation completion')
+    assert.equal(transformComplete.contentSource, 'original')
+    assert.equal(transformComplete.contentChanged, false)
+    assert.equal(transformComplete.resultLabel, 'sum8')
+    assert.equal(transformComplete.resultText, '0x26')
 
     await panel.fireDidDispose()
     await fs.rm(tmpDir, { recursive: true, force: true })

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -7,9 +7,12 @@
   import TransformResultPanel from './components/TransformResultPanel.svelte'
   import { formatNumber, strings } from './i18n'
   import {
+    MAX_BYTES_PER_ROW,
     MAX_ANALYSIS_PROFILE_BYTES,
     normalizeBytesPerRow,
+    normalizeBytesPerRowMode,
     type BytesPerRow,
+    type BytesPerRowMode,
     type HostToWebviewMessage,
     type InsertDirection,
     type ServerHealthMessage,
@@ -75,6 +78,8 @@
     title: string
     summary: string
     label: string
+    contentSource: WebviewSessionContentSource
+    contentSourceLabel: string
     value: string
     mimeType: string
     offset: number
@@ -106,21 +111,38 @@
 
   interface Props {
     initialBytesPerRow?: BytesPerRow
+    initialBytesPerRowMode?: BytesPerRowMode
   }
 
-  let { initialBytesPerRow = 16 }: Props = $props()
+  let {
+    initialBytesPerRow = 16,
+    initialBytesPerRowMode = 'fixed',
+  }: Props = $props()
 
   const restoredState = getPreviewState()
   const restoredViewportSnapshot = normalizeViewportSnapshot(
     restoredState?.viewportSnapshot
   )
 
+  const configuredBytesPerRow = normalizeBytesPerRow(
+    untrack(() => initialBytesPerRow)
+  )
+  const configuredBytesPerRowMode = normalizeBytesPerRowMode(
+    untrack(() => initialBytesPerRowMode)
+  )
+  let bytesPerRowMode = $state<BytesPerRowMode>(configuredBytesPerRowMode)
   let bytesPerRow = $state<BytesPerRow>(
     normalizeBytesPerRow(
-      restoredState?.bytesPerRow ?? untrack(() => initialBytesPerRow)
+      configuredBytesPerRowMode === 'auto'
+        ? restoredState?.bytesPerRow ?? configuredBytesPerRow
+        : configuredBytesPerRow
     )
   )
   const initialFileSize = restoredViewportSnapshot?.fileSize ?? 0
+  const restoredSelection = normalizePersistedSelection(
+    restoredState,
+    initialFileSize
+  )
   let fileSize = $state(initialFileSize)
   let visibleOffset = $state(restoredViewportSnapshot?.visibleOffset ?? 0)
   let viewportOffset = $state(restoredViewportSnapshot?.viewportOffset ?? 0)
@@ -185,8 +207,8 @@
   let serverHealth = $state<ServerHealthMessage | undefined>(undefined)
   let renderSamples = $state<number[]>([])
   let pendingAnalysisProfileKey = $state('')
-  let selectionAnchor = $state(-1)
-  let selectedOffset = $state(-1)
+  let selectionAnchor = $state(restoredSelection?.anchor ?? -1)
+  let selectedOffset = $state(restoredSelection?.offset ?? -1)
   let searchQuery = $state('')
   let replacementQuery = $state('')
   let searchHex = $state(false)
@@ -202,6 +224,7 @@
   let replaceMessage = $state('')
   let clipboardMessage = $state('')
   let lastPostedEditorStateKey = $state('')
+  let lastPostedAutoFitBytesPerRow = $state<number | undefined>(undefined)
 
   const selectionStart = $derived(
     selectionAnchor >= 0 && selectedOffset >= 0
@@ -337,9 +360,49 @@
   }
 
   function setBytesPerRow(bytes: BytesPerRow): void {
-    bytesPerRow = bytes
-    savePreviewState({ bytesPerRow: bytes })
-    postToHost({ type: 'setBytesPerRow', bytesPerRow: bytes })
+    const normalizedBytes = normalizeBytesPerRow(bytes)
+    bytesPerRowMode = 'fixed'
+    bytesPerRow = normalizedBytes
+    lastPostedAutoFitBytesPerRow = undefined
+    savePreviewState({
+      bytesPerRow: normalizedBytes,
+      bytesPerRowMode,
+    })
+    postToHost({ type: 'setBytesPerRow', bytesPerRow: normalizedBytes })
+  }
+
+  function setBytesPerRowMode(mode: BytesPerRowMode): void {
+    const normalizedMode = normalizeBytesPerRowMode(mode)
+    bytesPerRowMode = normalizedMode
+    lastPostedAutoFitBytesPerRow = undefined
+    savePreviewState({ bytesPerRowMode })
+    if (normalizedMode === 'auto') {
+      postToHost({ type: 'setBytesPerRowMode', mode: 'auto' })
+    } else {
+      setBytesPerRow(bytesPerRow)
+    }
+  }
+
+  function applyAutoFitBytesPerRow(bytes: BytesPerRow): void {
+    if (bytesPerRowMode !== 'auto') {
+      return
+    }
+
+    const normalizedBytes = normalizeBytesPerRow(bytes)
+    if (normalizedBytes !== bytesPerRow) {
+      bytesPerRow = normalizedBytes
+      savePreviewState({ bytesPerRow: normalizedBytes })
+    }
+    if (lastPostedAutoFitBytesPerRow === normalizedBytes) {
+      return
+    }
+
+    lastPostedAutoFitBytesPerRow = normalizedBytes
+    postToHost({
+      type: 'setBytesPerRow',
+      bytesPerRow: normalizedBytes,
+      persist: false,
+    })
   }
 
   function toggleProfilerExpanded(): void {
@@ -360,24 +423,53 @@
   function savePreviewState(
     overrides: Partial<{
       bytesPerRow: BytesPerRow
+      bytesPerRowMode: BytesPerRowMode
       offsetRadix: 'hex' | 'dec'
       insertDirection: InsertDirection
       searchPanelVisible: boolean
       profilerExpanded: boolean
       analysisSectionOrder: AnalysisSectionOrder
+      selectionAnchor: number
+      selectedOffset: number
       viewportSnapshot: PersistedViewportSnapshot | undefined
     }> = {}
   ): void {
     setPreviewState({
       bytesPerRow,
+      bytesPerRowMode,
       offsetRadix,
       insertDirection,
       searchPanelVisible,
       profilerExpanded,
       analysisSectionOrder,
+      selectionAnchor,
+      selectedOffset,
       viewportSnapshot,
       ...overrides,
     })
+  }
+
+  function normalizePersistedSelection(
+    rawState: unknown,
+    totalSize: number
+  ): { anchor: number; offset: number } | undefined {
+    if (!rawState || typeof rawState !== 'object' || totalSize <= 0) {
+      return undefined
+    }
+
+    const state = rawState as Record<string, unknown>
+    const anchor = safeInteger(state.selectionAnchor)
+    const offset = safeInteger(state.selectedOffset)
+    if (
+      anchor === undefined ||
+      offset === undefined ||
+      anchor >= totalSize ||
+      offset >= totalSize
+    ) {
+      return undefined
+    }
+
+    return { anchor, offset }
   }
 
   function normalizeViewportSnapshot(
@@ -818,12 +910,17 @@
     inspectorHighlightEnd = -1
   }
 
+  function saveSelectionState(): void {
+    savePreviewState({ selectionAnchor, selectedOffset })
+  }
+
   function selectOffset(offset: number, extend = false): void {
     const nextOffset = clampOffset(offset)
     if (nextOffset < 0) {
       selectionAnchor = -1
       selectedOffset = -1
       clipboardMessage = ''
+      saveSelectionState()
       return
     }
 
@@ -835,6 +932,7 @@
     pendingHexNibble = undefined
     pendingHexLabel = ''
     clearInspectorHighlight()
+    saveSelectionState()
 
     if (
       nextOffset < visibleOffset ||
@@ -850,6 +948,7 @@
       selectionAnchor = -1
       selectedOffset = -1
       clipboardMessage = ''
+      saveSelectionState()
       return
     }
 
@@ -860,6 +959,7 @@
     pendingHexNibble = undefined
     pendingHexLabel = ''
     clearInspectorHighlight()
+    saveSelectionState()
 
     if (
       start < visibleOffset ||
@@ -1369,6 +1469,28 @@
       : [computedContentInfo(size), ...nextSources]
   }
 
+  function contentSourceFallbackLabel(
+    contentSource: WebviewSessionContentSource
+  ): string {
+    switch (contentSource) {
+      case 'original':
+        return strings.transform.contentOriginal
+      case 'latestCheckpoint':
+        return strings.transform.contentLatestCheckpoint
+      default:
+        return strings.transform.contentComputed
+    }
+  }
+
+  function transformResultContentSourceLabel(
+    contentSource: WebviewSessionContentSource
+  ): string {
+    return (
+      contentSources.find((entry) => entry.content === contentSource)?.label ||
+      contentSourceFallbackLabel(contentSource)
+    )
+  }
+
   function formatSearchOffset(offset: number): string {
     return offsetRadix === 'dec'
       ? formatNumber(offset)
@@ -1610,13 +1732,11 @@
       return undefined
     }
 
+    const contentSource = message.contentSource || 'computed'
     const displayLength = message.contentChanged
       ? message.replacementLength || message.length || 1
       : message.length || 1
-    const rangeEnd = Math.min(
-      Math.max(0, fileSize - 1),
-      message.offset + displayLength - 1
-    )
+    const rangeEnd = message.offset + displayLength - 1
     const timestamp = Date.now()
     const title = transformPluginTitle(message.pluginId)
     const label = message.resultLabel || strings.transform.resultDefault
@@ -1624,10 +1744,12 @@
     transformResultSequence += 1
 
     return {
-      id: `${timestamp}-${transformResultSequence}-${message.pluginId}-${message.offset}-${displayLength}`,
+      id: `${timestamp}-${transformResultSequence}-${message.pluginId}-${contentSource}-${message.offset}-${displayLength}`,
       title,
       summary: describeTransformComplete(message),
       label,
+      contentSource,
+      contentSourceLabel: transformResultContentSourceLabel(contentSource),
       value: message.resultText,
       mimeType: message.resultMimeType,
       offset: message.offset,
@@ -1636,6 +1758,12 @@
       createdAtLabel,
       historyLabel: '',
     }
+  }
+
+  function shouldSelectTransformResultRange(
+    message: TransformCompleteMessage
+  ): boolean {
+    return (message.contentSource || 'computed') === 'computed'
   }
 
   function formatTransformResult(
@@ -2274,7 +2402,8 @@
         if (message.contentChanged) {
           clearSearchResults()
         }
-        if (message.offset >= 0) {
+        const shouldSelectRange = shouldSelectTransformResultRange(message)
+        if (shouldSelectRange && message.offset >= 0) {
           const transformedLength = message.contentChanged
             ? message.replacementLength || message.length || 1
             : message.length || 1
@@ -2282,8 +2411,10 @@
         }
         transformFeedback = describeTransformComplete(message)
         rememberTransformResult(createTransformResult(message))
-        pendingAnalysisProfileKey = ''
-        requestAnalysisProfile(true)
+        if (shouldSelectRange || message.contentChanged) {
+          pendingAnalysisProfileKey = ''
+          requestAnalysisProfile(true)
+        }
         break
       case 'fileActionComplete':
         transformInFlight = false
@@ -2418,6 +2549,7 @@
 <main class="app-shell">
   <Toolbar
     {bytesPerRow}
+    {bytesPerRowMode}
     {offsetRadix}
     {insertDirection}
     {fileSize}
@@ -2436,6 +2568,7 @@
     {selectionEnd}
     {selectionLength}
     onBytesPerRow={setBytesPerRow}
+    onBytesPerRowMode={setBytesPerRowMode}
     onOffsetRadix={setOffsetRadix}
     onInsertDirection={setInsertDirection}
     onGoToOffset={goToOffset}
@@ -2486,6 +2619,7 @@
         label={displayTransformResult.label}
         value={displayTransformResult.value}
         mimeType={displayTransformResult.mimeType}
+        contentSourceLabel={displayTransformResult.contentSourceLabel}
         rangeStart={displayTransformResult.rangeStart}
         rangeEnd={displayTransformResult.rangeEnd}
         length={displayTransformResult.length}
@@ -2499,6 +2633,8 @@
     {visibleOffset}
     scrollOffset={navigationOffset}
     {bytesPerRow}
+    autoFitBytesPerRow={bytesPerRowMode === 'auto'}
+    maxBytesPerRow={MAX_BYTES_PER_ROW}
     {offsetRadix}
     {selectedOffset}
     {selectionStart}
@@ -2544,6 +2680,7 @@
     readOnlyLabel={strings.grid.readOnly}
     readOnlyTitle={transformFeedback || strings.transform.inFlight}
     onVisibleRowsChange={setVisibleRows}
+    onAutoFitBytesPerRow={applyAutoFitBytesPerRow}
     onToggleProfilerExpanded={toggleProfilerExpanded}
     onProfilerModeChange={setProfilerMode}
     onMoveAnalysisSection={moveAnalysisSectionByDelta}

--- a/vscode-extension/webview-ui/src/components/EditorWorkspace.svelte
+++ b/vscode-extension/webview-ui/src/components/EditorWorkspace.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from 'svelte'
   import type {
     BytesPerRow,
     HostToWebviewMessage,
@@ -71,6 +72,8 @@
     canRedo?: boolean
     undoCount?: number
     redoCount?: number
+    autoFitBytesPerRow?: boolean
+    maxBytesPerRow?: number
     editDisabled?: boolean
     readOnlyLabel?: string
     readOnlyTitle?: string
@@ -84,6 +87,7 @@
     onTypeByte: (pane: GridEditPane, key: string) => boolean
     onDeleteByte: (backward: boolean) => boolean
     onVisibleRowsChange: (visibleRows: number) => void
+    onAutoFitBytesPerRow: (bytesPerRow: BytesPerRow) => void
     onToggleProfilerExpanded: () => void
     onProfilerModeChange: (mode: AnalysisMode) => void
     onMoveAnalysisSection: (
@@ -136,6 +140,8 @@
     canRedo = false,
     undoCount = 0,
     redoCount = 0,
+    autoFitBytesPerRow = false,
+    maxBytesPerRow = 64,
     editDisabled = false,
     readOnlyLabel = strings.grid.readOnly,
     readOnlyTitle = readOnlyLabel,
@@ -149,11 +155,104 @@
     onTypeByte,
     onDeleteByte,
     onVisibleRowsChange,
+    onAutoFitBytesPerRow,
     onToggleProfilerExpanded,
     onProfilerModeChange,
     onMoveAnalysisSection,
     onReorderAnalysisSection,
   }: Props = $props()
+
+  let gridScrollerElement = $state<HTMLDivElement>()
+  let autoFitFrame = $state<number | undefined>(undefined)
+
+  function measureAutoFitBytesPerRow(): BytesPerRow | undefined {
+    if (!gridScrollerElement || !autoFitBytesPerRow || preparing) {
+      return undefined
+    }
+
+    const grid = gridScrollerElement.querySelector('.preview-grid')
+    const row =
+      gridScrollerElement.querySelector('.grid-row') ||
+      gridScrollerElement.querySelector('.grid-header')
+    const hexCells = row?.querySelector('.hex-cells, .hex-heading')
+    const asciiCells = row?.querySelector('.ascii')
+    const offsetCell = row?.querySelector('.offset, .offset-heading')
+    if (!grid || !row || !hexCells || !offsetCell) {
+      return undefined
+    }
+
+    const gridStyle = getComputedStyle(grid)
+    const rowStyle = getComputedStyle(row)
+    const horizontalPadding =
+      (Number.parseFloat(gridStyle.paddingLeft) || 0) +
+      (Number.parseFloat(gridStyle.paddingRight) || 0)
+    const gap = Number.parseFloat(rowStyle.columnGap) || 0
+    const hexWidth = hexCells.getBoundingClientRect().width
+    const asciiWidth =
+      asciiCells?.getBoundingClientRect().width ||
+      Math.max(1, hexWidth / Math.max(1, bytesPerRow) / 3) * bytesPerRow
+    const perByteWidth = Math.max(
+      1,
+      (hexWidth + asciiWidth) / Math.max(1, bytesPerRow)
+    )
+    const fixedWidth =
+      offsetCell.getBoundingClientRect().width + gap * 2 + horizontalPadding
+    const availableWidth = Math.max(0, gridScrollerElement.clientWidth)
+    const rawFit = Math.floor((availableWidth - fixedWidth) / perByteWidth)
+    return Math.max(8, Math.min(maxBytesPerRow, rawFit))
+  }
+
+  async function reportAutoFitBytesPerRow(): Promise<void> {
+    await tick()
+    const nextBytesPerRow = measureAutoFitBytesPerRow()
+    if (nextBytesPerRow !== undefined) {
+      onAutoFitBytesPerRow(nextBytesPerRow)
+    }
+  }
+
+  function queueAutoFitBytesPerRow(): void {
+    if (!autoFitBytesPerRow || !gridScrollerElement || preparing) {
+      return
+    }
+    if (autoFitFrame !== undefined) {
+      cancelAnimationFrame(autoFitFrame)
+    }
+    autoFitFrame = requestAnimationFrame(() => {
+      autoFitFrame = undefined
+      void reportAutoFitBytesPerRow()
+    })
+  }
+
+  $effect(() => {
+    if (
+      gridScrollerElement &&
+      autoFitBytesPerRow &&
+      !preparing &&
+      profilerExpanded !== undefined &&
+      bytesPerRow >= 0 &&
+      data.length >= 0
+    ) {
+      queueAutoFitBytesPerRow()
+    }
+  })
+
+  $effect(() => {
+    if (!gridScrollerElement) {
+      return
+    }
+
+    const observer = new ResizeObserver(() => {
+      queueAutoFitBytesPerRow()
+    })
+    observer.observe(gridScrollerElement)
+    queueAutoFitBytesPerRow()
+    return () => {
+      if (autoFitFrame !== undefined) {
+        cancelAnimationFrame(autoFitFrame)
+      }
+      observer.disconnect()
+    }
+  })
 </script>
 
 <div class="editor-main">
@@ -164,35 +263,37 @@
         <span>{strings.grid.preparingFile}</span>
       </div>
     {:else}
-      <PreviewGrid
-        {data}
-        offset={visibleOffset}
-        {bytesPerRow}
-        {offsetRadix}
-        {selectedOffset}
-        {selectionStart}
-        {selectionEnd}
-        {activePane}
-        searchStart={searchStart}
-        searchEnd={searchEnd}
-        inspectorStart={inspectorStart}
-        inspectorEnd={inspectorEnd}
-        {externalHighlights}
-        {pendingHexLabel}
-        {canScrollUp}
-        {canScrollDown}
-        onSelect={onSelect}
-        onActivePaneChange={onActivePaneChange}
-        onMoveSelection={onMoveSelection}
-        onJumpToBoundary={onJumpToBoundary}
-        onScroll={onScroll}
-        onToggleEditMode={onToggleEditMode}
-        onTypeByte={onTypeByte}
-        onDeleteByte={onDeleteByte}
-        readOnly={editDisabled}
-        onVisibleRowsChange={onVisibleRowsChange}
-        editMode={editMode}
-      />
+      <div class="editor-grid-scroller" bind:this={gridScrollerElement}>
+        <PreviewGrid
+          {data}
+          offset={visibleOffset}
+          {bytesPerRow}
+          {offsetRadix}
+          {selectedOffset}
+          {selectionStart}
+          {selectionEnd}
+          {activePane}
+          searchStart={searchStart}
+          searchEnd={searchEnd}
+          inspectorStart={inspectorStart}
+          inspectorEnd={inspectorEnd}
+          {externalHighlights}
+          {pendingHexLabel}
+          {canScrollUp}
+          {canScrollDown}
+          onSelect={onSelect}
+          onActivePaneChange={onActivePaneChange}
+          onMoveSelection={onMoveSelection}
+          onJumpToBoundary={onJumpToBoundary}
+          onScroll={onScroll}
+          onToggleEditMode={onToggleEditMode}
+          onTypeByte={onTypeByte}
+          onDeleteByte={onDeleteByte}
+          readOnly={editDisabled}
+          onVisibleRowsChange={onVisibleRowsChange}
+          editMode={editMode}
+        />
+      </div>
       <FileScrollbar
         {fileSize}
         visibleOffset={scrollOffset}

--- a/vscode-extension/webview-ui/src/components/PreviewGrid.svelte
+++ b/vscode-extension/webview-ui/src/components/PreviewGrid.svelte
@@ -408,7 +408,7 @@
   }
 
   function handleWheel(event: WheelEvent): void {
-    if (event.deltaY === 0) {
+    if (event.deltaY === 0 || Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
       return
     }
 

--- a/vscode-extension/webview-ui/src/components/Toolbar.svelte
+++ b/vscode-extension/webview-ui/src/components/Toolbar.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-  import type {
-    BytesPerRow,
-    InsertDirection,
-    WebviewSessionContentInfo,
-    WebviewSessionContentSource,
-    WebviewTransformPlugin,
+  import {
+    FIXED_BYTES_PER_ROW_OPTIONS,
+    MAX_BYTES_PER_ROW,
+    MIN_BYTES_PER_ROW,
+    normalizeBytesPerRow,
+    type BytesPerRow,
+    type BytesPerRowMode,
+    type InsertDirection,
+    type WebviewSessionContentInfo,
+    type WebviewSessionContentSource,
+    type WebviewTransformPlugin,
   } from '../protocol'
   import { strings } from '../i18n'
   import OffsetJump from './OffsetJump.svelte'
@@ -22,6 +27,7 @@
 
   interface Props {
     bytesPerRow: BytesPerRow
+    bytesPerRowMode: BytesPerRowMode
     offsetRadix?: 'hex' | 'dec'
     insertDirection?: InsertDirection
     fileSize?: number
@@ -40,6 +46,7 @@
     selectionEnd?: number
     selectionLength?: number
     onBytesPerRow: (bytesPerRow: BytesPerRow) => void
+    onBytesPerRowMode: (mode: BytesPerRowMode) => void
     onOffsetRadix: (radix: 'hex' | 'dec') => void
     onInsertDirection: (direction: InsertDirection) => void
     onGoToOffset: (offset: number) => void
@@ -65,6 +72,7 @@
 
   let {
     bytesPerRow,
+    bytesPerRowMode,
     offsetRadix = 'hex',
     insertDirection = 'forward',
     fileSize = 0,
@@ -83,6 +91,7 @@
     selectionEnd = -1,
     selectionLength = 0,
     onBytesPerRow,
+    onBytesPerRowMode,
     onOffsetRadix,
     onInsertDirection,
     onGoToOffset,
@@ -100,22 +109,92 @@
     onApplyChangeLog,
   }: Props = $props()
 
-  const rowOptions: BytesPerRow[] = [8, 16, 32]
+  const rowOptions: BytesPerRow[] = [...FIXED_BYTES_PER_ROW_OPTIONS]
+  let customBytesPerRowValue = $state('')
+
+  function clampBytesPerRow(value: number): BytesPerRow {
+    if (!Number.isFinite(value)) {
+      return bytesPerRow
+    }
+    return normalizeBytesPerRow(
+      Math.max(MIN_BYTES_PER_ROW, Math.min(MAX_BYTES_PER_ROW, Math.floor(value)))
+    )
+  }
+
+  function handleCustomBytesInput(event: Event): void {
+    customBytesPerRowValue = (event.currentTarget as HTMLInputElement).value
+  }
+
+  function commitCustomBytesPerRow(force = false): void {
+    const nextBytesPerRow = clampBytesPerRow(
+      Number.parseInt(customBytesPerRowValue, 10)
+    )
+    customBytesPerRowValue = String(nextBytesPerRow)
+    if (
+      !force &&
+      bytesPerRowMode === 'auto' &&
+      nextBytesPerRow === bytesPerRow
+    ) {
+      return
+    }
+    onBytesPerRow(nextBytesPerRow)
+  }
+
+  function handleCustomBytesKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      commitCustomBytesPerRow(true)
+    }
+  }
+
+  function handleCustomBytesBlur(): void {
+    commitCustomBytesPerRow()
+  }
+
+  $effect(() => {
+    customBytesPerRowValue = String(bytesPerRow)
+  })
 </script>
 
 <div class="toolbar" role="toolbar" aria-label={strings.toolbar.label}>
-  <div class="segmented" aria-label={strings.toolbar.bytesPerRow}>
-    {#each rowOptions as option}
+  <div class="bytes-per-row-control">
+    <div class="segmented" aria-label={strings.toolbar.bytesPerRow}>
       <button
         type="button"
-        class:active={option === bytesPerRow}
-        aria-pressed={option === bytesPerRow}
-        title={strings.toolbar.bytesPerRowTitle(option)}
-        onclick={() => onBytesPerRow(option)}
+        class:active={bytesPerRowMode === 'auto'}
+        aria-pressed={bytesPerRowMode === 'auto'}
+        title={strings.toolbar.autoBytesPerRowTitle}
+        onclick={() => onBytesPerRowMode('auto')}
       >
-        {option}
+        {strings.toolbar.autoBytesPerRow}
       </button>
-    {/each}
+      {#each rowOptions as option}
+        <button
+          type="button"
+          class:active={bytesPerRowMode === 'fixed' && option === bytesPerRow}
+          aria-pressed={bytesPerRowMode === 'fixed' && option === bytesPerRow}
+          title={strings.toolbar.bytesPerRowTitle(option)}
+          onclick={() => onBytesPerRow(option)}
+        >
+          {option}
+        </button>
+      {/each}
+    </div>
+    <input
+      class="bytes-per-row-input"
+      type="number"
+      min={MIN_BYTES_PER_ROW}
+      max={MAX_BYTES_PER_ROW}
+      value={customBytesPerRowValue}
+      aria-label={strings.toolbar.customBytesPerRow}
+      title={strings.toolbar.customBytesPerRowTitle(
+        MIN_BYTES_PER_ROW,
+        MAX_BYTES_PER_ROW
+      )}
+      oninput={handleCustomBytesInput}
+      onblur={handleCustomBytesBlur}
+      onkeydown={handleCustomBytesKeydown}
+    />
   </div>
 
   <div class="segmented" aria-label={strings.toolbar.offsetRadix}>

--- a/vscode-extension/webview-ui/src/components/TransformResultPanel.svelte
+++ b/vscode-extension/webview-ui/src/components/TransformResultPanel.svelte
@@ -7,6 +7,7 @@
     label: string
     value: string
     mimeType?: string
+    contentSourceLabel: string
     rangeStart: string
     rangeEnd: string
     length: string
@@ -19,6 +20,7 @@
     label,
     value,
     mimeType = '',
+    contentSourceLabel,
     rangeStart,
     rangeEnd,
     length,
@@ -62,6 +64,8 @@
   <div class="transform-result-meta">
     <span class="analysis-label">{strings.transform.resultLabel}</span>
     <span class="analysis-value">{label}</span>
+    <span class="analysis-label">{strings.transform.contentSource}</span>
+    <span class="analysis-value">{contentSourceLabel}</span>
     {#if mimeType}
       <span class="analysis-label">{strings.transform.resultMimeType}</span>
       <span class="analysis-value">{mimeType}</span>

--- a/vscode-extension/webview-ui/src/i18n.ts
+++ b/vscode-extension/webview-ui/src/i18n.ts
@@ -29,6 +29,11 @@ const englishStrings = {
     label: 'OmegaEdit editor toolbar',
     bytesPerRow: 'Bytes per row',
     bytesPerRowTitle: (count: number) => `Show ${count} bytes per row`,
+    autoBytesPerRow: 'Auto',
+    autoBytesPerRowTitle: 'Fit bytes per row to the editor width',
+    customBytesPerRow: 'Custom bytes per row',
+    customBytesPerRowTitle: (min: number, max: number) =>
+      `Set bytes per row from ${min} to ${max}`,
     offsetRadix: 'Offset radix',
     hexOffsets: 'Hex',
     decOffsets: 'Dec',
@@ -479,6 +484,11 @@ const localeOverrides: Record<string, LocaleStringOverrides> = {
       bytesPerRow: 'Bytes por fila',
       bytesPerRowTitle: (count: number) =>
         `Mostrar ${formatNumber(count)} bytes por fila`,
+      autoBytesPerRow: 'Auto',
+      autoBytesPerRowTitle: 'Ajustar bytes por fila al ancho del editor',
+      customBytesPerRow: 'Bytes por fila personalizados',
+      customBytesPerRowTitle: (min: number, max: number) =>
+        `Establecer bytes por fila de ${formatNumber(min)} a ${formatNumber(max)}`,
       offsetRadix: 'Base del desplazamiento',
       hexOffsets: 'Hex',
       decOffsets: 'Dec',

--- a/vscode-extension/webview-ui/src/main.ts
+++ b/vscode-extension/webview-ui/src/main.ts
@@ -2,7 +2,7 @@ import App from './App.svelte'
 import './styles.css'
 import { mount } from 'svelte'
 import { setLanguage, strings, textDirectionForLanguage } from './i18n'
-import { normalizeBytesPerRow } from './protocol'
+import { normalizeBytesPerRow, normalizeBytesPerRowMode } from './protocol'
 
 const initialLanguage = document.documentElement.lang || navigator.language
 setLanguage(initialLanguage)
@@ -20,6 +20,9 @@ document.documentElement.dir = textDirectionForLanguage(activeLanguage)
 const initialBytesPerRow = normalizeBytesPerRow(
   Number.parseInt(target.dataset.bytesPerRow ?? '', 10)
 )
+const initialBytesPerRowMode = normalizeBytesPerRowMode(
+  target.dataset.bytesPerRowMode
+)
 
 try {
   target.replaceChildren()
@@ -27,6 +30,7 @@ try {
     target,
     props: {
       initialBytesPerRow,
+      initialBytesPerRowMode,
     },
   })
 } catch (error) {

--- a/vscode-extension/webview-ui/src/protocol.ts
+++ b/vscode-extension/webview-ui/src/protocol.ts
@@ -1,5 +1,6 @@
 export type {
   BytesPerRow,
+  BytesPerRowMode,
   HostToWebviewMessage,
   InsertDirection,
   ServerHealthMetric,
@@ -14,7 +15,15 @@ export type {
 } from '../../src/webviewProtocol'
 
 export {
+  AUTO_BYTES_PER_ROW_SETTING,
+  DEFAULT_BYTES_PER_ROW,
+  FIXED_BYTES_PER_ROW_OPTIONS,
   MAX_ANALYSIS_PROFILE_BYTES,
+  MAX_BYTES_PER_ROW,
   MAX_TRANSFORM_OPTIONS_LENGTH,
+  MIN_BYTES_PER_ROW,
+  bytesPerRowFromSetting,
   normalizeBytesPerRow,
+  normalizeBytesPerRowMode,
+  normalizeBytesPerRowSetting,
 } from '../../src/webviewProtocol'

--- a/vscode-extension/webview-ui/src/styles.css
+++ b/vscode-extension/webview-ui/src/styles.css
@@ -110,6 +110,33 @@ button:focus-visible {
   justify-content: flex-end;
 }
 
+.bytes-per-row-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.bytes-per-row-control .segmented {
+  --segmented-button-width: 44px;
+}
+
+.bytes-per-row-input {
+  width: 54px;
+  height: 26px;
+  padding: 3px 5px;
+  border: 1px solid var(--vscode-input-border, var(--vscode-editorGroup-border));
+  border-radius: 2px;
+  color: var(--vscode-input-foreground);
+  background: var(--vscode-input-background);
+  font: inherit;
+}
+
+.bytes-per-row-input:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .top-panels {
   min-width: 0;
   overflow: hidden;
@@ -813,6 +840,15 @@ button.dialog-backdrop:focus-visible {
   grid-template-columns: minmax(0, 1fr);
 }
 
+.editor-grid-scroller {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior: contain;
+}
+
 .preparing-file {
   display: flex;
   grid-column: 1 / -1;
@@ -1452,10 +1488,11 @@ button.dialog-backdrop:focus-visible {
   display: grid;
   grid-auto-rows: minmax(24px, auto);
   align-content: start;
-  min-width: 0;
-  max-width: 100%;
+  width: max-content;
+  min-width: 100%;
+  max-width: none;
   min-height: 0;
-  overflow: hidden;
+  overflow: visible;
   overscroll-behavior: contain;
   padding: 8px;
   font-family: var(--vscode-editor-font-family, monospace);
@@ -1467,12 +1504,228 @@ button.dialog-backdrop:focus-visible {
   --bytes-per-row: 8;
 }
 
+.preview-grid.bytes-9 {
+  --bytes-per-row: 9;
+}
+
+.preview-grid.bytes-10 {
+  --bytes-per-row: 10;
+}
+
+.preview-grid.bytes-11 {
+  --bytes-per-row: 11;
+}
+
+.preview-grid.bytes-12 {
+  --bytes-per-row: 12;
+}
+
+.preview-grid.bytes-13 {
+  --bytes-per-row: 13;
+}
+
+.preview-grid.bytes-14 {
+  --bytes-per-row: 14;
+}
+
+.preview-grid.bytes-15 {
+  --bytes-per-row: 15;
+}
+
 .preview-grid.bytes-16 {
   --bytes-per-row: 16;
 }
 
+.preview-grid.bytes-17 {
+  --bytes-per-row: 17;
+}
+
+.preview-grid.bytes-18 {
+  --bytes-per-row: 18;
+}
+
+.preview-grid.bytes-19 {
+  --bytes-per-row: 19;
+}
+
+.preview-grid.bytes-20 {
+  --bytes-per-row: 20;
+}
+
+.preview-grid.bytes-21 {
+  --bytes-per-row: 21;
+}
+
+.preview-grid.bytes-22 {
+  --bytes-per-row: 22;
+}
+
+.preview-grid.bytes-23 {
+  --bytes-per-row: 23;
+}
+
+.preview-grid.bytes-24 {
+  --bytes-per-row: 24;
+}
+
+.preview-grid.bytes-25 {
+  --bytes-per-row: 25;
+}
+
+.preview-grid.bytes-26 {
+  --bytes-per-row: 26;
+}
+
+.preview-grid.bytes-27 {
+  --bytes-per-row: 27;
+}
+
+.preview-grid.bytes-28 {
+  --bytes-per-row: 28;
+}
+
+.preview-grid.bytes-29 {
+  --bytes-per-row: 29;
+}
+
+.preview-grid.bytes-30 {
+  --bytes-per-row: 30;
+}
+
+.preview-grid.bytes-31 {
+  --bytes-per-row: 31;
+}
+
 .preview-grid.bytes-32 {
   --bytes-per-row: 32;
+}
+
+.preview-grid.bytes-33 {
+  --bytes-per-row: 33;
+}
+
+.preview-grid.bytes-34 {
+  --bytes-per-row: 34;
+}
+
+.preview-grid.bytes-35 {
+  --bytes-per-row: 35;
+}
+
+.preview-grid.bytes-36 {
+  --bytes-per-row: 36;
+}
+
+.preview-grid.bytes-37 {
+  --bytes-per-row: 37;
+}
+
+.preview-grid.bytes-38 {
+  --bytes-per-row: 38;
+}
+
+.preview-grid.bytes-39 {
+  --bytes-per-row: 39;
+}
+
+.preview-grid.bytes-40 {
+  --bytes-per-row: 40;
+}
+
+.preview-grid.bytes-41 {
+  --bytes-per-row: 41;
+}
+
+.preview-grid.bytes-42 {
+  --bytes-per-row: 42;
+}
+
+.preview-grid.bytes-43 {
+  --bytes-per-row: 43;
+}
+
+.preview-grid.bytes-44 {
+  --bytes-per-row: 44;
+}
+
+.preview-grid.bytes-45 {
+  --bytes-per-row: 45;
+}
+
+.preview-grid.bytes-46 {
+  --bytes-per-row: 46;
+}
+
+.preview-grid.bytes-47 {
+  --bytes-per-row: 47;
+}
+
+.preview-grid.bytes-48 {
+  --bytes-per-row: 48;
+}
+
+.preview-grid.bytes-49 {
+  --bytes-per-row: 49;
+}
+
+.preview-grid.bytes-50 {
+  --bytes-per-row: 50;
+}
+
+.preview-grid.bytes-51 {
+  --bytes-per-row: 51;
+}
+
+.preview-grid.bytes-52 {
+  --bytes-per-row: 52;
+}
+
+.preview-grid.bytes-53 {
+  --bytes-per-row: 53;
+}
+
+.preview-grid.bytes-54 {
+  --bytes-per-row: 54;
+}
+
+.preview-grid.bytes-55 {
+  --bytes-per-row: 55;
+}
+
+.preview-grid.bytes-56 {
+  --bytes-per-row: 56;
+}
+
+.preview-grid.bytes-57 {
+  --bytes-per-row: 57;
+}
+
+.preview-grid.bytes-58 {
+  --bytes-per-row: 58;
+}
+
+.preview-grid.bytes-59 {
+  --bytes-per-row: 59;
+}
+
+.preview-grid.bytes-60 {
+  --bytes-per-row: 60;
+}
+
+.preview-grid.bytes-61 {
+  --bytes-per-row: 61;
+}
+
+.preview-grid.bytes-62 {
+  --bytes-per-row: 62;
+}
+
+.preview-grid.bytes-63 {
+  --bytes-per-row: 63;
+}
+
+.preview-grid.bytes-64 {
+  --bytes-per-row: 64;
 }
 
 .preview-grid:focus-visible {
@@ -1490,7 +1743,7 @@ button.dialog-backdrop:focus-visible {
   grid-template-columns:
     minmax(9ch, 12ch)
     max-content
-    minmax(8ch, 1fr);
+    max-content;
   align-items: center;
   gap: 12px;
   min-width: max-content;
@@ -1544,6 +1797,11 @@ button.dialog-backdrop:focus-visible {
 .ascii-heading,
 .offset {
   color: var(--vscode-terminal-ansiCyan, #4fc1ff);
+}
+
+.ascii-heading {
+  display: inline-flex;
+  width: calc(var(--bytes-per-row) * 1ch);
 }
 
 .byte {
@@ -1686,6 +1944,29 @@ button.dialog-backdrop:focus-visible {
   background: var(--vscode-editor-selectionBackground);
 }
 
+.byte.selected:hover,
+.text-byte.selected:hover {
+  color: #111827;
+  background: var(--vscode-terminal-ansiYellow, #f59e0b);
+  border-color: var(--vscode-terminal-ansiYellow, #f59e0b);
+}
+
+body.vscode-light .byte.selected:hover,
+body.vscode-light .text-byte.selected:hover {
+  color: #ffffff;
+  background: var(--vscode-terminal-ansiRed, #a31515);
+  border-color: var(--vscode-terminal-ansiRed, #a31515);
+}
+
+body.vscode-high-contrast .byte.selected:hover,
+body.vscode-high-contrast .text-byte.selected:hover,
+body.vscode-high-contrast-light .byte.selected:hover,
+body.vscode-high-contrast-light .text-byte.selected:hover {
+  color: var(--vscode-editor-background);
+  background: var(--vscode-focusBorder);
+  border-color: var(--vscode-focusBorder);
+}
+
 .byte.focused,
 .text-byte.focused {
   border-color: var(--vscode-focusBorder);
@@ -1712,10 +1993,10 @@ button.dialog-backdrop:focus-visible {
 
 .ascii {
   display: flex;
-  min-width: 0;
-  overflow: hidden;
+  width: calc(var(--bytes-per-row) * 1ch);
+  min-width: calc(var(--bytes-per-row) * 1ch);
+  overflow: visible;
   color: var(--vscode-descriptionForeground);
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/vscode-extension/webview-ui/src/vscodeApi.ts
+++ b/vscode-extension/webview-ui/src/vscodeApi.ts
@@ -10,11 +10,14 @@ export interface PersistedViewportSnapshot {
 
 export interface PersistedPreviewState {
   bytesPerRow?: number
+  bytesPerRowMode?: 'fixed' | 'auto'
   offsetRadix?: 'hex' | 'dec'
   insertDirection?: 'forward' | 'backward'
   searchPanelVisible?: boolean
   profilerExpanded?: boolean
   analysisSectionOrder?: Record<string, string[]>
+  selectionAnchor?: number
+  selectedOffset?: number
   viewportSnapshot?: PersistedViewportSnapshot
 }
 


### PR DESCRIPTION
## Summary

This updates the VS Code data editor row sizing experience and result metadata behavior:

- Adds `omegaEdit.bytesPerRow` support for Auto mode (`0`) and fixed values from `8` through `64`.
- Adds toolbar controls for Auto, fixed presets, and a capped custom bytes-per-row input.
- Adds horizontal scrolling for wide editor rows and lets horizontal wheel gestures reach the scroller.
- Recalculates Auto row sizing when the editor pane changes width, including analyzer show/hide changes.
- Preserves selected ranges when row sizing changes.
- Fixes selected byte hover contrast so the byte value remains visible across themes.
- Shows transform/calculation content source in the results pane and avoids selecting ranges on current content for non-current sources.

## Why

Developers inspect data on very different monitor sizes and layouts. The editor should let them fill available horizontal space, avoid squeezing wide rows, and keep the current selection stable when layout settings change. Calculation results also need to make clear which content source produced the value, especially for snapshots or checkpoints.

## Validation

Run with Node 24 via `nvm`:

- `npm --prefix vscode-extension run lint`
- `npm --prefix vscode-extension run compile:extension`
- `npm --prefix vscode-extension run check:webview`
- `npm --prefix vscode-extension run compile:webview`
- `npm --prefix vscode-extension run test:unit`
- `npm --prefix vscode-extension run test:integration` (20 passing, 1 existing pending)
- `git diff --check`