### PR TITLE
feat: make transform change logs first class

### DIFF
--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -98,7 +98,7 @@ interface CollectedChangeLogEntries {
 }
 
 interface ParsedChangeLog {
-  changes: ChangeLogEntry[]
+  changes: NormalizedChangeLogEntry[]
   before?: ChangeLogFingerprint
   after?: ChangeLogFingerprint
 }
@@ -189,6 +189,10 @@ interface TransformPrimitiveDescriptor {
   optionsJson?: string
 }
 
+interface NormalizedChangeLogEntry extends ChangeLogEntry {
+  transformDescriptor?: TransformPrimitiveDescriptor
+}
+
 function parseJsonObject(text: string, name: string): Record<string, unknown> {
   assertJsonNestingLimit(text)
   let parsed: unknown
@@ -251,6 +255,30 @@ function parseTransformOptionsJson(
   return parseJsonObject(optionsJson, name)
 }
 
+function normalizeJsonForComparison(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeJsonForComparison)
+  }
+  if (!isRecord(value)) {
+    return value
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, normalizeJsonForComparison(value[key])])
+  )
+}
+
+function jsonObjectsEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>
+): boolean {
+  return (
+    JSON.stringify(normalizeJsonForComparison(left)) ===
+    JSON.stringify(normalizeJsonForComparison(right))
+  )
+}
+
 function transformOptionsMatchDescriptor(
   optionsJson: string | undefined,
   descriptorOptionsJson: string | undefined,
@@ -261,7 +289,40 @@ function transformOptionsMatchDescriptor(
     descriptorOptionsJson,
     name
   )
-  return JSON.stringify(options) === JSON.stringify(descriptorOptions)
+  return jsonObjectsEqual(options, descriptorOptions)
+}
+
+function assertTransformReplayResponse(
+  descriptor: TransformPrimitiveDescriptor,
+  offset: number,
+  length: number,
+  computedFileSizeBefore: number,
+  computedFileSizeAfter: number,
+  response: Awaited<ReturnType<typeof applyClientTransformPlugin>>
+): void {
+  if (response.pluginId !== descriptor.transformId) {
+    throw new Error(
+      `TRANSFORM ${descriptor.transformId} replay returned plugin ${response.pluginId}`
+    )
+  }
+  if (response.offset !== offset || response.length !== length) {
+    throw new Error(
+      `TRANSFORM ${descriptor.transformId} replay range mismatch: expected offset ${offset}, length ${length}; actual offset ${response.offset}, length ${response.length}`
+    )
+  }
+
+  const expectedFileSize =
+    computedFileSizeBefore - response.length + response.replacementLength
+  if (response.computedFileSize !== expectedFileSize) {
+    throw new Error(
+      `TRANSFORM ${descriptor.transformId} replay size mismatch: expected ${expectedFileSize}, actual ${response.computedFileSize}`
+    )
+  }
+  if (computedFileSizeAfter !== response.computedFileSize) {
+    throw new Error(
+      `TRANSFORM ${descriptor.transformId} replay session size mismatch: expected ${response.computedFileSize}, actual ${computedFileSizeAfter}`
+    )
+  }
 }
 
 function assertJsonNestingLimit(text: string): void {
@@ -500,7 +561,7 @@ function validateChangeLogDocumentMetadata(
 function normalizeChangeLogEntry(
   entry: unknown,
   index: number
-): ChangeLogEntry {
+): NormalizedChangeLogEntry {
   if (!isRecord(entry)) {
     throw new Error(`Change log entry ${index} must be an object`)
   }
@@ -536,7 +597,7 @@ function normalizeChangeLogEntry(
     throw new Error(`Change log entry ${index} DELETE data length mismatch`)
   }
 
-  const normalized: ChangeLogEntry = {
+  const normalized: NormalizedChangeLogEntry = {
     kind,
     offset: normalizedOffset,
     length: normalizedLength,
@@ -555,7 +616,7 @@ function normalizeChangeLogEntry(
         `Change log entry ${index} TRANSFORM metadata must be carried in data`
       )
     }
-    parseTransformPrimitiveDescriptor(
+    normalized.transformDescriptor = parseTransformPrimitiveDescriptor(
       dataBytes,
       `Change log entry ${index} TRANSFORM data`
     )
@@ -870,14 +931,19 @@ function createChangeLogDocument(
 }
 
 function serializeChangeLogEntry(entry: ChangeLogEntry): ChangeLogEntry {
-  return {
-    ...entry,
-    ...(entry.serial !== undefined
-      ? { serial: int64ToDecimal(entry.serial) }
-      : {}),
+  const serialized: ChangeLogEntry = {
+    kind: entry.kind,
     offset: int64ToDecimal(entry.offset),
     length: int64ToDecimal(entry.length),
+    data: entry.data,
   }
+  if (entry.serial !== undefined) {
+    serialized.serial = int64ToDecimal(entry.serial)
+  }
+  if (entry.groupId) {
+    serialized.groupId = entry.groupId
+  }
+  return serialized
 }
 
 function createChangeLogSummary(
@@ -1330,7 +1396,7 @@ export class OmegaEditToolkit {
     let appliedChangeCount = 0
     const startChangeCount = await getChangeCount(request.sessionId)
     try {
-      const applyChange = async (change: ChangeLogEntry) => {
+      const applyChange = async (change: NormalizedChangeLogEntry) => {
         const offset = normalizeNonNegativeInt64ForClient(
           change.offset,
           'change log entry offset'
@@ -1366,9 +1432,12 @@ export class OmegaEditToolkit {
             )
             return true
           case 'TRANSFORM': {
-            const descriptor = parseTransformPrimitiveDescriptor(
-              Buffer.from(change.data, 'hex'),
-              'TRANSFORM change data'
+            const descriptor = change.transformDescriptor
+            if (!descriptor) {
+              throw new Error('TRANSFORM change data was not normalized')
+            }
+            const computedFileSizeBefore = await getComputedFileSize(
+              request.sessionId
             )
             const response = await applyClientTransformPlugin(
               request.sessionId,
@@ -1382,17 +1451,28 @@ export class OmegaEditToolkit {
                 `TRANSFORM ${descriptor.transformId} replay produced no content change`
               )
             }
+            const computedFileSizeAfter = await getComputedFileSize(
+              request.sessionId
+            )
+            assertTransformReplayResponse(
+              descriptor,
+              offset,
+              length,
+              computedFileSizeBefore,
+              computedFileSizeAfter,
+              response
+            )
             return true
           }
         }
       }
-      const applyAndCountChange = async (change: ChangeLogEntry) => {
+      const applyAndCountChange = async (change: NormalizedChangeLogEntry) => {
         if (await applyChange(change)) {
           appliedChangeCount += 1
         }
       }
       if (changes.length > 0) {
-        let pendingBatch: ChangeLogEntry[] = []
+        let pendingBatch: NormalizedChangeLogEntry[] = []
         const flushBatch = async () => {
           if (pendingBatch.length === 0) {
             return

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -184,6 +184,86 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+interface TransformPrimitiveDescriptor {
+  transformId: string
+  optionsJson?: string
+}
+
+function parseJsonObject(text: string, name: string): Record<string, unknown> {
+  assertJsonNestingLimit(text)
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`${name} must be valid JSON: ${message}`)
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`${name} must be a JSON object`)
+  }
+  return parsed
+}
+
+function transformOptionsToJson(
+  args: Record<string, unknown>
+): string | undefined {
+  return Object.keys(args).length > 0 ? JSON.stringify(args) : undefined
+}
+
+function parseTransformPrimitiveDescriptor(
+  dataBytes: Uint8Array,
+  name: string
+): TransformPrimitiveDescriptor {
+  if (dataBytes.length === 0) {
+    throw new Error(`${name} requires data`)
+  }
+
+  const descriptorText = Buffer.from(dataBytes).toString('utf8')
+  const descriptor = parseJsonObject(descriptorText, name)
+  if (
+    typeof descriptor.transformId !== 'string' ||
+    !descriptor.transformId.trim()
+  ) {
+    throw new Error(`${name} requires transformId`)
+  }
+
+  const args = descriptor.args === undefined ? {} : descriptor.args
+  if (!isRecord(args)) {
+    throw new Error(`${name} args must be a JSON object`)
+  }
+
+  return {
+    transformId: descriptor.transformId.trim(),
+    optionsJson: transformOptionsToJson(args),
+  }
+}
+
+function parseTransformOptionsJson(
+  optionsJson: string | undefined,
+  name: string
+): Record<string, unknown> {
+  if (optionsJson === undefined || optionsJson === '') {
+    return {}
+  }
+  if (typeof optionsJson !== 'string') {
+    throw new Error(`${name} must be a string`)
+  }
+  return parseJsonObject(optionsJson, name)
+}
+
+function transformOptionsMatchDescriptor(
+  optionsJson: string | undefined,
+  descriptorOptionsJson: string | undefined,
+  name: string
+): boolean {
+  const options = parseTransformOptionsJson(optionsJson, name)
+  const descriptorOptions = parseTransformOptionsJson(
+    descriptorOptionsJson,
+    name
+  )
+  return JSON.stringify(options) === JSON.stringify(descriptorOptions)
+}
+
 function assertJsonNestingLimit(text: string): void {
   let depth = 0
   let inString = false
@@ -425,19 +505,7 @@ function normalizeChangeLogEntry(
     throw new Error(`Change log entry ${index} must be an object`)
   }
 
-  const {
-    kind,
-    offset,
-    length,
-    serial,
-    data,
-    groupId,
-    transformId,
-    optionsJson,
-    replacementLength,
-    computedFileSizeBefore,
-    computedFileSizeAfter,
-  } = entry
+  const { kind, offset, length, serial, data, groupId } = entry
   if (
     kind !== 'INSERT' &&
     kind !== 'DELETE' &&
@@ -456,16 +524,8 @@ function normalizeChangeLogEntry(
     `change log entry ${index} length`
   )
 
-  if (kind === 'TRANSFORM' && data !== undefined && data !== '') {
-    throw new Error(`Change log entry ${index} TRANSFORM does not carry data`)
-  }
-
   const dataBytes =
-    kind === 'TRANSFORM'
-      ? new Uint8Array(0)
-      : typeof data === 'string'
-        ? parseInputData(data, 'hex')
-        : new Uint8Array(0)
+    typeof data === 'string' ? parseInputData(data, 'hex') : new Uint8Array(0)
   if (
     (kind === 'INSERT' || kind === 'DELETE' || kind === 'OVERWRITE') &&
     dataBytes.length === 0
@@ -483,44 +543,22 @@ function normalizeChangeLogEntry(
     data: Buffer.from(dataBytes).toString('hex'),
   }
   if (kind === 'TRANSFORM') {
-    if (typeof transformId !== 'string' || !transformId.trim()) {
+    const legacyFields = [
+      'transformId',
+      'optionsJson',
+      'replacementLength',
+      'computedFileSizeBefore',
+      'computedFileSizeAfter',
+    ].filter((field) => Object.prototype.hasOwnProperty.call(entry, field))
+    if (legacyFields.length > 0) {
       throw new Error(
-        `Change log entry ${index} TRANSFORM requires transformId`
+        `Change log entry ${index} TRANSFORM metadata must be carried in data`
       )
     }
-    normalized.transformId = transformId.trim()
-
-    if (optionsJson !== undefined) {
-      if (typeof optionsJson !== 'string') {
-        throw new Error(
-          `Change log entry ${index} optionsJson must be a string`
-        )
-      }
-      normalized.optionsJson = optionsJson
-    }
-
-    for (const [key, value] of Object.entries({
-      replacementLength,
-      computedFileSizeBefore,
-      computedFileSizeAfter,
-    }) as Array<
-      [
-        (
-          | 'replacementLength'
-          | 'computedFileSizeBefore'
-          | 'computedFileSizeAfter'
-        ),
-        unknown,
-      ]
-    >) {
-      if (value === undefined) {
-        continue
-      }
-      normalized[key] = normalizeNonNegativeInt64ForClient(
-        value,
-        `change log entry ${index} ${key}`
-      )
-    }
+    parseTransformPrimitiveDescriptor(
+      dataBytes,
+      `Change log entry ${index} TRANSFORM data`
+    )
   }
   if (serial !== undefined) {
     normalized.serial = normalizePositiveInt64ForClient(
@@ -616,20 +654,31 @@ function changeDetailsToLogEntry(
     if (!transform?.transformId) {
       throw new Error('Transform change is missing transform metadata')
     }
+    const data = change.getData_asU8()
+    const descriptor = parseTransformPrimitiveDescriptor(
+      data,
+      'Transform change data'
+    )
+    if (transform.transformId !== descriptor.transformId) {
+      throw new Error('Transform change metadata does not match data')
+    }
+    if (
+      transform.optionsJson !== undefined &&
+      !transformOptionsMatchDescriptor(
+        transform.optionsJson,
+        descriptor.optionsJson,
+        'Transform change optionsJson'
+      )
+    ) {
+      throw new Error('Transform change options metadata does not match data')
+    }
 
     return {
       serial: change.getSerial(),
       kind,
       offset: change.getOffset(),
       length: change.getLength(),
-      data: '',
-      transformId: transform.transformId,
-      ...(transform.optionsJson !== undefined
-        ? { optionsJson: transform.optionsJson }
-        : {}),
-      replacementLength: transform.replacementLength,
-      computedFileSizeBefore: transform.computedFileSizeBefore,
-      computedFileSizeAfter: transform.computedFileSizeAfter,
+      data: Buffer.from(data).toString('hex'),
     }
   }
 
@@ -828,19 +877,6 @@ function serializeChangeLogEntry(entry: ChangeLogEntry): ChangeLogEntry {
       : {}),
     offset: int64ToDecimal(entry.offset),
     length: int64ToDecimal(entry.length),
-    ...(entry.replacementLength !== undefined
-      ? { replacementLength: int64ToDecimal(entry.replacementLength) }
-      : {}),
-    ...(entry.computedFileSizeBefore !== undefined
-      ? {
-          computedFileSizeBefore: int64ToDecimal(entry.computedFileSizeBefore),
-        }
-      : {}),
-    ...(entry.computedFileSizeAfter !== undefined
-      ? {
-          computedFileSizeAfter: int64ToDecimal(entry.computedFileSizeAfter),
-        }
-      : {}),
   }
 }
 
@@ -1330,60 +1366,20 @@ export class OmegaEditToolkit {
             )
             return true
           case 'TRANSFORM': {
-            if (!change.transformId) {
-              throw new Error('TRANSFORM change requires transformId')
-            }
-            const expectedSizeBefore =
-              change.computedFileSizeBefore !== undefined
-                ? normalizeNonNegativeInt64ForClient(
-                    change.computedFileSizeBefore,
-                    'change log entry computedFileSizeBefore'
-                  )
-                : undefined
-            if (expectedSizeBefore !== undefined) {
-              const actualSizeBefore = await getComputedFileSize(
-                request.sessionId
-              )
-              if (actualSizeBefore !== expectedSizeBefore) {
-                throw new Error(
-                  `TRANSFORM ${change.transformId} expected pre-transform size ${expectedSizeBefore}, found ${actualSizeBefore}`
-                )
-              }
-            }
+            const descriptor = parseTransformPrimitiveDescriptor(
+              Buffer.from(change.data, 'hex'),
+              'TRANSFORM change data'
+            )
             const response = await applyClientTransformPlugin(
               request.sessionId,
-              change.transformId,
+              descriptor.transformId,
               offset,
               length,
-              change.optionsJson
+              descriptor.optionsJson
             )
             if (!response.contentChanged) {
               throw new Error(
-                `TRANSFORM ${change.transformId} replay produced no content change`
-              )
-            }
-            if (
-              change.replacementLength !== undefined &&
-              response.replacementLength !==
-                normalizeNonNegativeInt64ForClient(
-                  change.replacementLength,
-                  'change log entry replacementLength'
-                )
-            ) {
-              throw new Error(
-                `TRANSFORM ${change.transformId} replacement length mismatch`
-              )
-            }
-            if (
-              change.computedFileSizeAfter !== undefined &&
-              response.computedFileSize !==
-                normalizeNonNegativeInt64ForClient(
-                  change.computedFileSizeAfter,
-                  'change log entry computedFileSizeAfter'
-                )
-            ) {
-              throw new Error(
-                `TRANSFORM ${change.transformId} post-transform size mismatch`
+                `TRANSFORM ${descriptor.transformId} replay produced no content change`
               )
             }
             return true

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -47,11 +47,6 @@ export interface ChangeLogEntry {
   offset: ChangeLogInt64
   length: ChangeLogInt64
   data: string
-  transformId?: string
-  optionsJson?: string
-  replacementLength?: ChangeLogInt64
-  computedFileSizeBefore?: ChangeLogInt64
-  computedFileSizeAfter?: ChangeLogInt64
   groupId?: string
 }
 

--- a/packages/ai/tests/specs/cli.spec.ts
+++ b/packages/ai/tests/specs/cli.spec.ts
@@ -1,0 +1,234 @@
+import { strict as assert } from 'assert'
+import { spawn } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { findFirstAvailablePort } from '@omega-edit/client'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/cjs/cli.js')
+
+function runOe(args: string[]): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      env: {
+        ...process.env,
+        OMEGA_EDIT_CLIENT_LOG_LEVEL: 'fatal',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    const timeout = setTimeout(() => {
+      child.kill()
+      reject(new Error(`oe ${args.join(' ')} timed out`))
+    }, 30_000)
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString()
+    })
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.on('close', (code) => {
+      clearTimeout(timeout)
+      if (code !== 0) {
+        reject(
+          new Error(
+            `oe ${args.join(' ')} exited ${code}: ${stderr || stdout}`.trim()
+          )
+        )
+        return
+      }
+
+      try {
+        resolve(JSON.parse(stdout) as Record<string, unknown>)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        reject(
+          new Error(
+            `oe ${args.join(' ')} did not return JSON: ${message}; stdout=${stdout}; stderr=${stderr}`
+          )
+        )
+      }
+    })
+  })
+}
+
+describe('@omega-edit/ai CLI', () => {
+  it('lets an AI agent drive OmegaEdit as a JSON command-line skill', async function () {
+    const port = await findFirstAvailablePort(21000, 21999)
+    assert.ok(port, 'expected an available port for CLI test')
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-cli-'))
+    const inputPath = path.join(tempDir, 'agent.bin')
+    const changeLogPath = path.join(tempDir, 'agent-change-log.json')
+    fs.writeFileSync(inputPath, Buffer.from('ABCDEFGH', 'utf8'))
+
+    const common = ['--port', String(port)]
+    let sessionId = ''
+
+    try {
+      const created = await runOe([
+        'create-session',
+        ...common,
+        '--file',
+        inputPath,
+      ])
+      sessionId = created.sessionId as string
+      assert.ok(sessionId.length > 0)
+
+      const readInitial = await runOe([
+        'view',
+        ...common,
+        '--session',
+        sessionId,
+        '--offset',
+        '0',
+        '--length',
+        '8',
+      ])
+      assert.equal(
+        ((readInitial.data as Record<string, unknown>).utf8 as string) || '',
+        'ABCDEFGH'
+      )
+
+      await runOe([
+        'patch',
+        ...common,
+        '--session',
+        sessionId,
+        '--operation',
+        'insert',
+        '--offset',
+        '1',
+        '--text',
+        '12',
+      ])
+      await runOe([
+        'patch',
+        ...common,
+        '--session',
+        sessionId,
+        '--operation',
+        'delete',
+        '--offset',
+        '3',
+        '--delete-length',
+        '2',
+      ])
+      await runOe([
+        'patch',
+        ...common,
+        '--session',
+        sessionId,
+        '--operation',
+        'overwrite',
+        '--offset',
+        '4',
+        '--text',
+        'xy',
+      ])
+      await runOe([
+        'patch',
+        ...common,
+        '--session',
+        sessionId,
+        '--operation',
+        'replace',
+        '--offset',
+        '6',
+        '--delete-length',
+        '2',
+        '--text',
+        'ZZZ',
+      ])
+
+      const replaced = 'A12DxyZZZ'
+      await runOe([
+        'apply-transform-plugin',
+        ...common,
+        '--session',
+        sessionId,
+        '--plugin',
+        'omega.example.base64',
+        '--offset',
+        '0',
+        '--length',
+        String(Buffer.byteLength(replaced, 'utf8')),
+      ])
+      const transformed = Buffer.from(replaced, 'utf8').toString('base64')
+
+      const readTransformed = await runOe([
+        'view',
+        ...common,
+        '--session',
+        sessionId,
+        '--offset',
+        '0',
+        '--length',
+        String(Buffer.byteLength(transformed, 'utf8')),
+      ])
+      assert.equal(
+        ((readTransformed.data as Record<string, unknown>).utf8 as string) ||
+          '',
+        transformed
+      )
+
+      await runOe(['undo', ...common, '--session', sessionId])
+      const readUndo = await runOe([
+        'view',
+        ...common,
+        '--session',
+        sessionId,
+        '--offset',
+        '0',
+        '--length',
+        String(Buffer.byteLength(replaced, 'utf8')),
+      ])
+      assert.equal(
+        ((readUndo.data as Record<string, unknown>).utf8 as string) || '',
+        replaced
+      )
+
+      await runOe(['redo', ...common, '--session', sessionId])
+      const exported = await runOe([
+        'export-change-log',
+        ...common,
+        '--session',
+        sessionId,
+        '--output',
+        changeLogPath,
+        '--overwrite',
+      ])
+      assert.equal(exported.format, 'omega-edit.change-log')
+      assert.equal(exported.complete, true)
+      assert.equal(fs.existsSync(changeLogPath), true)
+
+      const status = await runOe([
+        'session-status',
+        ...common,
+        '--session',
+        sessionId,
+      ])
+      assert.equal(status.computedSize, Buffer.byteLength(transformed, 'utf8'))
+      assert.equal(status.undoCount, 0)
+    } finally {
+      if (sessionId) {
+        await runOe([
+          'destroy-session',
+          ...common,
+          '--session',
+          sessionId,
+        ]).catch(() => undefined)
+      }
+      await runOe(['server-stop', ...common]).catch(() => undefined)
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -71,6 +71,19 @@ function parseTransformDataHex(data: string) {
   }
 }
 
+async function assertToolkitText(
+  toolkit: OmegaEditToolkit,
+  sessionId: string,
+  expected: string
+) {
+  const expectedLength = Buffer.byteLength(expected, 'utf8')
+  const status = await toolkit.sessionStatus(sessionId)
+  assert.equal(status.computedSize, expectedLength)
+  const range = await toolkit.readRange(sessionId, 0, expectedLength)
+  assert.equal(range.actualLength, expectedLength)
+  assert.equal(range.data.utf8, expected)
+}
+
 describe('@omega-edit/ai toolkit', () => {
   it('preserves the original connection failure as the cause', async function () {
     const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
@@ -836,6 +849,245 @@ describe('@omega-edit/ai toolkit', () => {
     } finally {
       if (createdSessionId) {
         await toolkit.destroySession(createdSessionId).catch(() => undefined)
+      }
+      await toolkit.stopServer().catch(() => undefined)
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('round-trips every first-class primitive through change logs and undo/redo', async function () {
+    const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
+    assert.ok(port, 'expected an available port for OmegaEdit')
+
+    const toolkit = new OmegaEditToolkit({ port: port!, autoStart: true })
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
+    const inputPath = path.join(tempDir, 'input.bin')
+    const replayPath = path.join(tempDir, 'replay.bin')
+    fs.writeFileSync(inputPath, Buffer.from('ABCDEFGH', 'utf8'))
+    fs.writeFileSync(replayPath, Buffer.from('ABCDEFGH', 'utf8'))
+
+    const replaced = 'A12DxyZZZ'
+    const transformed = Buffer.from(replaced, 'utf8').toString('base64')
+    const changes: ChangeLogEntry[] = [
+      {
+        serial: 1,
+        kind: 'INSERT',
+        offset: 1,
+        length: 0,
+        data: Buffer.from('12', 'utf8').toString('hex'),
+      },
+      {
+        serial: 2,
+        kind: 'DELETE',
+        offset: 3,
+        length: 2,
+        data: Buffer.from('BC', 'utf8').toString('hex'),
+      },
+      {
+        serial: 3,
+        kind: 'OVERWRITE',
+        offset: 4,
+        length: 2,
+        data: Buffer.from('xy', 'utf8').toString('hex'),
+      },
+      {
+        serial: 4,
+        kind: 'REPLACE',
+        offset: 6,
+        length: 2,
+        data: Buffer.from('ZZZ', 'utf8').toString('hex'),
+      },
+      {
+        serial: 5,
+        kind: 'TRANSFORM',
+        offset: 0,
+        length: Buffer.byteLength(replaced, 'utf8'),
+        data: makeTransformDataHex('omega.example.base64'),
+      },
+    ]
+
+    let sessionId = ''
+    let replaySessionId = ''
+
+    try {
+      const created = await toolkit.createSession(inputPath)
+      sessionId = created.sessionId
+
+      const result = await toolkit.applyChangeLog({
+        sessionId,
+        changes: makeChangeLogDocument(changes, {
+          before: makeUtf8Fingerprint('ABCDEFGH'),
+          after: makeUtf8Fingerprint(transformed),
+        }),
+      })
+      assert.equal(result.applied, true)
+      assert.equal(result.changeCount, 5)
+      assert.equal(result.inputChangeCount, 5)
+      await assertToolkitText(toolkit, sessionId, transformed)
+
+      let status = await toolkit.sessionStatus(sessionId)
+      assert.equal(status.changeCount, 6)
+      assert.equal(status.undoCount, 0)
+
+      await toolkit.undo(sessionId)
+      await assertToolkitText(toolkit, sessionId, replaced)
+      status = await toolkit.sessionStatus(sessionId)
+      assert.equal(status.changeCount, 5)
+      assert.equal(status.undoCount, 1)
+
+      await toolkit.undo(sessionId)
+      await assertToolkitText(toolkit, sessionId, 'ABCDEFGH')
+      status = await toolkit.sessionStatus(sessionId)
+      assert.equal(status.changeCount, 0)
+      assert.equal(status.undoCount, 6)
+
+      await toolkit.redo(sessionId)
+      await assertToolkitText(toolkit, sessionId, replaced)
+      status = await toolkit.sessionStatus(sessionId)
+      assert.equal(status.changeCount, 5)
+      assert.equal(status.undoCount, 1)
+
+      await toolkit.redo(sessionId)
+      await assertToolkitText(toolkit, sessionId, transformed)
+      status = await toolkit.sessionStatus(sessionId)
+      assert.equal(status.changeCount, 6)
+      assert.equal(status.undoCount, 0)
+
+      const replay = await toolkit.createSession(replayPath)
+      replaySessionId = replay.sessionId
+      const replayResult = await toolkit.applyChangeLog({
+        sessionId: replaySessionId,
+        changes: makeChangeLogDocument(changes, {
+          before: makeUtf8Fingerprint('ABCDEFGH'),
+          after: makeUtf8Fingerprint(transformed),
+        }),
+      })
+      assert.equal(replayResult.applied, true)
+      await assertToolkitText(toolkit, replaySessionId, transformed)
+    } finally {
+      if (sessionId) {
+        await toolkit.destroySession(sessionId).catch(() => undefined)
+      }
+      if (replaySessionId) {
+        await toolkit.destroySession(replaySessionId).catch(() => undefined)
+      }
+      await toolkit.stopServer().catch(() => undefined)
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('undoes and redoes each first-class change-log primitive independently', async function () {
+    const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
+    assert.ok(port, 'expected an available port for OmegaEdit')
+
+    const toolkit = new OmegaEditToolkit({ port: port!, autoStart: true })
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
+    const cases: Array<{
+      name: string
+      before: string
+      after: string
+      change: ChangeLogEntry
+    }> = [
+      {
+        name: 'INSERT',
+        before: 'ABCDEF',
+        after: 'A12BCDEF',
+        change: {
+          kind: 'INSERT',
+          offset: 1,
+          length: 0,
+          data: Buffer.from('12', 'utf8').toString('hex'),
+        },
+      },
+      {
+        name: 'DELETE',
+        before: 'ABCDEF',
+        after: 'ADEF',
+        change: {
+          kind: 'DELETE',
+          offset: 1,
+          length: 2,
+          data: Buffer.from('BC', 'utf8').toString('hex'),
+        },
+      },
+      {
+        name: 'OVERWRITE',
+        before: 'ABCDEF',
+        after: 'ABxyEF',
+        change: {
+          kind: 'OVERWRITE',
+          offset: 2,
+          length: 2,
+          data: Buffer.from('xy', 'utf8').toString('hex'),
+        },
+      },
+      {
+        name: 'REPLACE',
+        before: 'ABCDEF',
+        after: 'ABXYZEF',
+        change: {
+          kind: 'REPLACE',
+          offset: 2,
+          length: 2,
+          data: Buffer.from('XYZ', 'utf8').toString('hex'),
+        },
+      },
+      {
+        name: 'TRANSFORM',
+        before: 'ABCDEFGH',
+        after: Buffer.from('ABCDEFGH', 'utf8').toString('base64'),
+        change: {
+          kind: 'TRANSFORM',
+          offset: 0,
+          length: 8,
+          data: makeTransformDataHex('omega.example.base64'),
+        },
+      },
+    ]
+
+    const sessionIds: string[] = []
+
+    try {
+      for (const testCase of cases) {
+        const inputPath = path.join(tempDir, `${testCase.name}.bin`)
+        fs.writeFileSync(inputPath, Buffer.from(testCase.before, 'utf8'))
+        const created = await toolkit.createSession(inputPath)
+        sessionIds.push(created.sessionId)
+
+        const result = await toolkit.applyChangeLog({
+          sessionId: created.sessionId,
+          changes: makeChangeLogDocument([testCase.change], {
+            before: makeUtf8Fingerprint(testCase.before),
+            after: makeUtf8Fingerprint(testCase.after),
+          }),
+        })
+        assert.equal(result.applied, true, testCase.name)
+        assert.equal(result.changeCount, 1, testCase.name)
+        await assertToolkitText(toolkit, created.sessionId, testCase.after)
+
+        await toolkit.undo(created.sessionId)
+        await assertToolkitText(toolkit, created.sessionId, testCase.before)
+        let status = await toolkit.sessionStatus(created.sessionId)
+        assert.equal(status.changeCount, 0, testCase.name)
+        assert.equal(
+          status.undoCount,
+          testCase.name === 'REPLACE' ? 2 : 1,
+          testCase.name
+        )
+
+        await toolkit.redo(created.sessionId)
+        await assertToolkitText(toolkit, created.sessionId, testCase.after)
+        status = await toolkit.sessionStatus(created.sessionId)
+        assert.equal(
+          status.changeCount,
+          testCase.name === 'REPLACE' ? 2 : 1,
+          testCase.name
+        )
+        assert.equal(status.undoCount, 0, testCase.name)
+      }
+    } finally {
+      for (const sessionId of sessionIds) {
+        await toolkit.destroySession(sessionId).catch(() => undefined)
       }
       await toolkit.stopServer().catch(() => undefined)
       fs.rmSync(tempDir, { recursive: true, force: true })

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -1178,12 +1178,15 @@ describe('@omega-edit/ai toolkit', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
     const sourcePath = path.join(tempDir, 'source.bin')
     const replayPath = path.join(tempDir, 'replay.bin')
+    const mismatchReplayPath = path.join(tempDir, 'mismatch-replay.bin')
     const changeLogPath = path.join(tempDir, 'changes.json')
     fs.writeFileSync(sourcePath, Buffer.from('ABCDEFGH', 'utf8'))
     fs.writeFileSync(replayPath, Buffer.from('ABCDEFGH', 'utf8'))
+    fs.writeFileSync(mismatchReplayPath, Buffer.from('ABCDEFGH', 'utf8'))
 
     let sourceSessionId = ''
     let replaySessionId = ''
+    let mismatchReplaySessionId = ''
 
     try {
       const source = await toolkit.createSession(sourcePath)
@@ -1226,6 +1229,89 @@ describe('@omega-edit/ai toolkit', () => {
       assert.equal(replayedRange.data.utf8, 'QUJDREVGR0g=')
       const status = await toolkit.sessionStatus(replaySessionId)
       assert.equal(status.changeCount, 1)
+
+      const mismatchReplay = await toolkit.createSession(mismatchReplayPath)
+      mismatchReplaySessionId = mismatchReplay.sessionId
+      await assert.rejects(
+        () =>
+          toolkit.applyChangeLog({
+            sessionId: mismatchReplaySessionId,
+            changes: {
+              ...exportedLog,
+              after: makeUtf8Fingerprint('ZZZZZZZZZZZZ'),
+            },
+          }),
+        /after fingerprint mismatch/
+      )
+      await assertToolkitText(toolkit, mismatchReplaySessionId, 'ABCDEFGH')
+    } finally {
+      if (sourceSessionId) {
+        await toolkit.destroySession(sourceSessionId).catch(() => undefined)
+      }
+      if (replaySessionId) {
+        await toolkit.destroySession(replaySessionId).catch(() => undefined)
+      }
+      if (mismatchReplaySessionId) {
+        await toolkit
+          .destroySession(mismatchReplaySessionId)
+          .catch(() => undefined)
+      }
+      await toolkit.stopServer().catch(() => undefined)
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('exports transform options using semantic descriptor comparison', async function () {
+    const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
+    assert.ok(port, 'expected an available port for OmegaEdit')
+
+    const toolkit = new OmegaEditToolkit({ port: port!, autoStart: true })
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
+    const sourcePath = path.join(tempDir, 'source.bin')
+    const replayPath = path.join(tempDir, 'replay.bin')
+    const changeLogPath = path.join(tempDir, 'changes.json')
+    fs.writeFileSync(sourcePath, Buffer.from('ABC', 'utf8'))
+    fs.writeFileSync(replayPath, Buffer.from('ABC', 'utf8'))
+
+    let sourceSessionId = ''
+    let replaySessionId = ''
+
+    try {
+      const source = await toolkit.createSession(sourcePath)
+      sourceSessionId = source.sessionId
+      await toolkit.applyTransformPlugin({
+        sessionId: sourceSessionId,
+        pluginId: 'omega.example.bitwise',
+        offset: 0,
+        length: 3,
+        optionsJson: JSON.stringify({ byte: '0x20', operator: 'xor' }),
+      })
+      await assertToolkitText(toolkit, sourceSessionId, 'abc')
+      await toolkit.exportChangeLog(sourceSessionId, changeLogPath, true)
+
+      const exportedLog = JSON.parse(
+        await fs.promises.readFile(changeLogPath, 'utf8')
+      )
+      const transformChange = exportedLog.changes.find(
+        (change: ChangeLogEntry) => change.kind === 'TRANSFORM'
+      )
+      assert.ok(transformChange, 'expected exported transform change')
+      const transformDescriptor = parseTransformDataHex(transformChange.data)
+      assert.equal(transformDescriptor.transformId, 'omega.example.bitwise')
+      assert.deepEqual(transformDescriptor.args, {
+        byte: '0x20',
+        operator: 'xor',
+      })
+
+      const replay = await toolkit.createSession(replayPath)
+      replaySessionId = replay.sessionId
+      const applyResult = await toolkit.applyChangeLog({
+        sessionId: replaySessionId,
+        changes: exportedLog,
+      })
+      assert.equal(applyResult.applied, true)
+      assert.equal(applyResult.changeCount, 1)
+      await assertToolkitText(toolkit, replaySessionId, 'abc')
     } finally {
       if (sourceSessionId) {
         await toolkit.destroySession(sourceSessionId).catch(() => undefined)

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -55,6 +55,22 @@ function makeChangeLogDocument(
   return { ...document, ...overrides }
 }
 
+function makeTransformDataHex(
+  transformId: string,
+  args: Record<string, unknown> = {}
+) {
+  return Buffer.from(JSON.stringify({ transformId, args }), 'utf8').toString(
+    'hex'
+  )
+}
+
+function parseTransformDataHex(data: string) {
+  return JSON.parse(Buffer.from(data, 'hex').toString('utf8')) as {
+    transformId?: unknown
+    args?: unknown
+  }
+}
+
 describe('@omega-edit/ai toolkit', () => {
   it('preserves the original connection failure as the cause', async function () {
     const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
@@ -826,7 +842,83 @@ describe('@omega-edit/ai toolkit', () => {
     }
   })
 
-  it('rejects transform change logs when replay metadata differs', async function () {
+  it('treats transform change-log data as the canonical descriptor', async function () {
+    const toolkit = new OmegaEditToolkit({ autoStart: false })
+    const transformData = makeTransformDataHex('omega.example.base64', {
+      direction: 'encode',
+    })
+
+    const dryRun = await toolkit.applyChangeLog({
+      sessionId: 'dry-run-session',
+      dryRun: true,
+      changes: makeChangeLogDocument([
+        {
+          serial: 1,
+          kind: 'TRANSFORM',
+          offset: 0,
+          length: 8,
+          data: transformData,
+        },
+      ]),
+    })
+    assert.equal(dryRun.applied, false)
+    assert.equal(dryRun.inputChangeCount, 1)
+
+    await assert.rejects(
+      () =>
+        toolkit.applyChangeLog({
+          sessionId: 'dry-run-session',
+          dryRun: true,
+          changes: makeChangeLogDocument([
+            {
+              kind: 'TRANSFORM',
+              offset: 0,
+              length: 8,
+              data: '',
+            },
+          ]),
+        }),
+      /TRANSFORM data requires data/
+    )
+
+    await assert.rejects(
+      () =>
+        toolkit.applyChangeLog({
+          sessionId: 'dry-run-session',
+          dryRun: true,
+          changes: makeChangeLogDocument([
+            {
+              kind: 'TRANSFORM',
+              offset: 0,
+              length: 8,
+              data: transformData,
+              transformId: 'omega.example.base64',
+            } as unknown as ChangeLogEntry,
+          ]),
+        }),
+      /metadata must be carried in data/
+    )
+
+    await assert.rejects(
+      () =>
+        toolkit.applyChangeLog({
+          sessionId: 'dry-run-session',
+          dryRun: true,
+          changes: makeChangeLogDocument([
+            {
+              kind: 'TRANSFORM',
+              offset: 0,
+              length: 8,
+              data: transformData,
+              replacementLength: 12,
+            } as unknown as ChangeLogEntry,
+          ]),
+        }),
+      /metadata must be carried in data/
+    )
+  })
+
+  it('exports and replays transform change logs with first-class data', async function () {
     const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
     assert.ok(port, 'expected an available port for OmegaEdit')
 
@@ -852,30 +944,36 @@ describe('@omega-edit/ai toolkit', () => {
       })
       await toolkit.exportChangeLog(sourceSessionId, changeLogPath, true)
 
-      const tamperedLog = JSON.parse(
+      const exportedLog = JSON.parse(
         await fs.promises.readFile(changeLogPath, 'utf8')
       )
-      const transformChange = tamperedLog.changes.find(
+      const transformChange = exportedLog.changes.find(
         (change: ChangeLogEntry) => change.kind === 'TRANSFORM'
       )
       assert.ok(transformChange, 'expected exported transform change')
-      transformChange.replacementLength = '999'
+      assert.notEqual(transformChange.data, '')
+      const transformDescriptor = parseTransformDataHex(transformChange.data)
+      assert.equal(transformDescriptor.transformId, 'omega.example.base64')
+      assert.deepEqual(transformDescriptor.args, {})
+      assert.equal('transformId' in transformChange, false)
+      assert.equal('optionsJson' in transformChange, false)
+      assert.equal('replacementLength' in transformChange, false)
+      assert.equal('computedFileSizeBefore' in transformChange, false)
+      assert.equal('computedFileSizeAfter' in transformChange, false)
 
       const replay = await toolkit.createSession(replayPath)
       replaySessionId = replay.sessionId
-      await assert.rejects(
-        () =>
-          toolkit.applyChangeLog({
-            sessionId: replaySessionId,
-            changes: tamperedLog,
-          }),
-        /replacement length mismatch/
-      )
+      const applyResult = await toolkit.applyChangeLog({
+        sessionId: replaySessionId,
+        changes: exportedLog,
+      })
+      assert.equal(applyResult.applied, true)
+      assert.equal(applyResult.changeCount, 1)
 
-      const replayedRange = await toolkit.readRange(replaySessionId, 0, 8)
-      assert.equal(replayedRange.data.utf8, 'ABCDEFGH')
+      const replayedRange = await toolkit.readRange(replaySessionId, 0, 12)
+      assert.equal(replayedRange.data.utf8, 'QUJDREVGR0g=')
       const status = await toolkit.sessionStatus(replaySessionId)
-      assert.equal(status.changeCount, 0)
+      assert.equal(status.changeCount, 1)
     } finally {
       if (sourceSessionId) {
         await toolkit.destroySession(sourceSessionId).catch(() => undefined)

--- a/packages/client/src/editor_history.ts
+++ b/packages/client/src/editor_history.ts
@@ -30,11 +30,6 @@ export interface EditorChangeRecord {
   offset: number
   length: number
   data: string
-  transformId?: string
-  optionsJson?: string
-  replacementLength?: number
-  computedFileSizeBefore?: number
-  computedFileSizeAfter?: number
   groupId?: string
 }
 

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -48,6 +48,7 @@ import {
   getChangeCount,
   getChangeDetails,
   getClientVersion,
+  getComputedFileSize,
   getContentType,
   getCounts,
   getLanguage,
@@ -179,7 +180,7 @@ interface ChangeLogFingerprint {
 }
 
 interface ParsedChangeLog {
-  changes: ChangeRecord[]
+  changes: ParsedChangeRecord[]
   before?: ChangeLogFingerprint
   after?: ChangeLogFingerprint
 }
@@ -187,6 +188,10 @@ interface ParsedChangeLog {
 interface TransformPrimitiveDescriptor {
   transformId: string
   optionsJson?: string
+}
+
+interface ParsedChangeRecord extends ChangeRecord {
+  transformDescriptor?: TransformPrimitiveDescriptor
 }
 
 const SESSION_SYNC_TIMEOUT_MS = 2000
@@ -429,7 +434,64 @@ function transformOptionsMatchDescriptor(
     descriptorOptionsJson,
     name
   )
-  return JSON.stringify(options) === JSON.stringify(descriptorOptions)
+  return jsonObjectsEqual(options, descriptorOptions)
+}
+
+function normalizeJsonForComparison(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeJsonForComparison)
+  }
+  if (!isRecord(value)) {
+    return value
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, normalizeJsonForComparison(value[key])])
+  )
+}
+
+function jsonObjectsEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>
+): boolean {
+  return (
+    JSON.stringify(normalizeJsonForComparison(left)) ===
+    JSON.stringify(normalizeJsonForComparison(right))
+  )
+}
+
+function assertTransformReplayResponse(
+  descriptor: TransformPrimitiveDescriptor,
+  offset: number,
+  length: number,
+  computedFileSizeBefore: number,
+  computedFileSizeAfter: number,
+  response: Awaited<ReturnType<typeof applyTransformPlugin>>
+): void {
+  if (response.pluginId !== descriptor.transformId) {
+    throw new Error(
+      `Transform ${descriptor.transformId} replay returned plugin ${response.pluginId}`
+    )
+  }
+  if (response.offset !== offset || response.length !== length) {
+    throw new Error(
+      `Transform ${descriptor.transformId} replay range mismatch: expected offset ${offset}, length ${length}; actual offset ${response.offset}, length ${response.length}`
+    )
+  }
+
+  const expectedFileSize =
+    computedFileSizeBefore - response.length + response.replacementLength
+  if (response.computedFileSize !== expectedFileSize) {
+    throw new Error(
+      `Transform ${descriptor.transformId} replay size mismatch: expected ${expectedFileSize}, actual ${response.computedFileSize}`
+    )
+  }
+  if (computedFileSizeAfter !== response.computedFileSize) {
+    throw new Error(
+      `Transform ${descriptor.transformId} replay session size mismatch: expected ${response.computedFileSize}, actual ${computedFileSizeAfter}`
+    )
+  }
 }
 
 function initialWebviewState(bytesPerRow: BytesPerRow): WebviewEditorUiState {
@@ -1130,7 +1192,7 @@ function changeLogApplyErrorWithRollbackFailure(
   return error
 }
 
-function safeChangeRecord(value: unknown): ChangeRecord | undefined {
+function safeChangeRecord(value: unknown): ParsedChangeRecord | undefined {
   if (!isRecord(value)) {
     return undefined
   }
@@ -1253,15 +1315,34 @@ function safeChangeRecord(value: unknown): ChangeRecord | undefined {
           return undefined
         }
       }
+      let transformDescriptor: TransformPrimitiveDescriptor
       try {
-        parseTransformPrimitiveDescriptor(data, 'TRANSFORM change data')
+        transformDescriptor = parseTransformPrimitiveDescriptor(
+          data,
+          'TRANSFORM change data'
+        )
       } catch {
         return undefined
       }
 
       return groupId
-        ? { serial, kind: 'TRANSFORM', offset, length, data, groupId }
-        : { serial, kind: 'TRANSFORM', offset, length, data }
+        ? {
+            serial,
+            kind: 'TRANSFORM',
+            offset,
+            length,
+            data,
+            groupId,
+            transformDescriptor,
+          }
+        : {
+            serial,
+            kind: 'TRANSFORM',
+            offset,
+            length,
+            data,
+            transformDescriptor,
+          }
     }
     default:
       return undefined
@@ -4595,7 +4676,7 @@ export class HexEditorProvider
 
   private async applyChangeLogEntries(
     session: EditorSession,
-    changes: ChangeRecord[],
+    changes: ParsedChangeRecord[],
     expectedAfter?: ChangeLogFingerprint
   ): Promise<number> {
     if (!this.ensureSessionCanMutate(session, true)) {
@@ -4623,12 +4704,12 @@ export class HexEditorProvider
     }
 
     const applyOne = async (
-      change: ChangeRecord
+      change: ParsedChangeRecord
     ): Promise<ChangeRecord | undefined> => {
       const appliedChange = await this.applyChangeLogEntry(session, change)
       return appliedChange
     }
-    let pendingBatch: ChangeRecord[] = []
+    let pendingBatch: ParsedChangeRecord[] = []
     const flushBatch = async () => {
       if (pendingBatch.length === 0) {
         return
@@ -4699,7 +4780,7 @@ export class HexEditorProvider
 
   private async applyChangeLogEntry(
     session: EditorSession,
-    change: ChangeRecord
+    change: ParsedChangeRecord
   ): Promise<ChangeRecord | undefined> {
     switch (change.kind) {
       case 'INSERT': {
@@ -4753,11 +4834,14 @@ export class HexEditorProvider
           change.groupId
         )
       case 'TRANSFORM': {
-        const descriptor = parseTransformPrimitiveDescriptor(
-          change.data,
-          'TRANSFORM change data'
-        )
+        const descriptor = change.transformDescriptor
+        if (!descriptor) {
+          throw new Error('TRANSFORM change data was not normalized')
+        }
 
+        const computedFileSizeBefore = await getComputedFileSize(
+          session.sessionId
+        )
         const response = await applyTransformPlugin(
           session.sessionId,
           descriptor.transformId,
@@ -4773,6 +4857,17 @@ export class HexEditorProvider
         if (response.serial === undefined) {
           throw new Error('Transform did not return a change serial')
         }
+        const computedFileSizeAfter = await getComputedFileSize(
+          session.sessionId
+        )
+        assertTransformReplayResponse(
+          descriptor,
+          change.offset,
+          change.length,
+          computedFileSizeBefore,
+          computedFileSizeAfter,
+          response
+        )
 
         return {
           serial: response.serial,

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -48,7 +48,6 @@ import {
   getChangeCount,
   getChangeDetails,
   getClientVersion,
-  getComputedFileSize,
   getContentType,
   getCounts,
   getLanguage,
@@ -183,6 +182,11 @@ interface ParsedChangeLog {
   changes: ChangeRecord[]
   before?: ChangeLogFingerprint
   after?: ChangeLogFingerprint
+}
+
+interface TransformPrimitiveDescriptor {
+  transformId: string
+  optionsJson?: string
 }
 
 const SESSION_SYNC_TIMEOUT_MS = 2000
@@ -341,6 +345,91 @@ function safeHexString(
     return undefined
   }
   return text
+}
+
+function parseJsonObject(text: string, name: string): Record<string, unknown> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`${name} must be valid JSON: ${message}`)
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`${name} must be a JSON object`)
+  }
+  return parsed
+}
+
+function transformOptionsToJson(
+  args: Record<string, unknown>
+): string | undefined {
+  return Object.keys(args).length > 0 ? JSON.stringify(args) : undefined
+}
+
+function parseTransformOptionsJson(
+  optionsJson: string | undefined,
+  name: string
+): Record<string, unknown> {
+  if (optionsJson === undefined || optionsJson === '') {
+    return {}
+  }
+  return parseJsonObject(optionsJson, name)
+}
+
+function encodeTransformPrimitiveDataHex(
+  transformId: string,
+  optionsJson?: string
+): string {
+  const args = parseTransformOptionsJson(optionsJson, 'transform options')
+  return Buffer.from(
+    JSON.stringify({
+      transformId: transformId.trim(),
+      args,
+    }),
+    'utf8'
+  ).toString('hex')
+}
+
+function parseTransformPrimitiveDescriptor(
+  dataHex: string,
+  name: string
+): TransformPrimitiveDescriptor {
+  const data = Buffer.from(dataHex, 'hex')
+  if (data.length === 0) {
+    throw new Error(`${name} requires data`)
+  }
+
+  const descriptor = parseJsonObject(data.toString('utf8'), name)
+  if (
+    typeof descriptor.transformId !== 'string' ||
+    !descriptor.transformId.trim()
+  ) {
+    throw new Error(`${name} requires transformId`)
+  }
+
+  const args = descriptor.args === undefined ? {} : descriptor.args
+  if (!isRecord(args)) {
+    throw new Error(`${name} args must be a JSON object`)
+  }
+
+  return {
+    transformId: descriptor.transformId.trim(),
+    optionsJson: transformOptionsToJson(args),
+  }
+}
+
+function transformOptionsMatchDescriptor(
+  optionsJson: string | undefined,
+  descriptorOptionsJson: string | undefined,
+  name: string
+): boolean {
+  const options = parseTransformOptionsJson(optionsJson, name)
+  const descriptorOptions = parseTransformOptionsJson(
+    descriptorOptionsJson,
+    name
+  )
+  return JSON.stringify(options) === JSON.stringify(descriptorOptions)
 }
 
 function initialWebviewState(bytesPerRow: BytesPerRow): WebviewEditorUiState {
@@ -835,8 +924,29 @@ function changeDetailsToChangeRecord(
 
   if (kind === 'TRANSFORM') {
     const transform = change.getTransform()
+    const data = Buffer.from(change.getData_asU8()).toString('hex')
+    const descriptor = parseTransformPrimitiveDescriptor(
+      data,
+      'TRANSFORM change data'
+    )
     if (!transform?.transformId) {
       throw new Error('Transform change is missing transform metadata')
+    }
+    if (descriptor.transformId !== transform.transformId) {
+      throw new Error(
+        `Transform metadata mismatch: descriptor ${descriptor.transformId} does not match change ${transform.transformId}`
+      )
+    }
+    if (
+      !transformOptionsMatchDescriptor(
+        transform.optionsJson,
+        descriptor.optionsJson,
+        'transform options'
+      )
+    ) {
+      throw new Error(
+        `Transform metadata mismatch: options for ${transform.transformId} do not match change data`
+      )
     }
 
     return {
@@ -844,14 +954,7 @@ function changeDetailsToChangeRecord(
       kind,
       offset: change.getOffset(),
       length: change.getLength(),
-      data: '',
-      transformId: transform.transformId,
-      ...(transform.optionsJson !== undefined
-        ? { optionsJson: transform.optionsJson }
-        : {}),
-      replacementLength: transform.replacementLength,
-      computedFileSizeBefore: transform.computedFileSizeBefore,
-      computedFileSizeAfter: transform.computedFileSizeAfter,
+      data,
     }
   }
 
@@ -913,23 +1016,12 @@ function serializeChangeLogRecord(
   record: ChangeRecord
 ): Record<string, unknown> {
   return {
-    ...record,
     serial: int64ToDecimal(record.serial),
+    kind: record.kind,
     offset: int64ToDecimal(record.offset),
     length: int64ToDecimal(record.length),
-    ...(record.replacementLength !== undefined
-      ? { replacementLength: int64ToDecimal(record.replacementLength) }
-      : {}),
-    ...(record.computedFileSizeBefore !== undefined
-      ? {
-          computedFileSizeBefore: int64ToDecimal(record.computedFileSizeBefore),
-        }
-      : {}),
-    ...(record.computedFileSizeAfter !== undefined
-      ? {
-          computedFileSizeAfter: int64ToDecimal(record.computedFileSizeAfter),
-        }
-      : {}),
+    data: record.data,
+    ...(record.groupId ? { groupId: record.groupId } : {}),
   }
 }
 
@@ -1146,61 +1238,30 @@ function safeChangeRecord(value: unknown): ChangeRecord | undefined {
       } catch {
         return undefined
       }
-      const transformId = safeString(value.transformId, MAX_LABEL_LENGTH)
-      const optionsJson =
-        value.optionsJson === undefined
-          ? undefined
-          : safeString(value.optionsJson, Number.POSITIVE_INFINITY, true)
-      if (
-        length === undefined ||
-        !transformId ||
-        (value.optionsJson !== undefined && optionsJson === undefined) ||
-        (value.data !== undefined && value.data !== '')
-      ) {
+      const data = safeHexString(value.data, Number.POSITIVE_INFINITY)
+      if (!data) {
         return undefined
       }
-
-      const record: ChangeRecord = groupId
-        ? {
-            serial,
-            kind: 'TRANSFORM',
-            offset,
-            length,
-            data: '',
-            transformId,
-            groupId,
-          }
-        : {
-            serial,
-            kind: 'TRANSFORM',
-            offset,
-            length,
-            data: '',
-            transformId,
-          }
-      if (optionsJson !== undefined) {
-        record.optionsJson = optionsJson
-      }
-
       for (const key of [
+        'transformId',
+        'optionsJson',
         'replacementLength',
         'computedFileSizeBefore',
         'computedFileSizeAfter',
       ] as const) {
-        if (value[key] === undefined) {
-          continue
-        }
-        try {
-          record[key] = normalizeNonNegativeInt64ForClient(
-            value[key],
-            `change log entry ${key}`
-          )
-        } catch {
+        if (value[key] !== undefined) {
           return undefined
         }
       }
+      try {
+        parseTransformPrimitiveDescriptor(data, 'TRANSFORM change data')
+      } catch {
+        return undefined
+      }
 
-      return record
+      return groupId
+        ? { serial, kind: 'TRANSFORM', offset, length, data, groupId }
+        : { serial, kind: 'TRANSFORM', offset, length, data }
     }
     default:
       return undefined
@@ -3627,7 +3688,6 @@ export class HexEditorProvider
       const originalLength =
         length === 0 ? remainingLength : Math.min(length, remainingLength)
       const sessionSyncVersion = session.sessionSyncVersion
-      const computedFileSizeBefore = session.fileSize
       if (inspectOnly) {
         const response = await inspectSessionContent(
           session.sessionId,
@@ -3680,12 +3740,7 @@ export class HexEditorProvider
           kind: 'TRANSFORM',
           offset: response.offset,
           length: response.length,
-          data: '',
-          transformId: response.pluginId,
-          ...(optionsJson !== undefined ? { optionsJson } : {}),
-          replacementLength: response.replacementLength,
-          computedFileSizeBefore,
-          computedFileSizeAfter: response.computedFileSize,
+          data: encodeTransformPrimitiveDataHex(response.pluginId, optionsJson),
         })
         this.postEditState(session)
         this.notifyDocumentChanged(session)
@@ -4552,24 +4607,26 @@ export class HexEditorProvider
 
     const startChangeCount = await getChangeCount(session.sessionId)
     const sessionSyncVersion = session.sessionSyncVersion
-    const appliedChanges: ChangeRecord[] = []
+    const appliedTransactions: ChangeRecord[][] = []
     const recordAppliedChanges = async () => {
-      if (appliedChanges.length === 0) {
+      if (appliedTransactions.length === 0) {
         return
       }
 
-      session.history.recordLocalChanges(appliedChanges)
+      for (const transaction of appliedTransactions) {
+        session.history.recordLocalChanges(transaction)
+      }
       this.postEditState(session)
       this.notifyDocumentChanged(session)
       await this.waitForSessionSync(session, sessionSyncVersion)
       this.clearSearchState(session)
     }
 
-    const applyOne = async (change: ChangeRecord) => {
+    const applyOne = async (
+      change: ChangeRecord
+    ): Promise<ChangeRecord | undefined> => {
       const appliedChange = await this.applyChangeLogEntry(session, change)
-      if (appliedChange) {
-        appliedChanges.push(appliedChange)
-      }
+      return appliedChange
     }
     let pendingBatch: ChangeRecord[] = []
     const flushBatch = async () => {
@@ -4579,11 +4636,18 @@ export class HexEditorProvider
 
       const batch = pendingBatch
       pendingBatch = []
+      const appliedBatch: ChangeRecord[] = []
       await runSessionTransaction(session.sessionId, async () => {
         for (const change of batch) {
-          await applyOne(change)
+          const appliedChange = await applyOne(change)
+          if (appliedChange) {
+            appliedBatch.push(appliedChange)
+          }
         }
       })
+      if (appliedBatch.length > 0) {
+        appliedTransactions.push(appliedBatch)
+      }
     }
 
     try {
@@ -4591,7 +4655,10 @@ export class HexEditorProvider
         for (const change of changes) {
           if (change.kind === 'TRANSFORM') {
             await flushBatch()
-            await applyOne(change)
+            const appliedChange = await applyOne(change)
+            if (appliedChange) {
+              appliedTransactions.push([appliedChange])
+            }
           } else {
             pendingBatch.push(change)
           }
@@ -4624,7 +4691,10 @@ export class HexEditorProvider
     }
 
     await recordAppliedChanges()
-    return appliedChanges.length
+    return appliedTransactions.reduce(
+      (count, transaction) => count + transaction.length,
+      0
+    )
   }
 
   private async applyChangeLogEntry(
@@ -4683,65 +4753,25 @@ export class HexEditorProvider
           change.groupId
         )
       case 'TRANSFORM': {
-        if (!change.transformId) {
-          throw new Error('Transform change is missing transformId')
-        }
-
-        const expectedSizeBefore =
-          change.computedFileSizeBefore !== undefined
-            ? normalizeNonNegativeInt64ForClient(
-                change.computedFileSizeBefore,
-                'change log entry computedFileSizeBefore'
-              )
-            : undefined
-        const actualSizeBefore = await getComputedFileSize(session.sessionId)
-        if (
-          expectedSizeBefore !== undefined &&
-          actualSizeBefore !== expectedSizeBefore
-        ) {
-          throw new Error(
-            `Transform ${change.transformId} expected pre-transform size ${expectedSizeBefore}, found ${actualSizeBefore}`
-          )
-        }
+        const descriptor = parseTransformPrimitiveDescriptor(
+          change.data,
+          'TRANSFORM change data'
+        )
 
         const response = await applyTransformPlugin(
           session.sessionId,
-          change.transformId,
+          descriptor.transformId,
           change.offset,
           change.length,
-          change.optionsJson
+          descriptor.optionsJson
         )
         if (!response.contentChanged) {
           throw new Error(
-            `Transform ${change.transformId} replay produced no content change`
+            `Transform ${descriptor.transformId} replay produced no content change`
           )
         }
         if (response.serial === undefined) {
           throw new Error('Transform did not return a change serial')
-        }
-        if (
-          change.replacementLength !== undefined &&
-          response.replacementLength !==
-            normalizeNonNegativeInt64ForClient(
-              change.replacementLength,
-              'change log entry replacementLength'
-            )
-        ) {
-          throw new Error(
-            `Transform ${change.transformId} replacement length mismatch`
-          )
-        }
-        if (
-          change.computedFileSizeAfter !== undefined &&
-          response.computedFileSize !==
-            normalizeNonNegativeInt64ForClient(
-              change.computedFileSizeAfter,
-              'change log entry computedFileSizeAfter'
-            )
-        ) {
-          throw new Error(
-            `Transform ${change.transformId} post-transform size mismatch`
-          )
         }
 
         return {
@@ -4749,14 +4779,7 @@ export class HexEditorProvider
           kind: 'TRANSFORM',
           offset: response.offset,
           length: response.length,
-          data: '',
-          transformId: response.pluginId,
-          ...(change.optionsJson !== undefined
-            ? { optionsJson: change.optionsJson }
-            : {}),
-          replacementLength: response.replacementLength,
-          computedFileSizeBefore: actualSizeBefore,
-          computedFileSizeAfter: response.computedFileSize,
+          data: change.data,
           ...(change.groupId ? { groupId: change.groupId } : {}),
         }
       }

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -507,7 +507,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerJs, /listTransformPlugins/)
   assert.match(providerJs, /applyTransformPlugin/)
   assert.match(providerJs, /kind:\s*['"]TRANSFORM['"]/)
-  assert.match(providerJs, /transformId:\s*response\.pluginId/)
+  assert.match(providerJs, /encodeTransformPrimitiveDataHex/)
   assert.match(providerJs, /formatTransformCompletionMessage/)
   assert.match(providerJs, /omegaEdit\.hexEditorActive/)
   assert.match(providerJs, /omegaEdit\.canUndo/)

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict')
+const { createHash } = require('node:crypto')
 const fs = require('node:fs/promises')
 const os = require('node:os')
 const path = require('node:path')
@@ -39,6 +40,27 @@ const ABC_SHA256_FINGERPRINT = {
     algorithm: 'sha256',
     value: 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
   },
+}
+
+function makeUtf8Fingerprint(text) {
+  const data = Buffer.from(text, 'utf8')
+  return {
+    byteLength: data.byteLength.toString(),
+    digest: {
+      algorithm: 'sha256',
+      value: createHash('sha256').update(data).digest('hex'),
+    },
+  }
+}
+
+function makeTransformDataHex(transformId, args = {}) {
+  return Buffer.from(JSON.stringify({ transformId, args }), 'utf8').toString(
+    'hex'
+  )
+}
+
+function parseTransformDataHex(data) {
+  return JSON.parse(Buffer.from(data, 'hex').toString('utf8'))
 }
 
 suite('OmegaEdit VS Code extension', () => {
@@ -235,6 +257,162 @@ suite('OmegaEdit VS Code extension', () => {
     }
   })
 
+  test('lets a code assistant operate the editor through public VS Code commands', async () => {
+    const provider = getHexEditorProviderForTesting()
+    assert.ok(
+      provider,
+      'Expected the activated extension to expose its provider'
+    )
+
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-assistant-')
+    )
+    const samplePath = path.join(tmpDir, 'assistant.bin')
+    const changeLogPath = path.join(tmpDir, 'assistant-change-log.json')
+    await fs.writeFile(samplePath, Buffer.from('ABCDEFGH', 'utf8'))
+    const uri = vscode.Uri.file(samplePath)
+
+    const replaced = 'A12DxyZZZ'
+    const transformed = Buffer.from(replaced, 'utf8').toString('base64')
+    const changes = [
+      {
+        serial: '1',
+        kind: 'INSERT',
+        offset: '1',
+        length: '0',
+        data: Buffer.from('12', 'utf8').toString('hex'),
+      },
+      {
+        serial: '2',
+        kind: 'DELETE',
+        offset: '3',
+        length: '2',
+        data: Buffer.from('BC', 'utf8').toString('hex'),
+      },
+      {
+        serial: '3',
+        kind: 'OVERWRITE',
+        offset: '4',
+        length: '2',
+        data: Buffer.from('xy', 'utf8').toString('hex'),
+      },
+      {
+        serial: '4',
+        kind: 'REPLACE',
+        offset: '6',
+        length: '2',
+        data: Buffer.from('ZZZ', 'utf8').toString('hex'),
+      },
+      {
+        serial: '5',
+        kind: 'TRANSFORM',
+        offset: '0',
+        length: String(Buffer.byteLength(replaced, 'utf8')),
+        data: makeTransformDataHex('omega.example.base64'),
+      },
+    ]
+    await fs.writeFile(
+      changeLogPath,
+      JSON.stringify(
+        {
+          format: 'omega-edit.change-log',
+          version: 2,
+          complete: true,
+          before: makeUtf8Fingerprint('ABCDEFGH'),
+          after: makeUtf8Fingerprint(transformed),
+          changeCount: String(changes.length),
+          sourceChangeCount: String(changes.length),
+          unavailableChangeCount: '0',
+          unavailableChangeSerials: [],
+          changes,
+        },
+        null,
+        2
+      )
+    )
+
+    try {
+      await vscode.commands.executeCommand(
+        OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+        uri
+      )
+      const session = await waitForSession(provider, uri)
+      assert.ok(session, 'Expected a live session for the assistant test')
+
+      const initialState = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
+        { uri }
+      )
+      assert.equal(initialState.uri, uri.toString())
+      assert.equal(initialState.fileSize, 8)
+
+      await vscode.commands.executeCommand(
+        OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
+        {
+          uri,
+          sourceUri: vscode.Uri.file(changeLogPath),
+        }
+      )
+      await assertSessionText(session.sessionId, transformed)
+
+      const highlightedState = await vscode.commands.executeCommand(
+        OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
+        {
+          uri: uri.toString(),
+          reveal: true,
+          highlights: [
+            {
+              id: 'assistant.generated-change',
+              offset: 0,
+              length: Buffer.byteLength(transformed, 'utf8'),
+              kind: 'parsed',
+              label: 'Assistant-applied edit',
+              source: 'Code assistant',
+            },
+          ],
+        }
+      )
+      assert.deepEqual(highlightedState.externalHighlights, [
+        {
+          id: 'assistant.generated-change',
+          offset: 0,
+          length: Buffer.byteLength(transformed, 'utf8'),
+          kind: 'parsed',
+          label: 'Assistant-applied edit',
+          source: 'Code assistant',
+        },
+      ])
+      assert.equal(highlightedState.undoCount, 2)
+      assert.equal(highlightedState.redoCount, 0)
+
+      await provider.dispatchWebviewMessageForTesting(uri, { type: 'undo' })
+      await assertSessionText(session.sessionId, replaced)
+      let state = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
+        { uri }
+      )
+      assert.equal(state.undoCount, 1)
+      assert.equal(state.redoCount, 1)
+
+      await provider.dispatchWebviewMessageForTesting(uri, { type: 'undo' })
+      await assertSessionText(session.sessionId, 'ABCDEFGH')
+      state = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
+        { uri }
+      )
+      assert.equal(state.undoCount, 0)
+      assert.equal(state.redoCount, 2)
+
+      await provider.dispatchWebviewMessageForTesting(uri, { type: 'redo' })
+      await assertSessionText(session.sessionId, replaced)
+      await provider.dispatchWebviewMessageForTesting(uri, { type: 'redo' })
+      await assertSessionText(session.sessionId, transformed)
+    } finally {
+      await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   test('opens sample file through the explicit open-in-hex-editor command', async () => {
     const uri = vscode.Uri.file(
       path.resolve(__dirname, '..', 'workspace', 'sample.txt')
@@ -376,7 +554,9 @@ suite('OmegaEdit VS Code extension', () => {
     )
     assert.ok(
       script.changes.every((change) =>
-        ['DELETE', 'INSERT', 'OVERWRITE', 'TRANSFORM'].includes(change.kind)
+        ['DELETE', 'INSERT', 'OVERWRITE', 'REPLACE', 'TRANSFORM'].includes(
+          change.kind
+        )
       ),
       'Expected exported change kinds to stay within OmegaEdit operations'
     )
@@ -384,14 +564,21 @@ suite('OmegaEdit VS Code extension', () => {
       (change) => change.kind === 'TRANSFORM'
     )
     assert.ok(transformChange, 'Expected the base64 transform to be exported')
-    assert.equal(transformChange.transformId, 'omega.example.base64')
     assert.equal(transformChange.offset, '0')
     assert.equal(transformChange.length, '8')
-    assert.equal(transformChange.data, '')
-    assert.equal(transformChange.replacementLength, '12')
-    assert.equal(transformChange.computedFileSizeBefore, '8')
-    assert.equal(transformChange.computedFileSizeAfter, '12')
+    assert.notEqual(transformChange.data, '')
+    assert.deepEqual(parseTransformDataHex(transformChange.data), {
+      transformId: 'omega.example.base64',
+      args: {},
+    })
+    assert.equal(Object.hasOwn(transformChange, 'transformId'), false)
     assert.equal(Object.hasOwn(transformChange, 'optionsJson'), false)
+    assert.equal(Object.hasOwn(transformChange, 'replacementLength'), false)
+    assert.equal(
+      Object.hasOwn(transformChange, 'computedFileSizeBefore'),
+      false
+    )
+    assert.equal(Object.hasOwn(transformChange, 'computedFileSizeAfter'), false)
 
     const provider2 = new HexEditorProvider({ subscriptions: [] }, testPort)
     const panel2 = createMockWebviewPanel()
@@ -434,7 +621,7 @@ suite('OmegaEdit VS Code extension', () => {
       tamperedTransformChange,
       'Expected a transform change to tamper with'
     )
-    tamperedTransformChange.replacementLength = '999'
+    tamperedTransformChange.data = makeTransformDataHex('omega.example.missing')
     await fs.writeFile(
       tamperedScriptPath,
       JSON.stringify(tamperedScript, null, 2)
@@ -460,7 +647,7 @@ suite('OmegaEdit VS Code extension', () => {
           uri: document3.uri,
           sourceUri: vscode.Uri.file(tamperedScriptPath),
         }),
-      /replacement length mismatch/
+      /omega\.example\.missing|Failed to apply transform/i
     )
     const session3 = provider3.getSessionForTesting(document3.uri)
     assert.ok(session3, 'Expected a tampered replay session')

--- a/wiki/transform-primitives.md
+++ b/wiki/transform-primitives.md
@@ -31,6 +31,10 @@ arguments, for example:
 {"transformId":"builtin:ascii-to-lower","args":{}}
 ```
 
+Change-log entries use the same primitive shape. TRANSFORM entries do not carry
+`transformId`, `optionsJson`, replacement length, or computed-size side fields;
+the transform descriptor in `data` is the replay contract.
+
 The first implementation step makes `omega_change_get_bytes()` return the
 primitive payload. `omega_change_get_data()` is kept as an alias for callers that
 want a name tied to the primitive shape.


### PR DESCRIPTION
## Summary
- Make TRANSFORM change-log entries use the same first-class primitive shape as other edits: kind, range, and data.
- Treat the transform descriptor stored in data as the replay contract, and reject legacy transform side fields during import.
- Export/replay transforms from the canonical data payload and keep transform metadata only as a sanity check against core/server details.
- Bring the VS Code extension change-log parser/exporter onto the same first-class TRANSFORM contract.
- Add ruthless coverage for DELETE / INSERT / OVERWRITE / REPLACE / TRANSFORM change-log replay, undo/redo, CLI agent usage, MCP, and VS Code assistant-on-behalf-of-user flows.

## Validation
- `source ~/.nvm/nvm.sh && nvm use --silent && yarn workspace @omega-edit/ai build`
- `source ~/.nvm/nvm.sh && nvm use --silent && CPP_SERVER_BINARY="$PWD/.codex-tmp/native-server-build/omega-edit-grpc-server" yarn workspace @omega-edit/ai test -- tests/specs/toolkit.spec.ts tests/specs/cli.spec.ts`
- `source ~/.nvm/nvm.sh && nvm use --silent && CPP_SERVER_BINARY="$PWD/.codex-tmp/native-server-build/omega-edit-grpc-server" yarn workspace @omega-edit/ai test -- tests/specs/mcp.spec.ts`
- `source ~/.nvm/nvm.sh && nvm use --silent && CPP_SERVER_BINARY="$PWD/.codex-tmp/native-server-build/omega-edit-grpc-server" yarn workspace @omega-edit/ai test`
- `source ~/.nvm/nvm.sh && nvm use --silent && npm --prefix vscode-extension run compile`
- `source ~/.nvm/nvm.sh && nvm use --silent && npm --prefix vscode-extension run test:unit`
- `source ~/.nvm/nvm.sh && nvm use --silent && CPP_SERVER_BINARY="$PWD/.codex-tmp/native-server-build/omega-edit-grpc-server" npm --prefix vscode-extension run test:integration`
- `source ~/.nvm/nvm.sh && nvm use --silent && yarn lint`
- `git diff --check`

Note: local AI and VS Code integration tests used the existing `.codex-tmp/native-server-build/omega-edit-grpc-server` binary because the checked-in local `server/cpp/build` directory has a stale Windows/WSL CMake cache.