### PR TITLE
feat: make primitive payloads first class

### DIFF
--- a/core/src/examples/play.cpp
+++ b/core/src/examples/play.cpp
@@ -60,7 +60,7 @@ int save_changes_cbk(const omega_change_t *change_ptr, void *userdata) {
            omega_change_get_serial(change_ptr));
     // NOTE: This is for demonstration purposes only.  This is not a production-quality format.
     const auto bytes = omega_change_get_bytes(change_ptr);
-    const auto bytes_length = omega_change_get_length(change_ptr);
+    const auto bytes_length = omega_change_get_data_length(change_ptr);
     const auto required_buffer_size = bytes_length * 2 + 1;
     if (bytes) {
         if (required_buffer_size > file_info_ptr->bin_to_hex_buffer_size) {

--- a/core/src/examples/replay.cpp
+++ b/core/src/examples/replay.cpp
@@ -38,13 +38,14 @@ void session_change_cbk(const omega_session_t *session_ptr, omega_session_event_
             auto file_info_ptr = reinterpret_cast<file_info_t *>(omega_session_get_user_data_ptr(session_ptr));
             const auto change_ptr = reinterpret_cast<const omega_change_t *>(session_event_ptr);
             const auto bytes = omega_change_get_bytes(change_ptr);
-            const auto bytes_length = omega_change_get_length(change_ptr);
+            const auto bytes_length = omega_change_get_data_length(change_ptr);
             // NOTE: This is for demonstration purposes only.  This is not production safe JSON.
             clog << dec << R"({ "filename" : ")" << file_info_ptr->in_filename << R"(", "num_changes" : )"
                  << omega_session_get_num_changes(session_ptr) << R"(, "computed_file_size": )"
                  << omega_session_get_computed_file_size(session_ptr) << R"(, "change_serial": )"
                  << omega_change_get_serial(change_ptr) << R"(, "kind": ")" << omega_change_get_kind_as_char(change_ptr)
-                 << R"(", "offset": )" << omega_change_get_offset(change_ptr) << R"(, "length": )" << bytes_length;
+                 << R"(", "offset": )" << omega_change_get_offset(change_ptr) << R"(, "length": )"
+                 << omega_change_get_length(change_ptr);
             if (bytes) { clog << R"(, "bytes": ")" << string((const char *) bytes, bytes_length) << R"(")"; }
             clog << "}" << endl;
         }

--- a/core/src/include/omega_edit/change.h
+++ b/core/src/include/omega_edit/change.h
@@ -35,6 +35,23 @@ extern "C" {
 #endif
 
 /**
+ * Storage backing for a change primitive's data payload.
+ */
+typedef enum {
+    OMEGA_CHANGE_DATA_STORAGE_NONE = 0,      ///< No data payload is available for this change.
+    OMEGA_CHANGE_DATA_STORAGE_INLINE = 1,    ///< Data is stored inline with the change.
+    OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED = 2///< Data is stored in a session-owned backing file.
+} omega_change_data_storage_t;
+
+/**
+ * Payload selector for internal and diagnostic byte access.
+ */
+typedef enum {
+    OMEGA_CHANGE_PAYLOAD_DATA = 0,       ///< The primitive data payload.
+    OMEGA_CHANGE_PAYLOAD_INVERSE_DATA = 1///< Bytes removed by the primitive, when distinct from data.
+} omega_change_payload_role_t;
+
+/**
  * Given a change, return the original change offset
  * @param change_ptr change to get the original change offset from
  * @return original change offset
@@ -71,11 +88,40 @@ char omega_change_get_kind_as_char(const omega_change_t *change_ptr);
 int omega_change_get_transaction_bit(const omega_change_t *change_ptr);
 
 /**
- * Given a change, return a pointer to the byte data
- * @param change_ptr change to get the bytes data from
- * @return pointer to the byte data
+ * Given a change, return a pointer to the primitive byte payload.
+ *
+ * This is the first-class primitive view of the change data field:
+ * - INSERT/OVERWRITE payloads are the inserted or overwritten bytes.
+ * - DELETE payloads are exactly the original bytes removed by the edit.
+ * - TRANSFORM payloads are a JSON descriptor containing the transform id and arguments.
+ *
+ * Use omega_change_get_data_length and omega_change_get_data_storage to interpret the returned pointer.
+ *
+ * @param change_ptr change to get the primitive byte payload from
+ * @return pointer to primitive data, or NULL when no payload is available or materialization fails
  */
 const omega_byte_t *omega_change_get_bytes(const omega_change_t *change_ptr);
+
+/**
+ * Alias for omega_change_get_bytes.
+ * @param change_ptr change to get the primitive data payload from
+ * @return pointer to primitive data, or NULL when no payload is available or materialization fails
+ */
+const omega_byte_t *omega_change_get_data(const omega_change_t *change_ptr);
+
+/**
+ * Given a change, return the primitive data payload length.
+ * @param change_ptr change to inspect
+ * @return primitive data byte count, or 0 when no payload is available
+ */
+int64_t omega_change_get_data_length(const omega_change_t *change_ptr);
+
+/**
+ * Given a change, return how the primitive data payload is stored.
+ * @param change_ptr change to inspect
+ * @return primitive data storage kind
+ */
+omega_change_data_storage_t omega_change_get_data_storage(const omega_change_t *change_ptr);
 
 /**
  * Given a change, return a non-zero value if this is a transform change.

--- a/core/src/include/omega_edit/config.h
+++ b/core/src/include/omega_edit/config.h
@@ -63,6 +63,11 @@
 #define OMEGA_MEMORY_BUFFER_LIMIT (64LL * 1024LL * 1024LL)
 #endif//OMEGA_MEMORY_BUFFER_LIMIT
 
+#ifndef OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT
+/** Maximum primitive payload byte range stored inline before using file-backed storage. */
+#define OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT OMEGA_MEMORY_BUFFER_LIMIT
+#endif//OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT
+
 #ifndef OMEGA_BYTE_T
 /** Define the byte type to be used across the project */
 #define OMEGA_BYTE_T unsigned char

--- a/core/src/include/omega_edit/session.h
+++ b/core/src/include/omega_edit/session.h
@@ -357,6 +357,24 @@ int64_t omega_session_get_undo_snapshot_interval(const omega_session_t *session_
  */
 int64_t omega_session_set_undo_snapshot_interval(omega_session_t *session_ptr, int64_t interval);
 
+/**
+ * Given a session, return the inline primitive payload threshold. Change payloads larger than this threshold are stored
+ * in session-owned backing files when possible.
+ * @param session_ptr session to get the inline primitive payload threshold for
+ * @return threshold in bytes, or 0 for null sessions
+ */
+int64_t omega_session_get_change_inline_payload_limit(const omega_session_t *session_ptr);
+
+/**
+ * Set the inline primitive payload threshold for a session. A value of 0 stores every non-empty captured primitive
+ * payload in a backing file. Values above OMEGA_MEMORY_BUFFER_LIMIT are accepted, but materialized public byte buffers
+ * are still limited by OMEGA_MEMORY_BUFFER_LIMIT.
+ * @param session_ptr session to set the inline primitive payload threshold for
+ * @param limit threshold in bytes
+ * @return the new threshold, or 0 on error
+ */
+int64_t omega_session_set_change_inline_payload_limit(omega_session_t *session_ptr, int64_t limit);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/src/lib/change.cpp
+++ b/core/src/lib/change.cpp
@@ -20,6 +20,9 @@
 using omega_edit::internal::change_kind_t;
 using omega_edit::internal::omega_change_get_kind_;
 using omega_edit::internal::omega_change_get_transaction_bit_;
+using omega_edit::internal::omega_data_create_;
+using omega_edit::internal::omega_data_destroy_;
+using omega_edit::internal::omega_data_get_data_;
 using omega_edit::internal::omega_data_get_data_const_;
 
 static_assert(sizeof(omega_change_t) == sizeof(omega_change_struct), "omega_change_t size mismatch");
@@ -39,17 +42,53 @@ int64_t omega_change_get_serial(const omega_change_t *change_ptr) {
     return change_ptr->serial;
 }
 
+static inline const omega_byte_t *payload_bytes_(const omega_byte_payload_struct *payload_ptr) {
+    if (!payload_ptr || payload_ptr->length <= 0) { return nullptr; }
+    if (payload_ptr->storage == OMEGA_CHANGE_DATA_STORAGE_INLINE) {
+        return omega_data_get_data_const_(&payload_ptr->bytes, payload_ptr->length);
+    }
+    if (payload_ptr->storage != OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED || payload_ptr->file_path.empty()) {
+        return nullptr;
+    }
+    if (payload_ptr->cache.capacity() == payload_ptr->length) {
+        return omega_data_get_data_const_(&payload_ptr->cache, payload_ptr->length);
+    }
+    auto *const mutable_payload_ptr = const_cast<omega_byte_payload_struct *>(payload_ptr);
+    try {
+        omega_data_create_(&mutable_payload_ptr->cache, payload_ptr->length);
+    } catch (const std::bad_alloc &) { return nullptr; }
+    auto *const data_ptr = omega_data_get_data_(&mutable_payload_ptr->cache, payload_ptr->length);
+    if (!data_ptr || omega_util_read_file_segment(payload_ptr->file_path.c_str(), 0, data_ptr, payload_ptr->length) !=
+                             payload_ptr->length) {
+        omega_data_destroy_(&mutable_payload_ptr->cache, payload_ptr->length);
+        return nullptr;
+    }
+    data_ptr[payload_ptr->length] = '\0';
+    return data_ptr;
+}
+
 static inline const omega_byte_t *change_bytes_(const omega_change_t *change_ptr) {
     if (!change_ptr) { return nullptr; }
-    const auto kind = omega_change_get_kind_(change_ptr);
-    return (kind == change_kind_t::CHANGE_INSERT || kind == change_kind_t::CHANGE_OVERWRITE)
-                   ? omega_data_get_data_const_(&change_ptr->data, change_ptr->length)
-                   : nullptr;
+    return payload_bytes_(&change_ptr->data);
 }
 
 const omega_byte_t *omega_change_get_bytes(const omega_change_t *change_ptr) {
     if (!change_ptr) { return nullptr; }
     return change_bytes_(change_ptr);
+}
+
+const omega_byte_t *omega_change_get_data(const omega_change_t *change_ptr) {
+    return omega_change_get_bytes(change_ptr);
+}
+
+int64_t omega_change_get_data_length(const omega_change_t *change_ptr) {
+    if (!change_ptr || change_ptr->data.storage == OMEGA_CHANGE_DATA_STORAGE_NONE) { return 0; }
+    return change_ptr->data.length;
+}
+
+omega_change_data_storage_t omega_change_get_data_storage(const omega_change_t *change_ptr) {
+    if (!change_ptr) { return OMEGA_CHANGE_DATA_STORAGE_NONE; }
+    return change_ptr->data.storage;
 }
 
 char omega_change_get_kind_as_char(const omega_change_t *change_ptr) {

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -29,10 +29,12 @@
 #include "impl_/viewport_def.hpp"
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdlib>
 #include <limits>
 #include <memory>
 #include <new>
+#include <string>
 #include <vector>
 
 using omega_edit::internal::add_overflows_int64_;
@@ -45,8 +47,11 @@ using omega_edit::internal::ins_;
 using omega_edit::internal::is_builtin_transform_kind_;
 using omega_edit::internal::model_segment_kind_t;
 using omega_edit::internal::next_change_serial_;
+using omega_edit::internal::omega_change_copy_payload_bytes_;
 using omega_edit::internal::omega_change_get_kind_;
+using omega_edit::internal::omega_change_get_payload_length_;
 using omega_edit::internal::omega_change_get_transaction_bit_;
+using omega_edit::internal::omega_change_write_payload_bytes_;
 using omega_edit::internal::omega_data_create_;
 using omega_edit::internal::omega_data_destroy_;
 using omega_edit::internal::omega_model_segment_get_kind_;
@@ -85,6 +90,32 @@ namespace {
     constexpr int OMEGA_OUTPUT_PATH_SUFFIX_ATTEMPTS = 1000000;
 
     auto initialize_model_segments_(omega_model_segments_t &model_segments, int64_t length) -> bool;
+
+    struct captured_change_payload_t {
+        omega_byte_t *bytes{};
+        int64_t length{};
+        std::string file_path{};
+        omega_change_data_storage_t storage{OMEGA_CHANGE_DATA_STORAGE_NONE};
+
+        ~captured_change_payload_t() {
+            free(bytes);
+            if (storage == OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED && !file_path.empty()) {
+                omega_util_remove_file(file_path.c_str());
+            }
+        }
+
+        captured_change_payload_t() = default;
+        captured_change_payload_t(const captured_change_payload_t &) = delete;
+        auto operator=(const captured_change_payload_t &) -> captured_change_payload_t & = delete;
+
+        auto release_file_path() -> std::string {
+            storage = OMEGA_CHANGE_DATA_STORAGE_NONE;
+            length = 0;
+            std::string released;
+            released.swap(file_path);
+            return released;
+        }
+    };
 
     auto resolve_checkpoint_directory_(const char *file_path, const char *checkpoint_directory,
                                        std::string &checkpoint_directory_str) -> bool {
@@ -506,6 +537,7 @@ namespace {
         result->computed_length = segment_ptr->computed_length;
         result->change_offset = segment_ptr->change_offset;
         result->change_ptr = segment_ptr->change_ptr;
+        result->payload_role = segment_ptr->payload_role;
         return result;
     }
 
@@ -637,6 +669,114 @@ namespace {
             if (!safe_add_int64_(read_offset, (*iter)->computed_length, read_offset)) { return -1; }
         }
         return -1;
+    }
+
+    auto insert_payload_segment_(omega_model_t *model_ptr, const const_omega_change_ptr_t &change_ptr,
+                                 omega_change_payload_role_t payload_role, int64_t offset, int64_t length) -> int {
+        if (!model_ptr || !change_ptr || !valid_nonnegative_range_(offset, length)) { return -1; }
+        if (length == 0) { return 0; }
+        try {
+            model_ptr->model_segments.reserve(model_ptr->model_segments.size() + 2);
+        } catch (const std::bad_alloc &) { return -1; }
+
+        auto make_insert_segment = [&]() {
+            auto insert_segment_ptr = std::make_unique<omega_model_segment_t>();
+            insert_segment_ptr->computed_offset = offset;
+            insert_segment_ptr->computed_length = length;
+            insert_segment_ptr->change_offset = 0;
+            insert_segment_ptr->change_ptr = change_ptr;
+            insert_segment_ptr->payload_role = payload_role;
+            return insert_segment_ptr;
+        };
+
+        if (model_ptr->model_segments.empty()) {
+            if (offset != 0) { return -1; }
+            try {
+                model_ptr->model_segments.push_back(make_insert_segment());
+            } catch (const std::bad_alloc &) { return -1; }
+            return 0;
+        }
+
+        int64_t read_offset = 0;
+        for (auto iter = model_ptr->model_segments.begin(); iter != model_ptr->model_segments.end(); ++iter) {
+            int64_t segment_end = 0;
+            if (!safe_add_int64_((*iter)->computed_offset, (*iter)->computed_length, segment_end)) { return -1; }
+            if (read_offset != (*iter)->computed_offset) {
+                ABORT(print_model_segments_(model_ptr, CLOG);
+                      LOG_ERROR("break in model continuity, expected: " << read_offset
+                                                                        << ", got: " << (*iter)->computed_offset););
+            }
+            if (offset >= read_offset && offset <= segment_end) {
+                if (offset != read_offset) {
+                    const auto delta = offset - (*iter)->computed_offset;
+                    if (delta == (*iter)->computed_length) {
+                        ++iter;
+                    } else {
+                        auto split_segment_ptr = clone_model_segment_(*iter);
+                        if (!safe_add_int64_(split_segment_ptr->computed_offset, delta,
+                                             split_segment_ptr->computed_offset) ||
+                            !safe_add_int64_(split_segment_ptr->change_offset, delta,
+                                             split_segment_ptr->change_offset)) {
+                            return -1;
+                        }
+                        split_segment_ptr->computed_length -= delta;
+                        (*iter)->computed_length = delta;
+                        iter = model_ptr->model_segments.insert(iter + 1, std::move(split_segment_ptr));
+                    }
+                }
+
+                iter = model_ptr->model_segments.insert(iter, make_insert_segment());
+                for (++iter; iter != model_ptr->model_segments.end(); ++iter) {
+                    if (!safe_add_int64_((*iter)->computed_offset, length, (*iter)->computed_offset)) { return -1; }
+                }
+                return 0;
+            }
+            if (!safe_add_int64_(read_offset, (*iter)->computed_length, read_offset)) { return -1; }
+        }
+        return -1;
+    }
+
+    auto undo_change_in_model_(omega_model_t *model_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
+        if (!model_ptr || !change_ptr) { return -1; }
+        switch (omega_change_get_kind_(change_ptr.get())) {
+            case change_kind_t::CHANGE_INSERT: {
+                const auto payload_length =
+                        omega_change_get_payload_length_(change_ptr.get(), OMEGA_CHANGE_PAYLOAD_DATA);
+                if (payload_length != change_ptr->length) { return -1; }
+                const auto inverse_delete = del_(0, change_ptr->offset, payload_length, false);
+                return inverse_delete ? update_model_helper_(model_ptr, inverse_delete) : -1;
+            }
+            case change_kind_t::CHANGE_DELETE: {
+                const auto payload_length =
+                        omega_change_get_payload_length_(change_ptr.get(), OMEGA_CHANGE_PAYLOAD_DATA);
+                if (payload_length != change_ptr->length) { return -1; }
+                return insert_payload_segment_(model_ptr, change_ptr, OMEGA_CHANGE_PAYLOAD_DATA, change_ptr->offset,
+                                               payload_length);
+            }
+            case change_kind_t::CHANGE_OVERWRITE: {
+                const auto replacement_length =
+                        omega_change_get_payload_length_(change_ptr.get(), OMEGA_CHANGE_PAYLOAD_DATA);
+                if (replacement_length != change_ptr->length) { return -1; }
+                const auto inverse_delete = del_(0, change_ptr->offset, replacement_length, false);
+                if (!inverse_delete || update_model_helper_(model_ptr, inverse_delete) != 0) { return -1; }
+                const auto inverse_length =
+                        omega_change_get_payload_length_(change_ptr.get(), OMEGA_CHANGE_PAYLOAD_INVERSE_DATA);
+                return insert_payload_segment_(model_ptr, change_ptr, OMEGA_CHANGE_PAYLOAD_INVERSE_DATA,
+                                               change_ptr->offset, inverse_length);
+            }
+            default:
+                return -1;
+        }
+    }
+
+    auto undo_changes_in_model_(omega_session_t *session_ptr,
+                                const std::vector<const_omega_change_ptr_t> &undone_changes) -> int {
+        if (!session_ptr) { return -1; }
+        auto *const model_ptr = session_ptr->models_.back().get();
+        for (const auto &change_ptr : undone_changes) {
+            if (undo_change_in_model_(model_ptr, change_ptr) != 0) { return -1; }
+        }
+        return 0;
     }
 
     auto update_model_(omega_session_t *session_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
@@ -789,6 +929,30 @@ namespace {
         return 0;
     }
 
+    auto create_payload_file_(omega_session_t *session_ptr, char *payload_filename,
+                              size_t payload_filename_size) -> int {
+        if (!session_ptr || !payload_filename || payload_filename_size == 0) { return -1; }
+        const auto *const checkpoint_directory = omega_session_get_checkpoint_directory(session_ptr);
+        if (omega_util_directory_exists(checkpoint_directory) == 0) {
+            LOG_ERROR("checkpoint directory '" << checkpoint_directory << "' does not exist");
+            return -1;
+        }
+        const auto snprintf_result =
+                snprintf(payload_filename, payload_filename_size, "%s%c.OmegaEdit-payload.%zu.XXXXXX",
+                         checkpoint_directory, omega_util_directory_separator(), session_ptr->models_.size());
+        if (snprintf_result < 0 || static_cast<size_t>(snprintf_result) >= payload_filename_size) {
+            LOG_ERROR("failed to create payload filename template");
+            return -1;
+        }
+        const auto payload_fd = omega_util_mkstemp(payload_filename, 0600);// S_IRUSR | S_IWUSR
+        if (payload_fd < 0) {
+            LOG_ERROR("omega_util_mkstemp failed for payload file '" << payload_filename << "'");
+            return -1;
+        }
+        close(payload_fd);
+        return 0;
+    }
+
     auto promote_checkpoint_file_(omega_session_t *session_ptr, const char *checkpoint_filename, int64_t file_size,
                                   bool notify_transform,
                                   const const_omega_change_ptr_t &transform_change_ptr = nullptr) -> int64_t {
@@ -914,9 +1078,9 @@ namespace {
                     case model_segment_kind_t::SEGMENT_INSERT: {
                         int64_t source_offset = 0;
                         if (!safe_add_int64_(segment->change_offset, segment_start, source_offset)) { return -1; }
-                        if (static_cast<int64_t>(
-                                    fwrite(omega_change_get_bytes(segment->change_ptr.get()) + source_offset,
-                                           sizeof(omega_byte_t), segment_length, to_file_ptr)) != segment_length) {
+                        if (omega_change_write_payload_bytes_(segment->change_ptr.get(), segment->payload_role,
+                                                              source_offset, segment_length, to_file_ptr, io_buf,
+                                                              OMEGA_IO_BUFFER_SIZE) != segment_length) {
                             LOG_ERROR("fwrite failed");
                             return -1;
                         }
@@ -937,6 +1101,72 @@ namespace {
             if (segment_consumed >= segment->computed_length) { ++cursor.segment_iter; }
         }
         return processed;
+    }
+
+    auto save_session_range_to_payload_file_(omega_session_t *session_ptr, const char *payload_file_path,
+                                             int64_t offset, int64_t length) -> int {
+        if (!session_ptr || !payload_file_path || offset < 0 || length < 0) { return -1; }
+        auto *payload_file_ptr = FOPEN(payload_file_path, "wb");
+        if (!payload_file_ptr) {
+            LOG_ERRNO();
+            return -1;
+        }
+
+        std::unique_ptr<omega_byte_t[]> io_buf;
+        try {
+            io_buf = std::make_unique<omega_byte_t[]>(OMEGA_IO_BUFFER_SIZE);
+        } catch (const std::bad_alloc &) {
+            FCLOSE(payload_file_ptr);
+            return -1;
+        }
+
+        session_stream_cursor_t cursor;
+        int64_t end_offset = 0;
+        if (!safe_add_int64_(offset, length, end_offset) ||
+            !initialize_session_stream_cursor_(session_ptr, offset, cursor) ||
+            stream_session_range_(cursor, end_offset, payload_file_ptr, io_buf.get()) != length) {
+            FCLOSE(payload_file_ptr);
+            return -1;
+        }
+        FCLOSE(payload_file_ptr);
+        return omega_util_file_size(payload_file_path) == length ? 0 : -1;
+    }
+
+    auto capture_session_range_payload_(omega_session_t *session_ptr, int64_t offset, int64_t length,
+                                        captured_change_payload_t &payload) -> bool {
+        if (!session_ptr || offset < 0 || length < 0) { return false; }
+        if (length == 0) { return true; }
+        const auto inline_payload_limit =
+                (std::min)(session_ptr->change_inline_payload_limit_, static_cast<int64_t>(OMEGA_MEMORY_BUFFER_LIMIT));
+        if (length <= inline_payload_limit) {
+            omega_byte_t *bytes = nullptr;
+            int64_t byte_count = 0;
+            if (0 != omega_edit_save_segment_to_bytes(session_ptr, &bytes, &byte_count, offset, length) ||
+                byte_count != length) {
+                free(bytes);
+                return false;
+            }
+            payload.bytes = bytes;
+            payload.length = byte_count;
+            payload.storage = OMEGA_CHANGE_DATA_STORAGE_INLINE;
+            return true;
+        }
+
+        char payload_filename[FILENAME_MAX + 1];
+        if (0 != create_payload_file_(session_ptr, payload_filename, sizeof(payload_filename))) { return false; }
+        if (0 != save_session_range_to_payload_file_(session_ptr, payload_filename, offset, length)) {
+            omega_util_remove_file(payload_filename);
+            return false;
+        }
+        try {
+            payload.file_path = payload_filename;
+        } catch (const std::bad_alloc &) {
+            omega_util_remove_file(payload_filename);
+            return false;
+        }
+        payload.length = length;
+        payload.storage = OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED;
+        return true;
     }
 
     auto write_bytes_to_file_(FILE *file_ptr, const omega_byte_t *bytes, int64_t length) -> int64_t {
@@ -1124,50 +1354,47 @@ namespace {
                     break;
                 }
                 case model_segment_kind_t::SEGMENT_INSERT: {
-                    const auto *src = omega_change_get_bytes(segment->change_ptr.get()) + segment->change_offset;
                     const auto len = segment->computed_length;
                     int64_t segment_file_end = 0;
                     if (!safe_add_int64_(file_write_pos, len, segment_file_end)) {
                         FCLOSE(temp_fptr);
                         return -1;
                     }
-                    if (file_write_pos < transform_file_end && segment_file_end > transform_file_begin) {
-                        int64_t seg_remaining = len;
-                        int64_t seg_offset = 0;
-                        while (seg_remaining > 0) {
-                            const auto chunk = std::min(seg_remaining, OMEGA_IO_BUFFER_SIZE);
-                            memcpy(io_buf.get(), src + seg_offset, chunk);
-                            int64_t buf_begin = 0;
-                            if (!safe_add_int64_(file_write_pos, seg_offset, buf_begin)) {
-                                FCLOSE(temp_fptr);
-                                return -1;
-                            }
-                            int64_t buf_end = 0;
-                            if (!safe_add_int64_(buf_begin, chunk, buf_end)) {
-                                FCLOSE(temp_fptr);
-                                return -1;
-                            }
-                            if (buf_begin < transform_file_end && buf_end > transform_file_begin) {
-                                const auto t_start = std::max(transform_file_begin - buf_begin, int64_t(0));
-                                const auto t_end = std::min(transform_file_end - buf_begin, chunk);
-                                omega_util_apply_byte_transform(io_buf.get() + t_start, t_end - t_start, transform,
-                                                                user_data_ptr);
-                            }
-                            if (static_cast<int64_t>(fwrite(io_buf.get(), 1, chunk, temp_fptr)) != chunk) {
-                                FCLOSE(temp_fptr);
-                                LOG_ERROR("fwrite failed");
-                                return -1;
-                            }
-                            seg_remaining -= chunk;
-                            if (!safe_add_int64_(seg_offset, chunk, seg_offset)) {
-                                FCLOSE(temp_fptr);
-                                return -1;
-                            }
+                    int64_t seg_remaining = len;
+                    int64_t seg_offset = 0;
+                    while (seg_remaining > 0) {
+                        const auto chunk = std::min(seg_remaining, OMEGA_IO_BUFFER_SIZE);
+                        int64_t payload_offset = 0;
+                        if (!safe_add_int64_(segment->change_offset, seg_offset, payload_offset) ||
+                            omega_change_copy_payload_bytes_(segment->change_ptr.get(), segment->payload_role,
+                                                             payload_offset, io_buf.get(), chunk) != 0) {
+                            FCLOSE(temp_fptr);
+                            return -1;
                         }
-                    } else {
-                        if (static_cast<int64_t>(fwrite(src, 1, len, temp_fptr)) != len) {
+                        int64_t buf_begin = 0;
+                        if (!safe_add_int64_(file_write_pos, seg_offset, buf_begin)) {
+                            FCLOSE(temp_fptr);
+                            return -1;
+                        }
+                        int64_t buf_end = 0;
+                        if (!safe_add_int64_(buf_begin, chunk, buf_end)) {
+                            FCLOSE(temp_fptr);
+                            return -1;
+                        }
+                        if (buf_begin < transform_file_end && buf_end > transform_file_begin) {
+                            const auto t_start = std::max(transform_file_begin - buf_begin, int64_t(0));
+                            const auto t_end = std::min(transform_file_end - buf_begin, chunk);
+                            omega_util_apply_byte_transform(io_buf.get() + t_start, t_end - t_start, transform,
+                                                            user_data_ptr);
+                        }
+                        if (static_cast<int64_t>(fwrite(io_buf.get(), 1, chunk, temp_fptr)) != chunk) {
                             FCLOSE(temp_fptr);
                             LOG_ERROR("fwrite failed");
+                            return -1;
+                        }
+                        seg_remaining -= chunk;
+                        if (!safe_add_int64_(seg_offset, chunk, seg_offset)) {
+                            FCLOSE(temp_fptr);
                             return -1;
                         }
                     }
@@ -1495,11 +1722,18 @@ int64_t omega_edit_delete(omega_session_t *session_ptr, int64_t offset, int64_t 
     if (computed_file_size < 0) { return -1; }
     const auto serial = next_change_serial_(session_ptr);
     if (serial <= 0) { return -1; }
-    return (omega_session_changes_paused(session_ptr) == 0) && 0 < length && offset < computed_file_size
-                   ? update_(session_ptr,
-                             del_(serial, offset, std::min(length, static_cast<int64_t>(computed_file_size) - offset),
-                                  determine_change_transaction_bit_(session_ptr)))
-                   : 0;
+    if ((omega_session_changes_paused(session_ptr) != 0) || offset >= computed_file_size) { return 0; }
+
+    const auto effective_length = std::min(length, static_cast<int64_t>(computed_file_size) - offset);
+    captured_change_payload_t deleted_payload;
+    if (!capture_session_range_payload_(session_ptr, offset, effective_length, deleted_payload)) { return -1; }
+    const auto transaction_bit = determine_change_transaction_bit_(session_ptr);
+    const auto change_ptr = deleted_payload.storage == OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED
+                                    ? del_(serial, offset, effective_length, deleted_payload.release_file_path(),
+                                           effective_length, transaction_bit)
+                                    : del_(serial, offset, effective_length, deleted_payload.bytes,
+                                           deleted_payload.length, transaction_bit);
+    return update_(session_ptr, change_ptr);
 }
 
 int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
@@ -1535,10 +1769,21 @@ int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset,
     if (computed_file_size < 0) { return -1; }
     const auto serial = next_change_serial_(session_ptr);
     if (serial <= 0) { return -1; }
-    return (omega_session_changes_paused(session_ptr) == 0) && offset <= computed_file_size
-                   ? update_(session_ptr,
-                             ovr_(serial, offset, bytes, length, determine_change_transaction_bit_(session_ptr)))
-                   : 0;
+    if ((omega_session_changes_paused(session_ptr) != 0) || offset > computed_file_size) { return 0; }
+
+    const auto replaced_length = offset < computed_file_size ? std::min(length, computed_file_size - offset) : 0;
+    captured_change_payload_t replaced_payload;
+    if (replaced_length > 0 &&
+        !capture_session_range_payload_(session_ptr, offset, replaced_length, replaced_payload)) {
+        return -1;
+    }
+    const auto transaction_bit = determine_change_transaction_bit_(session_ptr);
+    const auto change_ptr = replaced_payload.storage == OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED
+                                    ? ovr_(serial, offset, bytes, length, replaced_payload.release_file_path(),
+                                           replaced_length, transaction_bit)
+                                    : ovr_(serial, offset, bytes, length, replaced_payload.bytes,
+                                           replaced_payload.length, transaction_bit);
+    return update_(session_ptr, change_ptr);
 }
 
 int64_t omega_edit_overwrite(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length) {
@@ -2024,8 +2269,9 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
                     close_and_cleanup_output();
                     return -7;
                 }
-                if (static_cast<int64_t>(fwrite(omega_change_get_bytes(segment->change_ptr.get()) + source_offset, 1,
-                                                segment_length, temp_fptr)) != segment_length) {
+                if (omega_change_write_payload_bytes_(segment->change_ptr.get(), segment->payload_role, source_offset,
+                                                      segment_length, temp_fptr, io_buf.get(),
+                                                      OMEGA_IO_BUFFER_SIZE) != segment_length) {
                     close_and_cleanup_output();
                     LOG_ERROR("fwrite failed");
                     return -7;
@@ -2240,14 +2486,22 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr) {
             model_ptr->changes_undone.reserve(model_ptr->changes_undone.size() + transaction_change_count);
         } catch (const std::bad_alloc &) { return -1; }
 
-        do {
-            undone_changes.push_back(model_ptr->changes.back());
-            model_ptr->changes.pop_back();
-        } while ((omega_session_changes_paused(session_ptr) == 0) && !model_ptr->changes.empty() &&
-                 transaction_bit == omega_change_get_transaction_bit_(model_ptr->changes.back().get()));
+        for (auto iter = model_ptr->changes.rbegin();
+             iter != model_ptr->changes.rend() && undone_changes.size() < transaction_change_count; ++iter) {
+            undone_changes.push_back(*iter);
+        }
 
-        const auto remaining_count = static_cast<int64_t>(model_ptr->changes.size());
-        if (0 != rebuild_model_to_change_count_(session_ptr, remaining_count)) { return -1; }
+        const auto remaining_count =
+                static_cast<int64_t>(model_ptr->changes.size() - static_cast<size_t>(transaction_change_count));
+        if (0 != undo_changes_in_model_(session_ptr, undone_changes)) {
+            rebuild_model_to_change_count_(session_ptr, static_cast<int64_t>(model_ptr->changes.size()));
+            return -1;
+        }
+
+        model_ptr->changes.erase(model_ptr->changes.end() - static_cast<std::ptrdiff_t>(transaction_change_count),
+                                 model_ptr->changes.end());
+        model_ptr->model_snapshots.erase(model_ptr->model_snapshots.upper_bound(remaining_count),
+                                         model_ptr->model_snapshots.end());
 
         for (const auto &change_ptr : undone_changes) {
             auto *const undone_change_ptr = change_ptr.get();

--- a/core/src/lib/impl_/change_def.hpp
+++ b/core/src/lib/impl_/change_def.hpp
@@ -15,9 +15,13 @@
 #ifndef OMEGA_EDIT_CHANGE_DEF_HPP
 #define OMEGA_EDIT_CHANGE_DEF_HPP
 
-#include "../../include/omega_edit/fwd_defs.h"
+#include "../../include/omega_edit/change.h"
+#include "../../include/omega_edit/filesystem.h"
 #include "data_def.hpp"
+#include <algorithm>
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <string>
 
@@ -30,6 +34,53 @@ namespace omega_edit::internal {
 #define OMEGA_CHANGE_KIND_MASK 0x03
 #define OMEGA_CHANGE_TRANSACTION_BIT 0x04
 
+struct omega_byte_payload_struct {
+    ~omega_byte_payload_struct() { reset(); }
+
+    void reset() {
+        if (storage == OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED && !file_path.empty()) {
+            omega_util_remove_file(file_path.c_str());
+        }
+        omega_edit::internal::omega_data_destroy_(&bytes, length);
+        omega_edit::internal::omega_data_destroy_(&cache, length);
+        length = 0;
+        storage = OMEGA_CHANGE_DATA_STORAGE_NONE;
+        file_path.clear();
+    }
+
+    omega_byte_payload_struct() = default;
+    omega_byte_payload_struct(const omega_byte_payload_struct &) = delete;
+    auto operator=(const omega_byte_payload_struct &) -> omega_byte_payload_struct & = delete;
+
+    omega_byte_payload_struct(omega_byte_payload_struct &&other) noexcept { move_from_(std::move(other)); }
+
+    auto operator=(omega_byte_payload_struct &&other) noexcept -> omega_byte_payload_struct & {
+        if (this != &other) {
+            reset();
+            move_from_(std::move(other));
+        }
+        return *this;
+    }
+
+    omega_data_t bytes{};
+    mutable omega_data_t cache{};
+    int64_t length{};
+    omega_change_data_storage_t storage{OMEGA_CHANGE_DATA_STORAGE_NONE};
+    std::string file_path{};
+
+private:
+    void move_from_(omega_byte_payload_struct &&other) noexcept {
+        bytes = std::move(other.bytes);
+        cache = std::move(other.cache);
+        length = other.length;
+        storage = other.storage;
+        file_path.swap(other.file_path);
+        other.length = 0;
+        other.storage = OMEGA_CHANGE_DATA_STORAGE_NONE;
+        other.file_path.clear();
+    }
+};
+
 struct omega_transform_change_data_struct {
     std::string transform_id{};
     std::string options_json{};
@@ -40,11 +91,12 @@ struct omega_transform_change_data_struct {
 };
 
 struct omega_change_struct {
-    int64_t serial{};   ///< Serial number of the change (increasing)
-    int64_t offset{};   ///< Offset at the time of the change
-    int64_t length{};   ///< Number of bytes at the time of the change
-    omega_data_t data{};///< Bytes to insert or overwrite
-    uint8_t kind{};     ///< Change kind
+    int64_t serial{};                        ///< Serial number of the change (increasing)
+    int64_t offset{};                        ///< Offset at the time of the change
+    int64_t length{};                        ///< Number of bytes at the time of the change
+    omega_byte_payload_struct data{};        ///< First-class primitive data payload
+    omega_byte_payload_struct inverse_data{};///< Bytes removed by the primitive when distinct from data
+    uint8_t kind{};                          ///< Change kind
     std::unique_ptr<omega_transform_change_data_struct> transform_data{};
 };
 
@@ -65,6 +117,70 @@ namespace omega_edit::internal {
 
     inline void omega_change_toggle_transaction_bit_(omega_change_t *change_ptr) {
         change_ptr->kind ^= OMEGA_CHANGE_TRANSACTION_BIT;// Toggle the transaction bit
+    }
+
+    inline const omega_byte_payload_struct *omega_change_get_payload_(const omega_change_t *change_ptr,
+                                                                      omega_change_payload_role_t payload_role) {
+        if (!change_ptr) { return nullptr; }
+        return payload_role == OMEGA_CHANGE_PAYLOAD_INVERSE_DATA ? &change_ptr->inverse_data : &change_ptr->data;
+    }
+
+    inline int64_t omega_change_get_payload_length_(const omega_change_t *change_ptr,
+                                                    omega_change_payload_role_t payload_role) {
+        const auto *payload = omega_change_get_payload_(change_ptr, payload_role);
+        return payload && payload->storage != OMEGA_CHANGE_DATA_STORAGE_NONE ? payload->length : 0;
+    }
+
+    inline const omega_byte_t *omega_change_get_inline_payload_bytes_(const omega_change_t *change_ptr,
+                                                                      omega_change_payload_role_t payload_role) {
+        const auto *payload = omega_change_get_payload_(change_ptr, payload_role);
+        if (!payload || payload->storage != OMEGA_CHANGE_DATA_STORAGE_INLINE || payload->length <= 0) {
+            return nullptr;
+        }
+        return omega_data_get_data_const_(&payload->bytes, payload->length);
+    }
+
+    inline int omega_change_copy_payload_bytes_(const omega_change_t *change_ptr,
+                                                omega_change_payload_role_t payload_role, int64_t offset,
+                                                omega_byte_t *buffer, int64_t byte_count) {
+        if (!buffer || offset < 0 || byte_count < 0) { return -1; }
+        if (byte_count == 0) { return 0; }
+        const auto *payload = omega_change_get_payload_(change_ptr, payload_role);
+        if (!payload || payload->length < 0 || offset > payload->length || byte_count > payload->length - offset) {
+            return -1;
+        }
+        switch (payload->storage) {
+            case OMEGA_CHANGE_DATA_STORAGE_INLINE: {
+                const auto *bytes = omega_data_get_data_const_(&payload->bytes, payload->length);
+                if (!bytes) { return -1; }
+                std::memcpy(buffer, bytes + offset, static_cast<size_t>(byte_count));
+                return 0;
+            }
+            case OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED:
+                return omega_util_read_file_segment(payload->file_path.c_str(), offset, buffer, byte_count) ==
+                                       byte_count
+                               ? 0
+                               : -1;
+            default:
+                return -1;
+        }
+    }
+
+    inline int64_t omega_change_write_payload_bytes_(const omega_change_t *change_ptr,
+                                                     omega_change_payload_role_t payload_role, int64_t offset,
+                                                     int64_t byte_count, FILE *to_file_ptr, omega_byte_t *io_buf,
+                                                     int64_t io_buf_capacity) {
+        if (!to_file_ptr || !io_buf || io_buf_capacity <= 0 || offset < 0 || byte_count < 0) { return -1; }
+        int64_t written = 0;
+        while (written < byte_count) {
+            const auto chunk = std::min(byte_count - written, io_buf_capacity);
+            if (omega_change_copy_payload_bytes_(change_ptr, payload_role, offset + written, io_buf, chunk) != 0 ||
+                static_cast<int64_t>(fwrite(io_buf, sizeof(omega_byte_t), chunk, to_file_ptr)) != chunk) {
+                return -1;
+            }
+            written += chunk;
+        }
+        return written;
     }
 
 }// namespace omega_edit::internal

--- a/core/src/lib/impl_/edit_private_helpers.hpp
+++ b/core/src/lib/impl_/edit_private_helpers.hpp
@@ -52,15 +52,116 @@ namespace omega_edit::internal {
         } catch (const std::bad_alloc &) { return nullptr; }
     }
 
-    inline auto populate_change_bytes_(omega_change_t *change_ptr, const omega_byte_t *bytes) -> bool {
+    inline auto populate_payload_inline_(omega_byte_payload_struct *payload_ptr, const omega_byte_t *bytes,
+                                         int64_t data_length) -> bool {
+        if (!payload_ptr || !bytes || data_length <= 0) { return false; }
         try {
-            omega_data_create_(&change_ptr->data, change_ptr->length);
-            auto *const change_data = omega_data_get_data_(&change_ptr->data, change_ptr->length);
+            omega_data_create_(&payload_ptr->bytes, data_length);
+            auto *const change_data = omega_data_get_data_(&payload_ptr->bytes, data_length);
             if (!change_data) { return false; }
-            std::memcpy(change_data, bytes, change_ptr->length);
-            change_data[change_ptr->length] = '\0';
+            std::memcpy(change_data, bytes, data_length);
+            change_data[data_length] = '\0';
+            payload_ptr->length = data_length;
+            payload_ptr->storage = OMEGA_CHANGE_DATA_STORAGE_INLINE;
             return true;
         } catch (const std::bad_alloc &) { return false; }
+    }
+
+    inline auto populate_payload_file_backed_(omega_byte_payload_struct *payload_ptr, std::string file_path,
+                                              int64_t data_length) -> bool {
+        if (!payload_ptr || file_path.empty() || data_length <= 0) { return false; }
+        payload_ptr->file_path.swap(file_path);
+        payload_ptr->length = data_length;
+        payload_ptr->storage = OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED;
+        return true;
+    }
+
+    inline auto populate_change_data_(omega_change_t *change_ptr, const omega_byte_t *bytes,
+                                      int64_t data_length) -> bool {
+        return change_ptr ? populate_payload_inline_(&change_ptr->data, bytes, data_length) : false;
+    }
+
+    inline auto populate_change_data_file_backed_(omega_change_t *change_ptr, std::string file_path,
+                                                  int64_t data_length) -> bool {
+        return change_ptr ? populate_payload_file_backed_(&change_ptr->data, std::move(file_path), data_length) : false;
+    }
+
+    inline auto del_(int64_t serial, int64_t offset, int64_t length, const omega_byte_t *deleted_bytes,
+                     int64_t deleted_byte_count, bool transaction_bit) -> const_omega_change_ptr_t {
+        auto change_ptr = del_(serial, offset, length, transaction_bit);
+        if (!change_ptr) { return nullptr; }
+        if (!deleted_bytes || deleted_byte_count != length ||
+            !populate_change_data_(change_ptr.get(), deleted_bytes, deleted_byte_count)) {
+            return nullptr;
+        }
+        return change_ptr;
+    }
+
+    inline auto del_(int64_t serial, int64_t offset, int64_t length, std::string deleted_bytes_file_path,
+                     int64_t deleted_byte_count, bool transaction_bit) -> const_omega_change_ptr_t {
+        auto change_ptr = del_(serial, offset, length, transaction_bit);
+        if (!change_ptr) {
+            if (!deleted_bytes_file_path.empty()) { omega_util_remove_file(deleted_bytes_file_path.c_str()); }
+            return nullptr;
+        }
+        if (deleted_byte_count != length || deleted_bytes_file_path.empty() ||
+            !populate_change_data_file_backed_(change_ptr.get(), std::move(deleted_bytes_file_path),
+                                               deleted_byte_count)) {
+            if (!deleted_bytes_file_path.empty()) { omega_util_remove_file(deleted_bytes_file_path.c_str()); }
+            return nullptr;
+        }
+        return change_ptr;
+    }
+
+    inline auto populate_change_bytes_(omega_change_t *change_ptr, const omega_byte_t *bytes) -> bool {
+        return change_ptr ? populate_change_data_(change_ptr, bytes, change_ptr->length) : false;
+    }
+
+    inline void append_json_escaped_string_(std::string &out, const std::string &value) {
+        for (const auto raw_ch : value) {
+            const auto ch = static_cast<unsigned char>(raw_ch);
+            switch (ch) {
+                case '"':
+                    out += "\\\"";
+                    break;
+                case '\\':
+                    out += "\\\\";
+                    break;
+                case '\b':
+                    out += "\\b";
+                    break;
+                case '\f':
+                    out += "\\f";
+                    break;
+                case '\n':
+                    out += "\\n";
+                    break;
+                case '\r':
+                    out += "\\r";
+                    break;
+                case '\t':
+                    out += "\\t";
+                    break;
+                default:
+                    if (ch < 0x20U) {
+                        char buffer[7];
+                        std::snprintf(buffer, sizeof(buffer), "\\u%04x", static_cast<unsigned>(ch));
+                        out += buffer;
+                    } else {
+                        out.push_back(static_cast<char>(ch));
+                    }
+                    break;
+            }
+        }
+    }
+
+    inline auto transform_change_data_json_(const omega_transform_change_data_struct &transform_data) -> std::string {
+        auto data_json = std::string(R"({"transformId":")");
+        append_json_escaped_string_(data_json, transform_data.transform_id);
+        data_json += R"(","args":)";
+        data_json += transform_data.options_json.empty() ? "{}" : transform_data.options_json;
+        data_json.push_back('}');
+        return data_json;
     }
 
     inline auto ins_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
@@ -80,6 +181,7 @@ namespace omega_edit::internal {
     }
 
     inline auto ovr_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
+                     const omega_byte_t *replaced_bytes, int64_t replaced_length,
                      bool transaction_bit) -> const_omega_change_ptr_t {
         if (!bytes) { return nullptr; }
         if (serial <= 0 || !valid_nonnegative_range_(offset, length)) { return nullptr; }
@@ -91,8 +193,29 @@ namespace omega_edit::internal {
             change_ptr->offset = offset;
             change_ptr->length = length;
             if (!populate_change_bytes_(change_ptr.get(), bytes)) { return nullptr; }
+            if (replaced_bytes && replaced_length > 0 &&
+                !populate_payload_inline_(&change_ptr->inverse_data, replaced_bytes, replaced_length)) {
+                return nullptr;
+            }
             return change_ptr;
         } catch (const std::bad_alloc &) { return nullptr; }
+    }
+
+    inline auto ovr_(int64_t serial, int64_t offset, const omega_byte_t *bytes, int64_t length,
+                     std::string replaced_bytes_file_path, int64_t replaced_length,
+                     bool transaction_bit) -> const_omega_change_ptr_t {
+        auto change_ptr = ovr_(serial, offset, bytes, length, nullptr, 0, transaction_bit);
+        if (!change_ptr) {
+            if (!replaced_bytes_file_path.empty()) { omega_util_remove_file(replaced_bytes_file_path.c_str()); }
+            return nullptr;
+        }
+        if (replaced_length > 0 &&
+            !populate_payload_file_backed_(&change_ptr->inverse_data, std::move(replaced_bytes_file_path),
+                                           replaced_length)) {
+            if (!replaced_bytes_file_path.empty()) { omega_util_remove_file(replaced_bytes_file_path.c_str()); }
+            return nullptr;
+        }
+        return change_ptr;
     }
 
     inline auto transform_(int64_t serial, int64_t offset, int64_t length, const char *transform_id,
@@ -117,6 +240,11 @@ namespace omega_edit::internal {
             change_ptr->transform_data->computed_file_size_before = file_size_before;
             change_ptr->transform_data->computed_file_size_after = file_size_after;
             change_ptr->transform_data->checkpoint_file_path = checkpoint_file_path;
+            const auto data_json = transform_change_data_json_(*change_ptr->transform_data);
+            if (!populate_change_data_(change_ptr.get(), reinterpret_cast<const omega_byte_t *>(data_json.data()),
+                                       static_cast<int64_t>(data_json.size()))) {
+                return nullptr;
+            }
             return change_ptr;
         } catch (const std::bad_alloc &) { return nullptr; }
     }

--- a/core/src/lib/impl_/internal_fun.cpp
+++ b/core/src/lib/impl_/internal_fun.cpp
@@ -113,8 +113,11 @@ namespace omega_edit::internal {
                     // segment
                     int64_t change_offset = 0;
                     if (!safe_add_int64_((*iter)->change_offset, delta, change_offset)) { return -1; }
-                    memcpy(data_segment_buffer + data_segment_ptr->length,
-                           omega_change_get_bytes((*iter)->change_ptr.get()) + change_offset, amount);
+                    if (omega_change_copy_payload_bytes_((*iter)->change_ptr.get(), (*iter)->payload_role,
+                                                         change_offset, data_segment_buffer + data_segment_ptr->length,
+                                                         amount) != 0) {
+                        return -1;
+                    }
                     break;
                 }
                 default:
@@ -142,8 +145,8 @@ namespace omega_edit::internal {
                    << omega_change_get_kind_as_char(change_ptr) << R"(", "offset": )"
                    << omega_change_get_offset(change_ptr) << R"(, "length": )" << omega_change_get_length(change_ptr);
         if (const auto bytes = omega_change_get_bytes(change_ptr); bytes) {
-            out_stream << R"(, "bytes": ")" << std::string((char const *) bytes, omega_change_get_length(change_ptr))
-                       << R"(")";
+            out_stream << R"(, "bytes": ")"
+                       << std::string((char const *) bytes, omega_change_get_data_length(change_ptr)) << R"(")";
         }
         out_stream << "}";
     }

--- a/core/src/lib/impl_/model_segment_def.hpp
+++ b/core/src/lib/impl_/model_segment_def.hpp
@@ -30,6 +30,7 @@ struct omega_model_segment_struct {
     int64_t computed_length{};            ///< Computed length can differ from the change as segments split
     int64_t change_offset{};              ///< Change offset is the offset in the change due to a split
     const_omega_change_ptr_t change_ptr{};///< Reference to parent change
+    omega_change_payload_role_t payload_role{OMEGA_CHANGE_PAYLOAD_DATA};
 };
 
 namespace omega_edit::internal {

--- a/core/src/lib/impl_/session_def.hpp
+++ b/core/src/lib/impl_/session_def.hpp
@@ -43,7 +43,8 @@ struct omega_session_struct {
     omega_models_t models_{};                  ///< Edit models (internal)
     int64_t num_changes_adjustment_{};         ///< Number of changes in checkpoints
     int64_t undo_snapshot_interval_{100};      ///< Undo model snapshot interval (0 = disabled, default 100)
-    int8_t session_flags_{};                   ///< Internal state flags
+    int64_t change_inline_payload_limit_{OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT}; ///< Inline primitive payload threshold
+    int8_t session_flags_{};                                                 ///< Internal state flags
     omega_session_event_t batched_session_event_kind_{SESSION_EVT_UNDEFINED};///< Event kind currently being batched
     omega_session_event_t pending_session_event_kind_{SESSION_EVT_UNDEFINED};///< Deferred event to flush at batch end
     const void *pending_session_event_ptr_{};     ///< Deferred event payload to flush at batch end

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -460,6 +460,17 @@ int64_t omega_session_set_undo_snapshot_interval(omega_session_t *session_ptr, i
     return session_ptr->undo_snapshot_interval_;
 }
 
+int64_t omega_session_get_change_inline_payload_limit(const omega_session_t *session_ptr) {
+    if (!session_ptr) { return 0; }
+    return session_ptr->change_inline_payload_limit_;
+}
+
+int64_t omega_session_set_change_inline_payload_limit(omega_session_t *session_ptr, int64_t limit) {
+    if (!session_ptr || limit < 0) { return 0; }
+    session_ptr->change_inline_payload_limit_ = limit;
+    return session_ptr->change_inline_payload_limit_;
+}
+
 bool omega_edit::internal::omega_session_get_transaction_bit_(const omega_session_t *session_ptr) {
     return (session_ptr->models_.back()->changes.empty()) ||
            omega_change_get_transaction_bit_(session_ptr->models_.back()->changes.back().get());

--- a/core/src/lib/stl_string_adaptor.cpp
+++ b/core/src/lib/stl_string_adaptor.cpp
@@ -17,7 +17,8 @@
 
 std::string omega_change_get_string(const omega_change_t *change_ptr) noexcept {
     if (const auto change_bytes = omega_change_get_bytes(change_ptr)) {
-        return {reinterpret_cast<const char *>(change_bytes), static_cast<size_t>(omega_change_get_length(change_ptr))};
+        return {reinterpret_cast<const char *>(change_bytes),
+                static_cast<size_t>(omega_change_get_data_length(change_ptr))};
     }
     return {};
 }

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -108,6 +108,129 @@ TEST_CASE("Apply Script", "[EditScript]") {
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Overwrite undo restores captured inverse bytes", "[UndoTests][PayloadTests]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "0123456789"));
+    REQUIRE(0 < omega_edit_overwrite_string(session_ptr, 8, "ABCDE"));
+    REQUIRE("01234567ABCDE" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    const auto *change_ptr = omega_session_get_last_change(session_ptr);
+    REQUIRE(change_ptr);
+    REQUIRE('O' == omega_change_get_kind_as_char(change_ptr));
+    REQUIRE(5 == omega_change_get_data_length(change_ptr));
+    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(change_ptr));
+
+    REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
+    REQUIRE("0123456789" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(2 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE("01234567ABCDE" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Large delete payloads are file backed", "[UndoTests][PayloadTests]") {
+    const auto file_path = (DATA_DIR / "large-delete-payload.dat").string();
+    const auto payload_limit = int64_t{32};
+    const auto file_byte_count = payload_limit - 1;
+    const std::string pattern = "OmegaEditPayload";
+    const std::string inserted = "MIXED";
+    const auto insert_offset = static_cast<int64_t>(pattern.size());
+    const auto delete_byte_count = file_byte_count + static_cast<int64_t>(inserted.size());
+    std::string original_content;
+    original_content.reserve(static_cast<size_t>(file_byte_count));
+    for (int64_t i = 0; i < file_byte_count; ++i) {
+        original_content.push_back(pattern[static_cast<size_t>(i % static_cast<int64_t>(pattern.size()))]);
+    }
+    auto expected_content = original_content;
+    expected_content.insert(static_cast<size_t>(insert_offset), inserted);
+    auto *file_ptr =
+            fill_file(file_path.c_str(), file_byte_count, pattern.c_str(), static_cast<int64_t>(pattern.size()));
+    REQUIRE(file_ptr);
+    FCLOSE(file_ptr);
+
+    const auto session_ptr = omega_edit_create_session(file_path.c_str(), nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(payload_limit == omega_session_set_change_inline_payload_limit(session_ptr, payload_limit));
+    REQUIRE(payload_limit == omega_session_get_change_inline_payload_limit(session_ptr));
+
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, insert_offset, inserted.c_str()));
+    REQUIRE(delete_byte_count == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(0 < omega_edit_delete(session_ptr, 0, delete_byte_count));
+    const auto *change_ptr = omega_session_get_last_change(session_ptr);
+    REQUIRE(change_ptr);
+    REQUIRE('D' == omega_change_get_kind_as_char(change_ptr));
+    REQUIRE(delete_byte_count == omega_change_get_length(change_ptr));
+    REQUIRE(delete_byte_count == omega_change_get_data_length(change_ptr));
+    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED == omega_change_get_data_storage(change_ptr));
+    const auto *deleted_bytes = omega_change_get_bytes(change_ptr);
+    REQUIRE(deleted_bytes);
+    REQUIRE(static_cast<omega_byte_t>(pattern.front()) == deleted_bytes[0]);
+    REQUIRE(static_cast<omega_byte_t>(inserted.front()) == deleted_bytes[insert_offset]);
+    REQUIRE(static_cast<omega_byte_t>(pattern.front()) ==
+            deleted_bytes[insert_offset + static_cast<int64_t>(inserted.size())]);
+    REQUIRE(static_cast<omega_byte_t>(
+                    pattern[static_cast<size_t>((file_byte_count - 1) % static_cast<int64_t>(pattern.size()))]) ==
+            deleted_bytes[delete_byte_count - 1]);
+
+    REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
+    REQUIRE(delete_byte_count == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(expected_content == omega_session_get_segment_string(session_ptr, 0, delete_byte_count));
+    REQUIRE(2 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+    omega_util_remove_file(file_path.c_str());
+}
+
+TEST_CASE("Large overwrite inverse payloads are file backed", "[UndoTests][PayloadTests]") {
+    const auto file_path = (DATA_DIR / "large-overwrite-inverse-payload.dat").string();
+    const auto payload_limit = int64_t{32};
+    const auto byte_count = payload_limit + 1;
+    const std::string pattern = "OriginalPayload";
+    auto *file_ptr = fill_file(file_path.c_str(), byte_count, pattern.c_str(), static_cast<int64_t>(pattern.size()));
+    REQUIRE(file_ptr);
+    FCLOSE(file_ptr);
+
+    std::vector<omega_byte_t> replacement(static_cast<size_t>(byte_count));
+    for (int64_t i = 0; i < byte_count; ++i) {
+        replacement[static_cast<size_t>(i)] = static_cast<omega_byte_t>('A' + (i % 26));
+    }
+
+    const auto session_ptr = omega_edit_create_session(file_path.c_str(), nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(payload_limit == omega_session_set_change_inline_payload_limit(session_ptr, payload_limit));
+    REQUIRE(payload_limit == omega_session_get_change_inline_payload_limit(session_ptr));
+
+    REQUIRE(0 < omega_edit_overwrite_bytes(session_ptr, 0, replacement.data(), byte_count));
+    const auto *change_ptr = omega_session_get_last_change(session_ptr);
+    REQUIRE(change_ptr);
+    REQUIRE('O' == omega_change_get_kind_as_char(change_ptr));
+    REQUIRE(byte_count == omega_change_get_length(change_ptr));
+    REQUIRE(byte_count == omega_change_get_data_length(change_ptr));
+    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(change_ptr));
+    REQUIRE(std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == omega_session_get_segment_string(session_ptr, 0, 26));
+
+    REQUIRE(-1 == omega_edit_undo_last_change(session_ptr));
+    REQUIRE(byte_count == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(pattern == omega_session_get_segment_string(session_ptr, 0, static_cast<int64_t>(pattern.size())));
+    REQUIRE(std::string(1, pattern[static_cast<size_t>((byte_count - 1) % static_cast<int64_t>(pattern.size()))]) ==
+            omega_session_get_segment_string(session_ptr, byte_count - 1, 1));
+
+    REQUIRE(1 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE(byte_count == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == omega_session_get_segment_string(session_ptr, 0, 26));
+    REQUIRE(std::string(1, static_cast<char>(replacement.back())) ==
+            omega_session_get_segment_string(session_ptr, byte_count - 1, 1));
+
+    omega_edit_destroy_session(session_ptr);
+    omega_util_remove_file(file_path.c_str());
+}
+
 TEST_CASE("Apply Builtin Transform", "[EditTransform]") {
     const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(session_ptr);
@@ -126,6 +249,10 @@ TEST_CASE("Apply Builtin Transform", "[EditTransform]") {
     REQUIRE(3 == omega_change_get_length(change_ptr));
     REQUIRE(std::string("builtin:ascii-to-lower") == omega_change_get_transform_id(change_ptr));
     REQUIRE(3 == omega_change_get_transform_replacement_length(change_ptr));
+    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(change_ptr));
+    REQUIRE(std::string(R"({"transformId":"builtin:ascii-to-lower","args":{}})") ==
+            std::string(reinterpret_cast<const char *>(omega_change_get_data(change_ptr)),
+                        static_cast<size_t>(omega_change_get_data_length(change_ptr))));
     REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
     REQUIRE("Abc xyz 09!" ==
             omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
@@ -809,14 +936,16 @@ TEST_CASE("Search-Forward", "[SearchTests]") {
     REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
     REQUIRE(omega_change_is_undone(omega_session_get_last_undo(session_ptr)));
     REQUIRE(-2 == omega_change_get_serial(omega_session_get_last_undo(session_ptr)));
-    REQUIRE('D' == omega_change_get_kind_as_char(omega_session_get_change(
-                           session_ptr, omega_change_get_serial(omega_session_get_last_undo(session_ptr)))));
-    REQUIRE(nullptr == omega_change_get_bytes(omega_session_get_change(
-                               session_ptr, omega_change_get_serial(omega_session_get_last_undo(session_ptr)))));
-    REQUIRE(omega_change_get_string(
-                    omega_session_get_change(session_ptr,
-                                             omega_change_get_serial(omega_session_get_last_undo(session_ptr))))
-                    .empty());
+    const auto *delete_change =
+            omega_session_get_change(session_ptr, omega_change_get_serial(omega_session_get_last_undo(session_ptr)));
+    REQUIRE('D' == omega_change_get_kind_as_char(delete_change));
+    REQUIRE(nullptr != omega_change_get_bytes(delete_change));
+    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(delete_change));
+    const auto deleted_bytes = std::string("012345");
+    REQUIRE(static_cast<int64_t>(deleted_bytes.size()) == omega_change_get_data_length(delete_change));
+    REQUIRE(deleted_bytes == std::string(reinterpret_cast<const char *>(omega_change_get_bytes(delete_change)),
+                                         static_cast<size_t>(omega_change_get_data_length(delete_change))));
+    REQUIRE(deleted_bytes == omega_change_get_string(delete_change));
     REQUIRE(omega_session_get_num_undone_changes(session_ptr) == 2);
     REQUIRE(0 < omega_edit_overwrite_string(session_ptr, 16, needle));
     REQUIRE(omega_session_get_num_undone_changes(session_ptr) == 0);

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -627,6 +627,8 @@ TEST_CASE("Null Pointer Safety", "[NullSafety]") {
     REQUIRE(-1 == omega_session_end_transaction(nullptr));
     REQUIRE(0 == omega_session_get_transaction_state(nullptr));
     REQUIRE(0 == omega_session_get_num_change_transactions(nullptr));
+    REQUIRE(0 == omega_session_get_change_inline_payload_limit(nullptr));
+    REQUIRE(0 == omega_session_set_change_inline_payload_limit(nullptr, 32));
 
     // These should not crash (void returns)
     omega_session_pause_viewport_event_callbacks(nullptr);
@@ -654,6 +656,9 @@ TEST_CASE("Null Pointer Safety", "[NullSafety]") {
     REQUIRE(0 == omega_change_get_length(nullptr));
     REQUIRE(0 == omega_change_get_serial(nullptr));
     REQUIRE(nullptr == omega_change_get_bytes(nullptr));
+    REQUIRE(nullptr == omega_change_get_data(nullptr));
+    REQUIRE(0 == omega_change_get_data_length(nullptr));
+    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_NONE == omega_change_get_data_storage(nullptr));
     REQUIRE('\0' == omega_change_get_kind_as_char(nullptr));
     REQUIRE(0 == omega_change_get_transaction_bit(nullptr));
     REQUIRE(0 == omega_change_is_undone(nullptr));

--- a/core/src/tests/test_util.hpp.in
+++ b/core/src/tests/test_util.hpp.in
@@ -16,15 +16,15 @@
 #define OMEGA_EDIT_TEST_UTIL_HPP
 
 #include "omega_edit/byte.h"
+#include "omega_edit/change.h"
 #include "omega_edit/config.h"
 #include "omega_edit/filesystem.h"
-#include "omega_edit/change.h"
 #include "omega_edit/session.h"
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
-#include <filesystem>
 
 using file_info_t = struct file_info_struct {
     size_t num_changes{};
@@ -84,19 +84,22 @@ static inline void session_change_cbk(const omega_session_t *session_ptr, omega_
             auto file_info_ptr = reinterpret_cast<file_info_t *>(omega_session_get_user_data_ptr(session_ptr));
             const auto change_ptr = reinterpret_cast<const omega_change_t *>(session_event_ptr);
             const auto bytes = omega_change_get_bytes(change_ptr);
-            const auto bytes_length = omega_change_get_length(change_ptr);
-            if (0 < omega_change_get_serial(change_ptr)) { ++file_info_ptr->num_changes; } else {
-                --file_info_ptr->num_changes;/* this is an UNDO */
+            const auto bytes_length = omega_change_get_data_length(change_ptr);
+            if (0 < omega_change_get_serial(change_ptr)) {
+                ++file_info_ptr->num_changes;
+            } else {
+                --file_info_ptr->num_changes; /* this is an UNDO */
             }
             auto file_path = omega_session_get_file_path(session_ptr);
             file_path = (file_path) ? file_path : "NO FILENAME";
             std::clog << std::dec << R"({ "filename" : ")" << file_path << R"(", "num_changes" : )"
-                    << omega_session_get_num_changes(session_ptr) << R"(, "computed_file_size": )"
-                    << omega_session_get_computed_file_size(session_ptr) << R"(, "change_transaction_bit": )"
-                    << omega_change_get_transaction_bit(change_ptr) << R"(, "change_serial": )"
-                    << omega_change_get_serial(change_ptr) << R"(, "change_kind": ")"
-                    << omega_change_get_kind_as_char(change_ptr) << R"(", "offset": )"
-                    << omega_change_get_offset(change_ptr) << R"(, "length": )" << omega_change_get_length(change_ptr);
+                      << omega_session_get_num_changes(session_ptr) << R"(, "computed_file_size": )"
+                      << omega_session_get_computed_file_size(session_ptr) << R"(, "change_transaction_bit": )"
+                      << omega_change_get_transaction_bit(change_ptr) << R"(, "change_serial": )"
+                      << omega_change_get_serial(change_ptr) << R"(, "change_kind": ")"
+                      << omega_change_get_kind_as_char(change_ptr) << R"(", "offset": )"
+                      << omega_change_get_offset(change_ptr) << R"(, "length": )"
+                      << omega_change_get_length(change_ptr);
             if (bytes) { std::clog << R"(, "bytes": ")" << std::string((const char *) bytes, bytes_length) << R"(")"; }
             std::clog << "}" << std::endl;
         }

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -466,8 +466,14 @@ function normalizeChangeLogEntry(
       : typeof data === 'string'
         ? parseInputData(data, 'hex')
         : new Uint8Array(0)
-  if ((kind === 'INSERT' || kind === 'OVERWRITE') && dataBytes.length === 0) {
+  if (
+    (kind === 'INSERT' || kind === 'DELETE' || kind === 'OVERWRITE') &&
+    dataBytes.length === 0
+  ) {
     throw new Error(`Change log entry ${index} ${kind} requires data`)
+  }
+  if (kind === 'DELETE' && dataBytes.length !== normalizedLength) {
+    throw new Error(`Change log entry ${index} DELETE data length mismatch`)
   }
 
   const normalized: ChangeLogEntry = {
@@ -632,9 +638,7 @@ function changeDetailsToLogEntry(
     kind,
     offset: change.getOffset(),
     length: kind === 'INSERT' ? 0 : change.getLength(),
-    data: Buffer.from(
-      kind === 'DELETE' ? new Uint8Array(0) : change.getData_asU8()
-    ).toString('hex'),
+    data: Buffer.from(change.getData_asU8()).toString('hex'),
   }
 }
 

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -539,7 +539,7 @@ describe('@omega-edit/ai toolkit', () => {
                   kind: 'DELETE',
                   offset: 1000,
                   length: 1,
-                  data: '',
+                  data: Buffer.from('x', 'utf8').toString('hex'),
                 },
               ],
               {

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -904,7 +904,7 @@ export interface GetChangeDetailsResponse {
   /**
    * @generated from protobuf field: optional bytes data = 6
    */
-  data?: Uint8Array // Payload bytes (for insert/overwrite).
+  data?: Uint8Array // Primitive payload bytes.
   /**
    * @generated from protobuf field: optional omega_edit.v1.TransformChangeDetails transform = 7
    */
@@ -950,7 +950,7 @@ export interface GetLastChangeResponse {
   /**
    * @generated from protobuf field: optional bytes data = 6
    */
-  data?: Uint8Array // Payload bytes (for insert/overwrite).
+  data?: Uint8Array // Primitive payload bytes.
   /**
    * @generated from protobuf field: optional omega_edit.v1.TransformChangeDetails transform = 7
    */
@@ -996,7 +996,7 @@ export interface GetLastUndoResponse {
   /**
    * @generated from protobuf field: optional bytes data = 6
    */
-  data?: Uint8Array // Payload bytes (for insert/overwrite).
+  data?: Uint8Array // Primitive payload bytes.
   /**
    * @generated from protobuf field: optional omega_edit.v1.TransformChangeDetails transform = 7
    */
@@ -2350,7 +2350,7 @@ export enum ChangeKind {
    */
   UNSPECIFIED = 0,
   /**
-   * Delete `length` bytes starting at `offset`.
+   * Delete `length` bytes starting at `offset`; change details carry the deleted bytes in `data`.
    *
    * @generated from protobuf enum value: CHANGE_KIND_DELETE = 1;
    */

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -283,7 +283,7 @@ enum IOFlags {
 // The kind of atomic edit applied to a session.
 enum ChangeKind {
     CHANGE_KIND_UNSPECIFIED = 0;
-    // Delete `length` bytes starting at `offset`.
+    // Delete `length` bytes starting at `offset`; change details carry the deleted bytes in `data`.
     CHANGE_KIND_DELETE = 1;
     // Insert `data` at `offset` without removing existing bytes.
     CHANGE_KIND_INSERT = 2;
@@ -756,7 +756,7 @@ message GetChangeDetailsResponse {
     ChangeKind kind = 3;                          // Type of edit.
     int64 offset = 4;                             // Byte offset.
     int64 length = 5;                             // Number of bytes affected.
-    optional bytes data = 6;                      // Payload bytes (for insert/overwrite).
+    optional bytes data = 6;                      // Primitive payload bytes.
     optional TransformChangeDetails transform = 7;// Transform metadata (for transform changes).
 }
 
@@ -772,7 +772,7 @@ message GetLastChangeResponse {
     ChangeKind kind = 3;                          // Type of edit.
     int64 offset = 4;                             // Byte offset.
     int64 length = 5;                             // Number of bytes affected.
-    optional bytes data = 6;                      // Payload bytes (for insert/overwrite).
+    optional bytes data = 6;                      // Primitive payload bytes.
     optional TransformChangeDetails transform = 7;// Transform metadata (for transform changes).
 }
 
@@ -788,7 +788,7 @@ message GetLastUndoResponse {
     ChangeKind kind = 3;                          // Type of edit.
     int64 offset = 4;                             // Byte offset.
     int64 length = 5;                             // Number of bytes affected.
-    optional bytes data = 6;                      // Payload bytes (for insert/overwrite).
+    optional bytes data = 6;                      // Primitive payload bytes.
     optional TransformChangeDetails transform = 7;// Transform metadata (for transform changes).
 }
 

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -785,9 +785,8 @@ namespace omega_edit {
             response->set_length(omega_change_get_length(change));
 
             const auto *bytes = omega_change_get_bytes(change);
-            if (bytes && omega_change_get_length(change) > 0) {
-                response->set_data(bytes, static_cast<size_t>(omega_change_get_length(change)));
-            }
+            const auto data_length = omega_change_get_data_length(change);
+            if (bytes && data_length > 0) { response->set_data(bytes, static_cast<size_t>(data_length)); }
 
             if (omega_change_is_transform(change)) {
                 auto *transform = response->mutable_transform();

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -860,10 +860,7 @@ function changeDetailsToChangeRecord(
     kind,
     offset: change.getOffset(),
     length: kind === 'INSERT' ? 0 : change.getLength(),
-    data:
-      kind === 'DELETE'
-        ? ''
-        : Buffer.from(change.getData_asU8()).toString('hex'),
+    data: Buffer.from(change.getData_asU8()).toString('hex'),
   }
 }
 
@@ -1091,9 +1088,13 @@ function safeChangeRecord(value: unknown): ChangeRecord | undefined {
       } catch {
         return undefined
       }
+      const data = safeHexString(value.data, Number.POSITIVE_INFINITY)
+      if (!data || data.length / 2 !== length) {
+        return undefined
+      }
       return groupId
-        ? { serial, kind: 'DELETE', offset, length, data: '', groupId }
-        : { serial, kind: 'DELETE', offset, length, data: '' }
+        ? { serial, kind: 'DELETE', offset, length, data, groupId }
+        : { serial, kind: 'DELETE', offset, length, data }
     }
     case 'OVERWRITE': {
       const data = safeHexString(value.data, Number.POSITIVE_INFINITY)
@@ -4657,7 +4658,7 @@ export class HexEditorProvider
           kind: 'DELETE',
           offset: change.offset,
           length: change.length,
-          data: '',
+          data: change.data,
           ...(change.groupId ? { groupId: change.groupId } : {}),
         }
       }

--- a/wiki/transform-primitives.md
+++ b/wiki/transform-primitives.md
@@ -1,0 +1,60 @@
+# First-Class Transform Primitives
+
+OmegaEdit changes should converge on one primitive shape:
+
+- `DELETE`
+- `INSERT`
+- `OVERWRITE`
+- `REPLACE`
+- `TRANSFORM`
+
+Each primitive carries:
+
+- primitive type
+- byte range (`offset`, `length`)
+- data payload
+
+For `INSERT`, `OVERWRITE`, and `REPLACE`, the data payload is replacement bytes.
+For `DELETE`, the data payload is exactly the deleted bytes. Small payloads are
+stored inline; larger payloads are file-backed in the session checkpoint
+directory. The inline/file-backed threshold defaults to
+`OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT` and can be lowered per session with
+`omega_session_set_change_inline_payload_limit()`, which keeps tests and
+low-memory callers from needing large allocations to exercise the file-backed
+path. That gives undo an inverse payload without replaying history. For
+`OVERWRITE`, the primary payload is the replacement bytes and the inverse
+payload is the bytes that were replaced, including file-backed storage for large
+ranges. For `TRANSFORM`, the data payload is JSON with the transform id and JSON
+arguments, for example:
+
+```json
+{"transformId":"builtin:ascii-to-lower","args":{}}
+```
+
+The first implementation step makes `omega_change_get_bytes()` return the
+primitive payload. `omega_change_get_data()` is kept as an alias for callers that
+want a name tied to the primitive shape.
+
+Large inverse payloads are not copied into memory-backed history. They use a
+session-owned file-backed payload path, while model segments read payload bytes
+through the same copy/write helpers regardless of storage.
+
+Undo now applies inverse primitives directly for ordinary edit changes:
+
+- `INSERT` undo deletes the inserted range.
+- `DELETE` undo inserts the captured delete payload.
+- `OVERWRITE` undo deletes the replacement payload and inserts the captured
+  inverse payload.
+
+Checkpoint-backed transform undo/redo still restores checkpoints.
+
+Open migration steps:
+
+- Promote `REPLACE` into the native core change kind instead of representing it
+  as a transaction of delete/insert operations.
+- Move protobuf change details further toward the same primitive shape by
+  carrying data storage metadata where useful.
+- Keep transform metadata accessors as compatibility helpers over the canonical
+  transform JSON payload.
+- Scope transform/plugin allocation ownership to the session or operation
+  instead of using process-global maps and locks for payload cleanup.


### PR DESCRIPTION
## Summary

- Makes change data a first-class primitive payload: INSERT/OVERWRITE carry replacement bytes, DELETE carries the exact deleted bytes, and TRANSFORM carries the transform JSON descriptor.
- Adds inline and session-owned file-backed payload storage, including a session-scoped inline payload threshold for memory-pressure tuning.
- Uses captured payloads to undo ordinary primitives directly instead of rebuilding the model by replaying history.
- Propagates the payload contract through C/C++ APIs, gRPC change details, AI/extension change logs, examples, and docs.

## Testing

- `cmake --build _build-codex-ninja`
- `LD_LIBRARY_PATH=_build-codex-ninja/core _build-codex-ninja/core/src/tests/omegaEdit_tests "[PayloadTests],[UndoTests],[SearchTests],[EditTransform]"`
- `ctest --build-config Debug --test-dir _build-codex-ninja/core --output-on-failure -E '^File Copy$'`
- `source ~/.nvm/nvm.sh && nvm use --silent && yarn lint`
- `cmake --install _build-codex-ninja --prefix .codex-tmp/native-core-install && cmake --build .codex-tmp/native-server-build`

Note: full local CTest still has the pre-existing `File Copy` mode-bit failure on `/mnt/d`; the excluded run validates the rest of the native suite.