### PR TITLE
fix: extension undo, sizing, and high-impact backlog items

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -29,79 +29,19 @@ Risk guide:
 1. **Undo performance batch**: implement the low-risk undo pieces first
    (transaction extents, redo batching, snapshot telemetry), then tackle
    in-place inverse undo.
-2. **Edit result semantics**: add a unified success predicate or typed result for
-   core mutators before more callers rely on mixed return conventions.
-3. **Plugin cancellation**: add cooperative cancellation to the transform plugin
+2. **Plugin cancellation**: add cooperative cancellation to the transform plugin
    request path and SDK helpers.
-4. **Streaming import**: pair existing streaming export with a streaming/chunked
+3. **Streaming import**: pair existing streaming export with a streaming/chunked
    import path.
-5. **Checkpoint caps/dedupe**: add server/API guardrails for unbounded checkpoint
+4. **Checkpoint caps/dedupe**: add server/API guardrails for unbounded checkpoint
    creation.
 
 The first batch gives a useful blend: high user-visible impact from undo work,
 plus lower-risk cleanup that reduces future surprises.
 
----
-
-## P0 Correctness / Data Integrity
-
-### 1. Mixed edit API success conventions
-
-**Impact:** High
-**Risk:** Medium
-**Area:** Core C API
-
-Core mutators such as `omega_edit_insert`, `omega_edit_delete`,
-`omega_edit_overwrite`, and `omega_edit_replace` return a positive change serial
-on success, `0` for no-op/rejected-without-error cases, and `-1` for invalid
-arguments. Batch/checkpoint helpers such as
-`omega_edit_replace_bytes_checkpointed`, `omega_edit_apply_script`,
-`omega_edit_replace_all_bytes`, and `omega_edit_replace_matches_bytes` return
-`0` on success and non-zero on failure.
-
-No single success predicate works across the editing surface. A caller can
-silently invert success/failure handling by applying the convention from one API
-family to another.
-
-Relevant code:
-- `core/src/include/omega_edit/edit.h`
-- `core/src/lib/edit.cpp`
-
-Suggested fix:
-- Add an explicit result type or documented helper predicate for new code.
-- Keep existing ABI-compatible functions, but introduce clearer wrappers for
-  serial-returning edits and status-returning batch/checkpoint operations.
-- Add tests that assert each public mutator's no-op, success, and failure
-  return semantics.
-
-### 2. Change-log rollback still compensates through undo
-
-**Impact:** High
-**Risk:** Medium to High
-**Area:** Core/server/client change-log import
-
-Change-log import is now much safer: it validates fingerprints, applies normal
-edit batches transactionally, and rolls back on failure. The remaining weakness
-is the rollback primitive itself. AI and VS Code import paths still compensate by
-undoing back to the starting change count. If that rollback path itself fails
-partway through, the session can still be left in an awkward intermediate state.
-
-Relevant code:
-- `packages/ai/src/service.ts`
-- `vscode-extension/src/hexEditorProvider.ts`
-- `core/src/lib/edit.cpp`
-
-Suggested fix:
-- Add a native "restore to change serial/count and discard redo" primitive.
-- Use that primitive from AI and VS Code import rollback.
-- Cover failure injection around apply and rollback so partial rollback cannot
-  be mistaken for success.
-
----
-
 ## P1 High-Impact Work
 
-### 3. Undo still rebuilds the model instead of applying inverse edits
+### 1. Undo still rebuilds the model instead of applying inverse edits
 
 **Impact:** High
 **Risk:** High
@@ -129,7 +69,7 @@ Suggested fix:
 - Use model integrity tests around mixed insert/delete/overwrite/replace
   sequences before replacing the rebuild path.
 
-### 4. Undo snapshot strategy is count-only and memory-blind
+### 2. Undo snapshot strategy is count-only and memory-blind
 
 **Impact:** High
 **Risk:** Medium to High
@@ -151,7 +91,7 @@ Suggested fix:
   cheap references instead of deep clones.
 - Surface basic metrics for snapshot count/bytes in tests or debug logs.
 
-### 5. Transform plugins have no cooperative cancellation
+### 3. Transform plugins have no cooperative cancellation
 
 **Impact:** High
 **Risk:** Medium
@@ -175,7 +115,7 @@ Suggested fix:
 - Check cancellation in built-in streaming loops between chunks.
 - Document plugin cleanup expectations on cancellation.
 
-### 6. Change-log import is still full-document JSON parsing
+### 4. Change-log import is still full-document JSON parsing
 
 **Impact:** High
 **Risk:** Medium to High
@@ -196,7 +136,7 @@ Suggested fix:
 - Validate document header/fingerprint before reading all entries.
 - Replay entries incrementally while preserving atomic rollback semantics.
 
-### 7. TypeScript live client still has a 2^53 int64 ceiling
+### 5. TypeScript live client still has a 2^53 int64 ceiling
 
 **Impact:** High for the "massive files" promise
 **Risk:** High
@@ -223,7 +163,7 @@ Suggested fix:
 
 ## P2 Medium-Impact / Medium-Risk Work
 
-### 8. Transform change replay is metadata-aware but not native-first
+### 6. Transform change replay is metadata-aware but not native-first
 
 **Impact:** Medium to High
 **Risk:** Medium to High
@@ -232,8 +172,7 @@ Suggested fix:
 Transform metadata is now carried through core/proto/server/client/export/import,
 and import can replay transforms through the server. The remaining gap is that
 replay still depends on the target environment having compatible plugin
-semantics, and rollback uses the general import compensation path rather than a
-dedicated native replay/import primitive.
+semantics rather than a dedicated native replay/import primitive.
 
 Suggested fix:
 - Define the guarantees expected of portable transform replay.
@@ -241,7 +180,7 @@ Suggested fix:
   operation end to end.
 - Keep verifying replayed size/replacement metadata after import.
 
-### 9. File-backed plugin allocation tracking is process-global
+### 7. File-backed plugin allocation tracking is process-global
 
 **Impact:** Medium
 **Risk:** Medium
@@ -261,7 +200,7 @@ Suggested fix:
 - Add stress coverage for concurrent transforms that allocate file-backed
   buffers.
 
-### 10. Server checkpoint creation has no cap or dedupe policy
+### 8. Server checkpoint creation has no cap or dedupe policy
 
 **Impact:** Medium
 **Risk:** Medium
@@ -281,7 +220,7 @@ Suggested fix:
 - Consider dedupe when the computed content equals the latest checkpoint.
 - Return explicit "not needed" or "limit reached" results where appropriate.
 
-### 11. C-string and byte edit APIs encode different zero-length semantics
+### 9. C-string and byte edit APIs encode different zero-length semantics
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -300,7 +239,7 @@ Suggested fix:
 - Keep byte APIs explicit-only.
 - Add examples that steer binary callers to `_bytes` variants.
 
-### 12. Long positional argument lists remain hard to use safely
+### 10. Long positional argument lists remain hard to use safely
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -319,7 +258,7 @@ Suggested fix:
 - Preserve existing positional APIs for ABI compatibility.
 - Use enum/boolean-like typed fields in the options structs.
 
-### 13. Viewport dirty state uses a negative-capacity sentinel
+### 11. Viewport dirty state uses a negative-capacity sentinel
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -344,7 +283,7 @@ Suggested fix:
 
 ## P3 Low-Risk / Opportunistic Work
 
-### 14. Snapshot allocation failure silently degrades undo speed
+### 12. Snapshot allocation failure silently degrades undo speed
 
 **Impact:** Low to Medium
 **Risk:** Low
@@ -360,7 +299,7 @@ Suggested fix:
 - Emit a debug/warn log or session diagnostic event when snapshot capture fails.
 - Add a test hook or allocator-failure test if the existing harness supports it.
 
-### 15. Transaction-boundary scan is linear per undo
+### 13. Transaction-boundary scan is linear per undo
 
 **Impact:** Low to Medium
 **Risk:** Low to Medium
@@ -376,7 +315,7 @@ Suggested fix:
 - Store transaction extents or cached transaction change counts.
 - Reuse the same metadata for redo batching.
 
-### 16. Redo still replays one change at a time
+### 14. Redo still replays one change at a time
 
 **Impact:** Low to Medium
 **Risk:** Low to Medium
@@ -409,6 +348,10 @@ These areas were in the old document but are no longer open backlog items:
   snapshot registry metadata under a short lock and execute under session/content
   guards.
 - Missing explicit undo-to-baseline reset path.
+- Mixed edit API success conventions; serial-returning and status-returning core
+  APIs now have explicit success predicates.
+- Undo-based change-log rollback; AI and VS Code imports now use a native
+  restore-to-change-count primitive that discards redo.
 - Session/viewport subscription lock ordering, handoff, queue closure, and
   ordered callback delivery.
 - Desired ID/path validation and default host/port duplication.

--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -1,575 +1,419 @@
-# OmegaEdit — Shortcomings, Bugs, Gaps & Missed Opportunities
+# OmegaEdit Current Shortcomings
 
-Living backlog of issues found while reviewing the `codex/checkpoint-change-log-actions`
-work, the follow-up audit, and the surrounding transform / change-log / checkpoint code.
-Grouped by theme, roughly prioritized within each group. File:line references point at the
-offending code.
+This is the current actionable backlog. It replaces the older historical audit,
+which had grown into a mix of fixed findings, follow-up notes, and a second
+prioritized review appended at the bottom.
 
-Status notes:
-- `Fixed` means the current follow-up branch addresses the item directly.
-- `Partially fixed` means the branch reduces the risk but leaves a larger design gap.
-- `New` means the item is validated against the current tree but has not been addressed.
+Items already fixed by recent work have been removed from the open list. In
+particular, the transform/change-log/checkpoint audit items that now have
+regression coverage are not repeated here. The recent VS Code extension issues
+around the initial Find toggle state, auto bytes-per-row overfitting, and the
+duplicate Ctrl-Z undo toast are also treated as fixed by the current extension
+branch/PR and are not listed as open.
 
----
+Priority guide:
+- **P0**: correctness, data integrity, or behavior that can mislead callers.
+- **P1**: high-impact product, performance, or robustness work.
+- **P2**: meaningful API or architecture improvement.
+- **P3**: polish, telemetry, or opportunistic cleanup.
 
-## A. Transforms (correctness — "sometimes don't run / don't create changes")
-
-This is the reported bug. Root causes are spread across all three layers.
-
-1. **`content_changed` is inferred, never confirmed against the core.**
-   `server/cpp/src/editor_service.cpp:1834` sets
-   `content_changed = operation_replaces && (effective_length > 0 || replacement_length > 0)`.
-   It does **not** check whether `omega_edit_replace_bytes` actually recorded a change
-   (no change-serial / change-count delta is consulted). A replace whose replacement is
-   byte-identical to the source, or a core replace that no-ops, still reports
-   `content_changed = true` — and the reverse can happen too. The server should report
-   change-happened based on the core change count before/after, not arithmetic on lengths.
-   **Status: Fixed.** The server now reports `content_changed` from observed session
-   change/checkpoint/file-size deltas around the transform operation.
-
-2. **Core silently treats "no replacement" as success with no change.**
-   `core/src/lib/transform.cpp:1001-1006`: when `requested_length == 0 && replacement_length == 0`
-   the code returns `0` (success) without recording any change. The plugin "ran" but nothing
-   happened, and nothing upstream can distinguish that from a real edit. There is no
-   change-count/serial returned from the apply call to disambiguate.
-   **Status: Fixed.** Replace/inspect plugins must now set the no-content-change response
-   flag for intentional zero-length no-ops; ambiguous zero-length replace responses fail.
-
-3. **Client-side no-op detection *undoes* real work and is silently size-gated.**
-   `vscode-extension/src/hexEditorProvider.ts:2296-2322`. After a successful transform the
-   extension re-reads the range, compares bytes, and if equal calls `undo()`. Problems:
-   - The comparison is only performed when both sides are `<= MAX_TRANSFORM_NOOP_COMPARE_BYTES`
-     (1 MiB, line 145). Above that, `canCompareNoOp` is false, the change is *kept* even if it
-     is a true no-op — so behavior flips based on size (a "limit" leaking into correctness).
-   - When it *does* fire, it issues an `undo()` to roll back the just-applied change. If the
-     plugin legitimately replaced bytes with equal bytes (e.g. idempotent normalize), the user
-   sees "nothing happened" even though the operation was valid. This is almost certainly a
-   contributor to "transforms don't create changes when they should."
-   - The undo is a second async round-trip gated on `waitForSessionSync`; if sync versioning
-     races, the wrong change can be undone.
-   **Status: Fixed.** The extension no longer performs the post-transform byte compare or
-   undoes a completed transform as a client-side no-op.
-
-4. **Transform is recorded only as a generic `REPLACE` in local history, losing identity.**
-   `vscode-extension/src/hexEditorProvider.ts:2324-2333` records the transform result as a
-   `REPLACE` change record with raw replacement bytes. The plugin id and options are dropped.
-   See gap G1 below (first-class Transform change kind).
-   **Status: Fixed.** Direct VS Code transform application now records a lightweight
-   `TRANSFORM` history entry with plugin id, options, replacement length, and size metadata
-   instead of materializing replacement bytes as a generic `REPLACE`.
-
-5. **Whole-replacement is buffered in memory as hex.**
-   The extension reads the entire replacement back via `getSegment` and stores it hex-encoded
-   in the in-memory change log (2× the byte size). For large transforms this is a latent OOM
-   and conflicts with the large-file promise. (Same hex-doubling appears in the AI change log.)
-   **Status: Partially fixed.** Direct VS Code transforms no longer read replacements back into
-   local history at all; general hex/in-memory change-log storage remains.
-
-6. **No surfaced reason when a transform genuinely does nothing.**
-   When `content_changed` is false there is no message explaining *why* (schema mismatch vs.
-   inspect-only plugin vs. true no-op). The webview just shows the transform "completed" with
-   no change. Users read this as "the transform didn't run."
-   **Status: Fixed.** The webview/toast path now distinguishes inspect-only calculations from
-   true no-content-change transforms, and bitwise/case-change identity paths report
-   no-content-change from the server.
-
-7. **Transform concurrency guard returns INTERNAL, not a typed state.**
-   `editor_service.cpp:1739` funnels "transform already in progress" through
-   `status_for_session_operation_start`, which can surface as a generic error string the UI
-   only pattern-matches on. Easy to misclassify as a failure.
-   **Status: Fixed.** The server operation-start guard maps transform/mutation busy states to
-   `FAILED_PRECONDITION`, and transform precondition rejection is now covered by client
-   integration coverage.
+Risk guide:
+- **Low**: mostly additive, localized, or test-only.
+- **Medium**: touches shared behavior but has clear boundaries.
+- **High**: broad API, format, or core model changes.
 
 ---
 
-## B. Atomicity / transactions (first-class, reversible operations)
+## Start Here
 
-8. **`applyChangeLog` is not atomic (AI).**
-   `packages/ai/src/service.ts` applies entries in a bare `for` loop of `insert/del/overwrite/replace`
-   with no transaction and no rollback. A failure midway leaves a partially-applied session
-   and no record of how far it got. Should wrap in a begin/end transaction (core supports
-   transaction state — see `omega_session_get_transaction_state` usage in the server) or, at
-   minimum, checkpoint before and restore on failure.
-   **Status: Fixed.** AI change-log apply now verifies the before fingerprint, applies normal
-   edit batches inside server transactions, verifies the after fingerprint before reporting
-   success, and rolls back to the starting change count on any apply/postcondition failure.
+1. **Undo performance batch**: implement the low-risk undo pieces first
+   (transaction extents, redo batching, snapshot telemetry), then tackle
+   in-place inverse undo.
+2. **Edit result semantics**: add a unified success predicate or typed result for
+   core mutators before more callers rely on mixed return conventions.
+3. **Plugin cancellation**: add cooperative cancellation to the transform plugin
+   request path and SDK helpers.
+4. **Streaming import**: pair existing streaming export with a streaming/chunked
+   import path.
+5. **Checkpoint caps/dedupe**: add server/API guardrails for unbounded checkpoint
+   creation.
 
-9. **`applyChangeLog` is not atomic (extension).**
-   `vscode-extension/src/hexEditorProvider.ts` `applyChangeLogEntries` has the same
-   sequential, non-transactional shape.
-   **Status: Fixed.** Extension import now verifies the before fingerprint, applies normal edit
-   batches inside server transactions, verifies the after fingerprint before recording local
-   history, and rolls back to the starting change count on any apply/postcondition failure.
-
-10. **Transforms are not atomic/first-class.** (User-requested flag — see G1.)
-    A transform that internally expands/shrinks/replaces is recorded as one opaque `REPLACE`
-    instead of a reversible, replayable `Transform` operation. Undo works by byte-replacement,
-    not by re-running/inverting the transform, so the change log cannot reproduce the transform
-    on a *different* file (the whole point of a portable change log).
-    **Status: Partially fixed.** Core/proto/server/client/export/import paths now carry
-    `TRANSFORM` metadata, and direct VS Code transforms now record that metadata locally.
-    Import now replays transforms through the server and verifies the replayed size/replacement
-    metadata before reporting success. Transform replay still depends on the target having the
-    same plugin semantics, and rollback still uses undo-to-start-count compensation rather than
-    a dedicated native import primitive.
-
-11. **Checkpoint rollback names must not promise snapshot restore semantics.**
-    The checkpoint operation calls `destroyLastCheckpoint`; there is no snapshot/restore
-    semantics here, just rollback of the current checkpoint model.
-    **Status: Fixed.** The AI toolkit/CLI/MCP tool, VS Code command/API/webview protocol,
-    toolbar, progress, and toasts now use rollback-checkpoint naming throughout.
-
-12. **Checkpoint creation is unconditional and unbounded.**
-    No cap on number of checkpoints, no dedupe, no "checkpoint only if dirty since last."
-    Repeated `createCheckpoint` calls grow state without feedback on cost.
-    **Status: Partially fixed.** VS Code now skips explicit checkpoint creation when the
-    session has no dirty changes and reports that no checkpoint was needed; server/API caps and
-    dedupe remain open.
+The first batch gives a useful blend: high user-visible impact from undo work,
+plus lower-risk cleanup that reduces future surprises.
 
 ---
 
-## C. UX / notifications
+## P0 Correctness / Data Integrity
 
-13. **Checkpoint & change-log confirmations land in the results pull-down, not a toast.**
-    (User-requested flag.) `hexEditorProvider.postSessionActionComplete` posts
-    `sessionActionComplete`, and `App.svelte:2124-2137` writes it into `transformFeedback`
-    (the transform/results feedback strip, rendered at `App.svelte:2147`). For
-    `rollbackCheckpoint` / session rollback the confirmation should pop as a VS Code toast
-    (`showInformationMessage`) instead of (or in addition to) the inline strip.
-    Note the host already fires a toast for some actions, so the two paths are inconsistent:
-    some actions toast + strip, some strip-only. Pick one rule and apply it uniformly.
-    **Status: Fixed.** Session action completions now rely on host toasts and no longer
-    populate the transform/results feedback strip; the Recent Transform Results control is
-    result-history only and no longer borrows transient status text.
+### 1. Mixed edit API success conventions
 
-14. **Inconsistent "rollback" vs "restore" vocabulary across the codebase.**
-    The checkpoint path previously mixed rollback and restore vocabulary for closely-related
-    concepts, confusing users and future maintainers.
-    **Status: Fixed.** The checkpoint command/API/protocol/tooling path now consistently uses
-    rollback terminology for drop-last-checkpoint behavior; restore terminology is reserved for
-    the true snapshot-restore API.
+**Impact:** High
+**Risk:** Medium
+**Area:** Core C API
 
-15. **Cancelled actions are reported as success-ish.**
-    `exportChangeLog` cancel returns `{ cancelled: true }` but still posts a
-    `sessionActionComplete` that the webview renders as feedback text; easy to misread.
-    **Status: Fixed.** Cancelled session actions now clear inline feedback instead of rendering
-    success-like completion text.
+Core mutators such as `omega_edit_insert`, `omega_edit_delete`,
+`omega_edit_overwrite`, and `omega_edit_replace` return a positive change serial
+on success, `0` for no-op/rejected-without-error cases, and `-1` for invalid
+arguments. Batch/checkpoint helpers such as
+`omega_edit_replace_bytes_checkpointed`, `omega_edit_apply_script`,
+`omega_edit_replace_all_bytes`, and `omega_edit_replace_matches_bytes` return
+`0` on success and non-zero on failure.
 
-16. **No progress for `exportChangeLog`.**
-    `collectChangeLogEntries` loops `getChangeDetails` serial-by-serial (one RPC per change,
-    up to 100k). For large sessions this is a long, silent, blocking operation with no progress
-    notification (apply has a progress bar; export does not).
-    **Status: Fixed.** VS Code export now wraps change-detail collection in a progress
-    notification.
+No single success predicate works across the editing surface. A caller can
+silently invert success/failure handling by applying the convention from one API
+family to another.
 
----
+Relevant code:
+- `core/src/include/omega_edit/edit.h`
+- `core/src/lib/edit.cpp`
 
-## D. The "remove limits" promise (hard caps that betray the mission)
+Suggested fix:
+- Add an explicit result type or documented helper predicate for new code.
+- Keep existing ABI-compatible functions, but introduce clearer wrappers for
+  serial-returning edits and status-returning batch/checkpoint operations.
+- Add tests that assert each public mutator's no-op, success, and failure
+  return semantics.
 
-17. **JS `Number.isSafeInteger` ceiling (2^53) on every offset/length.**
-    `packages/client/src/safe_int.ts` throws on any offset/length/count beyond 2^53 on both
-    input and output. The core is 64-bit (`int64_t`). Any file or offset past ~9 PB is
-    unreachable from the TS client. Defensible today, but it is a real ceiling that contradicts
-    "remove limits." Consider `BigInt` on the boundaries that can legitimately exceed 2^53.
-    **Status: Partially fixed.** Versioned change-log documents now accept decimal int64 strings
-    and export integer metadata/entry coordinates as decimal strings, so JSON precision is no
-    longer the change-log format boundary. The generated TypeScript gRPC client still uses
-    `long_type_number`; replay refuses values beyond the safe-number transport boundary instead
-    of rounding them. Full BigInt client APIs remain a deliberate protobuf/client migration.
+### 2. Change-log rollback still compensates through undo
 
-18. **Change-log entry/byte caps.**
-    AI: `MAX_CHANGE_LOG_ENTRIES = 100_000`, `MAX_CHANGE_LOG_ENTRY_BYTES = 32 MiB`,
-    `MAX_CHANGE_LOG_BYTES = 96 MiB` (`packages/ai/src/service.ts`). Extension mirrors these
-    (`hexEditorProvider.ts:146-148`). A session with >100k changes still cannot export a
-    non-streaming log. Export now fails loudly instead of hiding dropped changes, but for a tool
-    whose pitch is massive files, a 100k-change ceiling is low.
-    **Status: Fixed.** AI and VS Code change-log import/export no longer impose the former
-    entry-count, per-entry-byte, or document-byte caps. They still reject invalid JSON shape,
-    incomplete change details, and values that cannot be replayed safely through the current TS
-    transport.
+**Impact:** High
+**Risk:** Medium to High
+**Area:** Core/server/client change-log import
 
-19. **In-memory hex doubling everywhere.**
-    Change-log data is stored/transported as hex strings (2× bytes) in both AI and extension,
-    and transform replacements are fully materialized client-side. Streaming / chunked /
-    file-backed change logs would honor the large-file promise.
-    **Status: Partially fixed.** AI file-backed export and VS Code local-file export now stream
-    entries to a temporary file and return summary metadata instead of echoing the full entry
-    array back to the caller. The v2 JSON payload still encodes bytes as hex, and import still
-    parses the full JSON document before replay; chunked/binary or streaming-import formats
-    remain future API work.
+Change-log import is now much safer: it validates fingerprints, applies normal
+edit batches transactionally, and rolls back on failure. The remaining weakness
+is the rollback primitive itself. AI and VS Code import paths still compensate by
+undoing back to the starting change count. If that rollback path itself fails
+partway through, the session can still be left in an awkward intermediate state.
+
+Relevant code:
+- `packages/ai/src/service.ts`
+- `vscode-extension/src/hexEditorProvider.ts`
+- `core/src/lib/edit.cpp`
+
+Suggested fix:
+- Add a native "restore to change serial/count and discard redo" primitive.
+- Use that primitive from AI and VS Code import rollback.
+- Cover failure injection around apply and rollback so partial rollback cannot
+  be mistaken for success.
 
 ---
 
-## E. Change-log fidelity & format
+## P1 High-Impact Work
 
-20. **Export is lossy and silently so.**
-    `exportChangeLog` reconstructs entries from `getChangeDetails`, which only yields
-    INSERT/DELETE/OVERWRITE — never REPLACE or Transform. Changes absorbed into a checkpoint
-    baseline are dropped and only counted in `foldedChangeCount`. The exported log therefore
-    cannot faithfully reproduce a session that used checkpoints or transforms. This is presented
-    in the README as a feature ("portable…apply to a fleet of files"), which overstates fidelity.
-    **Status: Fixed.** Export now checks the core model first, rejects unavailable serials /
-    missing details instead of emitting an incomplete log, writes explicit completeness metadata,
-    and includes server-computed before/after size+digest fingerprints for non-streaming logs.
-    The old folded-count path has been removed.
+### 3. Undo still rebuilds the model instead of applying inverse edits
 
-21. **No schema validation / versioning enforcement on import.**
-    `normalizeChangeLogEntries` accepts an array *or* `{changes:[...]}` but does not check
-    `format`/`version` fields it itself writes. A v2 document or a foreign JSON array would be
-    applied (or partially applied) without a compatibility gate.
-    **Status: Fixed.** Imports must now match the OmegaEdit change-log format and version;
-    bare JSON arrays are rejected.
+**Impact:** High
+**Risk:** High
+**Area:** Core undo/redo
 
-22. **`groupId` and `serial` are carried but not honored.**
-    Import preserves `serial`/`groupId` (`service.ts` normalize) but apply ignores them — no
-    grouping/transaction reconstruction, serials are not validated for monotonicity or gaps.
-    **Status: Fixed.** AI and VS Code imports now reject partial, non-contiguous, or gapped
-    serial metadata; `groupId` metadata is validated for contiguous groups and preserved on
-    applied VS Code history records while the import remains one atomic server transaction.
+Undo pops the trailing change transaction, then rebuilds the computed model to
+the remaining change count with `rebuild_model_to_change_count_`. That routine
+clones the nearest snapshot and replays forward from it. The current default
+snapshot interval is non-zero (`100`), so the worst case is bounded by snapshot
+spacing, but a single undo can still replay many changes and full snapshots are
+deep clones of the segment tree.
 
-23. **Error sniffing by string match.**
-    `isMissingChangeDetailsError` matches `'NOT_FOUND'` / `'change not found'` substrings
-    (AI and extension). Brittle: depends on server message wording, not gRPC status codes.
-    **Status: Fixed.** `getChangeDetails` preserves the original gRPC error as `cause`, and
-    AI/extension importers now classify missing change details by gRPC status code only.
+Relevant code:
+- `core/src/lib/edit.cpp:655`
+- `core/src/lib/edit.cpp:719`
+- `core/src/lib/edit.cpp:2162`
+- `core/src/lib/impl_/session_def.hpp:45`
 
-24. **`getChangeDetails` request sends dummy fields.**
-    `packages/client/src/protobuf_ts/change.ts` fills `sessionEventKind`, `computedFileSize`,
-    `changeCount`, `undoCount` with zeros just to satisfy the shared request message. Harmless
-    now but couples a read to an event-shaped message; a stricter server could reject it.
-    **Status: Fixed.** `GetChangeDetailsRequest` now carries only `session_id` and optional
-    `serial`.
+Suggested fix:
+- Implement in-place inverse application for ordinary changes:
+  delete inverse for insert, insert inverse for delete, restore original bytes
+  for overwrite/replace.
+- Keep checkpoint-backed transform undo on its existing checkpoint path unless
+  or until transform changes get a dedicated inverse/replay primitive.
+- Use model integrity tests around mixed insert/delete/overwrite/replace
+  sequences before replacing the rebuild path.
 
----
+### 4. Undo snapshot strategy is count-only and memory-blind
 
-## F. Testing / build confidence
+**Impact:** High
+**Risk:** Medium to High
+**Area:** Core undo/redo memory behavior
 
-25. **No test asserts the transform-no-op / content_changed path.**
-    The reported bug area (A1–A3, A6) has no regression test. Add coverage for: identical-bytes
-    replace, inspect-only plugin, >1 MiB replace (no-op gate flips), and content_changed accuracy.
-    **Status: Fixed.** Added regression coverage for identical-byte transforms,
-    bitwise/case-change identity transforms, inspect-only/no-content-change reporting, and a
-    >1 MiB no-op transform to guard the former client-side size gate.
+Snapshots are full deep clones of the model segment tree and are taken only by
+change count. This ignores model size, segment count, and memory pressure. The
+current default interval is useful, but the policy is still crude for very large
+files or very dense edit histories.
 
-26. **Branch could not be type-checked/tested here.**
-    Node is v22 in this environment; repo requires 24, deps not installed. CI must run
-    `yarn workspace @omega-edit/ai test`, vscode-extension build+tests, and `yarn lint` before merge.
-    **Status: Fixed.** Local checks now run through `nvm` on Node 24; PR CI is queued.
+Relevant code:
+- `core/src/lib/edit.cpp:719`
+- `core/src/lib/impl_/session_def.hpp:45`
 
-27. **`applyChangeLog` round-trip test only covers the happy path.**
-    `packages/ai/tests/specs/toolkit.spec.ts` exercises a single OVERWRITE. No test for
-    multi-entry logs, REPLACE entries, partial-failure/atomicity, or the entry/byte caps.
-    **Status: Partially fixed.** Added malformed wrapped-change-log import coverage, a
-    partial-failure rollback regression, multi-entry/REPLACE atomicity coverage, transform
-    replay-metadata mismatch coverage, and true checkpoint-restore coverage. Cap-removal and
-    streaming-import coverage remain open.
+Suggested fix:
+- Make snapshot policy adaptive: change count plus approximate segment/tree
+  size or memory budget.
+- Consider structural sharing or copy-on-write segment nodes so snapshots are
+  cheap references instead of deep clones.
+- Surface basic metrics for snapshot count/bytes in tests or debug logs.
 
----
+### 5. Transform plugins have no cooperative cancellation
 
-## G. Gaps / future work (noted, not to implement now)
+**Impact:** High
+**Risk:** Medium
+**Area:** Core transform plugin SDK/server integration
 
-- **G1 — First-class `Transform` change kind.** (User-requested.) Treat Transform as a peer of
-  Insert/Delete/Overwrite/Replace: a change record `{ kind: 'TRANSFORM', offset, length,
-  pluginId, optionsJson }` carrying exactly the arguments needed to *re-run* the transform,
-  so the change log can reproduce it on another file rather than baking in resulting bytes.
-  Requires: core/proto change-kind support, server to record transform-as-change, client wrapper,
-  AI + extension change-log encode/decode, and undo-by-inverse-or-rerun semantics.
-- **G2 — True checkpoint restore** (snapshot + restore-to), distinct from drop-last-checkpoint.
-  **Status: Fixed.** Core/proto/server/client/AI/VS Code now expose restore-to-latest-checkpoint
-  semantics that keep the checkpoint snapshot, discard later edits/redo, refresh viewports, and
-  emit a distinct restore event.
-- **G3 — Streaming / file-backed change logs** to drop the in-memory and entry-count caps.
-  **Status: Partially fixed.** File-backed export streams entries and the former hard caps are
-  gone; streaming import/chunked payloads still need a format/API decision.
-- **G4 — BigInt offsets/lengths** at the TS boundary to lift the 2^53 ceiling.
-  **Status: Partially fixed for change-log documents.** Serialized change-log int64 fields accept
-  decimal strings, but the generated TypeScript gRPC client still uses `long_type_number`, so full
-  BigInt replay/client APIs remain open.
-- **G5 — Transactional `applyChangeLog`** (begin/end transaction or checkpoint-guarded) for atomicity.
-  **Status: Fixed for change-log import.** Normal edit batches are transactional and the whole
-  import rolls back on failure; a future native "restore to starting serial and discard redo"
-  primitive would still make rollback cheaper and more direct.
-- **G6 — gRPC status-code based error handling.** **Status: Fixed.** Missing change-detail
-  handling now follows preserved gRPC status codes instead of message text.
+Plugin execution has progress callbacks and chunked helpers, but
+`omega_transform_plugin_request_t` exposes no cancellation token/callback.
+Session destroy, checkpoint cleanup, or user cancel cannot politely ask an
+in-flight plugin to stop. For third-party plugins that hold external resources
+such as database handles, transactions, or file handles, forceful interruption is
+not a safe design.
 
----
+Relevant code:
+- `core/src/include/omega_edit/transform.h`
+- `core/src/include/omega_edit/transform_plugin_sdk.h`
+- `core/src/lib/transform.cpp`
 
-## H. Concurrency / lock ordering
+Suggested fix:
+- Add a host-owned cancellation callback/token to the plugin request.
+- Add SDK helper functions such as `omega_transform_plugin_sdk_is_cancelled`.
+- Check cancellation in built-in streaming loops between chunks.
+- Document plugin cleanup expectations on cancellation.
 
-28. **Session event subscription lock order can deadlock against core callbacks.**
-    `server/cpp/src/session_manager.cpp:417-460` builds session event notifications while
-    taking `session_subscription_mutex`. Core mutations call into the session event callback
-    while the handler already holds `core_mutex` through `lock_session`, so that path is
-    effectively `core_mutex -> session_subscription_mutex`. Subscription management takes the
-    reverse order: `subscribe_session_events` takes `session_subscription_mutex` and then
-    `core_mutex` to update event interest (`session_manager.cpp:963-982`), and the targeted
-    unsubscribe path does the same (`session_manager.cpp:1011-1034`). A concurrent edit event
-    plus subscribe/unsubscribe can therefore park each thread on the other's lock. The session
-    event path needs one consistent lock order, or the core event-interest update needs to be
-    split so subscription bookkeeping is never held while acquiring `core_mutex`.
-    **Status: Fixed.** Session event callbacks now copy matching subscriber queues while holding
-    only the subscription mutex and push after releasing it; subscription management releases
-    the subscription mutex before taking `core_mutex`.
+### 6. Change-log import is still full-document JSON parsing
 
-29. **Transform progress publishing relies on an implicit core lock.**
-    `server/cpp/src/session_manager.cpp:777-816` reads `omega_session_get_computed_file_size`,
-    `omega_session_get_num_changes`, and `omega_session_get_num_undone_changes` from
-    `info->session` without taking `core_mutex`. Today `ApplyTransformPlugin` calls it while a
-    `LockedSession` is alive (`editor_service.cpp:1742-1865`), but the method is exposed on
-    `SessionManager` with no contract enforcing that precondition. A future caller could race
-    session mutation or destruction and make progress reporting touch the non-thread-safe core
-    session outside its guard.
-    **Status: Fixed.** Transform progress publishing no longer reads core session state; progress
-    events carry lifecycle/progress payloads only, while normal core session events provide
-    authoritative size/change counters.
+**Impact:** High
+**Risk:** Medium to High
+**Area:** AI service, VS Code extension, change-log format
+
+Change-log export can stream entries to a local file and former hard caps have
+been removed. Import still parses the entire JSON document before replay, and
+payload bytes are still hex encoded. That means large imports can be memory-heavy
+even though export no longer has to be.
+
+Relevant code:
+- `packages/ai/src/service.ts`
+- `vscode-extension/src/hexEditorProvider.ts`
+
+Suggested fix:
+- Introduce a streaming/chunked import reader for the current JSON format, or
+  define a v3 chunked/binary format if streaming JSON is too contorted.
+- Validate document header/fingerprint before reading all entries.
+- Replay entries incrementally while preserving atomic rollback semantics.
+
+### 7. TypeScript live client still has a 2^53 int64 ceiling
+
+**Impact:** High for the "massive files" promise
+**Risk:** High
+**Area:** TypeScript protobuf/client API
+
+Change-log documents now accept decimal int64 strings, but the generated
+protobuf-ts client is still generated with `long_type_number`. The compatibility
+wrappers reject unsafe integer values rather than rounding them, which is the
+right failure mode, but live TS clients still cannot address offsets, lengths, or
+counts beyond `Number.MAX_SAFE_INTEGER`.
+
+Relevant code:
+- `packages/client/src/safe_int.ts`
+- `packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts`
+- `buf.gen.yaml`
+
+Suggested fix:
+- Plan a BigInt-capable protobuf/client migration.
+- Decide whether public TS APIs become BigInt-first, accept `number | bigint`,
+  or expose parallel BigInt methods.
+- Keep safe-number wrappers for legacy callers during the transition.
 
 ---
 
-## I. Session / subscription lifecycle
+## P2 Medium-Impact / Medium-Risk Work
 
-30. **Managed checkpoint root can be left behind on per-session directory creation failure.**
-    `create_managed_checkpoint_directory` creates and stores `managed_server_root_`, then creates
-    a per-session checkpoint directory under it (`session_manager.cpp:361-395`). If the server
-    root succeeds but the per-session directory creation fails, `create_session` erases the
-    pending session and returns (`session_manager.cpp:580-586`) without calling
-    `cleanup_managed_server_root_if_empty`. That can strand an empty managed root until a later
-    cleanup pass or process exit.
-    **Status: Fixed.** Session creation now attempts managed-root cleanup after erasing the
-    pending session when per-session checkpoint directory creation fails.
+### 8. Transform change replay is metadata-aware but not native-first
 
-31. **Viewport recreation drops the old subscription before the new one is confirmed.**
-    `packages/client/src/subscriptions.ts:224-247` cancels the current viewport subscription
-    before `subscribeViewportEvents` for the replacement viewport has succeeded. The caller
-    already documents the consequence in `editor_scoped_session.ts:232-242`: if
-    `setViewportId` fails, the newly-created viewport is destroyed, but the old viewport stream
-    has already been cancelled and the editor is left without active viewport events until
-    another recreation succeeds. The handoff should keep the old subscription live until the new
-    stream is confirmed.
-    **Status: Fixed.** Client viewport subscription handoff now keeps the active stream alive
-    until the replacement stream subscribes successfully.
+**Impact:** Medium to High
+**Risk:** Medium to High
+**Area:** Core/proto/server/change-log replay
 
-32. **Explicit viewport unsubscribe clears but does not close the active queue.**
-    `SessionManager::unsubscribe_viewport_events` clears the viewport event queue and disables
-    core interest, but leaves the queue open (`session_manager.cpp:1060-1075`). The streaming RPC
-    only exits when the client context is cancelled or the queue closes
-    (`editor_service.cpp:2071-2116`), while the explicit `UnsubscribeToViewportEvents` RPC just
-    calls that clear-only path (`editor_service.cpp:2127-2135`). A client that uses explicit
-    unsubscribe while a stream is still open can leave the old stream blocked, and a later
-    resubscribe reuses the same queue so multiple readers can compete for events.
-    **Status: Fixed.** Viewport event streams now use per-subscription queues; explicit
-    unsubscribe closes active viewport queues, while stream cleanup removes only the queue for
-    that stream.
+Transform metadata is now carried through core/proto/server/client/export/import,
+and import can replay transforms through the server. The remaining gap is that
+replay still depends on the target environment having compatible plugin
+semantics, and rollback uses the general import compensation path rather than a
+dedicated native replay/import primitive.
 
-33. **Subscription callbacks have no backpressure or sequential delivery contract.**
-    `packages/client/src/subscriptions.ts:147-161` schedules every incoming event handler through
-    a detached promise. Errors are routed to `onError`, so they are not silently swallowed, but
-    async `onEvent` work is not awaited before the next event is dispatched. Callers that do
-    asynchronous model or UI work can observe overlapping callbacks and out-of-order completion
-    even though the underlying stream delivered events in order.
-    **Status: Fixed.** Subscription event callbacks now run through a per-stream promise chain,
-    preserving delivery order and avoiding overlapping async handler execution.
+Suggested fix:
+- Define the guarantees expected of portable transform replay.
+- Add a native transform replay/import primitive if the server should own the
+  operation end to end.
+- Keep verifying replayed size/replacement metadata after import.
 
----
+### 9. File-backed plugin allocation tracking is process-global
 
-## J. Validation / configuration hygiene
+**Impact:** Medium
+**Risk:** Medium
+**Area:** Core transform plugin allocation
 
-34. **Caller-provided IDs and paths are only minimally validated.**
-    Desired session IDs and viewport IDs are accepted so long as they do not contain the `:`
-    separator (`session_manager.cpp:552-563`, `session_manager.cpp:848-866`), and most other
-    RPCs accept `session_id` strings directly for map lookups and error messages. The client
-    wrappers also pass `filePath`, `sessionIdDesired`, and `checkpointDirectory` through with no
-    shared maximum length, NUL-character, printable/opaque-ID, or log-safe policy. Generated IDs
-    are bounded, but caller-supplied IDs and paths can still be excessively large or log-hostile,
-    and tightening creation-time validation would contain that shape for all later operations.
-    **Status: Fixed.** Desired session and viewport IDs are now bounded caller tokens
-    (1-128 bytes; letters, digits, `_`, `.`, and `-` only), while `file_path` and
-    `checkpoint_directory` reject overlong, NUL-containing, or control-character inputs before
-    filesystem/core API use. Client integration coverage now asserts accepted safe IDs and
-    rejected unsafe IDs/path arguments.
+Large plugin allocations are tracked in a process-wide map protected by a single
+mutex. Unrelated sessions and plugins therefore contend on one global lock, and
+ownership boundaries are less clear than they could be.
 
-35. **Default server host/port constants are duplicated across packages.**
-    `packages/client/src/server.ts:47-48`, `packages/client/src/protobuf_ts/client.ts:36-37`,
-    and `packages/ai/src/constants.ts:1-2` each define `127.0.0.1:9000` independently. A future
-    default change can silently diverge between the legacy client, protobuf-ts client, and AI
-    tooling unless the defaults move to one shared source.
-    **Status: Fixed.** Default server host/port values now live in the shared client constants
-    module; the legacy client, protobuf-ts client, and AI tooling consume that single source.
+Relevant code:
+- `core/src/lib/transform.cpp:800`
 
-36. **Change-log JSON import is byte-bounded but not structure-bounded.**
-    `packages/ai/src/service.ts:254-268` caps change-log file size and entry count, then parses
-    the full file with `JSON.parse` before validating shape. A deeply nested but byte-small JSON
-    document can still spend parser/normalizer CPU or trip runtime recursion limits before the
-    normal entry caps are enforced. A streaming parser, nesting-depth guard, or pre-parse
-    structural limit would make the import boundary less fragile.
-    **Status: Fixed.** Change-log file imports now reject JSON nesting deeper than the supported
-    limit before calling `JSON.parse`.
+Suggested fix:
+- Move allocation ownership to a per-operation, per-session, or per-registry
+  structure.
+- Keep a narrow compatibility shim for response cleanup.
+- Add stress coverage for concurrent transforms that allocate file-backed
+  buffers.
 
-37. **Unary protobuf-ts RPCs have connection readiness deadlines but no per-call deadlines.**
-    `packages/client/src/protobuf_ts/client.ts:70-84` applies a 10-second deadline to
-    `waitForReady`, but the individual unary wrappers in `protobuf_ts/session.ts`,
-    `protobuf_ts/change.ts`, and `protobuf_ts/viewport.ts` call methods such as `saveSession`,
-    `replaceSession`, and `getSegment` without per-call gRPC deadlines or cancellation handles.
-    Once a client is considered ready, a hung server-side unary can keep the returned promise
-    pending indefinitely.
-    **Status: Fixed.** Hand-written protobuf-ts unary wrappers now pass a default deadline, with
-    `OMEGA_EDIT_UNARY_RPC_TIMEOUT_MS=0` available to disable it when needed.
+### 10. Server checkpoint creation has no cap or dedupe policy
 
----
+**Impact:** Medium
+**Risk:** Medium
+**Area:** Core/server/client checkpoint lifecycle
 
-## K. Core memory / lifetime correctness
+VS Code skips explicit checkpoint creation when the session is clean, but the
+server/core API still allows unbounded checkpoint creation. Repeated checkpoint
+calls can grow state without a cost signal or cap.
 
-38. **`omega_data_t` ownership is external and implicitly copyable.**
-    `core/src/lib/impl_/data_def.hpp:31-34` defines `omega_data_t` as a trivially copyable union
-    whose active storage is inferred from a separate length/capacity value stored in the owning
-    `omega_change_t` or `omega_segment_t`. Accidental value copies of `omega_change_t`,
-    `omega_segment_t`, or the union itself duplicate the raw pointer without duplicating ownership
-    state, while destruction is manual through `omega_data_destroy_`. The current code avoids many
-    obvious copies, but the type does not make ownership or non-copyability explicit, leaving a
-    latent double-free/aliasing trap for future maintenance.
-    **Status: Fixed.** `omega_data_t` is now a move-only RAII owner with explicit borrowed-buffer
-    support for scratch views. Owned byte storage releases in the member destructor/reset path, so
-    future accidental value copies fail at compile time instead of duplicating raw ownership.
+Relevant code:
+- `core/src/lib/edit.cpp:2235`
+- `proto/omega_edit/v1/omega_edit.proto`
+- `server/cpp/src/editor_service.cpp`
 
-39. **Reverse change visitors leak their iterator allocation.**
-    `core/src/lib/visit.cpp:77-84` allocates `change_iter.riter_ptr` for reverse iteration, but
-    `omega_visit_change_destroy_context` deletes only `change_iter.iter_ptr`
-    (`core/src/lib/visit.cpp:132-137`). A reverse visit context therefore leaks one
-    `omega_changes_t::const_reverse_iterator` each time it is destroyed.
-    **Status: Fixed.** Reverse visit contexts now delete `riter_ptr`; forward contexts continue
-    deleting `iter_ptr`.
+Suggested fix:
+- Add configurable checkpoint count/bytes caps.
+- Consider dedupe when the computed content equals the latest checkpoint.
+- Return explicit "not needed" or "limit reached" results where appropriate.
 
-40. **Internal change destruction casts away const ownership.**
-    Change history is stored as `std::shared_ptr<const omega_change_t>`, but cleanup paths in
-    `core/src/lib/edit.cpp:588-599` use `const_cast` to call `omega_data_destroy_` on change data.
-    The implementation currently creates non-const heap objects before storing them as const
-    shared pointers, so this works by convention, but the type system advertises immutable changes
-    while destruction still mutates their internals. Internal ownership should stay mutable or move
-    byte ownership into a self-destroying RAII member.
-    **Status: Fixed.** Internal change pointers now keep mutable ownership, and byte storage lives
-    in self-destroying `omega_data_t` members. Cleanup paths no longer cast away const to release
-    insert/overwrite bytes.
+### 11. C-string and byte edit APIs encode different zero-length semantics
 
-41. **C API allocation failures can escape through C entry points inconsistently.**
-    `omega_data_create_` throws `std::bad_array_new_length` for unrepresentable capacities
-    (`core/src/lib/impl_/data_def.hpp:45-48`) and other paths allocate with throwing `new[]`.
-    Some entry points, such as `omega_segment_create`, catch allocation failures and return
-    `nullptr`, while edit/change creation helpers in `core/src/lib/edit.cpp` do not consistently
-    translate allocation exceptions into C-style error returns. The public C API should not rely
-    on C++ exceptions escaping safely across callers.
-    **Status: Fixed.** Core C entry points and helpers that allocate change data, sessions,
-    viewports, segments, search contexts, checkpoint models, undo bookkeeping, and fixed-size I/O
-    buffers now translate allocation failures into `nullptr`/negative C-style returns and clean up
-    partially-created files/contexts.
+**Impact:** Medium
+**Risk:** Low to Medium
+**Area:** Core C API
 
-42. **`omega_session_get_file_path` returns an internal string pointer without a lifetime contract.**
-    `core/src/lib/session.cpp:105` returns `models_.back()->file_path.c_str()` directly. The
-    header says only that callers receive the file path, not that the pointer is borrowed and can
-    be invalidated by later session mutation, save/checkpoint model changes, or session
-    destruction. Either the documentation needs a clear borrowed-pointer lifetime note or the API
-    should return caller-owned storage.
-    **Status: Fixed.** The public header now documents the returned path as a session-owned
-    borrowed pointer with mutation/destruction lifetime limits.
+The C-string helpers infer length with `strlen` when the length argument is zero,
+while `_bytes` variants treat length zero as an explicit no-op. The headers warn
+about this now, but the API shape is still easy to misuse with embedded NULs or
+when callers expect zero to mean the same thing everywhere.
+
+Relevant code:
+- `core/src/include/omega_edit/edit.h`
+
+Suggested fix:
+- Add safer, clearly named APIs for inferred-length text edits.
+- Keep byte APIs explicit-only.
+- Add examples that steer binary callers to `_bytes` variants.
+
+### 12. Long positional argument lists remain hard to use safely
+
+**Impact:** Medium
+**Risk:** Low to Medium
+**Area:** Core C API ergonomics
+
+Search/replace and viewport APIs still use long positional lists and `int`
+booleans for options such as floating, ordering, and overwrite mode. Argument
+swaps are easy to miss at call sites.
+
+Relevant code:
+- `core/src/include/omega_edit/edit.h`
+- `core/src/include/omega_edit/viewport.h`
+
+Suggested fix:
+- Add options-struct APIs for new callers.
+- Preserve existing positional APIs for ABI compatibility.
+- Use enum/boolean-like typed fields in the options structs.
+
+### 13. Viewport dirty state uses a negative-capacity sentinel
+
+**Impact:** Medium
+**Risk:** Low to Medium
+**Area:** Core viewport internals
+
+Viewport data dirtiness is encoded by negating `data_segment.capacity`, while
+public capacity reads hide that with `abs`. This couples a state flag to a size
+field and requires every internal user to remember the convention.
+
+Relevant code:
+- `core/src/lib/edit.cpp:1443`
+- `core/src/lib/edit.cpp:2155`
+- `core/src/lib/edit.cpp:2259`
+- `core/src/lib/viewport.cpp:122`
+
+Suggested fix:
+- Add an explicit dirty flag to the viewport/data-segment structure.
+- Keep capacity non-negative internally.
+- Update tests that currently force dirty state by negating capacity.
 
 ---
 
-## L. Transform plugin hardening / performance
+## P3 Low-Risk / Opportunistic Work
 
-43. **Plugin option regex validation recompiles unbounded patterns.**
-    `core/src/lib/transform.cpp:503-508` reads a `pattern` string from a plugin argument schema
-    and constructs `std::regex(pattern_text)` during each validation. There is no pattern length
-    cap, compiled-regex cache, or timeout/backtracking guard. A plugin schema with a pathological
-    pattern can make option validation unexpectedly expensive, and repeated transforms pay the
-    regex compilation cost every time.
-    **Status: Fixed.** Schema regex validation now rejects oversized patterns, caches compiled
-    regex objects across validation calls, and applies a conservative safety gate before
-    compilation/evaluation that rejects backreferences, lookaround-style groups, and quantified
-    groups containing quantifiers or alternation. Native coverage asserts safe validation still
-    works and the risky pattern families are rejected.
+### 14. Snapshot allocation failure silently degrades undo speed
 
-44. **File-backed plugin allocation tracking is process-global.**
-    Large plugin allocations are tracked through the process-wide
-    `g_file_backed_allocations` map and `g_file_backed_allocations_mutex`
-    (`core/src/lib/transform.cpp:659-661`). This serializes allocation bookkeeping across all
-    sessions and plugins, so unrelated transforms on different sessions still contend on one
-    global lock. Per-operation or per-registry ownership would reduce contention and make cleanup
-    boundaries clearer.
-    **Status: New.**
+**Impact:** Low to Medium
+**Risk:** Low
+**Area:** Core undo telemetry
 
-45. **Plugin calculations/transforms need cooperative cancellation.**
-    Session destroy, checkpoint cleanup, or user cancellation should be able to ask outstanding
-    inspect calculations and transform plugin calls to stop politely. Today plugin execution has
-    progress callbacks and chunked readers, but no explicit cancellation token/callback in
-    `omega_transform_plugin_request_t`; forcing a native plugin to die mid-call would be unsafe
-    for third-party plugins that hold database connections, file handles, transactions, or other
-    external resources. Add a host-owned cancellation signal, have SDK helpers and built-in
-    streaming loops check it between chunks, and document that plugins should roll back/close
-    external resources before returning a cancelled status.
-    **Status: New.**
+When snapshot allocation fails, the snapshot is erased and undo performance can
+fall back to longer replay distances without any visible signal.
 
----
+Relevant code:
+- `core/src/lib/edit.cpp:724`
 
-## M. API design / portability
+Suggested fix:
+- Emit a debug/warn log or session diagnostic event when snapshot capture fails.
+- Add a test hook or allocator-failure test if the existing harness supports it.
 
-46. **Event interest masks use signed integers and `ALL_EVENTS (~0)`.**
-    `core/src/include/omega_edit/fwd_defs.h:64-67` defines `ALL_EVENTS` as `~0`, while session
-    and viewport interest APIs store masks in `int32_t`. The current event values fit below the
-    sign bit, but the all-events sentinel relies on signed representation and differs from the
-    TypeScript `ALL_EVENTS = ~NO_EVENTS` expression's 32-bit JavaScript behavior. A `uint32_t`
-    mask or explicit all-events constant would make the ABI clearer.
-    **Status: Fixed.** The C API now exposes explicit `SESSION_EVENTS_ALL` and
-    `VIEWPORT_EVENTS_ALL` masks, with `ALL_EVENTS` preserved as their positive union for source
-    compatibility. The TypeScript client derives the matching masks from generated proto enums,
-    and event-mask tests now assert the explicit known-bit behavior instead of `~0`.
+### 15. Transaction-boundary scan is linear per undo
 
-47. **Edit APIs mix serial-returning and status-code-returning conventions.**
-    Core mutators such as `omega_edit_insert`, `omega_edit_delete`, and `omega_edit_replace`
-    return a positive change serial on success, `0` for no-op/rejected-without-error cases, and
-    `-1` for invalid arguments. Batch/checkpoint helpers such as
-    `omega_edit_replace_bytes_checkpointed`, `omega_edit_apply_script`, and
-    `omega_edit_replace_all_bytes` return `0` on success and non-zero on failure. Callers cannot
-    use one success predicate across editing APIs, and mistakes can invert success handling.
-    **Status: New.**
+**Impact:** Low to Medium
+**Risk:** Low to Medium
+**Area:** Core undo performance
 
-48. **C-string and byte edit APIs encode different length semantics.**
-    The C-string helpers infer a length with `strlen` when the length argument is zero, while the
-    `_bytes` variants treat length zero as an explicit no-op. The current header documents the
-    difference, but the overload-like API shape remains easy to misuse for buffers that may contain
-    embedded NUL bytes or for callers expecting zero length to mean the same thing everywhere.
-    **Status: New.**
+Undo scans backward to find the current transaction extent each time. For very
+large transactions this is a repeated tail scan.
 
-49. **Search/replace and viewport APIs rely on long positional argument lists and `int` booleans.**
-    `omega_edit_replace_matches` / `omega_edit_replace_matches_bytes` take a long sequence of
-    positional range, matching, ordering, output-count, and mode arguments, while viewport creation
-    and modification use `int is_floating` rather than a boolean or options struct. These signatures
-    are hard to read at call sites and make argument swaps or non-boolean values easy to miss.
-    **Status: New.**
+Relevant code:
+- `core/src/lib/edit.cpp:2176`
 
-50. **Viewport dirty state is encoded as a negative capacity sentinel.**
-    `core/src/lib/viewport.cpp:117` negates `data_segment.capacity` to mark viewport data dirty,
-    and `omega_viewport_get_capacity` hides that by returning `std::abs(...)`. This couples a
-    state flag to a conceptually non-negative size field and requires every data-segment user to
-    remember the convention. A separate dirty flag would be more type-safe and less surprising.
-    **Status: New.**
+Suggested fix:
+- Store transaction extents or cached transaction change counts.
+- Reuse the same metadata for redo batching.
 
-51. **Output path collision handling stops after 999 suffixes.**
-    `core/src/lib/edit.cpp:189-206` and `core/src/lib/filesystem.cpp:313-321` try numeric suffixes
-    only from 1 through 999 before returning `EEXIST`/`nullptr`. Busy output directories or stale
-    temp/checkpoint files can exhaust that small namespace even though a timestamp, UUID, or wider
-    suffix range would still produce a valid path.
-    **Status: Fixed.** Output and available-filename helpers now search a much wider suffix range
-    before reporting collision exhaustion.
+### 16. Redo still replays one change at a time
+
+**Impact:** Low to Medium
+**Risk:** Low to Medium
+**Area:** Core redo performance
+
+Redo loops through `changes_undone` and calls `update_` one change at a time,
+paying repeated checks and per-change update overhead.
+
+Relevant code:
+- `core/src/lib/edit.cpp:2220`
+
+Suggested fix:
+- Batch redo by transaction.
+- Reuse notification batching and viewport-update coalescing where possible.
 
 ---
 
-## N. Build / dependency hygiene
+## Recently Fixed And Removed From The Open List
 
-52. **Deprecated or aging generator dependencies remain in the workspace.**
-    Root `package.json` still carries `@types/glob` even though modern `glob` ships its own types,
-    and `packages/client/package.json` still depends on `grpc-tools` for protobuf generation while
-    the runtime stack has otherwise moved to `@grpc/grpc-js`/protobuf-ts. These are not immediate
-    runtime bugs, but they keep extra native tooling and deprecated type packages in the install
-    surface.
-    **Status: Fixed.** Removed the direct root `@types/glob` dependency/resolution and moved
-    protobuf generation from `grpc-tools` to the pinned `@protobuf-ts/protoc` compiler used with
-    `@protobuf-ts/plugin`.
+These areas were in the old document but are no longer open backlog items:
+
+- Transform no-op/content-changed accuracy and client-side no-op undo.
+- Transform identity/history metadata in VS Code and change-log export/import.
+- Checkpoint rollback/restore naming and true restore-to-latest-checkpoint.
+- Atomic fingerprinted change-log apply with rollback compensation.
+- Change-log version enforcement, serial/group validation, completeness metadata,
+  and status-code-based missing-detail handling.
+- Former hard change-log entry/byte caps on export/import.
+- Service-wide transform plugin execution locking; server plugin calls now
+  snapshot registry metadata under a short lock and execute under session/content
+  guards.
+- Missing explicit undo-to-baseline reset path.
+- Session/viewport subscription lock ordering, handoff, queue closure, and
+  ordered callback delivery.
+- Desired ID/path validation and default host/port duplication.
+- Core memory ownership issues around `omega_data_t`, reverse visitor cleanup,
+  const-cast destruction, and allocation failure boundaries.
+- Transform option regex hardening.
+- Event mask signed `ALL_EVENTS` ambiguity.
+- Output collision suffix range and deprecated protobuf generator dependencies.

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -104,6 +104,16 @@ void omega_edit_destroy_viewport(omega_viewport_t *viewport_ptr);
 int omega_edit_clear_changes(omega_session_t *session_ptr);
 
 /**
+ * Restore a session to a previous active change count and discard redo history.
+ * The target count must be between the current model's available history base and the current active change count.
+ * Checkpoint-backed transform models created after the target count are discarded.
+ * @param session_ptr session to restore
+ * @param change_count active change count to keep
+ * @return zero on success and non-zero otherwise
+ */
+int omega_edit_restore_to_change_count(omega_session_t *session_ptr, int64_t change_count);
+
+/**
  * Given a session, undo the last change
  * @param session_ptr session to undo the last change for
  * @return negative serial number of the undone change if successful, zero otherwise
@@ -116,6 +126,20 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr);
  * @return positive serial number of the redone change if successful, zero otherwise
  */
 int64_t omega_edit_redo_last_undo(omega_session_t *session_ptr);
+
+/**
+ * Test a serial-returning edit result, such as omega_edit_insert or omega_edit_delete, for success.
+ * @param result edit result value
+ * @return non-zero when result is a positive change serial
+ */
+int omega_edit_serial_result_is_success(int64_t result);
+
+/**
+ * Test a status-returning edit result, such as omega_edit_clear_changes or omega_edit_apply_script, for success.
+ * @param result edit status value
+ * @return non-zero when result is zero
+ */
+int omega_edit_status_result_is_success(int result);
 
 /**
  * Save a segment of the the given session (the edited file) to the given file path.  If the save file already exists,

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -675,15 +675,11 @@ namespace {
         int64_t replay_from = 0;
         if (!snapshots.empty()) {
             auto snap_it = snapshots.upper_bound(remaining_count);
-            if (snap_it != snapshots.begin()) {
-                --snap_it;
-                try {
-                    model_ptr->model_segments = clone_model_segments_(snap_it->second);
-                } catch (const std::bad_alloc &) { return -1; }
-                replay_from = snap_it->first;
-            } else {
-                if (0 != reset_model_segments_to_original_(model_ptr)) { return -1; }
-            }
+            --snap_it;
+            try {
+                model_ptr->model_segments = clone_model_segments_(snap_it->second);
+            } catch (const std::bad_alloc &) { return -1; }
+            replay_from = snap_it->first;
         } else {
             if (0 != reset_model_segments_to_original_(model_ptr)) { return -1; }
         }

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -1311,8 +1311,7 @@ namespace {
         return redone_change_ptr->serial;
     }
 
-    int discard_top_model_(omega_session_t *session_ptr) {
-        if (!session_ptr || session_ptr->models_.size() <= 1) { return -1; }
+    void discard_top_model_(omega_session_t *session_ptr) {
         auto *const model_ptr = session_ptr->models_.back().get();
         if (model_ptr->file_ptr) {
             FCLOSE(model_ptr->file_ptr);
@@ -1323,7 +1322,6 @@ namespace {
         free_model_changes_undone_(model_ptr);
         session_ptr->models_.pop_back();
         session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
-        return 0;
     }
 }// namespace
 
@@ -2191,7 +2189,7 @@ int omega_edit_restore_to_change_count(omega_session_t *session_ptr, int64_t cha
         const auto model_base = model_ptr->change_serial_base;
         if (change_count < model_base ||
             (change_count == model_base && checkpoint_snapshot_change_count_(model_ptr) > 0)) {
-            if (0 != discard_top_model_(session_ptr)) { return -1; }
+            discard_top_model_(session_ptr);
             restored = true;
             continue;
         }
@@ -2199,9 +2197,7 @@ int omega_edit_restore_to_change_count(omega_session_t *session_ptr, int64_t cha
     }
 
     auto *const model_ptr = session_ptr->models_.back().get();
-    if (change_count < model_ptr->change_serial_base) { return -1; }
     const auto keep_count = change_count - model_ptr->change_serial_base;
-    if (keep_count < 0 || keep_count > static_cast<int64_t>(model_ptr->changes.size())) { return -1; }
 
     if (keep_count < static_cast<int64_t>(model_ptr->changes.size())) {
         model_ptr->changes.erase(model_ptr->changes.begin() + static_cast<std::ptrdiff_t>(keep_count),

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -652,16 +652,6 @@ namespace {
         return update_model_helper_(model_ptr, change_ptr);
     }
 
-    auto reset_model_segments_to_original_(omega_model_t *model_ptr) -> int {
-        if (!model_ptr) { return -1; }
-        int64_t length = 0;
-        if (model_ptr->file_ptr != nullptr) {
-            if (0 != FSEEK(model_ptr->file_ptr, 0L, SEEK_END)) { return -1; }
-            length = FTELL(model_ptr->file_ptr);
-        }
-        return initialize_model_segments_(model_ptr->model_segments, length) ? 0 : -1;
-    }
-
     auto rebuild_model_to_change_count_(omega_session_t *session_ptr, int64_t remaining_count) -> int {
         if (!session_ptr) { return -1; }
 
@@ -670,18 +660,30 @@ namespace {
         auto cleanup_it = snapshots.upper_bound(remaining_count);
         snapshots.erase(cleanup_it, snapshots.end());
 
-        if (remaining_count == 0) { return reset_model_segments_to_original_(model_ptr); }
-
         int64_t replay_from = 0;
         if (!snapshots.empty()) {
             auto snap_it = snapshots.upper_bound(remaining_count);
-            --snap_it;
-            try {
-                model_ptr->model_segments = clone_model_segments_(snap_it->second);
-            } catch (const std::bad_alloc &) { return -1; }
-            replay_from = snap_it->first;
+            if (snap_it != snapshots.begin()) {
+                --snap_it;
+                try {
+                    model_ptr->model_segments = clone_model_segments_(snap_it->second);
+                } catch (const std::bad_alloc &) { return -1; }
+                replay_from = snap_it->first;
+            } else {
+                int64_t length = 0;
+                if (model_ptr->file_ptr != nullptr) {
+                    if (0 != FSEEK(model_ptr->file_ptr, 0L, SEEK_END)) { return -1; }
+                    length = FTELL(model_ptr->file_ptr);
+                }
+                if (!initialize_model_segments_(model_ptr->model_segments, length)) { return -1; }
+            }
         } else {
-            if (0 != reset_model_segments_to_original_(model_ptr)) { return -1; }
+            int64_t length = 0;
+            if (model_ptr->file_ptr != nullptr) {
+                if (0 != FSEEK(model_ptr->file_ptr, 0L, SEEK_END)) { return -1; }
+                length = FTELL(model_ptr->file_ptr);
+            }
+            if (!initialize_model_segments_(model_ptr->model_segments, length)) { return -1; }
         }
 
         for (auto i = replay_from; i < remaining_count; ++i) {

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -1310,7 +1310,26 @@ namespace {
         omega_session_notify(session_ptr, SESSION_EVT_EDIT, redone_change_ptr);
         return redone_change_ptr->serial;
     }
+
+    int discard_top_model_(omega_session_t *session_ptr) {
+        if (!session_ptr || session_ptr->models_.size() <= 1) { return -1; }
+        auto *const model_ptr = session_ptr->models_.back().get();
+        if (model_ptr->file_ptr) {
+            FCLOSE(model_ptr->file_ptr);
+            model_ptr->file_ptr = nullptr;
+        }
+        if (!model_ptr->file_path.empty() && 0 != omega_util_remove_file(model_ptr->file_path.c_str())) { LOG_ERRNO(); }
+        free_model_changes_(model_ptr);
+        free_model_changes_undone_(model_ptr);
+        session_ptr->models_.pop_back();
+        session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
+        return 0;
+    }
 }// namespace
+
+int omega_edit_serial_result_is_success(int64_t result) { return result > 0 ? 1 : 0; }
+
+int omega_edit_status_result_is_success(int result) { return result == 0 ? 1 : 0; }
 
 omega_session_t *omega_edit_create_session(const char *file_path, omega_session_event_cbk_t cbk, void *user_data_ptr,
                                            int32_t event_interest, const char *checkpoint_directory) {
@@ -2158,6 +2177,48 @@ int omega_edit_clear_changes(omega_session_t *session_ptr) {
         omega_viewport_notify(viewport_ptr.get(), VIEWPORT_EVT_CLEAR, nullptr);
     }
     omega_session_notify(session_ptr, SESSION_EVT_CLEAR, nullptr);
+    return 0;
+}
+
+int omega_edit_restore_to_change_count(omega_session_t *session_ptr, int64_t change_count) {
+    if (!session_ptr || change_count < 0) { return -1; }
+    const auto current_change_count = omega_session_get_num_changes(session_ptr);
+    if (change_count > current_change_count) { return -1; }
+
+    bool restored = false;
+    while (session_ptr->models_.size() > 1) {
+        auto *const model_ptr = session_ptr->models_.back().get();
+        const auto model_base = model_ptr->change_serial_base;
+        if (change_count < model_base ||
+            (change_count == model_base && checkpoint_snapshot_change_count_(model_ptr) > 0)) {
+            if (0 != discard_top_model_(session_ptr)) { return -1; }
+            restored = true;
+            continue;
+        }
+        break;
+    }
+
+    auto *const model_ptr = session_ptr->models_.back().get();
+    if (change_count < model_ptr->change_serial_base) { return -1; }
+    const auto keep_count = change_count - model_ptr->change_serial_base;
+    if (keep_count < 0 || keep_count > static_cast<int64_t>(model_ptr->changes.size())) { return -1; }
+
+    if (keep_count < static_cast<int64_t>(model_ptr->changes.size())) {
+        model_ptr->changes.erase(model_ptr->changes.begin() + static_cast<std::ptrdiff_t>(keep_count),
+                                 model_ptr->changes.end());
+        restored = true;
+    }
+    if (!model_ptr->changes_undone.empty()) {
+        free_model_changes_undone_(model_ptr);
+        restored = true;
+    }
+    if (0 != rebuild_model_to_change_count_(session_ptr, keep_count)) { return -1; }
+
+    session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
+    if (restored) {
+        mark_all_viewports_changed_(session_ptr, VIEWPORT_EVT_CHANGES, nullptr);
+        omega_session_notify(session_ptr, SESSION_EVT_UNDO, nullptr);
+    }
     return 0;
 }
 

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -652,6 +652,16 @@ namespace {
         return update_model_helper_(model_ptr, change_ptr);
     }
 
+    auto reset_model_segments_to_original_(omega_model_t *model_ptr) -> int {
+        if (!model_ptr) { return -1; }
+        int64_t length = 0;
+        if (model_ptr->file_ptr != nullptr) {
+            if (0 != FSEEK(model_ptr->file_ptr, 0L, SEEK_END)) { return -1; }
+            length = FTELL(model_ptr->file_ptr);
+        }
+        return initialize_model_segments_(model_ptr->model_segments, length) ? 0 : -1;
+    }
+
     auto rebuild_model_to_change_count_(omega_session_t *session_ptr, int64_t remaining_count) -> int {
         if (!session_ptr) { return -1; }
 
@@ -659,6 +669,8 @@ namespace {
         auto &snapshots = model_ptr->model_snapshots;
         auto cleanup_it = snapshots.upper_bound(remaining_count);
         snapshots.erase(cleanup_it, snapshots.end());
+
+        if (remaining_count == 0) { return reset_model_segments_to_original_(model_ptr); }
 
         int64_t replay_from = 0;
         if (!snapshots.empty()) {
@@ -670,20 +682,10 @@ namespace {
                 } catch (const std::bad_alloc &) { return -1; }
                 replay_from = snap_it->first;
             } else {
-                int64_t length = 0;
-                if (model_ptr->file_ptr != nullptr) {
-                    if (0 != FSEEK(model_ptr->file_ptr, 0L, SEEK_END)) { return -1; }
-                    length = FTELL(model_ptr->file_ptr);
-                }
-                if (!initialize_model_segments_(model_ptr->model_segments, length)) { return -1; }
+                if (0 != reset_model_segments_to_original_(model_ptr)) { return -1; }
             }
         } else {
-            int64_t length = 0;
-            if (model_ptr->file_ptr != nullptr) {
-                if (0 != FSEEK(model_ptr->file_ptr, 0L, SEEK_END)) { return -1; }
-                length = FTELL(model_ptr->file_ptr);
-            }
-            if (!initialize_model_segments_(model_ptr->model_segments, length)) { return -1; }
+            if (0 != reset_model_segments_to_original_(model_ptr)) { return -1; }
         }
 
         for (auto i = replay_from; i < remaining_count; ++i) {

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -1240,3 +1240,66 @@ TEST_CASE("Undo Snapshot Optimization", "[UndoTests]") {
 
     omega_edit_destroy_session(session_ptr);
 }
+
+TEST_CASE("Edit result predicates distinguish serial and status conventions", "[EditResult]") {
+    REQUIRE(0 == omega_edit_serial_result_is_success(-1));
+    REQUIRE(0 == omega_edit_serial_result_is_success(0));
+    REQUIRE(1 == omega_edit_serial_result_is_success(1));
+
+    REQUIRE(1 == omega_edit_status_result_is_success(0));
+    REQUIRE(0 == omega_edit_status_result_is_success(-1));
+    REQUIRE(0 == omega_edit_status_result_is_success(1));
+}
+
+TEST_CASE("Restore To Change Count Discards Later Changes And Redo", "[UndoTests]") {
+    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+    const auto keep_count = omega_session_get_num_changes(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 3, "def"));
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 6, "ghi"));
+    REQUIRE("abcdefghi" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(0 > omega_edit_undo_last_change(session_ptr));
+    REQUIRE(1 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE("abcdef" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, keep_count));
+    REQUIRE(keep_count == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE("abc" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    REQUIRE(0 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE(-1 == omega_edit_restore_to_change_count(session_ptr, keep_count + 1));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Restore To Change Count Discards Transform Checkpoint Model", "[UndoTests][Transform]") {
+    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+    const auto keep_count = omega_session_get_num_changes(session_ptr);
+
+    const omega_edit_transform_t upper_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, upper_transform, 0, 3));
+    REQUIRE(keep_count + 1 == omega_session_get_num_changes(session_ptr));
+    REQUIRE("ABC" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+
+    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, keep_count));
+    REQUIRE(keep_count == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE("abc" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -1279,6 +1279,74 @@ TEST_CASE("Restore To Change Count Discards Later Changes And Redo", "[UndoTests
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Restore To Change Count Validates Inputs And No-Ops Current Count", "[UndoTests]") {
+    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(-1 == omega_edit_restore_to_change_count(nullptr, 0));
+    REQUIRE(-1 == omega_edit_restore_to_change_count(session_ptr, -1));
+    REQUIRE(-1 == omega_edit_restore_to_change_count(session_ptr, 1));
+    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, 0));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+    const auto current_count = omega_session_get_num_changes(session_ptr);
+    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, current_count));
+    REQUIRE(current_count == omega_session_get_num_changes(session_ptr));
+    REQUIRE("abc" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Restore To Change Count Discards Redo Without Dropping Active Changes", "[UndoTests]") {
+    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 3, "def"));
+    REQUIRE(0 > omega_edit_undo_last_change(session_ptr));
+    const auto current_count = omega_session_get_num_changes(session_ptr);
+    REQUIRE(1 == omega_session_get_num_undone_changes(session_ptr));
+
+    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, current_count));
+    REQUIRE(current_count == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE("abc" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(0 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Restore To Change Count Discards Explicit Checkpoint Models", "[UndoTests]") {
+    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+    const auto checkpoint_count = omega_session_get_num_changes(session_ptr);
+    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 3, "def"));
+
+    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, checkpoint_count));
+    REQUIRE(checkpoint_count == omega_session_get_num_changes(session_ptr));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE("abc" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, 0));
+    REQUIRE(0 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Restore To Change Count Discards Transform Checkpoint Model", "[UndoTests][Transform]") {
     auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
     REQUIRE(session_ptr);

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -1321,6 +1321,30 @@ TEST_CASE("Restore To Change Count Discards Redo Without Dropping Active Changes
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Restore To Change Count Rebuilds From Retained Undo Snapshot", "[UndoTests]") {
+    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(2 == omega_session_set_undo_snapshot_interval(session_ptr, 2));
+    for (auto i = 0; i < 7; ++i) {
+        const char bytes[] = {static_cast<char>('A' + i), '\0'};
+        REQUIRE(0 < omega_edit_insert_string(session_ptr, omega_session_get_computed_file_size(session_ptr), bytes));
+    }
+    REQUIRE(7 == omega_session_get_num_changes(session_ptr));
+    REQUIRE("ABCDEFG" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, 5));
+    REQUIRE(5 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE("ABCDE" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(0 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Restore To Change Count Discards Explicit Checkpoint Models", "[UndoTests]") {
     auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
     REQUIRE(session_ptr);

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -37,6 +37,7 @@ import {
   replaceSession as replaceWholeSession,
   resetClient,
   restoreLastCheckpoint as restoreClientCheckpoint,
+  restoreToChangeCount,
   runSessionTransaction,
   saveSession,
   searchSession,
@@ -683,27 +684,14 @@ async function rollbackSessionToChangeCount(
   sessionId: string,
   targetChangeCount: number
 ): Promise<boolean> {
-  let currentChangeCount = await getChangeCount(sessionId)
-  let rolledBack = false
-  while (currentChangeCount > targetChangeCount) {
-    await undo(sessionId)
-    rolledBack = true
-    const nextChangeCount = await getChangeCount(sessionId)
-    if (nextChangeCount >= currentChangeCount) {
-      throw new Error(
-        `Rollback did not reduce change count from ${currentChangeCount}`
-      )
-    }
-    currentChangeCount = nextChangeCount
-  }
-
-  if (currentChangeCount !== targetChangeCount) {
+  const response = await restoreToChangeCount(sessionId, targetChangeCount)
+  if (response.changeCount !== targetChangeCount) {
     throw new Error(
-      `Rollback ended at change count ${currentChangeCount}, expected ${targetChangeCount}`
+      `Rollback ended at change count ${response.changeCount}, expected ${targetChangeCount}`
     )
   }
 
-  return rolledBack
+  return response.discardedChangeCount > 0 || response.discardedUndoCount > 0
 }
 
 function changeLogApplyErrorWithRollbackFailure(

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -103,6 +103,8 @@ import type { ResumeSessionChangesResponse } from './omega_edit'
 import type { ResumeSessionChangesRequest } from './omega_edit'
 import type { PauseSessionChangesResponse } from './omega_edit'
 import type { PauseSessionChangesRequest } from './omega_edit'
+import type { RestoreToChangeCountResponse } from './omega_edit'
+import type { RestoreToChangeCountRequest } from './omega_edit'
 import type { ClearChangesResponse } from './omega_edit'
 import type { ClearChangesRequest } from './omega_edit'
 import type { RedoLastUndoResponse } from './omega_edit'
@@ -461,6 +463,43 @@ export interface IEditorServiceClient {
     callback: (
       err: grpc.ServiceError | null,
       value?: ClearChangesResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  /**
+   * Restore the session to a previous active change count and discard redo history.
+   *
+   * @generated from protobuf rpc: RestoreToChangeCount
+   */
+  restoreToChangeCount(
+    input: RestoreToChangeCountRequest,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: RestoreToChangeCountResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  restoreToChangeCount(
+    input: RestoreToChangeCountRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: RestoreToChangeCountResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  restoreToChangeCount(
+    input: RestoreToChangeCountRequest,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: RestoreToChangeCountResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  restoreToChangeCount(
+    input: RestoreToChangeCountRequest,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: RestoreToChangeCountResponse
     ) => void
   ): grpc.ClientUnaryCall
   /**
@@ -2354,6 +2393,47 @@ export class EditorServiceClient
     )
   }
   /**
+   * Restore the session to a previous active change count and discard redo history.
+   *
+   * @generated from protobuf rpc: RestoreToChangeCount
+   */
+  restoreToChangeCount(
+    input: RestoreToChangeCountRequest,
+    metadata:
+      | grpc.Metadata
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: RestoreToChangeCountResponse
+        ) => void),
+    options?:
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: RestoreToChangeCountResponse
+        ) => void),
+    callback?: (
+      err: grpc.ServiceError | null,
+      value?: RestoreToChangeCountResponse
+    ) => void
+  ): grpc.ClientUnaryCall {
+    const method = EditorService.methods[8]
+    return this.makeUnaryRequest<
+      RestoreToChangeCountRequest,
+      RestoreToChangeCountResponse
+    >(
+      `/${EditorService.typeName}/${method.name}`,
+      (value: RestoreToChangeCountRequest): Buffer =>
+        Buffer.from(method.I.toBinary(value, this._binaryOptions)),
+      (value: Buffer): RestoreToChangeCountResponse =>
+        method.O.fromBinary(value, this._binaryOptions),
+      input,
+      metadata as any,
+      options as any,
+      callback as any
+    )
+  }
+  /**
    * Pause acceptance of new changes on the session.  Any SubmitChange calls
    * while paused will be rejected.
    *
@@ -2379,7 +2459,7 @@ export class EditorServiceClient
       value?: PauseSessionChangesResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[8]
+    const method = EditorService.methods[9]
     return this.makeUnaryRequest<
       PauseSessionChangesRequest,
       PauseSessionChangesResponse
@@ -2420,7 +2500,7 @@ export class EditorServiceClient
       value?: ResumeSessionChangesResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[9]
+    const method = EditorService.methods[10]
     return this.makeUnaryRequest<
       ResumeSessionChangesRequest,
       ResumeSessionChangesResponse
@@ -2467,7 +2547,7 @@ export class EditorServiceClient
       value?: SessionBeginTransactionResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[10]
+    const method = EditorService.methods[11]
     return this.makeUnaryRequest<
       SessionBeginTransactionRequest,
       SessionBeginTransactionResponse
@@ -2508,7 +2588,7 @@ export class EditorServiceClient
       value?: SessionEndTransactionResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[11]
+    const method = EditorService.methods[12]
     return this.makeUnaryRequest<
       SessionEndTransactionRequest,
       SessionEndTransactionResponse
@@ -2554,7 +2634,7 @@ export class EditorServiceClient
       value?: CreateViewportResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[12]
+    const method = EditorService.methods[13]
     return this.makeUnaryRequest<CreateViewportRequest, CreateViewportResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: CreateViewportRequest): Buffer =>
@@ -2592,7 +2672,7 @@ export class EditorServiceClient
       value?: ModifyViewportResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[13]
+    const method = EditorService.methods[14]
     return this.makeUnaryRequest<ModifyViewportRequest, ModifyViewportResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: ModifyViewportRequest): Buffer =>
@@ -2631,7 +2711,7 @@ export class EditorServiceClient
       value?: ViewportHasChangesResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[14]
+    const method = EditorService.methods[15]
     return this.makeUnaryRequest<
       ViewportHasChangesRequest,
       ViewportHasChangesResponse
@@ -2672,7 +2752,7 @@ export class EditorServiceClient
       value?: GetViewportDataResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[15]
+    const method = EditorService.methods[16]
     return this.makeUnaryRequest<
       GetViewportDataRequest,
       GetViewportDataResponse
@@ -2713,7 +2793,7 @@ export class EditorServiceClient
       value?: DestroyViewportResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[16]
+    const method = EditorService.methods[17]
     return this.makeUnaryRequest<
       DestroyViewportRequest,
       DestroyViewportResponse
@@ -2754,7 +2834,7 @@ export class EditorServiceClient
       value?: PauseViewportEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[17]
+    const method = EditorService.methods[18]
     return this.makeUnaryRequest<
       PauseViewportEventsRequest,
       PauseViewportEventsResponse
@@ -2795,7 +2875,7 @@ export class EditorServiceClient
       value?: ResumeViewportEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[18]
+    const method = EditorService.methods[19]
     return this.makeUnaryRequest<
       ResumeViewportEventsRequest,
       ResumeViewportEventsResponse
@@ -2837,7 +2917,7 @@ export class EditorServiceClient
       value?: NotifyChangedViewportsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[19]
+    const method = EditorService.methods[20]
     return this.makeUnaryRequest<
       NotifyChangedViewportsRequest,
       NotifyChangedViewportsResponse
@@ -2883,7 +2963,7 @@ export class EditorServiceClient
       value?: GetChangeDetailsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[20]
+    const method = EditorService.methods[21]
     return this.makeUnaryRequest<
       GetChangeDetailsRequest,
       GetChangeDetailsResponse
@@ -2924,7 +3004,7 @@ export class EditorServiceClient
       value?: GetLastChangeResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[21]
+    const method = EditorService.methods[22]
     return this.makeUnaryRequest<GetLastChangeRequest, GetLastChangeResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetLastChangeRequest): Buffer =>
@@ -2956,7 +3036,7 @@ export class EditorServiceClient
       value?: GetLastUndoResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[22]
+    const method = EditorService.methods[23]
     return this.makeUnaryRequest<GetLastUndoRequest, GetLastUndoResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetLastUndoRequest): Buffer =>
@@ -2998,7 +3078,7 @@ export class EditorServiceClient
       value?: GetComputedFileSizeResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[23]
+    const method = EditorService.methods[24]
     return this.makeUnaryRequest<
       GetComputedFileSizeRequest,
       GetComputedFileSizeResponse
@@ -3039,7 +3119,7 @@ export class EditorServiceClient
       value?: GetByteOrderMarkResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[24]
+    const method = EditorService.methods[25]
     return this.makeUnaryRequest<
       GetByteOrderMarkRequest,
       GetByteOrderMarkResponse
@@ -3080,7 +3160,7 @@ export class EditorServiceClient
       value?: GetContentTypeResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[25]
+    const method = EditorService.methods[26]
     return this.makeUnaryRequest<GetContentTypeRequest, GetContentTypeResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetContentTypeRequest): Buffer =>
@@ -3113,7 +3193,7 @@ export class EditorServiceClient
       value?: GetLanguageResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[26]
+    const method = EditorService.methods[27]
     return this.makeUnaryRequest<GetLanguageRequest, GetLanguageResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetLanguageRequest): Buffer =>
@@ -3143,7 +3223,7 @@ export class EditorServiceClient
       | ((err: grpc.ServiceError | null, value?: GetCountResponse) => void),
     callback?: (err: grpc.ServiceError | null, value?: GetCountResponse) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[27]
+    const method = EditorService.methods[28]
     return this.makeUnaryRequest<GetCountRequest, GetCountResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetCountRequest): Buffer =>
@@ -3181,7 +3261,7 @@ export class EditorServiceClient
       value?: CheckSessionModelResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[28]
+    const method = EditorService.methods[29]
     return this.makeUnaryRequest<
       CheckSessionModelRequest,
       CheckSessionModelResponse
@@ -3222,7 +3302,7 @@ export class EditorServiceClient
       value?: GetSessionFingerprintResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[29]
+    const method = EditorService.methods[30]
     return this.makeUnaryRequest<
       GetSessionFingerprintRequest,
       GetSessionFingerprintResponse
@@ -3263,7 +3343,7 @@ export class EditorServiceClient
       value?: GetSessionContentInfoResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[30]
+    const method = EditorService.methods[31]
     return this.makeUnaryRequest<
       GetSessionContentInfoRequest,
       GetSessionContentInfoResponse
@@ -3304,7 +3384,7 @@ export class EditorServiceClient
       value?: InspectSessionContentResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[31]
+    const method = EditorService.methods[32]
     return this.makeUnaryRequest<
       InspectSessionContentRequest,
       InspectSessionContentResponse
@@ -3345,7 +3425,7 @@ export class EditorServiceClient
       value?: GetSessionCountResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[32]
+    const method = EditorService.methods[33]
     return this.makeUnaryRequest<
       GetSessionCountRequest,
       GetSessionCountResponse
@@ -3380,7 +3460,7 @@ export class EditorServiceClient
       value?: GetSegmentResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[33]
+    const method = EditorService.methods[34]
     return this.makeUnaryRequest<GetSegmentRequest, GetSegmentResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetSegmentRequest): Buffer =>
@@ -3423,7 +3503,7 @@ export class EditorServiceClient
       value?: SearchSessionResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[34]
+    const method = EditorService.methods[35]
     return this.makeUnaryRequest<SearchSessionRequest, SearchSessionResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: SearchSessionRequest): Buffer =>
@@ -3463,7 +3543,7 @@ export class EditorServiceClient
       value?: ReplaceSessionResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[35]
+    const method = EditorService.methods[36]
     return this.makeUnaryRequest<ReplaceSessionRequest, ReplaceSessionResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: ReplaceSessionRequest): Buffer =>
@@ -3503,7 +3583,7 @@ export class EditorServiceClient
       value?: ReplaceSessionCheckpointedResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[36]
+    const method = EditorService.methods[37]
     return this.makeUnaryRequest<
       ReplaceSessionCheckpointedRequest,
       ReplaceSessionCheckpointedResponse
@@ -3544,7 +3624,7 @@ export class EditorServiceClient
       value?: CreateCheckpointResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[37]
+    const method = EditorService.methods[38]
     return this.makeUnaryRequest<
       CreateCheckpointRequest,
       CreateCheckpointResponse
@@ -3586,7 +3666,7 @@ export class EditorServiceClient
       value?: DestroyLastCheckpointResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[38]
+    const method = EditorService.methods[39]
     return this.makeUnaryRequest<
       DestroyLastCheckpointRequest,
       DestroyLastCheckpointResponse
@@ -3628,7 +3708,7 @@ export class EditorServiceClient
       value?: RestoreLastCheckpointResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[39]
+    const method = EditorService.methods[40]
     return this.makeUnaryRequest<
       RestoreLastCheckpointRequest,
       RestoreLastCheckpointResponse
@@ -3669,7 +3749,7 @@ export class EditorServiceClient
       value?: ListTransformPluginsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[40]
+    const method = EditorService.methods[41]
     return this.makeUnaryRequest<
       ListTransformPluginsRequest,
       ListTransformPluginsResponse
@@ -3711,7 +3791,7 @@ export class EditorServiceClient
       value?: ApplyTransformPluginResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[41]
+    const method = EditorService.methods[42]
     return this.makeUnaryRequest<
       ApplyTransformPluginRequest,
       ApplyTransformPluginResponse
@@ -3753,7 +3833,7 @@ export class EditorServiceClient
       value?: GetByteFrequencyProfileResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[42]
+    const method = EditorService.methods[43]
     return this.makeUnaryRequest<
       GetByteFrequencyProfileRequest,
       GetByteFrequencyProfileResponse
@@ -3795,7 +3875,7 @@ export class EditorServiceClient
       value?: GetCharacterCountsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[43]
+    const method = EditorService.methods[44]
     return this.makeUnaryRequest<
       GetCharacterCountsRequest,
       GetCharacterCountsResponse
@@ -3840,7 +3920,7 @@ export class EditorServiceClient
       value?: ServerControlResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[44]
+    const method = EditorService.methods[45]
     return this.makeUnaryRequest<ServerControlRequest, ServerControlResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: ServerControlRequest): Buffer =>
@@ -3873,7 +3953,7 @@ export class EditorServiceClient
       value?: GetHeartbeatResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[45]
+    const method = EditorService.methods[46]
     return this.makeUnaryRequest<GetHeartbeatRequest, GetHeartbeatResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetHeartbeatRequest): Buffer =>
@@ -3902,7 +3982,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToSessionEventsResponse> {
-    const method = EditorService.methods[46]
+    const method = EditorService.methods[47]
     return this.makeServerStreamRequest<
       SubscribeToSessionEventsRequest,
       SubscribeToSessionEventsResponse
@@ -3928,7 +4008,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToViewportEventsResponse> {
-    const method = EditorService.methods[47]
+    const method = EditorService.methods[48]
     return this.makeServerStreamRequest<
       SubscribeToViewportEventsRequest,
       SubscribeToViewportEventsResponse
@@ -3968,7 +4048,7 @@ export class EditorServiceClient
       value?: UnsubscribeToSessionEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[48]
+    const method = EditorService.methods[49]
     return this.makeUnaryRequest<
       UnsubscribeToSessionEventsRequest,
       UnsubscribeToSessionEventsResponse
@@ -4009,7 +4089,7 @@ export class EditorServiceClient
       value?: UnsubscribeToViewportEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[49]
+    const method = EditorService.methods[50]
     return this.makeUnaryRequest<
       UnsubscribeToViewportEventsRequest,
       UnsubscribeToViewportEventsResponse

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -448,6 +448,48 @@ export interface ClearChangesResponse {
   id: string // Session ID.
 }
 /**
+ * Request to restore a session to a previous active change count.
+ *
+ * @generated from protobuf message omega_edit.v1.RestoreToChangeCountRequest
+ */
+export interface RestoreToChangeCountRequest {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session ID.
+  /**
+   * @generated from protobuf field: int64 change_count = 2
+   */
+  changeCount: number // Active change count to keep.
+}
+/**
+ * Response after restoring a session to a previous active change count.
+ *
+ * @generated from protobuf message omega_edit.v1.RestoreToChangeCountResponse
+ */
+export interface RestoreToChangeCountResponse {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session that was restored.
+  /**
+   * @generated from protobuf field: int64 change_count = 2
+   */
+  changeCount: number // Session change count after restore.
+  /**
+   * @generated from protobuf field: int64 discarded_change_count = 3
+   */
+  discardedChangeCount: number // Number of active changes discarded.
+  /**
+   * @generated from protobuf field: int64 discarded_undo_count = 4
+   */
+  discardedUndoCount: number // Number of redo/undone changes discarded.
+  /**
+   * @generated from protobuf field: int64 remaining_checkpoint_count = 5
+   */
+  remainingCheckpointCount: number // Checkpoint count after restore.
+}
+/**
  * Request to pause change acceptance on a session.
  *
  * @generated from protobuf message omega_edit.v1.PauseSessionChangesRequest
@@ -4641,6 +4683,220 @@ class ClearChangesResponse$Type extends MessageType<ClearChangesResponse> {
  * @generated MessageType for protobuf message omega_edit.v1.ClearChangesResponse
  */
 export const ClearChangesResponse = new ClearChangesResponse$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class RestoreToChangeCountRequest$Type extends MessageType<RestoreToChangeCountRequest> {
+  constructor() {
+    super('omega_edit.v1.RestoreToChangeCountRequest', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'change_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<RestoreToChangeCountRequest>
+  ): RestoreToChangeCountRequest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.changeCount = 0
+    if (value !== undefined)
+      reflectionMergePartial<RestoreToChangeCountRequest>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: RestoreToChangeCountRequest
+  ): RestoreToChangeCountRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* int64 change_count */ 2:
+          message.changeCount = reader.int64().toNumber()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: RestoreToChangeCountRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* int64 change_count = 2; */
+    if (message.changeCount !== 0)
+      writer.tag(2, WireType.Varint).int64(message.changeCount)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.RestoreToChangeCountRequest
+ */
+export const RestoreToChangeCountRequest =
+  new RestoreToChangeCountRequest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class RestoreToChangeCountResponse$Type extends MessageType<RestoreToChangeCountResponse> {
+  constructor() {
+    super('omega_edit.v1.RestoreToChangeCountResponse', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'change_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 3,
+        name: 'discarded_change_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 4,
+        name: 'discarded_undo_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 5,
+        name: 'remaining_checkpoint_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<RestoreToChangeCountResponse>
+  ): RestoreToChangeCountResponse {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.changeCount = 0
+    message.discardedChangeCount = 0
+    message.discardedUndoCount = 0
+    message.remainingCheckpointCount = 0
+    if (value !== undefined)
+      reflectionMergePartial<RestoreToChangeCountResponse>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: RestoreToChangeCountResponse
+  ): RestoreToChangeCountResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* int64 change_count */ 2:
+          message.changeCount = reader.int64().toNumber()
+          break
+        case /* int64 discarded_change_count */ 3:
+          message.discardedChangeCount = reader.int64().toNumber()
+          break
+        case /* int64 discarded_undo_count */ 4:
+          message.discardedUndoCount = reader.int64().toNumber()
+          break
+        case /* int64 remaining_checkpoint_count */ 5:
+          message.remainingCheckpointCount = reader.int64().toNumber()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: RestoreToChangeCountResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* int64 change_count = 2; */
+    if (message.changeCount !== 0)
+      writer.tag(2, WireType.Varint).int64(message.changeCount)
+    /* int64 discarded_change_count = 3; */
+    if (message.discardedChangeCount !== 0)
+      writer.tag(3, WireType.Varint).int64(message.discardedChangeCount)
+    /* int64 discarded_undo_count = 4; */
+    if (message.discardedUndoCount !== 0)
+      writer.tag(4, WireType.Varint).int64(message.discardedUndoCount)
+    /* int64 remaining_checkpoint_count = 5; */
+    if (message.remainingCheckpointCount !== 0)
+      writer.tag(5, WireType.Varint).int64(message.remainingCheckpointCount)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.RestoreToChangeCountResponse
+ */
+export const RestoreToChangeCountResponse =
+  new RestoreToChangeCountResponse$Type()
 // @generated message type with reflection information, may provide speed optimized methods
 class PauseSessionChangesRequest$Type extends MessageType<PauseSessionChangesRequest> {
   constructor() {
@@ -13806,6 +14062,12 @@ export const EditorService = new ServiceType('omega_edit.v1.EditorService', [
     options: {},
     I: ClearChangesRequest,
     O: ClearChangesResponse,
+  },
+  {
+    name: 'RestoreToChangeCount',
+    options: {},
+    I: RestoreToChangeCountRequest,
+    O: RestoreToChangeCountResponse,
   },
   {
     name: 'PauseSessionChanges',

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -46,6 +46,7 @@ import {
   type ReplaceSessionCheckpointedRequest,
   type ReplaceSessionCheckpointedResponse,
   type RestoreLastCheckpointResponse,
+  type RestoreToChangeCountResponse,
   type SaveSessionRequest,
   type SaveSessionResponse,
   type SearchSessionRequest,
@@ -1481,6 +1482,51 @@ export async function restoreLastCheckpoint(
         }
       }
     )
+  })
+}
+
+export async function restoreToChangeCount(
+  sessionId: string,
+  changeCount: number
+): Promise<RestoreToChangeCountResponse> {
+  const log = getLogger()
+  const request = { sessionId, changeCount }
+  debugLog(log, () => ({
+    fn: 'protobufTs.restoreToChangeCount',
+    rqst: request,
+  }))
+  const client = await getClient()
+
+  return new Promise<RestoreToChangeCountResponse>((resolve, reject) => {
+    callUnary(client, client.restoreToChangeCount, request, (err, response) => {
+      if (err) {
+        log.error({
+          fn: 'protobufTs.restoreToChangeCount',
+          rqst: request,
+          err: {
+            msg: err.message,
+            details: err.details,
+            code: err.code,
+            stack: err.stack,
+          },
+        })
+        return reject(makeWrappedError('restoreToChangeCount', err))
+      }
+
+      try {
+        const required = requireResponse(
+          response as RestoreToChangeCountResponse | undefined,
+          'restoreToChangeCount'
+        )
+        debugLog(log, () => ({
+          fn: 'protobufTs.restoreToChangeCount',
+          resp: required,
+        }))
+        return resolve(required)
+      } catch (error) {
+        return reject(makeWrappedError('restoreToChangeCount', error))
+      }
+    })
   })
 }
 

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -30,6 +30,7 @@ import {
   type GetSessionFingerprintResponse as RawGetSessionFingerprintResponse,
   type InspectSessionContentResponse as RawInspectSessionContentResponse,
   type RestoreLastCheckpointResponse as RawRestoreLastCheckpointResponse,
+  type RestoreToChangeCountResponse as RawRestoreToChangeCountResponse,
   type SessionContentInfo as RawSessionContentInfo,
   type SessionContentFingerprint as RawSessionContentFingerprint,
   type TransformProgress,
@@ -61,6 +62,7 @@ import {
   replaceSession as rawReplaceSession,
   replaceSessionCheckpointed as rawReplaceSessionCheckpointed,
   restoreLastCheckpoint as rawRestoreLastCheckpoint,
+  restoreToChangeCount as rawRestoreToChangeCount,
   resumeSessionChanges as rawResumeSessionChanges,
   saveSession as rawSaveSession,
   searchSession as rawSearchSession,
@@ -171,6 +173,7 @@ export type TransformPluginOperation =
 export type TransformPluginInfo = RawTransformPluginInfo
 export type ApplyTransformPluginResponse = RawApplyTransformPluginResponse
 export type RestoreLastCheckpointResponse = RawRestoreLastCheckpointResponse
+export type RestoreToChangeCountResponse = RawRestoreToChangeCountResponse
 export type CheckSessionModelResponse = RawCheckSessionModelResponse
 export type SessionContentInfo = RawSessionContentInfo
 export type GetSessionContentInfoResponse = RawGetSessionContentInfoResponse
@@ -305,6 +308,32 @@ export async function restoreLastCheckpoint(
     requireSafeIntegerOutput(
       'discarded change count',
       response.discardedChangeCount
+    )
+    return response
+  })
+}
+
+export async function restoreToChangeCount(
+  session_id: string,
+  change_count: number
+): Promise<RestoreToChangeCountResponse> {
+  return await enqueueSessionMutation(session_id, async () => {
+    const response = await rawRestoreToChangeCount(
+      session_id,
+      requireSafeIntegerInput('restore change count', change_count)
+    )
+    requireSafeIntegerOutput('change count', response.changeCount)
+    requireSafeIntegerOutput(
+      'discarded change count',
+      response.discardedChangeCount
+    )
+    requireSafeIntegerOutput(
+      'discarded undo count',
+      response.discardedUndoCount
+    )
+    requireSafeIntegerOutput(
+      'remaining checkpoint count',
+      response.remainingCheckpointCount
     )
     return response
   })

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -49,6 +49,8 @@ import {
   profileSession,
   saveSession,
   SaveStatus,
+  restoreToChangeCount,
+  undo,
 } from '@omega-edit/client'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -1072,6 +1074,42 @@ describe('Sessions', () => {
       expect(await destroyLastCheckpoint(session_id)).to.equal(0)
       expect(await getSessionBytes(session_id)).to.deep.equal(seed)
       expect(await getChangeCount(session_id)).to.equal(0)
+    } finally {
+      if (session_id) {
+        await destroySession(session_id)
+      }
+    }
+  })
+
+  it('Should restore to an earlier change count and discard redo', async () => {
+    let session_id = ''
+
+    try {
+      const session = await createSessionFromBytes(
+        Buffer.from('restore seed'),
+        'restore_change_count_test'
+      )
+      session_id = session.getSessionId()
+
+      await insert(session_id, 12, Buffer.from(' one'))
+      const keepCount = await getChangeCount(session_id)
+      await insert(session_id, 16, Buffer.from(' two'))
+      await del(session_id, 0, 8)
+      expect(await getSessionBytes(session_id)).to.deep.equal(
+        Buffer.from('seed one two')
+      )
+      await undo(session_id)
+      expect(await getSessionBytes(session_id)).to.deep.equal(
+        Buffer.from('restore seed one two')
+      )
+
+      const response = await restoreToChangeCount(session_id, keepCount)
+      expect(response.changeCount).to.equal(keepCount)
+      expect(response.discardedChangeCount).to.equal(1)
+      expect(response.discardedUndoCount).to.equal(1)
+      expect(await getSessionBytes(session_id)).to.deep.equal(
+        Buffer.from('restore seed one')
+      )
     } finally {
       if (session_id) {
         await destroySession(session_id)

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -585,10 +585,10 @@ message RestoreToChangeCountRequest {
 
 // Response after restoring a session to a previous active change count.
 message RestoreToChangeCountResponse {
-    string session_id = 1;                 // Session that was restored.
-    int64 change_count = 2;                // Session change count after restore.
-    int64 discarded_change_count = 3;      // Number of active changes discarded.
-    int64 discarded_undo_count = 4;        // Number of redo/undone changes discarded.
+    string session_id = 1;               // Session that was restored.
+    int64 change_count = 2;              // Session change count after restore.
+    int64 discarded_change_count = 3;    // Number of active changes discarded.
+    int64 discarded_undo_count = 4;      // Number of redo/undone changes discarded.
     int64 remaining_checkpoint_count = 5;// Checkpoint count after restore.
 }
 

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -85,6 +85,9 @@ service EditorService {
     // Undo *all* changes in the session, returning it to its original state.
     rpc ClearChanges(ClearChangesRequest) returns (ClearChangesResponse);
 
+    // Restore the session to a previous active change count and discard redo history.
+    rpc RestoreToChangeCount(RestoreToChangeCountRequest) returns (RestoreToChangeCountResponse);
+
     // Pause acceptance of new changes on the session.  Any SubmitChange calls
     // while paused will be rejected.
     rpc PauseSessionChanges(PauseSessionChangesRequest) returns (PauseSessionChangesResponse);
@@ -572,6 +575,21 @@ message ClearChangesRequest {
 // Response after clearing all changes.
 message ClearChangesResponse {
     string id = 1;// Session ID.
+}
+
+// Request to restore a session to a previous active change count.
+message RestoreToChangeCountRequest {
+    string session_id = 1; // Session ID.
+    int64 change_count = 2;// Active change count to keep.
+}
+
+// Response after restoring a session to a previous active change count.
+message RestoreToChangeCountResponse {
+    string session_id = 1;                 // Session that was restored.
+    int64 change_count = 2;                // Session change count after restore.
+    int64 discarded_change_count = 3;      // Number of active changes discarded.
+    int64 discarded_undo_count = 4;        // Number of redo/undone changes discarded.
+    int64 remaining_checkpoint_count = 5;// Checkpoint count after restore.
 }
 
 // Request to pause change acceptance on a session.

--- a/server/cpp/cmake/FetchCLD3.cmake
+++ b/server/cpp/cmake/FetchCLD3.cmake
@@ -21,9 +21,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     cld3
-    GIT_REPOSITORY https://github.com/google/cld3.git
-    GIT_TAG        b48dc46512566f5a2d41118c8c1116c4f96dc661
-    GIT_SHALLOW    TRUE
+    URL       https://github.com/google/cld3/archive/b48dc46512566f5a2d41118c8c1116c4f96dc661.tar.gz
+    URL_HASH SHA256=d0d4ea2fddcbc7d10ace2c37309feb09da87e8ce7ced6ce73592da1359f4765f
 )
 
 FetchContent_GetProperties(cld3)

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -1090,6 +1090,50 @@ namespace omega_edit {
             return grpc::Status::OK;
         }
 
+        grpc::Status
+        EditorServiceImpl::RestoreToChangeCount(grpc::ServerContext * /*context*/,
+                                                const ::omega_edit::v1::RestoreToChangeCountRequest *request,
+                                                ::omega_edit::v1::RestoreToChangeCountResponse *response) {
+            if (request->change_count() < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "change_count must be non-negative");
+            }
+
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "restore to change count",
+                                                          request->session_id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            const auto before_change_count = omega_session_get_num_changes(session);
+            const auto before_undo_count = omega_session_get_num_undone_changes(session);
+            if (request->change_count() > before_change_count) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "change_count cannot exceed current session change count");
+            }
+
+            if (0 != omega_edit_restore_to_change_count(session, request->change_count())) {
+                return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                    "failed to restore session to requested change count");
+            }
+
+            const auto after_change_count = omega_session_get_num_changes(session);
+            const auto after_undo_count = omega_session_get_num_undone_changes(session);
+            response->set_session_id(request->session_id());
+            response->set_change_count(after_change_count);
+            response->set_discarded_change_count(
+                    before_change_count > after_change_count ? before_change_count - after_change_count : 0);
+            response->set_discarded_undo_count(
+                    before_undo_count > after_undo_count ? before_undo_count - after_undo_count : 0);
+            response->set_remaining_checkpoint_count(omega_session_get_num_checkpoints(session));
+            return grpc::Status::OK;
+        }
+
         // ---------- Session Control ----------
 
         grpc::Status EditorServiceImpl::PauseSessionChanges(grpc::ServerContext * /*context*/,

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -292,6 +292,33 @@ namespace omega_edit {
             ~transform_plugin_response_guard() { omega_transform_plugin_response_clear(&response); }
         };
 
+        struct transform_plugin_metadata {
+            bool found{};
+            omega_transform_plugin_operation_t operation{OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT};
+            uint32_t flags{};
+            bool has_args_schema{};
+            std::string args_schema;
+
+            const char *args_schema_ptr() const { return has_args_schema ? args_schema.c_str() : nullptr; }
+        };
+
+        static transform_plugin_metadata
+        snapshot_transform_plugin_metadata(const omega_transform_plugin_registry_t *registry,
+                                           const std::string &plugin_id) {
+            transform_plugin_metadata metadata{};
+            const auto *info = omega_transform_plugin_registry_find_info(registry, plugin_id.c_str());
+            if (!info) { return metadata; }
+
+            metadata.found = true;
+            metadata.operation = info->operation;
+            metadata.flags = info->flags;
+            if (info->args_schema) {
+                metadata.has_args_schema = true;
+                metadata.args_schema = info->args_schema;
+            }
+            return metadata;
+        }
+
         struct transform_progress_context {
             SessionManager *session_manager{};
             std::string session_id;
@@ -1618,35 +1645,36 @@ namespace omega_edit {
                 }
 
                 session_content_file_reader reader{snapshot_file_path, 0, byte_length};
+                transform_plugin_metadata plugin_metadata;
                 {
-                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
-                    const auto *plugin_info = omega_transform_plugin_registry_find_info(
-                            transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
-                    if (!plugin_info) {
-                        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                            "session fingerprint digest plugin is not registered: " +
-                                                    std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                    }
-                    if (plugin_info->operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-                        (plugin_info->flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-                        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                            "session fingerprint digest plugin must be a streaming inspect plugin");
-                    }
-                    if (0 != omega_transform_plugin_options_match_args_schema(options_json.c_str(),
-                                                                              plugin_info->args_schema)) {
-                        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                            "unsupported fingerprint digest algorithm: " + algorithm);
-                    }
+                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
+                    plugin_metadata = snapshot_transform_plugin_metadata(transform_plugin_registry_,
+                                                                         SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
+                }
+                if (!plugin_metadata.found) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "session fingerprint digest plugin is not registered: " +
+                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
+                }
+                if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
+                    (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "session fingerprint digest plugin must be a streaming inspect plugin");
+                }
+                if (0 != omega_transform_plugin_options_match_args_schema(options_json.c_str(),
+                                                                          plugin_metadata.args_schema_ptr())) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "unsupported fingerprint digest algorithm: " + algorithm);
+                }
 
-                    if (0 != omega_transform_plugin_registry_inspect_reader(
-                                     transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
-                                     options_json.c_str(), checkpoint_directory.c_str(),
-                                     read_session_content_file_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE,
-                                     nullptr, nullptr, &plugin_response.response)) {
-                        return grpc::Status(grpc::StatusCode::ABORTED,
-                                            "session fingerprint digest plugin failed: " +
-                                                    std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                    }
+                if (0 != omega_transform_plugin_registry_inspect_reader(
+                                 transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
+                                 options_json.c_str(), checkpoint_directory.c_str(), read_session_content_file_chunk,
+                                 &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE, nullptr, nullptr,
+                                 &plugin_response.response)) {
+                    return grpc::Status(grpc::StatusCode::ABORTED,
+                                        "session fingerprint digest plugin failed: " +
+                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
                 }
             } else {
                 auto locked_session = session_manager_.lock_session(request->session_id());
@@ -1660,36 +1688,37 @@ namespace omega_edit {
                                         "session content length unavailable for fingerprint");
                 }
 
+                transform_plugin_metadata plugin_metadata;
                 {
-                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
-                    const auto *plugin_info = omega_transform_plugin_registry_find_info(
-                            transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
-                    if (!plugin_info) {
-                        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                            "session fingerprint digest plugin is not registered: " +
-                                                    std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                    }
-                    if (plugin_info->operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-                        (plugin_info->flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-                        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                            "session fingerprint digest plugin must be a streaming inspect plugin");
-                    }
-                    if (0 != omega_transform_plugin_options_match_args_schema(options_json.c_str(),
-                                                                              plugin_info->args_schema)) {
-                        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                            "unsupported fingerprint digest algorithm: " + algorithm);
-                    }
+                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
+                    plugin_metadata = snapshot_transform_plugin_metadata(transform_plugin_registry_,
+                                                                         SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
+                }
+                if (!plugin_metadata.found) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "session fingerprint digest plugin is not registered: " +
+                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
+                }
+                if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
+                    (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "session fingerprint digest plugin must be a streaming inspect plugin");
+                }
+                if (0 != omega_transform_plugin_options_match_args_schema(options_json.c_str(),
+                                                                          plugin_metadata.args_schema_ptr())) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "unsupported fingerprint digest algorithm: " + algorithm);
+                }
 
-                    session_content_reader reader{session, inspection_content, 0, byte_length};
-                    if (0 != omega_transform_plugin_registry_inspect_reader(
-                                     transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
-                                     options_json.c_str(), omega_session_get_checkpoint_directory(session),
-                                     read_session_content_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE,
-                                     nullptr, nullptr, &plugin_response.response)) {
-                        return grpc::Status(grpc::StatusCode::INTERNAL,
-                                            "session fingerprint digest plugin failed: " +
-                                                    std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                    }
+                session_content_reader reader{session, inspection_content, 0, byte_length};
+                if (0 != omega_transform_plugin_registry_inspect_reader(
+                                 transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
+                                 options_json.c_str(), omega_session_get_checkpoint_directory(session),
+                                 read_session_content_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE, nullptr,
+                                 nullptr, &plugin_response.response)) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        "session fingerprint digest plugin failed: " +
+                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
                 }
             }
 
@@ -1798,32 +1827,34 @@ namespace omega_edit {
                 }
 
                 session_content_file_reader reader{snapshot_file_path, effective_offset, effective_length};
+                transform_plugin_metadata plugin_metadata;
                 {
-                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
-                    const auto *plugin_info = omega_transform_plugin_registry_find_info(transform_plugin_registry_,
-                                                                                        request->plugin_id().c_str());
-                    if (!plugin_info) {
-                        return grpc::Status(grpc::StatusCode::NOT_FOUND,
-                                            "transform plugin not found: " + request->plugin_id());
-                    }
-                    if (plugin_info->operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-                        (plugin_info->flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-                        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                            "session content inspection requires a streaming inspect plugin");
-                    }
-                    const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
-                    if (0 != omega_transform_plugin_options_match_args_schema(options_json, plugin_info->args_schema)) {
-                        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                            "transform options do not match schema: " + request->plugin_id());
-                    }
-                    if (0 != omega_transform_plugin_registry_inspect_reader(
-                                     transform_plugin_registry_, request->plugin_id().c_str(), effective_offset,
-                                     effective_length, options_json, checkpoint_directory.c_str(),
-                                     read_session_content_file_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE,
-                                     nullptr, nullptr, &plugin_response.response)) {
-                        return grpc::Status(grpc::StatusCode::ABORTED,
-                                            "session content inspection failed: " + request->plugin_id());
-                    }
+                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
+                    plugin_metadata =
+                            snapshot_transform_plugin_metadata(transform_plugin_registry_, request->plugin_id());
+                }
+                if (!plugin_metadata.found) {
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND,
+                                        "transform plugin not found: " + request->plugin_id());
+                }
+                if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
+                    (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "session content inspection requires a streaming inspect plugin");
+                }
+                const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
+                if (0 !=
+                    omega_transform_plugin_options_match_args_schema(options_json, plugin_metadata.args_schema_ptr())) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "transform options do not match schema: " + request->plugin_id());
+                }
+                if (0 != omega_transform_plugin_registry_inspect_reader(
+                                 transform_plugin_registry_, request->plugin_id().c_str(), effective_offset,
+                                 effective_length, options_json, checkpoint_directory.c_str(),
+                                 read_session_content_file_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE,
+                                 nullptr, nullptr, &plugin_response.response)) {
+                    return grpc::Status(grpc::StatusCode::ABORTED,
+                                        "session content inspection failed: " + request->plugin_id());
                 }
             } else {
                 auto locked_session = session_manager_.lock_session(request->session_id());
@@ -1837,32 +1868,34 @@ namespace omega_edit {
                 if (!range_status.ok()) { return range_status; }
 
                 session_content_reader reader{session, content, effective_offset, effective_length};
+                transform_plugin_metadata plugin_metadata;
                 {
-                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
-                    const auto *plugin_info = omega_transform_plugin_registry_find_info(transform_plugin_registry_,
-                                                                                        request->plugin_id().c_str());
-                    if (!plugin_info) {
-                        return grpc::Status(grpc::StatusCode::NOT_FOUND,
-                                            "transform plugin not found: " + request->plugin_id());
-                    }
-                    if (plugin_info->operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-                        (plugin_info->flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-                        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                            "session content inspection requires a streaming inspect plugin");
-                    }
-                    const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
-                    if (0 != omega_transform_plugin_options_match_args_schema(options_json, plugin_info->args_schema)) {
-                        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                            "transform options do not match schema: " + request->plugin_id());
-                    }
-                    if (0 != omega_transform_plugin_registry_inspect_reader(
-                                     transform_plugin_registry_, request->plugin_id().c_str(), effective_offset,
-                                     effective_length, options_json, omega_session_get_checkpoint_directory(session),
-                                     read_session_content_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE,
-                                     nullptr, nullptr, &plugin_response.response)) {
-                        return grpc::Status(grpc::StatusCode::INTERNAL,
-                                            "session content inspection failed: " + request->plugin_id());
-                    }
+                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
+                    plugin_metadata =
+                            snapshot_transform_plugin_metadata(transform_plugin_registry_, request->plugin_id());
+                }
+                if (!plugin_metadata.found) {
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND,
+                                        "transform plugin not found: " + request->plugin_id());
+                }
+                if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
+                    (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        "session content inspection requires a streaming inspect plugin");
+                }
+                const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
+                if (0 !=
+                    omega_transform_plugin_options_match_args_schema(options_json, plugin_metadata.args_schema_ptr())) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "transform options do not match schema: " + request->plugin_id());
+                }
+                if (0 != omega_transform_plugin_registry_inspect_reader(
+                                 transform_plugin_registry_, request->plugin_id().c_str(), effective_offset,
+                                 effective_length, options_json, omega_session_get_checkpoint_directory(session),
+                                 read_session_content_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE, nullptr,
+                                 nullptr, &plugin_response.response)) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        "session content inspection failed: " + request->plugin_id());
                 }
             }
 
@@ -2243,7 +2276,7 @@ namespace omega_edit {
         EditorServiceImpl::ListTransformPlugins(grpc::ServerContext * /*context*/,
                                                 const ::omega_edit::v1::ListTransformPluginsRequest * /*request*/,
                                                 ::omega_edit::v1::ListTransformPluginsResponse *response) {
-            std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
+            std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
             const auto count = omega_transform_plugin_registry_get_count(transform_plugin_registry_);
             for (int64_t i = 0; i < count; ++i) {
                 fill_transform_plugin_info(omega_transform_plugin_registry_get_info(transform_plugin_registry_, i),
@@ -2302,41 +2335,39 @@ namespace omega_edit {
                     make_transform_progress(request->plugin_id(), operation_id, "starting", "Transform started"));
             transform_plugin_response_guard plugin_response;
             int64_t transform_serial = 0;
+            transform_plugin_metadata plugin_metadata;
             {
-                // Serializes registry/plugin-library access while the session lock above serializes
-                // access to the non-thread-safe omega_session_t.
-                std::lock_guard<std::mutex> plugin_lock(transform_plugin_mutex_);
-                const auto *plugin_info = omega_transform_plugin_registry_find_info(transform_plugin_registry_,
-                                                                                    request->plugin_id().c_str());
-                if (!plugin_info) {
-                    session_manager_.publish_transform_progress(
-                            request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
-                            make_transform_progress(request->plugin_id(), operation_id, "failed",
-                                                    "Transform plugin not found"));
-                    return grpc::Status(grpc::StatusCode::NOT_FOUND,
-                                        "transform plugin not found: " + request->plugin_id());
-                }
+                std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
+                plugin_metadata = snapshot_transform_plugin_metadata(transform_plugin_registry_, request->plugin_id());
+            }
+            if (!plugin_metadata.found) {
+                session_manager_.publish_transform_progress(
+                        request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
+                        make_transform_progress(request->plugin_id(), operation_id, "failed",
+                                                "Transform plugin not found"));
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "transform plugin not found: " + request->plugin_id());
+            }
 
-                operation = plugin_info->operation;
-                const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
-                if (0 != omega_transform_plugin_options_match_args_schema(options_json, plugin_info->args_schema)) {
-                    session_manager_.publish_transform_progress(
-                            request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
-                            make_transform_progress(request->plugin_id(), operation_id, "failed",
-                                                    "Transform options do not match schema"));
-                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                        "transform options do not match schema: " + request->plugin_id());
-                }
-                if (0 != omega_transform_plugin_registry_apply_to_session_with_progress_and_serial(
-                                 transform_plugin_registry_, request->plugin_id().c_str(), session, offset, length,
-                                 options_json, transform_progress_callback, &progress_context,
-                                 &plugin_response.response, &transform_serial)) {
-                    session_manager_.publish_transform_progress(
-                            request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
-                            make_transform_progress(request->plugin_id(), operation_id, "failed",
-                                                    "Transform plugin failed"));
-                    return grpc::Status(grpc::StatusCode::INTERNAL, "transform plugin failed: " + request->plugin_id());
-                }
+            operation = plugin_metadata.operation;
+            const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
+            if (0 !=
+                omega_transform_plugin_options_match_args_schema(options_json, plugin_metadata.args_schema_ptr())) {
+                session_manager_.publish_transform_progress(
+                        request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
+                        make_transform_progress(request->plugin_id(), operation_id, "failed",
+                                                "Transform options do not match schema"));
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "transform options do not match schema: " + request->plugin_id());
+            }
+            if (0 != omega_transform_plugin_registry_apply_to_session_with_progress_and_serial(
+                             transform_plugin_registry_, request->plugin_id().c_str(), session, offset, length,
+                             options_json, transform_progress_callback, &progress_context, &plugin_response.response,
+                             &transform_serial)) {
+                session_manager_.publish_transform_progress(
+                        request->session_id(), static_cast<int32_t>(SESSION_EVT_TRANSFORM_FAILED),
+                        make_transform_progress(request->plugin_id(), operation_id, "failed",
+                                                "Transform plugin failed"));
+                return grpc::Status(grpc::StatusCode::INTERNAL, "transform plugin failed: " + request->plugin_id());
             }
 
             if (plugin_response.response.result_length < 0 ||

--- a/server/cpp/src/editor_service.h
+++ b/server/cpp/src/editor_service.h
@@ -264,7 +264,7 @@ namespace omega_edit {
             std::unique_ptr<IContentTypeDetector> content_type_detector_;
             std::unique_ptr<ILanguageDetector> language_detector_;
             omega_transform_plugin_registry_t *transform_plugin_registry_{nullptr};
-            std::mutex transform_plugin_mutex_;
+            std::mutex transform_plugin_registry_mutex_;
             std::chrono::steady_clock::time_point start_time_;
             std::atomic<bool> graceful_shutdown_{false};
 

--- a/server/cpp/src/editor_service.h
+++ b/server/cpp/src/editor_service.h
@@ -82,6 +82,10 @@ namespace omega_edit {
                                       const ::omega_edit::v1::ClearChangesRequest *request,
                                       ::omega_edit::v1::ClearChangesResponse *response) override;
 
+            grpc::Status RestoreToChangeCount(grpc::ServerContext *context,
+                                              const ::omega_edit::v1::RestoreToChangeCountRequest *request,
+                                              ::omega_edit::v1::RestoreToChangeCountResponse *response) override;
+
             grpc::Status PauseSessionChanges(grpc::ServerContext *context,
                                              const ::omega_edit::v1::PauseSessionChangesRequest *request,
                                              ::omega_edit::v1::PauseSessionChangesResponse *response) override;

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -70,6 +70,7 @@ import {
   replaceSessionCheckpointed,
   redo,
   restoreLastCheckpoint,
+  restoreToChangeCount,
   runSessionTransaction,
   saveSession,
   SessionContentSource,
@@ -1013,27 +1014,14 @@ async function rollbackSessionToChangeCount(
   sessionId: string,
   targetChangeCount: number
 ): Promise<boolean> {
-  let currentChangeCount = await getChangeCount(sessionId)
-  let rolledBack = false
-  while (currentChangeCount > targetChangeCount) {
-    await undo(sessionId)
-    rolledBack = true
-    const nextChangeCount = await getChangeCount(sessionId)
-    if (nextChangeCount >= currentChangeCount) {
-      throw new Error(
-        `Rollback did not reduce change count from ${currentChangeCount}`
-      )
-    }
-    currentChangeCount = nextChangeCount
-  }
-
-  if (currentChangeCount !== targetChangeCount) {
+  const response = await restoreToChangeCount(sessionId, targetChangeCount)
+  if (response.changeCount !== targetChangeCount) {
     throw new Error(
-      `Rollback ended at change count ${currentChangeCount}, expected ${targetChangeCount}`
+      `Rollback ended at change count ${response.changeCount}, expected ${targetChangeCount}`
     )
   }
 
-  return rolledBack
+  return response.discardedChangeCount > 0 || response.discardedUndoCount > 0
 }
 
 function changeLogApplyErrorWithRollbackFailure(

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -163,7 +163,7 @@
   let inspectorHighlightStart = $state(-1)
   let inspectorHighlightEnd = $state(-1)
   let inspectorExpanded = $state(true)
-  let searchPanelVisible = $state(restoredState?.searchPanelVisible ?? true)
+  let searchPanelVisible = $state(restoredState?.searchPanelVisible ?? false)
   let profilerExpanded = $state(restoredState?.profilerExpanded ?? true)
   let profilerMode = $state<AnalysisMode>('profile')
   let analysisSectionOrder = $state<AnalysisSectionOrder>(
@@ -1829,21 +1829,6 @@
     )
   }
 
-  function historyShortcut(event: KeyboardEvent): 'undo' | 'redo' | undefined {
-    if ((!event.ctrlKey && !event.metaKey) || event.altKey) {
-      return undefined
-    }
-
-    const key = event.key.toLowerCase()
-    if (key === 'z') {
-      return event.shiftKey ? 'redo' : 'undo'
-    }
-    if (key === 'y' && !event.shiftKey) {
-      return 'redo'
-    }
-    return undefined
-  }
-
   function normalizeHexInput(
     value: string,
     allowEmpty: boolean
@@ -2495,17 +2480,6 @@
       handleHostMessage(event.data)
     }
     const keyListener = (event: KeyboardEvent) => {
-      const historyAction = historyShortcut(event)
-      if (historyAction && !isEditableTarget(event.target)) {
-        event.preventDefault()
-        if (transformInFlight) {
-          clipboardMessage = strings.transform.inFlight
-          replaceMessage = strings.transform.inFlight
-          return
-        }
-        postToHost({ type: historyAction })
-        return
-      }
       if (
         event.defaultPrevented ||
         event.key !== 'Insert' ||

--- a/vscode-extension/webview-ui/src/components/EditorWorkspace.svelte
+++ b/vscode-extension/webview-ui/src/components/EditorWorkspace.svelte
@@ -164,6 +164,10 @@
 
   let gridScrollerElement = $state<HTMLDivElement>()
   let autoFitFrame = $state<number | undefined>(undefined)
+  let autoFitOverflowCap = $state<
+    { width: number; bytesPerRow: BytesPerRow } | undefined
+  >(undefined)
+  const AUTO_FIT_WIDTH_GUARD_PX = 24
 
   function measureAutoFitBytesPerRow(): BytesPerRow | undefined {
     if (!gridScrollerElement || !autoFitBytesPerRow || preparing) {
@@ -171,9 +175,8 @@
     }
 
     const grid = gridScrollerElement.querySelector('.preview-grid')
-    const row =
-      gridScrollerElement.querySelector('.grid-row') ||
-      gridScrollerElement.querySelector('.grid-header')
+    const header = gridScrollerElement.querySelector('.grid-header')
+    const row = gridScrollerElement.querySelector('.grid-row') || header
     const hexCells = row?.querySelector('.hex-cells, .hex-heading')
     const asciiCells = row?.querySelector('.ascii')
     const offsetCell = row?.querySelector('.offset, .offset-heading')
@@ -186,19 +189,71 @@
     const horizontalPadding =
       (Number.parseFloat(gridStyle.paddingLeft) || 0) +
       (Number.parseFloat(gridStyle.paddingRight) || 0)
-    const gap = Number.parseFloat(rowStyle.columnGap) || 0
+    const gapFromStyle = Number.parseFloat(rowStyle.columnGap)
     const hexWidth = hexCells.getBoundingClientRect().width
     const asciiWidth =
       asciiCells?.getBoundingClientRect().width ||
       Math.max(1, hexWidth / Math.max(1, bytesPerRow) / 3) * bytesPerRow
+    const measuredRowWidth = row.getBoundingClientRect().width
+    const measuredGap = Math.max(
+      0,
+      (measuredRowWidth -
+        offsetCell.getBoundingClientRect().width -
+        hexWidth -
+        asciiWidth) /
+        2
+    )
+    const gap = Number.isFinite(gapFromStyle) ? gapFromStyle : measuredGap
+    const hexByteWidth =
+      row.querySelector('.byte, .hex-heading span')?.getBoundingClientRect()
+        .width || hexWidth / Math.max(1, bytesPerRow)
+    const asciiByteWidth =
+      row.querySelector('.text-byte')?.getBoundingClientRect().width ||
+      asciiWidth / Math.max(1, bytesPerRow)
     const perByteWidth = Math.max(
       1,
-      (hexWidth + asciiWidth) / Math.max(1, bytesPerRow)
+      hexByteWidth + asciiByteWidth
     )
     const fixedWidth =
-      offsetCell.getBoundingClientRect().width + gap * 2 + horizontalPadding
+      Math.max(
+        offsetCell.getBoundingClientRect().width,
+        header
+          ?.querySelector('.offset-heading')
+          ?.getBoundingClientRect().width ?? 0
+      ) +
+      gap * 2 +
+      horizontalPadding +
+      AUTO_FIT_WIDTH_GUARD_PX
     const availableWidth = Math.max(0, gridScrollerElement.clientWidth)
+    const overflowWidth = Math.max(
+      0,
+      gridScrollerElement.scrollWidth - availableWidth
+    )
+    if (overflowWidth > 1) {
+      const overflowBytes = Math.ceil(overflowWidth / perByteWidth)
+      const cappedBytesPerRow = Math.max(
+        8,
+        Math.min(maxBytesPerRow, bytesPerRow - overflowBytes)
+      )
+      autoFitOverflowCap = {
+        width: availableWidth,
+        bytesPerRow: cappedBytesPerRow,
+      }
+      return cappedBytesPerRow
+    }
+
     const rawFit = Math.floor((availableWidth - fixedWidth) / perByteWidth)
+    if (
+      autoFitOverflowCap &&
+      Math.abs(availableWidth - autoFitOverflowCap.width) <= perByteWidth
+    ) {
+      return Math.max(
+        8,
+        Math.min(maxBytesPerRow, rawFit, autoFitOverflowCap.bytesPerRow)
+      )
+    }
+
+    autoFitOverflowCap = undefined
     return Math.max(8, Math.min(maxBytesPerRow, rawFit))
   }
 

--- a/vscode-extension/webview-ui/src/components/Toolbar.svelte
+++ b/vscode-extension/webview-ui/src/components/Toolbar.svelte
@@ -85,7 +85,7 @@
     transformFeedback = '',
     transformResults = [],
     activeTransformResultId = '',
-    searchPanelVisible = true,
+    searchPanelVisible = false,
     selectedOffset = -1,
     selectionStart = -1,
     selectionEnd = -1,


### PR DESCRIPTION
## Summary
- Fix the VS Code extension issues reported around Find initial state, auto bytes-per-row sizing after redraw, and duplicate Ctrl/Cmd-Z undo handling.
- Refresh `SHORTCOMINGS.md` to remove fixed work and keep the current prioritized backlog focused.
- Narrow server transform plugin locking so plugin execution is guarded by session/content state instead of a process-wide transform execution lock.
- Add core edit result success predicates for serial-returning vs status-returning APIs.
- Add a native restore-to-change-count primitive, expose it through proto/server/client APIs, and use it for AI and VS Code change-log import rollback instead of undo loops.

## Validation
- `git diff --check`
- `clang-format --dry-run --Werror core/src/include/omega_edit/edit.h core/src/lib/edit.cpp core/src/tests/omegaEdit_tests.cpp server/cpp/src/editor_service.cpp server/cpp/src/editor_service.h`
- `source ~/.nvm/nvm.sh && nvm use --silent && yarn lint`
- `cmake --build /tmp/omega-edit-codex-build --parallel`
- `ctest --test-dir /tmp/omega-edit-codex-build/core --output-on-failure`
- `source ~/.nvm/nvm.sh && nvm use --silent && yarn workspace @omega-edit/client build`
- `source ~/.nvm/nvm.sh && nvm use --silent && yarn workspace @omega-edit/ai build`
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run compile --prefix vscode-extension`
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run lint --prefix vscode-extension`
- `source ~/.nvm/nvm.sh && nvm use --silent && npm run test:unit --prefix vscode-extension`

## Notes
- `yarn workspace @omega-edit/client test` and `yarn workspace @omega-edit/ai test` were blocked before test execution by the existing `server/cpp/build` CMake cache being configured for `d:/GitHub/...` with a Windows Ninja path, while this run is in WSL at `/mnt/d/GitHub/...`.
- I did not rewrite or remove that Windows server build cache. A skipped-prereq client test would use the stale packaged server binary, which predates the new RPC, so I stopped that run rather than treating it as signal.
