### PR TITLE
chore: address Claude findings

### DIFF
--- a/.github/workflows/ts-format.yml
+++ b/.github/workflows/ts-format.yml
@@ -21,8 +21,12 @@ on:
 
 jobs:
   build:
-    name: TypeScript code passes Biome checks
+    name: TypeScript code passes Biome checks on Node ${{ matrix.node-version }}
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [22, 24]
+      fail-fast: false
     steps:
       - name: Checkout current branch (full) 🛎️
         uses: actions/checkout@v7
@@ -34,7 +38,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           registry-url: 'https://registry.npmjs.org'
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
 
       - name: yarn lint - all workspaces 🧶

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ For an installed package instead of a source checkout, use the Codex MCP format 
 - machine-readable CLI and MCP responses are easier for agents to consume than terminal scraping
 - the same primitives work for both human-operated scripts and agent-hosted tool calls
 
+### Server Trust Boundary
+
+The bundled gRPC server is an unauthenticated local editing service. By default it binds to `127.0.0.1`; keep it on
+loopback or a Unix domain socket unless the surrounding environment supplies its own access control. Non-loopback TCP
+binds, such as `0.0.0.0`, require the explicit `--insecure-allow-non-loopback` opt-in because any client that can reach
+the server can read, edit, save, and invoke registered transform plugins with the server process's privileges.
+
 ## Transform Plugins
 
 OmegaEdit can discover native transform plugins from `.so`, `.dylib`, and `.dll` files. Plugins can replace a selected range, expand or shrink content, or inspect a range and return a result such as a checksum or hash. The separately packaged examples include bitwise transforms, ASCII case changes, binary/text codecs, zlib compression, character transcoding, decimal field helpers, record/text escaping, TLV/varint inspectors, and MD5/SHA/BLAKE/CRC/checksum-style inspection. See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the ABI, SDK helpers, plugin package layout, server registration options, and exemplar plugins.
@@ -130,13 +137,16 @@ User documentation is published to https://ctc-oss.github.io/omega-edit/.
 - **conan** C/C++ package manager (https://conan.io)
 - **git** for version control (https://git-scm.com)
 - **make** or **ninja** for running the build scripts (https://www.gnu.org/software/make/ or https://ninja-build.org)
+- **Node.js 22+** and **yarn** for building, testing, and packaging the node artifacts (https://yarnpkg.com)
 - **nvm** or **nodeenv** for using specific versions of node.js
+
+Optional documentation tools:
+
 - **doxygen** to generate API documentation (https://www.doxygen.nl)
 - **graphviz** to generate API documentation (https://graphviz.org)
 - **sphinx** to generate user documentation (https://www.sphinx-doc.org)
   - **sphinx RTD theme** (https://github.com/readthedocs/sphinx_rtd_theme)
   - **breathe** ReStructuredText and Sphinx bridge to Doxygen (https://github.com/michaeljones/breathe)
-- **yarn** for building, testing, and packaging the node artifacts (https://yarnpkg.com)
 
 ### IDE
 

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -19,6 +19,7 @@
 #include "../include/omega_edit/session.h"
 #include "../include/omega_edit/viewport.h"
 #include "impl_/change_def.hpp"
+#include "impl_/edit_private_helpers.hpp"
 #include "impl_/internal_fun.hpp"
 #include "impl_/macros.h"
 #include "impl_/model_def.hpp"
@@ -35,20 +36,31 @@
 #include <vector>
 
 using omega_edit::internal::add_overflows_int64_;
+using omega_edit::internal::apply_builtin_transform_;
+using omega_edit::internal::builtin_transform_id_;
+using omega_edit::internal::builtin_transform_options_json_;
 using omega_edit::internal::change_kind_t;
+using omega_edit::internal::del_;
+using omega_edit::internal::ins_;
+using omega_edit::internal::is_builtin_transform_kind_;
 using omega_edit::internal::model_segment_kind_t;
+using omega_edit::internal::next_change_serial_;
 using omega_edit::internal::omega_change_get_kind_;
 using omega_edit::internal::omega_change_get_transaction_bit_;
 using omega_edit::internal::omega_data_create_;
 using omega_edit::internal::omega_data_destroy_;
-using omega_edit::internal::omega_data_get_data_;
 using omega_edit::internal::omega_model_segment_get_kind_;
-using omega_edit::internal::omega_session_begin_event_batch_;
-using omega_edit::internal::omega_session_end_event_batch_;
 using omega_edit::internal::omega_session_get_transaction_bit_;
+using omega_edit::internal::ovr_;
 using omega_edit::internal::populate_data_segment_;
 using omega_edit::internal::print_model_segments_;
+using omega_edit::internal::restore_viewport_callbacks_;
 using omega_edit::internal::safe_add_int64_;
+using omega_edit::internal::scoped_search_context_t;
+using omega_edit::internal::scoped_session_event_batch_t;
+using omega_edit::internal::scoped_transaction_t;
+using omega_edit::internal::session_stream_cursor_t;
+using omega_edit::internal::transform_;
 using omega_edit::internal::valid_nonnegative_range_;
 
 #ifdef OMEGA_BUILD_WINDOWS
@@ -71,11 +83,6 @@ using omega_edit::internal::valid_nonnegative_range_;
 namespace {
     constexpr int64_t OMEGA_IO_BUFFER_SIZE = 65536;
     constexpr int OMEGA_OUTPUT_PATH_SUFFIX_ATTEMPTS = 1000000;
-
-    inline int64_t next_change_serial_(const omega_session_t *session_ptr) {
-        const auto change_count = omega_session_get_num_changes(session_ptr);
-        return change_count < (std::numeric_limits<int64_t>::max)() ? change_count + 1 : 0;
-    }
 
     auto initialize_model_segments_(omega_model_segments_t &model_segments, int64_t length) -> bool;
 
@@ -288,161 +295,6 @@ namespace {
         } catch (const std::bad_alloc &) { return false; }
     }
 
-    inline auto del_(int64_t serial, int64_t offset, int64_t length, bool transaction_bit) -> const_omega_change_ptr_t {
-        // serial == 0 is used internally while decomposing OVERWRITE into DELETE+INSERT model updates.
-        // Public delete entry points validate serial/range before creating DELETE changes.
-        try {
-            const auto change_ptr = std::make_shared<omega_change_t>();
-            change_ptr->serial = serial;
-            change_ptr->kind =
-                    (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_DELETE;
-            change_ptr->offset = offset;
-            change_ptr->length = length;
-            return change_ptr;
-        } catch (const std::bad_alloc &) { return nullptr; }
-    }
-
-    inline auto populate_change_bytes_(omega_change_t *change_ptr, const omega_byte_t *bytes) -> bool {
-        try {
-            omega_data_create_(&change_ptr->data, change_ptr->length);
-            auto *const change_data = omega_data_get_data_(&change_ptr->data, change_ptr->length);
-            if (!change_data) { return false; }
-            memcpy(change_data, bytes, change_ptr->length);
-            change_data[change_ptr->length] = '\0';
-            return true;
-        } catch (const std::bad_alloc &) { return false; }
-    }
-
-    inline auto ins_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
-                     bool transaction_bit) -> const_omega_change_ptr_t {
-        if (!bytes) { return nullptr; }
-        if (serial <= 0 || !valid_nonnegative_range_(offset, length)) { return nullptr; }
-        try {
-            auto change_ptr = std::make_shared<omega_change_t>();
-            change_ptr->serial = serial;
-            change_ptr->kind =
-                    (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_INSERT;
-            change_ptr->offset = offset;
-            change_ptr->length = length;
-            if (!populate_change_bytes_(change_ptr.get(), bytes)) { return nullptr; }
-            return change_ptr;
-        } catch (const std::bad_alloc &) { return nullptr; }
-    }
-
-    inline auto ovr_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
-                     bool transaction_bit) -> const_omega_change_ptr_t {
-        if (!bytes) { return nullptr; }
-        if (serial <= 0 || !valid_nonnegative_range_(offset, length)) { return nullptr; }
-        try {
-            auto change_ptr = std::make_shared<omega_change_t>();
-            change_ptr->serial = serial;
-            change_ptr->kind =
-                    (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_OVERWRITE;
-            change_ptr->offset = offset;
-            change_ptr->length = length;
-            if (!populate_change_bytes_(change_ptr.get(), bytes)) { return nullptr; }
-            return change_ptr;
-        } catch (const std::bad_alloc &) { return nullptr; }
-    }
-
-    inline auto transform_(int64_t serial, int64_t offset, int64_t length, const char *transform_id,
-                           const char *options_json, int64_t replacement_length, int64_t file_size_before,
-                           int64_t file_size_after, const char *checkpoint_file_path,
-                           bool transaction_bit) -> const_omega_change_ptr_t {
-        if (serial <= 0 || !valid_nonnegative_range_(offset, length) || replacement_length < 0 ||
-            file_size_before < 0 || file_size_after < 0 || !checkpoint_file_path || !*checkpoint_file_path) {
-            return nullptr;
-        }
-        try {
-            auto change_ptr = std::make_shared<omega_change_t>();
-            change_ptr->serial = serial;
-            change_ptr->kind =
-                    (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_TRANSFORM;
-            change_ptr->offset = offset;
-            change_ptr->length = length;
-            change_ptr->transform_data = std::make_unique<omega_transform_change_data_struct>();
-            change_ptr->transform_data->transform_id = (transform_id && *transform_id) ? transform_id : "transform";
-            if (options_json) { change_ptr->transform_data->options_json = options_json; }
-            change_ptr->transform_data->replacement_length = replacement_length;
-            change_ptr->transform_data->computed_file_size_before = file_size_before;
-            change_ptr->transform_data->computed_file_size_after = file_size_after;
-            change_ptr->transform_data->checkpoint_file_path = checkpoint_file_path;
-            return change_ptr;
-        } catch (const std::bad_alloc &) { return nullptr; }
-    }
-
-    inline auto restore_viewport_callbacks_(omega_session_t *session_ptr, bool callbacks_were_paused,
-                                            bool notify_changed_viewports) -> void {
-        if (!session_ptr || callbacks_were_paused) { return; }
-        omega_session_resume_viewport_event_callbacks(session_ptr);
-        if (notify_changed_viewports) { omega_session_notify_changed_viewports(session_ptr); }
-    }
-
-    class scoped_transaction_t {
-    public:
-        explicit scoped_transaction_t(omega_session_t *session_ptr) : session_ptr_(session_ptr) {
-            if (!session_ptr_) {
-                begin_result_ = -1;
-                return;
-            }
-            if (omega_session_get_transaction_state(session_ptr_) == 0) {
-                begin_result_ = omega_session_begin_transaction(session_ptr_);
-                owns_transaction_ = (begin_result_ == 0);
-            }
-        }
-
-        ~scoped_transaction_t() {
-            if (owns_transaction_) { omega_session_end_transaction(session_ptr_); }
-        }
-
-        bool ok() const { return begin_result_ == 0; }
-
-    private:
-        omega_session_t *session_ptr_{};
-        int begin_result_{0};
-        bool owns_transaction_{false};
-    };
-
-    class scoped_session_event_batch_t {
-    public:
-        scoped_session_event_batch_t(omega_session_t *session_ptr, omega_session_event_t session_event)
-            : session_ptr_(session_ptr) {
-            omega_session_begin_event_batch_(session_ptr_, session_event);
-        }
-
-        ~scoped_session_event_batch_t() { omega_session_end_event_batch_(session_ptr_); }
-
-    private:
-        omega_session_t *session_ptr_{};
-    };
-
-    class scoped_search_context_t {
-    public:
-        explicit scoped_search_context_t(omega_search_context_t *context_ptr) : context_ptr_(context_ptr) {}
-
-        ~scoped_search_context_t() { reset(); }
-
-        scoped_search_context_t(const scoped_search_context_t &) = delete;
-        auto operator=(const scoped_search_context_t &) -> scoped_search_context_t & = delete;
-
-        auto get() const -> omega_search_context_t * { return context_ptr_; }
-
-        void reset(omega_search_context_t *context_ptr = nullptr) {
-            if (context_ptr_ != nullptr) { omega_search_destroy_context(context_ptr_); }
-            context_ptr_ = context_ptr;
-        }
-
-    private:
-        omega_search_context_t *context_ptr_{};
-    };
-
-    struct session_stream_cursor_t {
-        const omega_session_t *session_ptr{};
-        omega_model_segments_t::const_iterator segment_iter{};
-        omega_model_segments_t::const_iterator segment_end{};
-        int64_t offset{};
-    };
-
     int64_t write_file_segment_(FILE *from_file_ptr, int64_t offset, int64_t byte_count, FILE *to_file_ptr,
                                 omega_byte_t *io_buf);
 
@@ -512,68 +364,6 @@ namespace {
                 return replace_bytes_impl_(session_ptr, op.offset, op.length, op.bytes, op.bytes_length);
             default:
                 return -1;
-        }
-    }
-
-    auto is_builtin_transform_kind_(omega_edit_transform_kind_t kind) -> bool {
-        switch (kind) {
-            case OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER:
-            case OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER:
-            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
-            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
-            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    auto builtin_transform_id_(omega_edit_transform_kind_t kind) -> const char * {
-        switch (kind) {
-            case OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER:
-                return "builtin:ascii-to-upper";
-            case OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER:
-                return "builtin:ascii-to-lower";
-            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
-                return "builtin:bitwise-and";
-            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
-                return "builtin:bitwise-or";
-            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR:
-                return "builtin:bitwise-xor";
-            default:
-                return "builtin:unknown";
-        }
-    }
-
-    auto builtin_transform_options_json_(const omega_edit_transform_t &transform) -> std::string {
-        switch (transform.kind) {
-            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
-            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
-            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR: {
-                char buffer[32];
-                snprintf(buffer, sizeof(buffer), "{\"operand\":%u}", static_cast<unsigned>(transform.operand));
-                return buffer;
-            }
-            default:
-                return {};
-        }
-    }
-
-    omega_byte_t apply_builtin_transform_(omega_byte_t byte, void *user_data_ptr) {
-        const auto *const transform_ptr = reinterpret_cast<const omega_edit_transform_t *>(user_data_ptr);
-        switch (transform_ptr->kind) {
-            case OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER:
-                return (byte >= 'a' && byte <= 'z') ? static_cast<omega_byte_t>(byte - ('a' - 'A')) : byte;
-            case OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER:
-                return (byte >= 'A' && byte <= 'Z') ? static_cast<omega_byte_t>(byte + ('a' - 'A')) : byte;
-            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
-                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_AND);
-            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
-                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_OR);
-            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR:
-                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_XOR);
-            default:
-                return byte;
         }
     }
 

--- a/core/src/lib/impl_/edit_private_helpers.hpp
+++ b/core/src/lib/impl_/edit_private_helpers.hpp
@@ -1,0 +1,260 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+ * implied.  See the License for the specific language governing permissions and limitations under the License.       *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#ifndef OMEGA_EDIT_PRIVATE_HELPERS_HPP
+#define OMEGA_EDIT_PRIVATE_HELPERS_HPP
+
+#include "../../include/omega_edit/edit.h"
+#include "../../include/omega_edit/search.h"
+#include "../../include/omega_edit/session.h"
+#include "../../include/omega_edit/utility.h"
+#include "change_def.hpp"
+#include "data_def.hpp"
+#include "model_def.hpp"
+#include "safe_math.hpp"
+#include "session_def.hpp"
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <new>
+#include <string>
+
+namespace omega_edit::internal {
+
+    inline int64_t next_change_serial_(const omega_session_t *session_ptr) {
+        const auto change_count = omega_session_get_num_changes(session_ptr);
+        return change_count < (std::numeric_limits<int64_t>::max)() ? change_count + 1 : 0;
+    }
+
+    inline auto del_(int64_t serial, int64_t offset, int64_t length, bool transaction_bit) -> const_omega_change_ptr_t {
+        // serial == 0 is used internally while decomposing OVERWRITE into DELETE+INSERT model updates.
+        // Public delete entry points validate serial/range before creating DELETE changes.
+        try {
+            const auto change_ptr = std::make_shared<omega_change_t>();
+            change_ptr->serial = serial;
+            change_ptr->kind =
+                    (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_DELETE;
+            change_ptr->offset = offset;
+            change_ptr->length = length;
+            return change_ptr;
+        } catch (const std::bad_alloc &) { return nullptr; }
+    }
+
+    inline auto populate_change_bytes_(omega_change_t *change_ptr, const omega_byte_t *bytes) -> bool {
+        try {
+            omega_data_create_(&change_ptr->data, change_ptr->length);
+            auto *const change_data = omega_data_get_data_(&change_ptr->data, change_ptr->length);
+            if (!change_data) { return false; }
+            std::memcpy(change_data, bytes, change_ptr->length);
+            change_data[change_ptr->length] = '\0';
+            return true;
+        } catch (const std::bad_alloc &) { return false; }
+    }
+
+    inline auto ins_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
+                     bool transaction_bit) -> const_omega_change_ptr_t {
+        if (!bytes) { return nullptr; }
+        if (serial <= 0 || !valid_nonnegative_range_(offset, length)) { return nullptr; }
+        try {
+            auto change_ptr = std::make_shared<omega_change_t>();
+            change_ptr->serial = serial;
+            change_ptr->kind =
+                    (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_INSERT;
+            change_ptr->offset = offset;
+            change_ptr->length = length;
+            if (!populate_change_bytes_(change_ptr.get(), bytes)) { return nullptr; }
+            return change_ptr;
+        } catch (const std::bad_alloc &) { return nullptr; }
+    }
+
+    inline auto ovr_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
+                     bool transaction_bit) -> const_omega_change_ptr_t {
+        if (!bytes) { return nullptr; }
+        if (serial <= 0 || !valid_nonnegative_range_(offset, length)) { return nullptr; }
+        try {
+            auto change_ptr = std::make_shared<omega_change_t>();
+            change_ptr->serial = serial;
+            change_ptr->kind =
+                    (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_OVERWRITE;
+            change_ptr->offset = offset;
+            change_ptr->length = length;
+            if (!populate_change_bytes_(change_ptr.get(), bytes)) { return nullptr; }
+            return change_ptr;
+        } catch (const std::bad_alloc &) { return nullptr; }
+    }
+
+    inline auto transform_(int64_t serial, int64_t offset, int64_t length, const char *transform_id,
+                           const char *options_json, int64_t replacement_length, int64_t file_size_before,
+                           int64_t file_size_after, const char *checkpoint_file_path,
+                           bool transaction_bit) -> const_omega_change_ptr_t {
+        if (serial <= 0 || !valid_nonnegative_range_(offset, length) || replacement_length < 0 ||
+            file_size_before < 0 || file_size_after < 0 || !checkpoint_file_path || !*checkpoint_file_path) {
+            return nullptr;
+        }
+        try {
+            auto change_ptr = std::make_shared<omega_change_t>();
+            change_ptr->serial = serial;
+            change_ptr->kind =
+                    (transaction_bit ? OMEGA_CHANGE_TRANSACTION_BIT : 0x00) | (uint8_t) change_kind_t::CHANGE_TRANSFORM;
+            change_ptr->offset = offset;
+            change_ptr->length = length;
+            change_ptr->transform_data = std::make_unique<omega_transform_change_data_struct>();
+            change_ptr->transform_data->transform_id = (transform_id && *transform_id) ? transform_id : "transform";
+            if (options_json) { change_ptr->transform_data->options_json = options_json; }
+            change_ptr->transform_data->replacement_length = replacement_length;
+            change_ptr->transform_data->computed_file_size_before = file_size_before;
+            change_ptr->transform_data->computed_file_size_after = file_size_after;
+            change_ptr->transform_data->checkpoint_file_path = checkpoint_file_path;
+            return change_ptr;
+        } catch (const std::bad_alloc &) { return nullptr; }
+    }
+
+    inline auto restore_viewport_callbacks_(omega_session_t *session_ptr, bool callbacks_were_paused,
+                                            bool notify_changed_viewports) -> void {
+        if (!session_ptr || callbacks_were_paused) { return; }
+        omega_session_resume_viewport_event_callbacks(session_ptr);
+        if (notify_changed_viewports) { omega_session_notify_changed_viewports(session_ptr); }
+    }
+
+    class scoped_transaction_t {
+    public:
+        explicit scoped_transaction_t(omega_session_t *session_ptr) : session_ptr_(session_ptr) {
+            if (!session_ptr_) {
+                begin_result_ = -1;
+                return;
+            }
+            if (omega_session_get_transaction_state(session_ptr_) == 0) {
+                begin_result_ = omega_session_begin_transaction(session_ptr_);
+                owns_transaction_ = (begin_result_ == 0);
+            }
+        }
+
+        ~scoped_transaction_t() {
+            if (owns_transaction_) { omega_session_end_transaction(session_ptr_); }
+        }
+
+        bool ok() const { return begin_result_ == 0; }
+
+    private:
+        omega_session_t *session_ptr_{};
+        int begin_result_{0};
+        bool owns_transaction_{false};
+    };
+
+    class scoped_session_event_batch_t {
+    public:
+        scoped_session_event_batch_t(omega_session_t *session_ptr, omega_session_event_t session_event)
+            : session_ptr_(session_ptr) {
+            omega_session_begin_event_batch_(session_ptr_, session_event);
+        }
+
+        ~scoped_session_event_batch_t() { omega_session_end_event_batch_(session_ptr_); }
+
+    private:
+        omega_session_t *session_ptr_{};
+    };
+
+    class scoped_search_context_t {
+    public:
+        explicit scoped_search_context_t(omega_search_context_t *context_ptr) : context_ptr_(context_ptr) {}
+
+        ~scoped_search_context_t() { reset(); }
+
+        scoped_search_context_t(const scoped_search_context_t &) = delete;
+        auto operator=(const scoped_search_context_t &) -> scoped_search_context_t & = delete;
+
+        auto get() const -> omega_search_context_t * { return context_ptr_; }
+
+        void reset(omega_search_context_t *context_ptr = nullptr) {
+            if (context_ptr_ != nullptr) { omega_search_destroy_context(context_ptr_); }
+            context_ptr_ = context_ptr;
+        }
+
+    private:
+        omega_search_context_t *context_ptr_{};
+    };
+
+    struct session_stream_cursor_t {
+        const omega_session_t *session_ptr{};
+        omega_model_segments_t::const_iterator segment_iter{};
+        omega_model_segments_t::const_iterator segment_end{};
+        int64_t offset{};
+    };
+
+    inline auto is_builtin_transform_kind_(omega_edit_transform_kind_t kind) -> bool {
+        switch (kind) {
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER:
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER:
+            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
+            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
+            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    inline auto builtin_transform_id_(omega_edit_transform_kind_t kind) -> const char * {
+        switch (kind) {
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER:
+                return "builtin:ascii-to-upper";
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER:
+                return "builtin:ascii-to-lower";
+            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
+                return "builtin:bitwise-and";
+            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
+                return "builtin:bitwise-or";
+            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR:
+                return "builtin:bitwise-xor";
+            default:
+                return "builtin:unknown";
+        }
+    }
+
+    inline auto builtin_transform_options_json_(const omega_edit_transform_t &transform) -> std::string {
+        switch (transform.kind) {
+            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
+            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
+            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR: {
+                char buffer[32];
+                std::snprintf(buffer, sizeof(buffer), "{\"operand\":%u}", static_cast<unsigned>(transform.operand));
+                return buffer;
+            }
+            default:
+                return {};
+        }
+    }
+
+    inline omega_byte_t apply_builtin_transform_(omega_byte_t byte, void *user_data_ptr) {
+        const auto *const transform_ptr = reinterpret_cast<const omega_edit_transform_t *>(user_data_ptr);
+        switch (transform_ptr->kind) {
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER:
+                return (byte >= 'a' && byte <= 'z') ? static_cast<omega_byte_t>(byte - ('a' - 'A')) : byte;
+            case OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER:
+                return (byte >= 'A' && byte <= 'Z') ? static_cast<omega_byte_t>(byte + ('a' - 'A')) : byte;
+            case OMEGA_EDIT_TRANSFORM_BITWISE_AND:
+                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_AND);
+            case OMEGA_EDIT_TRANSFORM_BITWISE_OR:
+                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_OR);
+            case OMEGA_EDIT_TRANSFORM_BITWISE_XOR:
+                return omega_util_mask_byte(byte, transform_ptr->operand, MASK_XOR);
+            default:
+                return byte;
+        }
+    }
+
+}// namespace omega_edit::internal
+
+#endif//OMEGA_EDIT_PRIVATE_HELPERS_HPP

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -122,7 +122,9 @@ USER omega
 WORKDIR /data
 
 # The server listens on 0.0.0.0:9000 inside the container (not 127.0.0.1)
-# so that Docker port mapping works correctly.
+# so that Docker port mapping works correctly. Docker network and published-port
+# configuration are the container trust boundary, so the non-loopback bind is an
+# explicit opt-in here.
 ENV OMEGA_EDIT_SERVER_HOST="0.0.0.0" \
     OMEGA_EDIT_SERVER_PORT="9000"
 
@@ -133,4 +135,4 @@ HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
   CMD ["/usr/local/bin/grpc_health_probe", "-addr=127.0.0.1:9000", "-connect-timeout=500ms", "-rpc-timeout=500ms"]
 
 ENTRYPOINT ["omega-edit-grpc-server"]
-CMD ["--interface", "0.0.0.0", "--port", "9000"]
+CMD ["--interface", "0.0.0.0", "--port", "9000", "--insecure-allow-non-loopback"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,8 @@
 # Security notes:
 #   - The published port is bound to 127.0.0.1 by default so the unauthenticated
 #     gRPC endpoint is not exposed beyond the host unless you opt into it.
+#   - The server listens on 0.0.0.0 inside the container so Docker port mapping
+#     works; the image command passes --insecure-allow-non-loopback explicitly.
 #   - The container runs with a read-only root filesystem; only /data and /tmp
 #     remain writable.
 #   - The server runs as the caller-supplied UID/GID instead of root. Export

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@omega-edit/core",
   "version": "2.0.0",
-  "private": "true",
+  "private": true,
   "description": "OmegaEdit Client and Server",
   "publisher": "CTC-OSS",
   "repository": {
@@ -14,7 +14,7 @@
   "author": "CTC-OSS",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^24.0.0"
+    "node": ">=22"
   },
   "workspaces": [
     "packages/*"
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
-    "@types/node": "^26.0.1",
+    "@types/node": "^22.20.0",
     "copy-webpack-plugin": "^14.0.0",
     "run-script-os": "^1.1.6",
     "ts-loader": "^9.6.2",
@@ -41,7 +41,7 @@
   },
   "resolutions": {
     "@types/eslint-scope": "8.4.0",
-    "@types/node": "26.0.1",
+    "@types/node": "22.20.0",
     "copy-webpack-plugin/**/ajv": "8.20.0",
     "copy-webpack-plugin/**/picomatch": "4.0.4",
     "copy-webpack-plugin/serialize-javascript": "7.0.6",

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -152,6 +152,7 @@ The AI surface is intentionally bounded:
 - search result counts are capped by `OMEGA_EDIT_AI_MAX_SEARCH_RESULTS` (default `1000`)
 - preview context is capped by `OMEGA_EDIT_AI_PREVIEW_CONTEXT_BYTES` (default `64`)
 - auto-start refuses to launch Ωedit™ if the target port is already occupied by a non-Ωedit™ service
+- auto-start keeps the unauthenticated native server on loopback unless `--insecure-allow-non-loopback` is supplied
 
 ## Notes
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -32,7 +32,7 @@
   "author": "CTC-OSS",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^24.0.0"
+    "node": ">=22"
   },
   "scripts": {
     "clean": "rimraf dist",
@@ -50,7 +50,7 @@
     "@omega-edit/client": "2.0.0"
   },
   "devDependencies": {
-    "@types/node": "^26.0.0",
+    "@types/node": "^22.20.0",
     "rimraf": "^6.1.3",
     "vitest": "^4.1.9"
   }

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -12,6 +12,7 @@ const commonOptions = {
   host: { type: 'string' as const },
   port: { type: 'string' as const },
   'no-autostart': { type: 'boolean' as const },
+  'insecure-allow-non-loopback': { type: 'boolean' as const },
 }
 
 function printJson(value: unknown): void {
@@ -56,6 +57,8 @@ function usage(): string {
     `  --host <host>          OmegaEdit server host (default ${DEFAULT_HOST})`,
     `  --port <port>          OmegaEdit server port (default ${DEFAULT_PORT})`,
     '  --no-autostart         Refuse to auto-start OmegaEdit when not already running',
+    '  --insecure-allow-non-loopback',
+    '                         Permit auto-starting an unauthenticated server outside loopback',
   ].join('\n')
 }
 
@@ -95,6 +98,7 @@ function getToolkit(values: Record<string, string | boolean | undefined>) {
         ? parseIntegerOption(values.port as string, 'port')
         : undefined,
     autoStart: values['no-autostart'] ? false : true,
+    insecureAllowNonLoopback: values['insecure-allow-non-loopback'] === true,
   })
 }
 

--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -733,6 +733,7 @@ async function main(): Promise<void> {
       host: { type: 'string' },
       port: { type: 'string' },
       'no-autostart': { type: 'boolean' },
+      'insecure-allow-non-loopback': { type: 'boolean' },
     },
     allowPositionals: false,
   })
@@ -744,6 +745,8 @@ async function main(): Promise<void> {
         ? Number.parseInt(parsed.values.port as string, 10)
         : DEFAULT_PORT,
     autoStart: parsed.values['no-autostart'] ? false : true,
+    insecureAllowNonLoopback:
+      parsed.values['insecure-allow-non-loopback'] === true,
   })
 
   const tools = buildTools(toolkit)

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -975,6 +975,7 @@ export class OmegaEditToolkit {
   readonly maxEditBytes: number
   readonly maxSearchResults: number
   readonly previewContextBytes: number
+  readonly insecureAllowNonLoopback: boolean
 
   constructor(options: ToolkitOptions = {}) {
     this.host = options.host || DEFAULT_HOST
@@ -986,6 +987,7 @@ export class OmegaEditToolkit {
       options.maxSearchResults || DEFAULT_MAX_SEARCH_RESULTS
     this.previewContextBytes =
       options.previewContextBytes || DEFAULT_PREVIEW_CONTEXT_BYTES
+    this.insecureAllowNonLoopback = options.insecureAllowNonLoopback === true
   }
 
   private async waitForServerToStop(timeoutMs: number = 10000): Promise<void> {
@@ -1032,7 +1034,14 @@ export class OmegaEditToolkit {
         )
       }
 
-      await startServer(this.port, this.host)
+      await startServer(
+        this.port,
+        this.host,
+        undefined,
+        this.insecureAllowNonLoopback
+          ? { insecureAllowNonLoopback: true }
+          : undefined
+      )
       await this.connectToServer()
       return
     }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -16,6 +16,7 @@ export interface ToolkitOptions {
   maxEditBytes?: number
   maxSearchResults?: number
   previewContextBytes?: number
+  insecureAllowNonLoopback?: boolean
 }
 
 export interface EncodedData {

--- a/packages/client/DEVELOPMENT.md
+++ b/packages/client/DEVELOPMENT.md
@@ -15,7 +15,7 @@ If you find yourself adding any other recurring poll against session or viewport
 
 ## Prerequisites
 
-- Node.js 24.x
+- Node.js 22 or newer; Node.js 24 is used by the primary CI lane and `.nvmrc`
 - Yarn (v1 or compatible)
 - The `@omega-edit/server` package must be built and packaged first
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -88,6 +88,9 @@ await stopServerGraceful()
 
 `startServer(..., heartbeat)` and `startServerUnixSocket(..., heartbeat)` accept the same `HeartbeatOptions` bag exported from `@omega-edit/server`, including native logging fields such as `logFile`, `logLevel`, and `logConfigFile`.
 
+The bundled server is unauthenticated. Keep TCP binds on `127.0.0.1`/`localhost` or use Unix domain sockets unless an
+outer layer controls access. Binding outside loopback requires `insecureAllowNonLoopback: true`.
+
 Shutdown migration note:
 
 - In the 2.x line, `stopServerGraceful()` and `stopServerImmediate()` return a structured result object with `responseCode`, `serverProcessId`, and `status` instead of returning only a numeric response code.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,7 +32,7 @@
   "author": "CTC-OSS",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^24.0.0"
+    "node": ">=22"
   },
   "config": {
     "protocVersion": "35.1"

--- a/packages/client/src/shims/omega-edit-server.ts
+++ b/packages/client/src/shims/omega-edit-server.ts
@@ -39,6 +39,8 @@ export interface HeartbeatOptions {
   logFile?: string
   logLevel?: string
   logConfigFile?: string
+  transformPluginDirectories?: string[]
+  insecureAllowNonLoopback?: boolean
 }
 
 export declare function runServer(

--- a/packages/server/DEVELOPMENT.md
+++ b/packages/server/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This document covers building, packaging, and contributing to the `@omega-edit/s
 
 ## Prerequisites
 
-- Node.js 16+
+- Node.js 22 or newer; Node.js 24 is used by the primary CI lane and `.nvmrc`
 - Yarn (v1 or compatible)
 - CMake 3.16+ and a C++17 compiler (for building the native gRPC server)
 - gRPC and Protobuf libraries (fetched automatically by CMake)

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -72,9 +72,17 @@ const proc = await runServer(9000, '127.0.0.1', '/tmp/server.pid', {
 const proc2 = await runServerWithArgs([
   '--interface=0.0.0.0',
   '--port=9000',
+  '--insecure-allow-non-loopback',
   '--unix-socket=/tmp/omega.sock',
 ])
 ```
+
+## Security Boundary
+
+The native gRPC server has no built-in authentication. Its default `127.0.0.1` TCP bind and Unix domain socket mode are
+the intended trust boundary. Non-loopback TCP binds require `--insecure-allow-non-loopback` or the
+`insecureAllowNonLoopback` option because any reachable client can create sessions, read and edit files, save output,
+and invoke registered transform plugins with the server process's privileges.
 
 ### Standalone Binary
 
@@ -120,6 +128,7 @@ interface HeartbeatOptions {
   logLevel?: string              // Native log level: debug, info, warn, error
   logConfigFile?: string         // Compatibility shim for logback-style XML config
   transformPluginDirectories?: string[] // Directories containing transform plugin shared libraries
+  insecureAllowNonLoopback?: boolean // Permit unauthenticated non-loopback TCP binds
 }
 ```
 
@@ -147,6 +156,7 @@ The native binary supports:
 | `--log-level` | Set native server log verbosity |
 | `--log-config` | Read log file/level from a logback-style XML config |
 | `--transform-plugin-dir` | Register transform plugins from a directory; repeat for multiple directories |
+| `--insecure-allow-non-loopback` | Permit unauthenticated TCP binds outside loopback |
 
 The package includes the first-party transform plugins for the current platform and
 registers them automatically when no explicit transform plugin directories are supplied.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,7 +18,7 @@
   "author": "CTC-OSS",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^24.0.0"
+    "node": ">=22"
   },
   "scripts": {
     "test": "echo 'C++ server tests run via yarn workspace @omega-edit/client test'",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -55,6 +55,8 @@ export interface HeartbeatOptions {
   logConfigFile?: string
   /** Register transform plugins from these directories. */
   transformPluginDirectories?: string[]
+  /** Permit unauthenticated TCP binds outside loopback. */
+  insecureAllowNonLoopback?: boolean
 }
 
 /**
@@ -374,6 +376,9 @@ function heartbeatToArgs(
   }
   if (opts?.logLevel !== undefined) {
     args.push(`--log-level=${opts.logLevel}`)
+  }
+  if (opts?.insecureAllowNonLoopback) {
+    args.push('--insecure-allow-non-loopback')
   }
   const configuredTransformPluginDirectories =
     opts?.transformPluginDirectories?.filter(

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -27,6 +27,7 @@
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
@@ -112,6 +113,28 @@ static bool parse_log_level(const std::string &value, const std::string &name, L
         return false;
     }
     return true;
+}
+
+static bool env_value_is_true(const char *value) {
+    if (!value) { return false; }
+    std::string normalized;
+    normalized.reserve(std::strlen(value));
+    for (const char *ptr = value; *ptr; ++ptr) {
+        normalized.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(*ptr))));
+    }
+    return normalized == "1" || normalized == "true" || normalized == "yes" || normalized == "on";
+}
+
+static std::string normalized_bind_address(std::string value) {
+    if (value.size() >= 2 && value.front() == '[' && value.back() == ']') { value = value.substr(1, value.size() - 2); }
+    for (char &ch : value) { ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch))); }
+    return value;
+}
+
+static bool is_loopback_bind_address(const std::string &interface_addr) {
+    const auto normalized = normalized_bind_address(interface_addr);
+    return normalized == "localhost" || normalized == "ip6-localhost" || normalized == "::1" ||
+           normalized == "0:0:0:0:0:0:0:1" || normalized.rfind("127.", 0) == 0;
 }
 
 static std::string current_timestamp() {
@@ -269,6 +292,8 @@ static void print_usage(const char *progname) {
               << "  -f, --pidfile <path>             Write PID to file\n"
               << "  -u, --unix-socket <path>         Unix domain socket path (Linux/macOS only)\n"
               << "      --unix-socket-only           Bind only to Unix domain socket\n"
+              << "      --insecure-allow-non-loopback\n"
+              << "                                   Permit TCP binds outside loopback without authentication\n"
               << "\nLogging options:\n"
               << "      --log-file <path>            Append native server logs to file\n"
               << "      --log-level <level>          Native log level (debug, info, warn, error)\n"
@@ -301,6 +326,7 @@ int main(int argc, char **argv) {
     std::string log_file;
     std::string log_config_file;
     bool unix_socket_only = false;
+    bool insecure_allow_non_loopback = false;
     LogLevel log_level = LogLevel::Info;
 
     // Heartbeat / session-reaping defaults (0 = disabled)
@@ -320,8 +346,10 @@ int main(int argc, char **argv) {
     }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_UNIX_SOCKET")) { unix_socket = env; }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_UNIX_SOCKET_ONLY")) {
-        std::string val(env);
-        if (val == "true" || val == "1") { unix_socket_only = true; }
+        if (env_value_is_true(env)) { unix_socket_only = true; }
+    }
+    if (const char *env = std::getenv("OMEGA_EDIT_SERVER_INSECURE_ALLOW_NON_LOOPBACK")) {
+        insecure_allow_non_loopback = env_value_is_true(env);
     }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_PIDFILE")) { pidfile = env; }
     if (const char *env = std::getenv("OMEGA_EDIT_SERVER_LOG_CONFIG")) {
@@ -381,6 +409,8 @@ int main(int argc, char **argv) {
             return 0;
         } else if (arg == "--unix-socket-only") {
             unix_socket_only = true;
+        } else if (arg == "--insecure-allow-non-loopback") {
+            insecure_allow_non_loopback = true;
         } else if (arg == "--shutdown-when-no-sessions") {
             shutdown_when_no_sessions = true;
         } else {
@@ -569,6 +599,18 @@ int main(int argc, char **argv) {
                                             std::to_string(pid) + " bound to " + unix_addr + ": ready...");
 #endif
     } else {
+        if (!is_loopback_bind_address(interface_addr)) {
+            if (!insecure_allow_non_loopback) {
+                log_message(LogLevel::Error,
+                            "Refusing unauthenticated non-loopback TCP bind to " + interface_addr +
+                                    ". Bind 127.0.0.1/localhost or pass --insecure-allow-non-loopback.");
+                return 1;
+            }
+            log_message(
+                    LogLevel::Warn,
+                    "Ωedit gRPC server is binding outside loopback without authentication. Clients that can reach " +
+                            interface_addr + " can act with this process's file and plugin privileges.");
+        }
         std::string server_address = interface_addr + ":" + std::to_string(port);
         builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
         log_message(LogLevel::Info, std::string("Ωedit gRPC server (v") + SERVER_VERSION + ") with PID " +

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -64,7 +64,7 @@ The example now leans on higher-level editor-facing helpers from `@omega-edit/cl
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) 24.x
+- [Node.js](https://nodejs.org/) 22 or newer; Node.js 24 is used by the primary CI lane and `.nvmrc`
 - [VS Code](https://code.visualstudio.com/) >= 1.110
 
 The current VS Code floor is `1.110` because that is the oldest version exercised in CI and it matches the `@types/vscode` version used to compile the example. If the support range is widened later, the CI matrix should be widened with it.

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
-        "@types/node": "^24.0.0",
+        "@types/node": "^22.20.0",
         "@types/vscode": "^1.110.0",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.7.1",
@@ -25,7 +25,7 @@
         "vite": "^8.0.16"
       },
       "engines": {
-        "node": "^24.0.0",
+        "node": ">=22",
         "vscode": "^1.110.0"
       }
     },
@@ -54,7 +54,7 @@
         "tsconfig-paths": "^4.2.0"
       },
       "engines": {
-        "node": "^24.0.0"
+        "node": ">=22"
       }
     },
     "node_modules/@azu/format-text": {
@@ -1192,12 +1192,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -5974,9 +5974,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "node_modules/unicorn-magic": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/ctc-oss/omega-edit/issues"
   },
   "engines": {
-    "node": "^24.0.0",
+    "node": ">=22",
     "vscode": "^1.110.0"
   },
   "categories": [
@@ -290,7 +290,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@types/node": "^24.0.0",
+    "@types/node": "^22.20.0",
     "@types/vscode": "^1.110.0",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,12 +516,12 @@
   dependencies:
     minimatch "*"
 
-"@types/node@*", "@types/node@26.0.1", "@types/node@>=13.7.0", "@types/node@^26.0.0", "@types/node@^26.0.1":
-  version "26.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.0.1.tgz#4a60e2c7a6d68bd261e265f8983bfe1601263ce3"
-  integrity sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==
+"@types/node@*", "@types/node@22.20.0", "@types/node@>=13.7.0", "@types/node@^22.20.0":
+  version "22.20.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.0.tgz#431f5007396bc1a1a47b9c7df60f3e5e0b5b7304"
+  integrity sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==
   dependencies:
-    undici-types "~8.3.0"
+    undici-types "~6.21.0"
 
 "@types/unist@*":
   version "3.0.3"
@@ -2103,10 +2103,10 @@ uc.micro@^2.0.0, uc.micro@^2.1.0:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
   integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
-undici-types@~8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
-  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 update-browserslist-db@^1.2.0:
   version "1.2.3"


### PR DESCRIPTION
## Summary

This PR reaps the high-value findings from `Claude-Findings.md` without taking on broad unrelated refactors.

- relaxes the Node engine floor from Node 24-only to Node 22+ and adds a Node 22 TypeScript lint CI lane
- makes unauthenticated native gRPC server TCP binds outside loopback require an explicit insecure opt-in
- threads that opt-in through server, client, AI CLI, and MCP startup paths
- documents the server trust boundary across the root, server, client, and AI READMEs
- extracts private `edit.cpp` helper machinery into `impl_/edit_private_helpers.hpp` to reduce the size and reasoning burden of `edit.cpp`

## Why

The project is broadly healthy, so the useful findings were mostly about operational sharp edges: an unnecessarily narrow Node engine declaration, an implicit network trust boundary, and source files getting large enough to make careful review harder.

## Validation

- `clang-format -i core/src/lib/edit.cpp core/src/lib/impl_/edit_private_helpers.hpp server/cpp/src/main.cpp`
- `cmake --build _build-codex-ninja --target omega_edit`
- `YARN_IGNORE_ENGINES=1 yarn lint`
- `YARN_IGNORE_ENGINES=1 yarn workspace @omega-edit/ai build`
- `./node_modules/.bin/tsc -p packages/server/tsconfig.json --noEmit`
- `git diff --check`

## Notes

Full native gRPC server rebuild was not possible in this WSL checkout because `server/cpp/build` contains a stale Windows CMake cache and a fresh WSL configure cannot find `ProtobufConfig.cmake` / `protobuf-config.cmake`.