### PR TITLE
feat: expose assistant session context and command parity

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -36,6 +36,9 @@ yarn add @omega-edit/ai
 # Create a session against a file
 oe create-session --file ./sample.bin
 
+# Ask what this session is and which command surfaces are available
+oe session-context --session <session-id> --file ./sample.bin
+
 # Inspect a bounded range
 oe view --session <session-id> --offset 0 --length 64
 
@@ -78,6 +81,12 @@ for the ABI, SDK helpers, plugin directory layout, and exemplar plugin IDs for
 codecs, transcodes, record/message helpers, and digest/checksum inspectors.
 
 All CLI commands emit JSON to stdout and return non-zero exit codes on failure.
+`oe session-context` returns the compact assistant-readable session snapshot:
+session id, optional file path, computed/original sizes, dirty/history state,
+viewport availability, transform availability, change-log status, and the
+command/API equivalents for major editor actions. The MCP server exposes the
+same payload through `omega_edit_session_context`, so chat assistants can
+operate from structured JSON instead of scraping the VS Code webview.
 Exported change logs are portable `omega-edit.change-log` documents containing
 the byte operations needed to apply the same edits to another session, another
 file, or a fleet of compatible files. Change-log integer fields are decimal

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -35,6 +35,7 @@ function usage(): string {
     '  create-session --file <path>',
     '  destroy-session --session <id>',
     '  session-status --session <id>',
+    '  session-context --session <id> [--file <path>]',
     '  create-checkpoint --session <id>',
     '  rollback-checkpoint --session <id>  # roll back the most recent checkpoint',
     '  restore-checkpoint --session <id>   # restore content to the most recent checkpoint',
@@ -247,6 +248,24 @@ async function runCommand(
             diffMode: 'last-change-summary',
           }
         : result
+    }
+    case 'session-context': {
+      const parsed = parseArgs({
+        args,
+        options: {
+          ...commonOptions,
+          session: { type: 'string' as const },
+          file: { type: 'string' as const },
+        },
+        allowPositionals: false,
+      })
+      return await getToolkit(parsed.values).assistantContext(
+        requireStringOption(
+          parsed.values.session as string | undefined,
+          'session'
+        ),
+        parsed.values.file as string | undefined
+      )
     }
     case 'create-checkpoint': {
       const parsed = parseArgs({

--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -271,6 +271,25 @@ function buildTools(toolkit: OmegaEditToolkit): ToolDefinition[] {
       },
     },
     {
+      name: 'omega_edit_session_context',
+      description:
+        'Get stable assistant-readable context for a session, including history, viewport, transforms, change-log status, and command surfaces.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          filePath: { type: 'string' },
+        },
+        required: ['sessionId'],
+      },
+      run: async (argumentsObject) => {
+        return await toolkit.assistantContext(
+          getString(argumentsObject, 'sessionId', true)!,
+          getString(argumentsObject, 'filePath')
+        )
+      },
+    },
+    {
       name: 'omega_edit_create_checkpoint',
       description:
         'Create an OmegaEdit checkpoint for the current session state.',

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -102,111 +102,187 @@ const DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM = 'sha256'
 const GRPC_NOT_FOUND = 5
 const MAX_INT64 = 9_223_372_036_854_775_807n
 
+const OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND = 'omegaEdit.openInHexEditor'
+const OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND = 'omegaEdit.getAssistantContext'
+const OMEGA_EDIT_GET_EDITOR_STATE_COMMAND = 'omegaEdit.getEditorState'
+const OMEGA_EDIT_GO_TO_OFFSET_COMMAND = 'omegaEdit.goToOffset'
+const OMEGA_EDIT_UNDO_COMMAND = 'omegaEdit.undo'
+const OMEGA_EDIT_REDO_COMMAND = 'omegaEdit.redo'
+const OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND =
+  'omegaEdit.refreshTransformPlugins'
+const OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND = 'omegaEdit.createCheckpoint'
+const OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND = 'omegaEdit.restoreCheckpoint'
+const OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND = 'omegaEdit.rollbackCheckpoint'
+const OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND = 'omegaEdit.exportChangeLog'
+const OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND = 'omegaEdit.applyChangeLog'
+const OMEGA_EDIT_ROLLBACK_SESSION_COMMAND = 'omegaEdit.rollbackSession'
+const OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND =
+  'omegaEdit.setExternalHighlights'
+const OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND =
+  'omegaEdit.clearExternalHighlights'
+const OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND = 'omegaEdit.loadRangeMap'
+const OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND = 'omegaEdit.unloadRangeMap'
+
 const ASSISTANT_COMMAND_SURFACES: readonly AssistantCommandSurfaceEntry[] = [
   {
     action: 'openSession',
     ui: 'Open in Data Editor',
-    vscodeCommand: 'omegaEdit.openInHexEditor',
-    extensionApi: 'open',
-    cli: 'oe create-session --file <path>',
-    mcpTool: 'omega_edit_create_session',
+    vscodeCommands: [OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND],
+    extensionApis: ['open'],
+    cliCommands: ['oe create-session --file <path>'],
+    mcpTools: ['omega_edit_create_session'],
     result: 'structured session id and file path',
   },
   {
     action: 'assistantContext',
-    vscodeCommand: 'omegaEdit.getAssistantContext',
-    extensionApi: 'getAssistantContext',
-    cli: 'oe session-context --session <id> [--file <path>]',
-    mcpTool: 'omega_edit_session_context',
+    vscodeCommands: [OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND],
+    extensionApis: ['getAssistantContext'],
+    cliCommands: ['oe session-context --session <id> [--file <path>]'],
+    mcpTools: ['omega_edit_session_context'],
     result: 'stable assistant-readable session context JSON',
   },
   {
     action: 'editorState',
-    vscodeCommand: 'omegaEdit.getEditorState',
-    extensionApi: 'getEditorState',
+    vscodeCommands: [OMEGA_EDIT_GET_EDITOR_STATE_COMMAND],
+    extensionApis: ['getEditorState'],
     result: 'raw editor state JSON for VS Code integrations',
   },
   {
     action: 'navigateRange',
     ui: 'Go to Offset',
-    vscodeCommand: 'omegaEdit.goToOffset',
-    extensionApi: 'reveal',
-    cli: 'oe view --session <id> --offset <n> --length <n>',
-    mcpTool: 'omega_edit_read_range',
+    vscodeCommands: [OMEGA_EDIT_GO_TO_OFFSET_COMMAND],
+    extensionApis: ['reveal'],
+    cliCommands: ['oe view --session <id> --offset <n> --length <n>'],
+    mcpTools: ['omega_edit_read_range'],
     result: 'selected offset or bounded range bytes',
   },
   {
     action: 'profileRange',
-    cli: 'oe profile-range --session <id> --offset <n> --length <n>',
-    mcpTool: 'omega_edit_profile_range',
+    cliCommands: ['oe profile-range --session <id> --offset <n> --length <n>'],
+    mcpTools: ['omega_edit_profile_range'],
     result: 'bounded range profile metrics',
   },
   {
     action: 'search',
     ui: 'Search',
-    cli: 'oe search --session <id> --text <value>',
-    mcpTool: 'omega_edit_search',
+    cliCommands: ['oe search --session <id> --text <value>'],
+    mcpTools: ['omega_edit_search'],
     result: 'structured match offsets and lengths',
   },
   {
     action: 'patchRange',
     ui: 'Insert, delete, overwrite, or replace bytes',
-    cli: 'oe patch --session <id> --offset <n> --operation <kind>',
-    mcpTool: 'omega_edit_apply_patch',
+    cliCommands: ['oe patch --session <id> --offset <n> --operation <kind>'],
+    mcpTools: ['omega_edit_apply_patch'],
     result: 'operation kind, range, serial, preview, and resulting state',
   },
   {
     action: 'undoRedo',
     ui: 'Undo / Redo',
-    vscodeCommand: 'omegaEdit.undo / omegaEdit.redo',
-    cli: 'oe undo --session <id> / oe redo --session <id>',
-    mcpTool: 'omega_edit_undo / omega_edit_redo',
+    vscodeCommands: [OMEGA_EDIT_UNDO_COMMAND, OMEGA_EDIT_REDO_COMMAND],
+    cliCommands: ['oe undo --session <id>', 'oe redo --session <id>'],
+    mcpTools: ['omega_edit_undo', 'omega_edit_redo'],
     result: 'serial and updated history counts',
   },
   {
     action: 'transforms',
     ui: 'Refresh or apply transform plugins',
-    vscodeCommand: 'omegaEdit.refreshTransformPlugins',
-    cli: 'oe list-transform-plugins / oe apply-transform-plugin --session <id> --plugin <id>',
-    mcpTool:
-      'omega_edit_list_transform_plugins / omega_edit_apply_transform_plugin',
+    vscodeCommands: [OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND],
+    cliCommands: [
+      'oe list-transform-plugins',
+      'oe apply-transform-plugin --session <id> --plugin <id>',
+    ],
+    mcpTools: [
+      'omega_edit_list_transform_plugins',
+      'omega_edit_apply_transform_plugin',
+    ],
     result: 'plugin metadata or transform operation result',
   },
   {
     action: 'checkpoints',
     ui: 'Create, restore, or roll back checkpoints',
-    vscodeCommand:
-      'omegaEdit.createCheckpoint / omegaEdit.restoreCheckpoint / omegaEdit.rollbackCheckpoint',
-    extensionApi: 'createCheckpoint / restoreCheckpoint / rollbackCheckpoint',
-    cli: 'oe create-checkpoint / oe restore-checkpoint / oe rollback-checkpoint',
-    mcpTool:
-      'omega_edit_create_checkpoint / omega_edit_restore_checkpoint / omega_edit_rollback_checkpoint',
+    vscodeCommands: [
+      OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND,
+      OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
+      OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
+    ],
+    extensionApis: [
+      'createCheckpoint',
+      'restoreCheckpoint',
+      'rollbackCheckpoint',
+    ],
+    cliCommands: [
+      'oe create-checkpoint',
+      'oe restore-checkpoint',
+      'oe rollback-checkpoint',
+    ],
+    mcpTools: [
+      'omega_edit_create_checkpoint',
+      'omega_edit_restore_checkpoint',
+      'omega_edit_rollback_checkpoint',
+    ],
     result: 'checkpoint count and resulting state',
   },
   {
     action: 'changeLog',
     ui: 'Export or apply change log',
-    vscodeCommand: 'omegaEdit.exportChangeLog / omegaEdit.applyChangeLog',
-    extensionApi: 'exportChangeLog / applyChangeLog',
-    cli: 'oe export-change-log / oe apply-change-log',
-    mcpTool: 'omega_edit_export_change_log / omega_edit_apply_change_log',
+    vscodeCommands: [
+      OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND,
+      OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
+    ],
+    extensionApis: ['exportChangeLog', 'applyChangeLog'],
+    cliCommands: ['oe export-change-log', 'oe apply-change-log'],
+    mcpTools: ['omega_edit_export_change_log', 'omega_edit_apply_change_log'],
     result: 'change-log format, source counts, fingerprints, and state',
   },
   {
     action: 'rollbackSession',
     ui: 'Roll Back Session',
-    vscodeCommand: 'omegaEdit.rollbackSession',
+    vscodeCommands: [OMEGA_EDIT_ROLLBACK_SESSION_COMMAND],
     result: 'resulting editor state',
   },
   {
     action: 'annotations',
-    vscodeCommand:
-      'omegaEdit.setExternalHighlights / omegaEdit.clearExternalHighlights / omegaEdit.loadRangeMap / omegaEdit.unloadRangeMap',
-    extensionApi:
-      'setExternalHighlights / clearExternalHighlights / loadRangeMap / unloadRangeMap',
+    vscodeCommands: [
+      OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
+      OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND,
+      OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND,
+      OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND,
+    ],
+    extensionApis: [
+      'setExternalHighlights',
+      'clearExternalHighlights',
+      'loadRangeMap',
+      'unloadRangeMap',
+    ],
     result: 'annotation counts, selected range, and resulting editor state',
   },
 ]
+
+function cloneAssistantCommandSurfaces(): AssistantCommandSurfaceEntry[] {
+  return ASSISTANT_COMMAND_SURFACES.map((entry) => {
+    const clone: AssistantCommandSurfaceEntry = {
+      action: entry.action,
+      result: entry.result,
+    }
+    if (entry.ui) {
+      clone.ui = entry.ui
+    }
+    if (entry.vscodeCommands) {
+      clone.vscodeCommands = [...entry.vscodeCommands]
+    }
+    if (entry.extensionApis) {
+      clone.extensionApis = [...entry.extensionApis]
+    }
+    if (entry.cliCommands) {
+      clone.cliCommands = [...entry.cliCommands]
+    }
+    if (entry.mcpTools) {
+      clone.mcpTools = [...entry.mcpTools]
+    }
+    return clone
+  })
+}
 
 interface CollectedChangeLogEntries {
   changes?: ChangeLogEntry[]
@@ -1498,6 +1574,10 @@ export class OmegaEditToolkit {
       computedSize,
       changeCount,
       undoCount,
+      // The backend's UNDOS count is the undone-change stack, which is
+      // exposed to editor users as redo stack depth.
+      undoStackDepth: changeCount,
+      redoStackDepth: undoCount,
       viewportCount,
       checkpointCount,
       lastChange,
@@ -1558,14 +1638,16 @@ export class OmegaEditToolkit {
       },
       history: {
         changeCount: status.changeCount,
-        undoCount: status.changeCount,
-        redoCount: status.undoCount,
-        canUndo: status.changeCount > 0,
-        canRedo: status.undoCount > 0,
+        undoCount: status.undoStackDepth,
+        redoCount: status.redoStackDepth,
+        undoStackDepth: status.undoStackDepth,
+        redoStackDepth: status.redoStackDepth,
+        canUndo: status.undoStackDepth > 0,
+        canRedo: status.redoStackDepth > 0,
         checkpointCount: status.checkpointCount,
         checkpointAvailable: status.checkpointCount > 0,
         savedChangeDepth: null,
-        pendingChanges: status.changeCount > 0,
+        pendingChanges: status.undoStackDepth > 0,
         pendingOperation: null,
         pendingCount: 0,
       },
@@ -1591,7 +1673,7 @@ export class OmegaEditToolkit {
         sourceChangeCount: status.changeCount,
         completeExportAvailable: true,
       },
-      commands: ASSISTANT_COMMAND_SURFACES.map((entry) => ({ ...entry })),
+      commands: cloneAssistantCommandSurfaces(),
     }
   }
 

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -173,7 +173,7 @@ const ASSISTANT_COMMAND_SURFACES: readonly AssistantCommandSurfaceEntry[] = [
     action: 'patchRange',
     ui: 'Insert, delete, overwrite, or replace bytes',
     cliCommands: ['oe patch --session <id> --offset <n> --operation <kind>'],
-    mcpTools: ['omega_edit_apply_patch'],
+    mcpTools: ['omega_edit_preview_patch', 'omega_edit_apply_patch'],
     result: 'operation kind, range, serial, preview, and resulting state',
   },
   {

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -60,6 +60,8 @@ import {
 } from './constants'
 import { concatBytes, encodeData, parseInputData } from './codec'
 import {
+  AssistantCommandSurfaceEntry,
+  AssistantSessionContext,
   ApplyTransformPluginRequest,
   ApplyTransformPluginResult,
   ApplyChangeLogRequest,
@@ -88,9 +90,116 @@ import {
 const MAX_CHANGE_LOG_JSON_NESTING = 256
 const CHANGE_LOG_FORMAT = 'omega-edit.change-log'
 const CHANGE_LOG_VERSION = 2
+const ASSISTANT_CONTEXT_VERSION = 1
 const DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM = 'sha256'
 const GRPC_NOT_FOUND = 5
 const MAX_INT64 = 9_223_372_036_854_775_807n
+
+const ASSISTANT_COMMAND_SURFACES: readonly AssistantCommandSurfaceEntry[] = [
+  {
+    action: 'openSession',
+    ui: 'Open in Data Editor',
+    vscodeCommand: 'omegaEdit.openInHexEditor',
+    extensionApi: 'open',
+    cli: 'oe create-session --file <path>',
+    mcpTool: 'omega_edit_create_session',
+    result: 'structured session id and file path',
+  },
+  {
+    action: 'assistantContext',
+    vscodeCommand: 'omegaEdit.getAssistantContext',
+    extensionApi: 'getAssistantContext',
+    cli: 'oe session-context --session <id> [--file <path>]',
+    mcpTool: 'omega_edit_session_context',
+    result: 'stable assistant-readable session context JSON',
+  },
+  {
+    action: 'editorState',
+    vscodeCommand: 'omegaEdit.getEditorState',
+    extensionApi: 'getEditorState',
+    result: 'raw editor state JSON for VS Code integrations',
+  },
+  {
+    action: 'navigateRange',
+    ui: 'Go to Offset',
+    vscodeCommand: 'omegaEdit.goToOffset',
+    extensionApi: 'reveal',
+    cli: 'oe view --session <id> --offset <n> --length <n>',
+    mcpTool: 'omega_edit_read_range',
+    result: 'selected offset or bounded range bytes',
+  },
+  {
+    action: 'profileRange',
+    cli: 'oe profile-range --session <id> --offset <n> --length <n>',
+    mcpTool: 'omega_edit_profile_range',
+    result: 'bounded range profile metrics',
+  },
+  {
+    action: 'search',
+    ui: 'Search',
+    cli: 'oe search --session <id> --text <value>',
+    mcpTool: 'omega_edit_search',
+    result: 'structured match offsets and lengths',
+  },
+  {
+    action: 'patchRange',
+    ui: 'Insert, delete, overwrite, or replace bytes',
+    cli: 'oe patch --session <id> --offset <n> --operation <kind>',
+    mcpTool: 'omega_edit_apply_patch',
+    result: 'operation kind, range, serial, preview, and resulting state',
+  },
+  {
+    action: 'undoRedo',
+    ui: 'Undo / Redo',
+    vscodeCommand: 'omegaEdit.undo / omegaEdit.redo',
+    cli: 'oe undo --session <id> / oe redo --session <id>',
+    mcpTool: 'omega_edit_undo / omega_edit_redo',
+    result: 'serial and updated history counts',
+  },
+  {
+    action: 'transforms',
+    ui: 'Refresh or apply transform plugins',
+    vscodeCommand: 'omegaEdit.refreshTransformPlugins',
+    cli: 'oe list-transform-plugins / oe apply-transform-plugin --session <id> --plugin <id>',
+    mcpTool:
+      'omega_edit_list_transform_plugins / omega_edit_apply_transform_plugin',
+    result: 'plugin metadata or transform operation result',
+  },
+  {
+    action: 'checkpoints',
+    ui: 'Create, restore, or roll back checkpoints',
+    vscodeCommand:
+      'omegaEdit.createCheckpoint / omegaEdit.restoreCheckpoint / omegaEdit.rollbackCheckpoint',
+    extensionApi: 'createCheckpoint / restoreCheckpoint / rollbackCheckpoint',
+    cli: 'oe create-checkpoint / oe restore-checkpoint / oe rollback-checkpoint',
+    mcpTool:
+      'omega_edit_create_checkpoint / omega_edit_restore_checkpoint / omega_edit_rollback_checkpoint',
+    result: 'checkpoint count and resulting state',
+  },
+  {
+    action: 'changeLog',
+    ui: 'Export or apply change log',
+    vscodeCommand: 'omegaEdit.exportChangeLog / omegaEdit.applyChangeLog',
+    extensionApi: 'exportChangeLog / applyChangeLog',
+    cli: 'oe export-change-log / oe apply-change-log',
+    mcpTool: 'omega_edit_export_change_log / omega_edit_apply_change_log',
+    result: 'change-log format, source counts, fingerprints, and state',
+  },
+  {
+    action: 'rollbackSession',
+    ui: 'Roll Back Session',
+    vscodeCommand: 'omegaEdit.rollbackSession',
+    result: 'resulting editor state',
+  },
+  {
+    action: 'annotations',
+    vscodeCommand:
+      'omegaEdit.setExternalHighlights / omegaEdit.clearExternalHighlights / omegaEdit.loadRangeMap / omegaEdit.unloadRangeMap',
+    extensionApi:
+      'setExternalHighlights / clearExternalHighlights / loadRangeMap / unloadRangeMap',
+    result: 'annotation counts, selected range, and resulting editor state',
+  },
+]
 
 interface CollectedChangeLogEntries {
   changes?: ChangeLogEntry[]
@@ -1236,6 +1345,97 @@ export class OmegaEditToolkit {
       viewportCount,
       checkpointCount,
       lastChange,
+    }
+  }
+
+  async assistantContext(
+    sessionId: string,
+    filePath?: string
+  ): Promise<AssistantSessionContext> {
+    const status = await this.sessionStatus(sessionId)
+    const [rawPlugins, originalFingerprint] = await Promise.all([
+      listClientTransformPlugins(),
+      getChangeLogFingerprint(
+        sessionId,
+        SessionFingerprintContent.ORIGINAL
+      ).catch(() => undefined),
+    ])
+    const plugins = rawPlugins.map((plugin) => ({
+      id: plugin.id,
+      name: plugin.name,
+      description: plugin.description,
+      operation: plugin.operation,
+      operationName:
+        transformPluginOperationNames.get(plugin.operation) ||
+        `${plugin.operation}`,
+      flags: plugin.flags,
+      abiVersion: plugin.abiVersion,
+    }))
+
+    return {
+      version: ASSISTANT_CONTEXT_VERSION,
+      session: {
+        id: sessionId,
+        uri: null,
+        filePath: filePath || null,
+        contentType: null,
+        language: null,
+      },
+      sizes: {
+        computed: status.computedSize,
+        original: originalFingerprint
+          ? int64ToDecimal(originalFingerprint.byteLength)
+          : null,
+      },
+      dirty: status.changeCount > 0,
+      selection: null,
+      viewport: {
+        count: status.viewportCount,
+        activeViewportId: null,
+        visibleOffset: null,
+        visibleByteCount: null,
+        bytesPerRow: null,
+        offsetRadix: null,
+        activePane: null,
+        editMode: null,
+        insertDirection: null,
+      },
+      history: {
+        changeCount: status.changeCount,
+        undoCount: status.changeCount,
+        redoCount: status.undoCount,
+        canUndo: status.changeCount > 0,
+        canRedo: status.undoCount > 0,
+        checkpointCount: status.checkpointCount,
+        checkpointAvailable: status.checkpointCount > 0,
+        savedChangeDepth: null,
+        pendingChanges: status.changeCount > 0,
+        pendingOperation: null,
+        pendingCount: 0,
+      },
+      transforms: {
+        inFlight: false,
+        available: plugins.length > 0,
+        pluginCount: plugins.length,
+        plugins: plugins.map((plugin) => ({
+          id: plugin.id,
+          name: plugin.name,
+          description: plugin.description,
+          operation: plugin.operation,
+          operationName: plugin.operationName,
+          flags: plugin.flags,
+          abiVersion: plugin.abiVersion,
+        })),
+      },
+      changeLog: {
+        format: CHANGE_LOG_FORMAT,
+        version: CHANGE_LOG_VERSION,
+        exportAvailable: true,
+        applyAvailable: true,
+        sourceChangeCount: status.changeCount,
+        completeExportAvailable: true,
+      },
+      commands: ASSISTANT_COMMAND_SURFACES.map((entry) => ({ ...entry })),
     }
   }
 

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -106,6 +106,8 @@ const OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND = 'omegaEdit.openInHexEditor'
 const OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND = 'omegaEdit.getAssistantContext'
 const OMEGA_EDIT_GET_EDITOR_STATE_COMMAND = 'omegaEdit.getEditorState'
 const OMEGA_EDIT_GO_TO_OFFSET_COMMAND = 'omegaEdit.goToOffset'
+const OMEGA_EDIT_SEARCH_NEXT_COMMAND = 'omegaEdit.searchNext'
+const OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND = 'omegaEdit.searchPrevious'
 const OMEGA_EDIT_UNDO_COMMAND = 'omegaEdit.undo'
 const OMEGA_EDIT_REDO_COMMAND = 'omegaEdit.redo'
 const OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND =
@@ -165,6 +167,10 @@ const ASSISTANT_COMMAND_SURFACES: readonly AssistantCommandSurfaceEntry[] = [
   {
     action: 'search',
     ui: 'Search',
+    vscodeCommands: [
+      OMEGA_EDIT_SEARCH_NEXT_COMMAND,
+      OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
+    ],
     cliCommands: ['oe search --session <id> --text <value>'],
     mcpTools: ['omega_edit_search'],
     result: 'structured match offsets and lengths',

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -41,6 +41,8 @@ export interface SessionStatus {
   computedSize: number
   changeCount: number
   undoCount: number
+  undoStackDepth: number
+  redoStackDepth: number
   viewportCount: number
   checkpointCount: number
   lastChange?: {
@@ -54,10 +56,10 @@ export interface SessionStatus {
 export interface AssistantCommandSurfaceEntry {
   action: string
   ui?: string
-  vscodeCommand?: string
-  extensionApi?: string
-  cli?: string
-  mcpTool?: string
+  vscodeCommands?: string[]
+  extensionApis?: string[]
+  cliCommands?: string[]
+  mcpTools?: string[]
   result: string
 }
 
@@ -106,6 +108,8 @@ export interface AssistantSessionContext {
     changeCount: number
     undoCount: number
     redoCount: number
+    undoStackDepth: number
+    redoStackDepth: number
     canUndo: boolean
     canRedo: boolean
     checkpointCount: number | null

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -51,6 +51,87 @@ export interface SessionStatus {
   }
 }
 
+export interface AssistantCommandSurfaceEntry {
+  action: string
+  ui?: string
+  vscodeCommand?: string
+  extensionApi?: string
+  cli?: string
+  mcpTool?: string
+  result: string
+}
+
+export interface AssistantTransformPluginSummary {
+  id: string
+  name: string
+  description?: string
+  operation: number
+  operationName?: string
+  flags: number
+  abiVersion?: number
+}
+
+export interface AssistantSessionContext {
+  version: 1
+  session: {
+    id: string
+    uri: string | null
+    filePath: string | null
+    contentType: string | null
+    language: string | null
+  }
+  sizes: {
+    computed: number
+    original: number | string | null
+  }
+  dirty: boolean
+  selection: {
+    offset: number
+    start: number
+    end: number
+    length: number
+  } | null
+  viewport: {
+    count: number
+    activeViewportId: string | null
+    visibleOffset: number | null
+    visibleByteCount: number | null
+    bytesPerRow: number | null
+    offsetRadix: string | null
+    activePane: string | null
+    editMode: string | null
+    insertDirection: string | null
+  }
+  history: {
+    changeCount: number
+    undoCount: number
+    redoCount: number
+    canUndo: boolean
+    canRedo: boolean
+    checkpointCount: number | null
+    checkpointAvailable: boolean
+    savedChangeDepth: number | null
+    pendingChanges: boolean
+    pendingOperation: 'undo' | 'redo' | null
+    pendingCount: number
+  }
+  transforms: {
+    inFlight: boolean
+    available: boolean
+    pluginCount: number
+    plugins: AssistantTransformPluginSummary[]
+  }
+  changeLog: {
+    format: 'omega-edit.change-log'
+    version: 2
+    exportAvailable: boolean
+    applyAvailable: boolean
+    sourceChangeCount: number
+    completeExportAvailable: boolean
+  }
+  commands: AssistantCommandSurfaceEntry[]
+}
+
 export interface ChangeLogEntry {
   serial?: ChangeLogInt64
   kind: ChangeLogEntryKind

--- a/packages/ai/tests/specs/assistantCommandSurface.ts
+++ b/packages/ai/tests/specs/assistantCommandSurface.ts
@@ -65,6 +65,10 @@ export function assertAssistantCommandSurface(
   assert.deepEqual(byAction.get('assistantContext')?.mcpTools, [
     'omega_edit_session_context',
   ])
+  assert.deepEqual(byAction.get('search')?.vscodeCommands, [
+    'omegaEdit.searchNext',
+    'omegaEdit.searchPrevious',
+  ])
   assert.deepEqual(byAction.get('patchRange')?.mcpTools, [
     'omega_edit_preview_patch',
     'omega_edit_apply_patch',

--- a/packages/ai/tests/specs/assistantCommandSurface.ts
+++ b/packages/ai/tests/specs/assistantCommandSurface.ts
@@ -1,0 +1,89 @@
+import { strict as assert } from 'assert'
+
+const LEGACY_SURFACE_FIELDS = [
+  'vscodeCommand',
+  'extensionApi',
+  'cli',
+  'mcpTool',
+]
+
+const ARRAY_SURFACE_FIELDS = [
+  'vscodeCommands',
+  'extensionApis',
+  'cliCommands',
+  'mcpTools',
+]
+
+export function assertAssistantCommandSurface(
+  commands: unknown
+): Array<Record<string, unknown>> {
+  assert.ok(Array.isArray(commands), 'expected assistant commands array')
+  assert.ok(commands.length > 0, 'expected assistant command entries')
+
+  const entries = commands as Array<Record<string, unknown>>
+  for (const entry of entries) {
+    assert.equal(typeof entry.action, 'string', 'entry action is named')
+    assert.equal(typeof entry.result, 'string', `${entry.action}.result`)
+
+    for (const legacyField of LEGACY_SURFACE_FIELDS) {
+      assert.equal(
+        Object.hasOwn(entry, legacyField),
+        false,
+        `${entry.action}.${legacyField} must not leak legacy singular field`
+      )
+    }
+
+    for (const arrayField of ARRAY_SURFACE_FIELDS) {
+      if (!Object.hasOwn(entry, arrayField)) {
+        continue
+      }
+
+      const values = entry[arrayField]
+      assert.ok(Array.isArray(values), `${entry.action}.${arrayField}`)
+      assert.ok(values.length > 0, `${entry.action}.${arrayField} not empty`)
+      for (const value of values) {
+        assert.equal(typeof value, 'string', `${entry.action}.${arrayField}`)
+        assert.equal(
+          value.includes(' / '),
+          false,
+          `${entry.action}.${arrayField} must use separate array values`
+        )
+      }
+    }
+  }
+
+  const byAction = new Map(entries.map((entry) => [entry.action, entry]))
+  assert.deepEqual(byAction.get('assistantContext')?.vscodeCommands, [
+    'omegaEdit.getAssistantContext',
+  ])
+  assert.deepEqual(byAction.get('assistantContext')?.extensionApis, [
+    'getAssistantContext',
+  ])
+  assert.deepEqual(byAction.get('assistantContext')?.cliCommands, [
+    'oe session-context --session <id> [--file <path>]',
+  ])
+  assert.deepEqual(byAction.get('assistantContext')?.mcpTools, [
+    'omega_edit_session_context',
+  ])
+  assert.deepEqual(byAction.get('undoRedo')?.vscodeCommands, [
+    'omegaEdit.undo',
+    'omegaEdit.redo',
+  ])
+  assert.deepEqual(byAction.get('undoRedo')?.cliCommands, [
+    'oe undo --session <id>',
+    'oe redo --session <id>',
+  ])
+  assert.deepEqual(byAction.get('undoRedo')?.mcpTools, [
+    'omega_edit_undo',
+    'omega_edit_redo',
+  ])
+
+  return entries
+}
+
+export function assertAssistantContextPayloadBudget(context: unknown): void {
+  assert.ok(
+    Buffer.byteLength(JSON.stringify(context), 'utf8') < 32 * 1024,
+    'assistant context should stay compact for small sessions'
+  )
+}

--- a/packages/ai/tests/specs/assistantCommandSurface.ts
+++ b/packages/ai/tests/specs/assistantCommandSurface.ts
@@ -65,6 +65,10 @@ export function assertAssistantCommandSurface(
   assert.deepEqual(byAction.get('assistantContext')?.mcpTools, [
     'omega_edit_session_context',
   ])
+  assert.deepEqual(byAction.get('patchRange')?.mcpTools, [
+    'omega_edit_preview_patch',
+    'omega_edit_apply_patch',
+  ])
   assert.deepEqual(byAction.get('undoRedo')?.vscodeCommands, [
     'omegaEdit.undo',
     'omegaEdit.redo',

--- a/packages/ai/tests/specs/cli.spec.ts
+++ b/packages/ai/tests/specs/cli.spec.ts
@@ -5,6 +5,10 @@ import * as os from 'os'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 import { findFirstAvailablePort } from '@omega-edit/client'
+import {
+  assertAssistantCommandSurface,
+  assertAssistantContextPayloadBudget,
+} from './assistantCommandSurface'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const CLI_PATH = path.resolve(__dirname, '../../dist/cjs/cli.js')
@@ -243,6 +247,8 @@ describe('@omega-edit/ai CLI', () => {
       ])
       assert.equal(status.computedSize, Buffer.byteLength(transformed, 'utf8'))
       assert.equal(status.undoCount, 0)
+      assert.equal(status.undoStackDepth, status.changeCount)
+      assert.equal(status.redoStackDepth, status.undoCount)
 
       const context = await runOe([
         'session-context',
@@ -267,12 +273,57 @@ describe('@omega-edit/ai CLI', () => {
         status.changeCount
       )
       assert.equal((context.history as Record<string, unknown>).redoCount, 0)
-      assert.equal(context.selection, null)
-      assert.ok(
-        ((context.commands as Array<Record<string, unknown>>) || []).some(
-          (entry) => entry.mcpTool === 'omega_edit_session_context'
-        )
+      assert.equal(
+        (context.history as Record<string, unknown>).undoStackDepth,
+        status.changeCount
       )
+      assert.equal(
+        (context.history as Record<string, unknown>).redoStackDepth,
+        status.undoCount
+      )
+      assert.equal(context.selection, null)
+      assertAssistantCommandSurface(context.commands)
+      assertAssistantContextPayloadBudget(context)
+
+      await runOe(['undo', ...common, '--session', sessionId])
+      const undoneStatus = await runOe([
+        'session-status',
+        ...common,
+        '--session',
+        sessionId,
+      ])
+      assert.equal(undoneStatus.undoStackDepth, undoneStatus.changeCount)
+      assert.equal(undoneStatus.redoStackDepth, undoneStatus.undoCount)
+      assert.ok(
+        (undoneStatus.redoStackDepth as number) > 0,
+        'undo should expose redo stack depth'
+      )
+
+      const undoneContext = await runOe([
+        'session-context',
+        ...common,
+        '--session',
+        sessionId,
+        '--file',
+        inputPath,
+      ])
+      assert.equal(
+        (undoneContext.history as Record<string, unknown>).undoCount,
+        undoneStatus.changeCount
+      )
+      assert.equal(
+        (undoneContext.history as Record<string, unknown>).redoCount,
+        undoneStatus.undoCount
+      )
+      assert.equal(
+        (undoneContext.history as Record<string, unknown>).undoStackDepth,
+        undoneStatus.changeCount
+      )
+      assert.equal(
+        (undoneContext.history as Record<string, unknown>).redoStackDepth,
+        undoneStatus.undoCount
+      )
+      assertAssistantContextPayloadBudget(undoneContext)
     } finally {
       if (sessionId) {
         await runOe([

--- a/packages/ai/tests/specs/cli.spec.ts
+++ b/packages/ai/tests/specs/cli.spec.ts
@@ -218,6 +218,36 @@ describe('@omega-edit/ai CLI', () => {
       ])
       assert.equal(status.computedSize, Buffer.byteLength(transformed, 'utf8'))
       assert.equal(status.undoCount, 0)
+
+      const context = await runOe([
+        'session-context',
+        ...common,
+        '--session',
+        sessionId,
+        '--file',
+        inputPath,
+      ])
+      assert.equal(context.version, 1)
+      assert.equal((context.session as Record<string, unknown>).id, sessionId)
+      assert.equal(
+        (context.session as Record<string, unknown>).filePath,
+        inputPath
+      )
+      assert.equal(
+        (context.sizes as Record<string, unknown>).computed,
+        Buffer.byteLength(transformed, 'utf8')
+      )
+      assert.equal(
+        (context.history as Record<string, unknown>).undoCount,
+        status.changeCount
+      )
+      assert.equal((context.history as Record<string, unknown>).redoCount, 0)
+      assert.equal(context.selection, null)
+      assert.ok(
+        ((context.commands as Array<Record<string, unknown>>) || []).some(
+          (entry) => entry.mcpTool === 'omega_edit_session_context'
+        )
+      )
     } finally {
       if (sessionId) {
         await runOe([

--- a/packages/ai/tests/specs/mcp.spec.ts
+++ b/packages/ai/tests/specs/mcp.spec.ts
@@ -8,6 +8,10 @@ import * as readline from 'readline'
 import { fileURLToPath } from 'url'
 import { findFirstAvailablePort } from '@omega-edit/client'
 import { OmegaEditToolkit } from '../../src/service'
+import {
+  assertAssistantCommandSurface,
+  assertAssistantContextPayloadBudget,
+} from './assistantCommandSurface'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -233,16 +237,18 @@ describe('@omega-edit/ai mcp server', () => {
         (sessionContextStructured.sizes as Record<string, unknown>).computed,
         Buffer.byteLength('hello world hello', 'utf8')
       )
-      assert.ok(
-        (
-          (sessionContextStructured.commands as Array<
-            Record<string, unknown>
-          >) || []
-        ).some(
-          (entry) =>
-            entry.cli === 'oe session-context --session <id> [--file <path>]'
-        )
+      assertAssistantCommandSurface(sessionContextStructured.commands)
+      assert.equal(
+        (sessionContextStructured.history as Record<string, unknown>)
+          .undoStackDepth,
+        (sessionContextStructured.history as Record<string, unknown>).undoCount
       )
+      assert.equal(
+        (sessionContextStructured.history as Record<string, unknown>)
+          .redoStackDepth,
+        (sessionContextStructured.history as Record<string, unknown>).redoCount
+      )
+      assertAssistantContextPayloadBudget(sessionContextStructured)
 
       const listPluginsResponse = await sendRequest('tools/call', {
         name: 'omega_edit_list_transform_plugins',

--- a/packages/ai/tests/specs/mcp.spec.ts
+++ b/packages/ai/tests/specs/mcp.spec.ts
@@ -177,6 +177,10 @@ describe('@omega-edit/ai mcp server', () => {
         tools.some((tool) => tool.name === 'omega_edit_apply_change_log'),
         'expected omega_edit_apply_change_log in tool list'
       )
+      assert.ok(
+        tools.some((tool) => tool.name === 'omega_edit_session_context'),
+        'expected omega_edit_session_context in tool list'
+      )
 
       const createSessionResponse = await sendRequest('tools/call', {
         name: 'omega_edit_create_session',
@@ -189,6 +193,40 @@ describe('@omega-edit/ai mcp server', () => {
       ).structuredContent as Record<string, unknown>) || { sessionId: '' }
       createdSessionId = createStructured.sessionId as string
       assert.ok(createdSessionId.length > 0)
+
+      const sessionContextResponse = await sendRequest('tools/call', {
+        name: 'omega_edit_session_context',
+        arguments: {
+          sessionId: createdSessionId,
+          filePath: inputPath,
+        },
+      })
+      const sessionContextStructured =
+        ((sessionContextResponse.result as Record<string, unknown>)
+          .structuredContent as Record<string, unknown>) || {}
+      assert.equal(sessionContextStructured.version, 1)
+      assert.equal(
+        (sessionContextStructured.session as Record<string, unknown>).id,
+        createdSessionId
+      )
+      assert.equal(
+        (sessionContextStructured.session as Record<string, unknown>).filePath,
+        inputPath
+      )
+      assert.equal(
+        (sessionContextStructured.sizes as Record<string, unknown>).computed,
+        Buffer.byteLength('hello world hello', 'utf8')
+      )
+      assert.ok(
+        (
+          (sessionContextStructured.commands as Array<
+            Record<string, unknown>
+          >) || []
+        ).some(
+          (entry) =>
+            entry.cli === 'oe session-context --session <id> [--file <path>]'
+        )
+      )
 
       const listPluginsResponse = await sendRequest('tools/call', {
         name: 'omega_edit_list_transform_plugins',

--- a/packages/ai/tests/specs/toolkit.spec.ts
+++ b/packages/ai/tests/specs/toolkit.spec.ts
@@ -8,6 +8,10 @@ import * as omegaEditClient from '@omega-edit/client'
 import { OmegaEditToolkit } from '../../src/service'
 import { parseInputData } from '../../src/codec'
 import type { ChangeLogDocument, ChangeLogEntry } from '../../src/types'
+import {
+  assertAssistantCommandSurface,
+  assertAssistantContextPayloadBudget,
+} from './assistantCommandSurface'
 
 const EMPTY_SHA256_FINGERPRINT = {
   byteLength: 0,
@@ -584,6 +588,94 @@ describe('@omega-edit/ai toolkit', () => {
         await toolkit.destroySession(createdSessionId)
       }
       await toolkit.stopServer()
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps assistant context compact, cloned, and truthful through undo and redo', async function () {
+    const port = await omegaEditClient.findFirstAvailablePort(19000, 19999)
+    assert.ok(port, 'expected an available port for OmegaEdit')
+
+    const toolkit = new OmegaEditToolkit({ port: port!, autoStart: true })
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omega-edit-ai-'))
+    const inputPath = path.join(tempDir, 'assistant.bin')
+    fs.writeFileSync(inputPath, Buffer.from('seed', 'utf8'))
+
+    let sessionId = ''
+
+    try {
+      const created = await toolkit.createSession(inputPath)
+      sessionId = created.sessionId
+
+      for (let index = 0; index < 96; index += 1) {
+        await toolkit.applyPatch({
+          sessionId,
+          kind: 'insert',
+          offset: 4 + index,
+          data: parseInputData(String.fromCharCode(65 + (index % 26)), 'utf8'),
+        })
+      }
+
+      let status = await toolkit.sessionStatus(sessionId)
+      assert.equal(status.changeCount, 96)
+      assert.equal(status.undoCount, 0)
+      assert.equal(status.undoStackDepth, 96)
+      assert.equal(status.redoStackDepth, 0)
+
+      const context = await toolkit.assistantContext(sessionId, inputPath)
+      assert.equal(context.history.changeCount, 96)
+      assert.equal(context.history.undoCount, 96)
+      assert.equal(context.history.redoCount, 0)
+      assert.equal(context.history.undoStackDepth, 96)
+      assert.equal(context.history.redoStackDepth, 0)
+      assert.equal(context.history.canUndo, true)
+      assert.equal(context.history.canRedo, false)
+      assert.equal(context.history.pendingChanges, true)
+      assert.equal(context.changeLog.sourceChangeCount, 96)
+      assertAssistantCommandSurface(context.commands)
+      assertAssistantContextPayloadBudget(context)
+
+      const assistantEntry = context.commands.find(
+        (entry) => entry.action === 'assistantContext'
+      )
+      assert.ok(assistantEntry)
+      assistantEntry.mcpTools?.push('omega_edit_poisoned_context')
+      const freshContext = await toolkit.assistantContext(sessionId, inputPath)
+      assert.deepEqual(
+        freshContext.commands.find(
+          (entry) => entry.action === 'assistantContext'
+        )?.mcpTools,
+        ['omega_edit_session_context']
+      )
+
+      await toolkit.undo(sessionId)
+      status = await toolkit.sessionStatus(sessionId)
+      assert.equal(status.changeCount, 95)
+      assert.equal(status.undoCount, 1)
+      assert.equal(status.undoStackDepth, 95)
+      assert.equal(status.redoStackDepth, 1)
+
+      const undoneContext = await toolkit.assistantContext(sessionId, inputPath)
+      assert.equal(undoneContext.history.changeCount, 95)
+      assert.equal(undoneContext.history.undoCount, 95)
+      assert.equal(undoneContext.history.redoCount, 1)
+      assert.equal(undoneContext.history.undoStackDepth, 95)
+      assert.equal(undoneContext.history.redoStackDepth, 1)
+      assert.equal(undoneContext.history.canUndo, true)
+      assert.equal(undoneContext.history.canRedo, true)
+      assertAssistantContextPayloadBudget(undoneContext)
+
+      await toolkit.redo(sessionId)
+      status = await toolkit.sessionStatus(sessionId)
+      assert.equal(status.changeCount, 96)
+      assert.equal(status.undoCount, 0)
+      assert.equal(status.undoStackDepth, 96)
+      assert.equal(status.redoStackDepth, 0)
+    } finally {
+      if (sessionId) {
+        await toolkit.destroySession(sessionId).catch(() => undefined)
+      }
+      await toolkit.stopServer().catch(() => undefined)
       fs.rmSync(tempDir, { recursive: true, force: true })
     }
   })

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -298,11 +298,12 @@ const extension = vscode.extensions.getExtension<OmegaEditExtensionApi>(
 )
 const omegaEdit = await extension?.activate()
 
-if (omegaEdit?.version !== 1) {
+if (omegaEdit?.version !== 2) {
   throw new Error('Unsupported OmegaEdit Data Editor API version')
 }
 
 await omegaEdit?.open(document.uri, { offset: 128 })
+const context = omegaEdit?.getAssistantContext({ uri: document.uri })
 await omegaEdit?.setExternalHighlights({
   uri: document.uri,
   reveal: true,
@@ -318,6 +319,28 @@ await omegaEdit?.setExternalHighlights({
   ],
 })
 ```
+
+### Assistant Command Parity
+
+Assistants and scripted integrations should use structured command/API results,
+not webview scraping. The `omegaEdit.getAssistantContext` command and
+`getAssistantContext()` extension API method return the current session id, file
+path, computed/original sizes, selection, active viewport, undo/redo counts,
+transform state, change-log status, and the command-surface map below.
+
+| UI action | VS Code command | Extension API | CLI / MCP equivalent |
+| --- | --- | --- | --- |
+| Open a file | `omegaEdit.openInHexEditor` | `open` | `oe create-session` / `omega_edit_create_session` |
+| Get assistant context | `omegaEdit.getAssistantContext` | `getAssistantContext` | `oe session-context` / `omega_edit_session_context` |
+| Get raw editor state | `omegaEdit.getEditorState` | `getEditorState` | Context fields from `oe session-context` |
+| Go to offset / read bytes | `omegaEdit.goToOffset` | `reveal` | `oe view` / `omega_edit_read_range` |
+| Profile or search bytes | Search UI commands | n/a | `oe profile-range`, `oe search` / `omega_edit_profile_range`, `omega_edit_search` |
+| Insert/delete/overwrite/replace | Webview edit actions | n/a | `oe patch` / `omega_edit_preview_patch`, `omega_edit_apply_patch` |
+| Undo / redo | `omegaEdit.undo`, `omegaEdit.redo` | n/a | `oe undo`, `oe redo` / `omega_edit_undo`, `omega_edit_redo` |
+| Transform plugins | `omegaEdit.refreshTransformPlugins` | n/a | `oe list-transform-plugins`, `oe apply-transform-plugin` / transform MCP tools |
+| Checkpoints | Checkpoint commands | `createCheckpoint`, `restoreCheckpoint`, `rollbackCheckpoint` | Checkpoint CLI / MCP tools |
+| Change logs | `omegaEdit.exportChangeLog`, `omegaEdit.applyChangeLog` | `exportChangeLog`, `applyChangeLog` | `oe export-change-log`, `oe apply-change-log` / change-log MCP tools |
+| External highlights / range maps | Hidden annotation commands | Highlight and range-map API methods | VS Code API only |
 
 ### Daffodil Integration Notes
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -157,6 +157,10 @@
         "title": "%omegaEdit.command.getEditorState.title%"
       },
       {
+        "command": "omegaEdit.getAssistantContext",
+        "title": "%omegaEdit.command.getAssistantContext.title%"
+      },
+      {
         "command": "omegaEdit.setExternalHighlights",
         "title": "%omegaEdit.command.setExternalHighlights.title%"
       },
@@ -249,6 +253,10 @@
         },
         {
           "command": "omegaEdit.getEditorState",
+          "when": "false"
+        },
+        {
+          "command": "omegaEdit.getAssistantContext",
           "when": "false"
         },
         {

--- a/vscode-extension/package.nls.json
+++ b/vscode-extension/package.nls.json
@@ -23,6 +23,7 @@
   "omegaEdit.command.restoreCheckpoint.title": "OmegaEdit: Restore Last Checkpoint",
   "omegaEdit.command.createCheckpoint.title": "OmegaEdit: Create Checkpoint",
   "omegaEdit.command.getEditorState.title": "OmegaEdit: Get Editor State",
+  "omegaEdit.command.getAssistantContext.title": "OmegaEdit: Get Assistant Context",
   "omegaEdit.command.setExternalHighlights.title": "OmegaEdit: Set External Highlights",
   "omegaEdit.command.clearExternalHighlights.title": "OmegaEdit: Clear External Highlights",
   "omegaEdit.command.loadRangeMap.title": "OmegaEdit: Load Range Map",

--- a/vscode-extension/src/api.ts
+++ b/vscode-extension/src/api.ts
@@ -1,4 +1,5 @@
 import type * as vscode from 'vscode'
+import type { AssistantSessionContext } from './assistantContext'
 import type {
   ExternalHighlightKind,
   InsertDirection,
@@ -10,12 +11,13 @@ export const OMEGA_EDIT_EXTENSION_PUBLISHER = 'ctc-oss'
 export const OMEGA_EDIT_EXTENSION_NAME = 'omega-edit-data-editor'
 export const OMEGA_EDIT_EXTENSION_ID =
   `${OMEGA_EDIT_EXTENSION_PUBLISHER}.${OMEGA_EDIT_EXTENSION_NAME}` as const
-export const OMEGA_EDIT_EXTENSION_API_VERSION = 4
+export const OMEGA_EDIT_EXTENSION_API_VERSION = 2
 
 export type OmegaEditExternalHighlightKind = ExternalHighlightKind
 export type OmegaEditExternalHighlight = WebviewExternalHighlight
 export type OmegaEditEditorState = WebviewEditorState
 export type OmegaEditInsertDirection = InsertDirection
+export type OmegaEditAssistantContext = AssistantSessionContext
 
 export interface OmegaEditEditorSelector {
   uri?: vscode.Uri | string
@@ -147,6 +149,9 @@ export interface OmegaEditExtensionApi {
   getEditorState(
     options?: vscode.Uri | string | OmegaEditEditorSelector
   ): OmegaEditEditorState | undefined
+  getAssistantContext(
+    options?: vscode.Uri | string | OmegaEditEditorSelector
+  ): OmegaEditAssistantContext | undefined
   setExternalHighlights(
     request: OmegaEditExternalHighlightRequest
   ): Promise<OmegaEditEditorState | undefined>

--- a/vscode-extension/src/assistantContext.ts
+++ b/vscode-extension/src/assistantContext.ts
@@ -29,10 +29,10 @@ export const OMEGA_EDIT_ASSISTANT_CONTEXT_VERSION = 1
 export interface AssistantCommandSurfaceEntry {
   action: string
   ui?: string
-  vscodeCommand?: string
-  extensionApi?: string
-  cli?: string
-  mcpTool?: string
+  vscodeCommands?: string[]
+  extensionApis?: string[]
+  cliCommands?: string[]
+  mcpTools?: string[]
   result: string
 }
 
@@ -81,6 +81,8 @@ export interface AssistantSessionContext {
     changeCount: number
     undoCount: number
     redoCount: number
+    undoStackDepth: number
+    redoStackDepth: number
     canUndo: boolean
     canRedo: boolean
     checkpointCount: number | null
@@ -112,106 +114,161 @@ export const OMEGA_EDIT_ASSISTANT_COMMAND_SURFACES: readonly AssistantCommandSur
     {
       action: 'openSession',
       ui: 'Open in Data Editor',
-      vscodeCommand: OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
-      extensionApi: 'open',
-      cli: 'oe create-session --file <path>',
-      mcpTool: 'omega_edit_create_session',
+      vscodeCommands: [OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND],
+      extensionApis: ['open'],
+      cliCommands: ['oe create-session --file <path>'],
+      mcpTools: ['omega_edit_create_session'],
       result: 'structured session id and file path',
     },
     {
       action: 'assistantContext',
-      vscodeCommand: OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
-      extensionApi: 'getAssistantContext',
-      cli: 'oe session-context --session <id> [--file <path>]',
-      mcpTool: 'omega_edit_session_context',
+      vscodeCommands: [OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND],
+      extensionApis: ['getAssistantContext'],
+      cliCommands: ['oe session-context --session <id> [--file <path>]'],
+      mcpTools: ['omega_edit_session_context'],
       result: 'stable assistant-readable session context JSON',
     },
     {
       action: 'editorState',
-      vscodeCommand: OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
-      extensionApi: 'getEditorState',
+      vscodeCommands: [OMEGA_EDIT_GET_EDITOR_STATE_COMMAND],
+      extensionApis: ['getEditorState'],
       result: 'raw editor state JSON for VS Code integrations',
     },
     {
       action: 'navigateRange',
       ui: 'Go to Offset',
-      vscodeCommand: OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
-      extensionApi: 'reveal',
-      cli: 'oe view --session <id> --offset <n> --length <n>',
-      mcpTool: 'omega_edit_read_range',
+      vscodeCommands: [OMEGA_EDIT_GO_TO_OFFSET_COMMAND],
+      extensionApis: ['reveal'],
+      cliCommands: ['oe view --session <id> --offset <n> --length <n>'],
+      mcpTools: ['omega_edit_read_range'],
       result: 'selected offset or bounded range bytes',
     },
     {
       action: 'profileRange',
-      cli: 'oe profile-range --session <id> --offset <n> --length <n>',
-      mcpTool: 'omega_edit_profile_range',
+      cliCommands: [
+        'oe profile-range --session <id> --offset <n> --length <n>',
+      ],
+      mcpTools: ['omega_edit_profile_range'],
       result: 'bounded range profile metrics',
     },
     {
       action: 'search',
       ui: 'Search',
-      cli: 'oe search --session <id> --text <value>',
-      mcpTool: 'omega_edit_search',
+      cliCommands: ['oe search --session <id> --text <value>'],
+      mcpTools: ['omega_edit_search'],
       result: 'structured match offsets and lengths',
     },
     {
       action: 'patchRange',
       ui: 'Insert, delete, overwrite, or replace bytes',
-      cli: 'oe patch --session <id> --offset <n> --operation <kind>',
-      mcpTool: 'omega_edit_apply_patch',
+      cliCommands: ['oe patch --session <id> --offset <n> --operation <kind>'],
+      mcpTools: ['omega_edit_apply_patch'],
       result: 'operation kind, range, serial, preview, and resulting state',
     },
     {
       action: 'undoRedo',
       ui: 'Undo / Redo',
-      vscodeCommand: `${OMEGA_EDIT_UNDO_COMMAND} / ${OMEGA_EDIT_REDO_COMMAND}`,
-      cli: 'oe undo --session <id> / oe redo --session <id>',
-      mcpTool: 'omega_edit_undo / omega_edit_redo',
+      vscodeCommands: [OMEGA_EDIT_UNDO_COMMAND, OMEGA_EDIT_REDO_COMMAND],
+      cliCommands: ['oe undo --session <id>', 'oe redo --session <id>'],
+      mcpTools: ['omega_edit_undo', 'omega_edit_redo'],
       result: 'serial and updated history counts',
     },
     {
       action: 'transforms',
       ui: 'Refresh or apply transform plugins',
-      vscodeCommand: OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND,
-      cli: 'oe list-transform-plugins / oe apply-transform-plugin --session <id> --plugin <id>',
-      mcpTool:
-        'omega_edit_list_transform_plugins / omega_edit_apply_transform_plugin',
+      vscodeCommands: [OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND],
+      cliCommands: [
+        'oe list-transform-plugins',
+        'oe apply-transform-plugin --session <id> --plugin <id>',
+      ],
+      mcpTools: [
+        'omega_edit_list_transform_plugins',
+        'omega_edit_apply_transform_plugin',
+      ],
       result: 'plugin metadata or transform operation result',
     },
     {
       action: 'checkpoints',
       ui: 'Create, restore, or roll back checkpoints',
-      vscodeCommand: `${OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND} / ${OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND} / ${OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND}`,
-      extensionApi: 'createCheckpoint / restoreCheckpoint / rollbackCheckpoint',
-      cli: 'oe create-checkpoint / oe restore-checkpoint / oe rollback-checkpoint',
-      mcpTool:
-        'omega_edit_create_checkpoint / omega_edit_restore_checkpoint / omega_edit_rollback_checkpoint',
+      vscodeCommands: [
+        OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND,
+        OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
+        OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
+      ],
+      extensionApis: [
+        'createCheckpoint',
+        'restoreCheckpoint',
+        'rollbackCheckpoint',
+      ],
+      cliCommands: [
+        'oe create-checkpoint',
+        'oe restore-checkpoint',
+        'oe rollback-checkpoint',
+      ],
+      mcpTools: [
+        'omega_edit_create_checkpoint',
+        'omega_edit_restore_checkpoint',
+        'omega_edit_rollback_checkpoint',
+      ],
       result: 'checkpoint count and resulting state',
     },
     {
       action: 'changeLog',
       ui: 'Export or apply change log',
-      vscodeCommand: `${OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND} / ${OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND}`,
-      extensionApi: 'exportChangeLog / applyChangeLog',
-      cli: 'oe export-change-log / oe apply-change-log',
-      mcpTool: 'omega_edit_export_change_log / omega_edit_apply_change_log',
+      vscodeCommands: [
+        OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND,
+        OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
+      ],
+      extensionApis: ['exportChangeLog', 'applyChangeLog'],
+      cliCommands: ['oe export-change-log', 'oe apply-change-log'],
+      mcpTools: ['omega_edit_export_change_log', 'omega_edit_apply_change_log'],
       result: 'change-log format, source counts, fingerprints, and state',
     },
     {
       action: 'rollbackSession',
       ui: 'Roll Back Session',
-      vscodeCommand: OMEGA_EDIT_ROLLBACK_SESSION_COMMAND,
+      vscodeCommands: [OMEGA_EDIT_ROLLBACK_SESSION_COMMAND],
       result: 'resulting editor state',
     },
     {
       action: 'annotations',
-      vscodeCommand: `${OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND} / ${OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND} / ${OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND} / ${OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND}`,
-      extensionApi:
-        'setExternalHighlights / clearExternalHighlights / loadRangeMap / unloadRangeMap',
+      vscodeCommands: [
+        OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
+        OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND,
+        OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND,
+        OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND,
+      ],
+      extensionApis: [
+        'setExternalHighlights',
+        'clearExternalHighlights',
+        'loadRangeMap',
+        'unloadRangeMap',
+      ],
       result: 'annotation counts, selected range, and resulting editor state',
     },
   ]
 
 export function cloneAssistantCommandSurfaces(): AssistantCommandSurfaceEntry[] {
-  return OMEGA_EDIT_ASSISTANT_COMMAND_SURFACES.map((entry) => ({ ...entry }))
+  return OMEGA_EDIT_ASSISTANT_COMMAND_SURFACES.map((entry) => {
+    const clone: AssistantCommandSurfaceEntry = {
+      action: entry.action,
+      result: entry.result,
+    }
+    if (entry.ui) {
+      clone.ui = entry.ui
+    }
+    if (entry.vscodeCommands) {
+      clone.vscodeCommands = [...entry.vscodeCommands]
+    }
+    if (entry.extensionApis) {
+      clone.extensionApis = [...entry.extensionApis]
+    }
+    if (entry.cliCommands) {
+      clone.cliCommands = [...entry.cliCommands]
+    }
+    if (entry.mcpTools) {
+      clone.mcpTools = [...entry.mcpTools]
+    }
+    return clone
+  })
 }

--- a/vscode-extension/src/assistantContext.ts
+++ b/vscode-extension/src/assistantContext.ts
@@ -13,6 +13,8 @@ import {
   OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
   OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
   OMEGA_EDIT_ROLLBACK_SESSION_COMMAND,
+  OMEGA_EDIT_SEARCH_NEXT_COMMAND,
+  OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
   OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
   OMEGA_EDIT_UNDO_COMMAND,
   OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND,
@@ -154,6 +156,10 @@ export const OMEGA_EDIT_ASSISTANT_COMMAND_SURFACES: readonly AssistantCommandSur
     {
       action: 'search',
       ui: 'Search',
+      vscodeCommands: [
+        OMEGA_EDIT_SEARCH_NEXT_COMMAND,
+        OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
+      ],
       cliCommands: ['oe search --session <id> --text <value>'],
       mcpTools: ['omega_edit_search'],
       result: 'structured match offsets and lengths',

--- a/vscode-extension/src/assistantContext.ts
+++ b/vscode-extension/src/assistantContext.ts
@@ -162,7 +162,7 @@ export const OMEGA_EDIT_ASSISTANT_COMMAND_SURFACES: readonly AssistantCommandSur
       action: 'patchRange',
       ui: 'Insert, delete, overwrite, or replace bytes',
       cliCommands: ['oe patch --session <id> --offset <n> --operation <kind>'],
-      mcpTools: ['omega_edit_apply_patch'],
+      mcpTools: ['omega_edit_preview_patch', 'omega_edit_apply_patch'],
       result: 'operation kind, range, serial, preview, and resulting state',
     },
     {

--- a/vscode-extension/src/assistantContext.ts
+++ b/vscode-extension/src/assistantContext.ts
@@ -1,0 +1,217 @@
+import {
+  OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
+  OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND,
+  OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND,
+  OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND,
+  OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
+  OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
+  OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+  OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND,
+  OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+  OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND,
+  OMEGA_EDIT_REDO_COMMAND,
+  OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
+  OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
+  OMEGA_EDIT_ROLLBACK_SESSION_COMMAND,
+  OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
+  OMEGA_EDIT_UNDO_COMMAND,
+  OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND,
+} from './constants'
+import type {
+  GridEditPane,
+  InsertDirection,
+  OffsetRadix,
+  WebviewEditMode,
+} from './webviewProtocol'
+
+export const OMEGA_EDIT_ASSISTANT_CONTEXT_VERSION = 1
+
+export interface AssistantCommandSurfaceEntry {
+  action: string
+  ui?: string
+  vscodeCommand?: string
+  extensionApi?: string
+  cli?: string
+  mcpTool?: string
+  result: string
+}
+
+export interface AssistantTransformPluginSummary {
+  id: string
+  name: string
+  description?: string
+  operation: number
+  operationName?: string
+  flags: number
+  abiVersion?: number
+}
+
+export interface AssistantSessionContext {
+  version: typeof OMEGA_EDIT_ASSISTANT_CONTEXT_VERSION
+  session: {
+    id: string
+    uri: string | null
+    filePath: string | null
+    contentType: string | null
+    language: string | null
+  }
+  sizes: {
+    computed: number
+    original: number | string | null
+  }
+  dirty: boolean
+  selection: {
+    offset: number
+    start: number
+    end: number
+    length: number
+  } | null
+  viewport: {
+    count: number
+    activeViewportId: string | null
+    visibleOffset: number | null
+    visibleByteCount: number | null
+    bytesPerRow: number | null
+    offsetRadix: OffsetRadix | null
+    activePane: GridEditPane | null
+    editMode: WebviewEditMode | null
+    insertDirection: InsertDirection | null
+  }
+  history: {
+    changeCount: number
+    undoCount: number
+    redoCount: number
+    canUndo: boolean
+    canRedo: boolean
+    checkpointCount: number | null
+    checkpointAvailable: boolean
+    savedChangeDepth: number | null
+    pendingChanges: boolean
+    pendingOperation: 'undo' | 'redo' | null
+    pendingCount: number
+  }
+  transforms: {
+    inFlight: boolean
+    available: boolean
+    pluginCount: number
+    plugins: AssistantTransformPluginSummary[]
+  }
+  changeLog: {
+    format: 'omega-edit.change-log'
+    version: 2
+    exportAvailable: boolean
+    applyAvailable: boolean
+    sourceChangeCount: number
+    completeExportAvailable: boolean
+  }
+  commands: AssistantCommandSurfaceEntry[]
+}
+
+export const OMEGA_EDIT_ASSISTANT_COMMAND_SURFACES: readonly AssistantCommandSurfaceEntry[] =
+  [
+    {
+      action: 'openSession',
+      ui: 'Open in Data Editor',
+      vscodeCommand: OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
+      extensionApi: 'open',
+      cli: 'oe create-session --file <path>',
+      mcpTool: 'omega_edit_create_session',
+      result: 'structured session id and file path',
+    },
+    {
+      action: 'assistantContext',
+      vscodeCommand: OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
+      extensionApi: 'getAssistantContext',
+      cli: 'oe session-context --session <id> [--file <path>]',
+      mcpTool: 'omega_edit_session_context',
+      result: 'stable assistant-readable session context JSON',
+    },
+    {
+      action: 'editorState',
+      vscodeCommand: OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
+      extensionApi: 'getEditorState',
+      result: 'raw editor state JSON for VS Code integrations',
+    },
+    {
+      action: 'navigateRange',
+      ui: 'Go to Offset',
+      vscodeCommand: OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+      extensionApi: 'reveal',
+      cli: 'oe view --session <id> --offset <n> --length <n>',
+      mcpTool: 'omega_edit_read_range',
+      result: 'selected offset or bounded range bytes',
+    },
+    {
+      action: 'profileRange',
+      cli: 'oe profile-range --session <id> --offset <n> --length <n>',
+      mcpTool: 'omega_edit_profile_range',
+      result: 'bounded range profile metrics',
+    },
+    {
+      action: 'search',
+      ui: 'Search',
+      cli: 'oe search --session <id> --text <value>',
+      mcpTool: 'omega_edit_search',
+      result: 'structured match offsets and lengths',
+    },
+    {
+      action: 'patchRange',
+      ui: 'Insert, delete, overwrite, or replace bytes',
+      cli: 'oe patch --session <id> --offset <n> --operation <kind>',
+      mcpTool: 'omega_edit_apply_patch',
+      result: 'operation kind, range, serial, preview, and resulting state',
+    },
+    {
+      action: 'undoRedo',
+      ui: 'Undo / Redo',
+      vscodeCommand: `${OMEGA_EDIT_UNDO_COMMAND} / ${OMEGA_EDIT_REDO_COMMAND}`,
+      cli: 'oe undo --session <id> / oe redo --session <id>',
+      mcpTool: 'omega_edit_undo / omega_edit_redo',
+      result: 'serial and updated history counts',
+    },
+    {
+      action: 'transforms',
+      ui: 'Refresh or apply transform plugins',
+      vscodeCommand: OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND,
+      cli: 'oe list-transform-plugins / oe apply-transform-plugin --session <id> --plugin <id>',
+      mcpTool:
+        'omega_edit_list_transform_plugins / omega_edit_apply_transform_plugin',
+      result: 'plugin metadata or transform operation result',
+    },
+    {
+      action: 'checkpoints',
+      ui: 'Create, restore, or roll back checkpoints',
+      vscodeCommand: `${OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND} / ${OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND} / ${OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND}`,
+      extensionApi: 'createCheckpoint / restoreCheckpoint / rollbackCheckpoint',
+      cli: 'oe create-checkpoint / oe restore-checkpoint / oe rollback-checkpoint',
+      mcpTool:
+        'omega_edit_create_checkpoint / omega_edit_restore_checkpoint / omega_edit_rollback_checkpoint',
+      result: 'checkpoint count and resulting state',
+    },
+    {
+      action: 'changeLog',
+      ui: 'Export or apply change log',
+      vscodeCommand: `${OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND} / ${OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND}`,
+      extensionApi: 'exportChangeLog / applyChangeLog',
+      cli: 'oe export-change-log / oe apply-change-log',
+      mcpTool: 'omega_edit_export_change_log / omega_edit_apply_change_log',
+      result: 'change-log format, source counts, fingerprints, and state',
+    },
+    {
+      action: 'rollbackSession',
+      ui: 'Roll Back Session',
+      vscodeCommand: OMEGA_EDIT_ROLLBACK_SESSION_COMMAND,
+      result: 'resulting editor state',
+    },
+    {
+      action: 'annotations',
+      vscodeCommand: `${OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND} / ${OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND} / ${OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND} / ${OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND}`,
+      extensionApi:
+        'setExternalHighlights / clearExternalHighlights / loadRangeMap / unloadRangeMap',
+      result: 'annotation counts, selected range, and resulting editor state',
+    },
+  ]
+
+export function cloneAssistantCommandSurfaces(): AssistantCommandSurfaceEntry[] {
+  return OMEGA_EDIT_ASSISTANT_COMMAND_SURFACES.map((entry) => ({ ...entry }))
+}

--- a/vscode-extension/src/constants.ts
+++ b/vscode-extension/src/constants.ts
@@ -18,6 +18,8 @@ export const OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND =
   'omegaEdit.restoreCheckpoint'
 export const OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND = 'omegaEdit.createCheckpoint'
 export const OMEGA_EDIT_GET_EDITOR_STATE_COMMAND = 'omegaEdit.getEditorState'
+export const OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND =
+  'omegaEdit.getAssistantContext'
 export const OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND =
   'omegaEdit.setExternalHighlights'
 export const OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND =

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -738,6 +738,12 @@ export async function activate(
         if (typeof options === 'number') {
           return provider.revealOffset({ offset: options })
         }
+        if (
+          (options === undefined || options === null) &&
+          offset !== undefined
+        ) {
+          return provider.revealOffset({ offset })
+        }
 
         if (
           offset !== undefined ||

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -39,6 +39,7 @@ import {
   OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
   OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND,
   OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND,
+  OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
   OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
   OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
   OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND,
@@ -550,6 +551,9 @@ function createOmegaEditExtensionApi(
     getEditorState(options) {
       return provider.getEditorState(options)
     },
+    getAssistantContext(options) {
+      return provider.getAssistantContext(options)
+    },
     async setExternalHighlights(request: OmegaEditExternalHighlightRequest) {
       return provider.setExternalHighlights(request)
     },
@@ -725,7 +729,23 @@ export async function activate(
   context.subscriptions.push(
     vscode.commands.registerCommand(
       OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
-      async () => {
+      async (options?: unknown, offset?: number) => {
+        if (typeof options === 'number') {
+          return provider.revealOffset({ offset: options })
+        }
+
+        if (
+          offset !== undefined ||
+          (isRecord(options) && 'offset' in options)
+        ) {
+          return provider.revealOffset(
+            normalizeRevealOptions(
+              options as vscode.Uri | string | OmegaEditRevealOptions,
+              offset
+            )
+          )
+        }
+
         const input = await vscode.window.showInputBox({
           prompt: vscode.l10n.t('Enter byte offset (decimal or 0x hex)'),
           placeHolder: '0x0000',
@@ -740,22 +760,23 @@ export async function activate(
         if (input !== undefined) {
           const offset = parseOffsetInput(input)
           if (offset !== undefined) {
-            provider.goToOffset(offset)
+            return provider.revealOffset({ offset })
           }
         }
+        return undefined
       }
     )
   )
 
   context.subscriptions.push(
     vscode.commands.registerCommand(OMEGA_EDIT_UNDO_COMMAND, async () => {
-      await provider.undoActive()
+      return await provider.undoActive()
     })
   )
 
   context.subscriptions.push(
     vscode.commands.registerCommand(OMEGA_EDIT_REDO_COMMAND, async () => {
-      await provider.redoActive()
+      return await provider.redoActive()
     })
   )
 
@@ -769,13 +790,13 @@ export async function activate(
 
   context.subscriptions.push(
     vscode.commands.registerCommand(OMEGA_EDIT_SEARCH_NEXT_COMMAND, () => {
-      provider.searchNextActive()
+      return provider.searchNextActive()
     })
   )
 
   context.subscriptions.push(
     vscode.commands.registerCommand(OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND, () => {
-      provider.searchPreviousActive()
+      return provider.searchPreviousActive()
     })
   )
 
@@ -783,7 +804,7 @@ export async function activate(
     vscode.commands.registerCommand(
       OMEGA_EDIT_REFRESH_TRANSFORM_PLUGINS_COMMAND,
       async () => {
-        await provider.refreshActiveTransformPlugins()
+        return await provider.refreshActiveTransformPlugins()
       }
     )
   )
@@ -792,7 +813,7 @@ export async function activate(
     vscode.commands.registerCommand(
       OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND,
       async (options?: unknown) => {
-        await provider.exportChangeLog(options)
+        return await provider.exportChangeLog(options)
       }
     )
   )
@@ -801,7 +822,7 @@ export async function activate(
     vscode.commands.registerCommand(
       OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
       async (options?: unknown) => {
-        await provider.applyChangeLog(options)
+        return await provider.applyChangeLog(options)
       }
     )
   )
@@ -810,7 +831,7 @@ export async function activate(
     vscode.commands.registerCommand(
       OMEGA_EDIT_ROLLBACK_SESSION_COMMAND,
       async () => {
-        await provider.rollbackActiveSession()
+        return await provider.rollbackActiveSession()
       }
     )
   )
@@ -819,7 +840,7 @@ export async function activate(
     vscode.commands.registerCommand(
       OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND,
       async (options?: unknown) => {
-        await provider.rollbackCheckpoint(options)
+        return await provider.rollbackCheckpoint(options)
       }
     )
   )
@@ -828,7 +849,7 @@ export async function activate(
     vscode.commands.registerCommand(
       OMEGA_EDIT_RESTORE_CHECKPOINT_COMMAND,
       async (options?: unknown) => {
-        await provider.restoreCheckpoint(options)
+        return await provider.restoreCheckpoint(options)
       }
     )
   )
@@ -837,7 +858,7 @@ export async function activate(
     vscode.commands.registerCommand(
       OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND,
       async (options?: unknown) => {
-        await provider.createCheckpoint(options)
+        return await provider.createCheckpoint(options)
       }
     )
   )
@@ -846,6 +867,13 @@ export async function activate(
     vscode.commands.registerCommand(
       OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
       (options?: unknown) => provider.getEditorState(options)
+    )
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
+      (options?: unknown) => provider.getAssistantContext(options)
     )
   )
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -801,13 +801,13 @@ export async function activate(
 
   context.subscriptions.push(
     vscode.commands.registerCommand(OMEGA_EDIT_SEARCH_NEXT_COMMAND, () => {
-      return provider.searchNextActive()
+      provider.searchNextActive()
     })
   )
 
   context.subscriptions.push(
     vscode.commands.registerCommand(OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND, () => {
-      return provider.searchPreviousActive()
+      provider.searchPreviousActive()
     })
   )
 

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -4454,7 +4454,7 @@ export class HexEditorProvider
         checkpointCount: null,
         checkpointAvailable: checkpointSource !== undefined,
         savedChangeDepth: editState.savedChangeDepth,
-        pendingChanges: dirty || session.changeCount > 0,
+        pendingChanges: dirty,
         pendingOperation: session.pendingHistoryOperation ?? null,
         pendingCount: session.pendingHistoryCount ?? 0,
       },

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -92,6 +92,11 @@ import { finished } from 'node:stream/promises'
 import * as vscode from 'vscode'
 import { OMEGA_EDIT_VIEW_TYPE } from './constants'
 import {
+  type AssistantSessionContext,
+  cloneAssistantCommandSurfaces,
+  OMEGA_EDIT_ASSISTANT_CONTEXT_VERSION,
+} from './assistantContext'
+import {
   getSvelteWebviewContent,
   getSvelteWebviewLocalResourceRoot,
 } from './svelteWebview'
@@ -1977,35 +1982,49 @@ export class HexEditorProvider
     await this.handleWebviewMessage(session, msg)
   }
 
-  public async undoActive(): Promise<void> {
-    if (!this.activeSession) {
+  public async undoActive(): Promise<WebviewEditorState | undefined> {
+    const session = this.activeSession
+    if (!session) {
       return
     }
-    await this.enqueueHistoryCommand(this.activeSession, 'undo', true)
+    await this.enqueueHistoryCommand(session, 'undo', true)
+    return this.buildEditorState(session)
   }
 
-  public async redoActive(): Promise<void> {
-    if (!this.activeSession) {
+  public async redoActive(): Promise<WebviewEditorState | undefined> {
+    const session = this.activeSession
+    if (!session) {
       return
     }
-    await this.enqueueHistoryCommand(this.activeSession, 'redo', true)
+    await this.enqueueHistoryCommand(session, 'redo', true)
+    return this.buildEditorState(session)
   }
 
-  public searchNextActive(): void {
+  public searchNextActive(): WebviewEditorState | undefined {
     this.postSearchNavigationCommand('forward')
+    return this.activeSession
+      ? this.buildEditorState(this.activeSession)
+      : undefined
   }
 
-  public searchPreviousActive(): void {
+  public searchPreviousActive(): WebviewEditorState | undefined {
     this.postSearchNavigationCommand('backward')
+    return this.activeSession
+      ? this.buildEditorState(this.activeSession)
+      : undefined
   }
 
-  public async refreshActiveTransformPlugins(): Promise<void> {
-    if (!this.activeSession) {
+  public async refreshActiveTransformPlugins(): Promise<
+    WebviewEditorState | undefined
+  > {
+    const session = this.activeSession
+    if (!session) {
       void vscode.window.showWarningMessage(openEditorFirstMessage())
       return
     }
 
-    await this.sendTransformPlugins(this.activeSession)
+    await this.sendTransformPlugins(session)
+    return this.buildEditorState(session)
   }
 
   private postSearchNavigationCommand(direction: 'forward' | 'backward'): void {
@@ -2359,6 +2378,11 @@ export class HexEditorProvider
   getEditorState(options?: unknown): WebviewEditorState | undefined {
     const session = this.resolveCommandSession(options)
     return session ? this.buildEditorState(session) : undefined
+  }
+
+  getAssistantContext(options?: unknown): AssistantSessionContext | undefined {
+    const session = this.resolveCommandSession(options)
+    return session ? this.buildAssistantContext(session) : undefined
   }
 
   async setExternalHighlights(
@@ -3365,19 +3389,21 @@ export class HexEditorProvider
     }
   }
 
-  async rollbackActiveSession(): Promise<void> {
-    if (!this.activeSession) {
+  async rollbackActiveSession(): Promise<WebviewEditorState | undefined> {
+    const session = this.activeSession
+    if (!session) {
       void vscode.window.showWarningMessage(openEditorFirstMessage())
       return
     }
-    if (!this.ensureSessionCanMutate(this.activeSession, true)) {
+    if (!this.ensureSessionCanMutate(session, true)) {
       return
     }
 
-    await this.revertSessionChanges(this.activeSession, true)
+    await this.revertSessionChanges(session, true)
     void vscode.window.showInformationMessage(
       vscode.l10n.t('Rolled back OmegaEdit session')
     )
+    return this.buildEditorState(session)
   }
 
   // --- Event Subscriptions ---
@@ -3821,6 +3847,92 @@ export class HexEditorProvider
       contentSources: session.contentSources,
       contentType: session.contentType,
       language: session.language,
+    }
+  }
+
+  private buildAssistantContext(
+    session: EditorSession
+  ): AssistantSessionContext {
+    const editState = session.history.getEditState()
+    const originalSource = session.contentSources.find(
+      (source) => source.content === 'original' && source.available
+    )
+    const checkpointSource = session.contentSources.find(
+      (source) => source.content === 'latestCheckpoint' && source.available
+    )
+    const dirty = editState.isDirty || !!session.restoredFromBackup
+    const selection =
+      session.webviewState.selectedOffset >= 0
+        ? {
+            offset: session.webviewState.selectedOffset,
+            start: session.webviewState.selectionStart,
+            end: session.webviewState.selectionEnd,
+            length: session.webviewState.selectionLength,
+          }
+        : null
+
+    return {
+      version: OMEGA_EDIT_ASSISTANT_CONTEXT_VERSION,
+      session: {
+        id: session.sessionId,
+        uri: session.document.uri.toString(),
+        filePath: session.filePath,
+        contentType: session.contentType ?? null,
+        language: session.language ?? null,
+      },
+      sizes: {
+        computed: session.fileSize,
+        original: originalSource?.byteLength ?? null,
+      },
+      dirty,
+      selection,
+      viewport: {
+        count: 1,
+        activeViewportId: session.viewportId,
+        visibleOffset: session.webviewState.visibleOffset,
+        visibleByteCount: session.webviewState.visibleByteCount,
+        bytesPerRow: session.webviewState.bytesPerRow,
+        offsetRadix: session.webviewState.offsetRadix,
+        activePane: session.webviewState.activePane,
+        editMode: session.webviewState.editMode,
+        insertDirection: session.webviewState.insertDirection,
+      },
+      history: {
+        changeCount: session.changeCount,
+        undoCount: editState.undoCount,
+        redoCount: editState.redoCount,
+        canUndo: editState.canUndo,
+        canRedo: editState.canRedo,
+        checkpointCount: null,
+        checkpointAvailable: checkpointSource !== undefined,
+        savedChangeDepth: editState.savedChangeDepth,
+        pendingChanges: dirty || session.changeCount > 0,
+        pendingOperation: session.pendingHistoryOperation ?? null,
+        pendingCount: session.pendingHistoryCount ?? 0,
+      },
+      transforms: {
+        inFlight: session.transformInFlight,
+        available: session.transformPlugins.length > 0,
+        pluginCount: session.transformPlugins.length,
+        plugins: session.transformPlugins.map((plugin) => ({
+          id: plugin.id,
+          name: plugin.name,
+          description: plugin.description,
+          operation: plugin.operation,
+          operationName: `${plugin.operation}`,
+          flags: plugin.flags,
+          abiVersion: plugin.abiVersion,
+        })),
+      },
+      changeLog: {
+        format: CHANGE_LOG_FORMAT,
+        version: CHANGE_LOG_VERSION,
+        exportAvailable: !session.transformInFlight,
+        applyAvailable: !session.transformInFlight,
+        sourceChangeCount: session.changeCount,
+        completeExportAvailable: !session.transformInFlight,
+      },
+      commands: cloneAssistantCommandSurfaces(),
     }
   }
 

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -2244,18 +2244,12 @@ export class HexEditorProvider
     return this.buildEditorState(session)
   }
 
-  public searchNextActive(): WebviewEditorState | undefined {
+  public searchNextActive(): void {
     this.postSearchNavigationCommand('forward')
-    return this.activeSession
-      ? this.buildEditorState(this.activeSession)
-      : undefined
   }
 
-  public searchPreviousActive(): WebviewEditorState | undefined {
+  public searchPreviousActive(): void {
     this.postSearchNavigationCommand('backward')
-    return this.activeSession
-      ? this.buildEditorState(this.activeSession)
-      : undefined
   }
 
   public async refreshActiveTransformPlugins(): Promise<

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -4453,6 +4453,8 @@ export class HexEditorProvider
         changeCount: session.changeCount,
         undoCount: editState.undoCount,
         redoCount: editState.redoCount,
+        undoStackDepth: editState.undoCount,
+        redoStackDepth: editState.redoCount,
         canUndo: editState.canUndo,
         canRedo: editState.canRedo,
         checkpointCount: null,

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -16,6 +16,7 @@ const {
   OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND,
   OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND,
   OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND,
+  OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
   OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
   OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
   OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND,
@@ -70,7 +71,7 @@ function findRangeMapTreeNode(nodes, id) {
 test('package.json matches shared extension constants', () => {
   assert.equal(packageJson.main, './out/extension.js')
   assert.equal(packageJson.types, './out/api.d.ts')
-  assert.equal(OMEGA_EDIT_EXTENSION_API_VERSION, 4)
+  assert.equal(OMEGA_EDIT_EXTENSION_API_VERSION, 2)
   assert.equal(packageJson.name, OMEGA_EDIT_EXTENSION_NAME)
   assert.equal(packageJson.publisher, OMEGA_EDIT_EXTENSION_PUBLISHER)
   assert.equal(
@@ -201,6 +202,7 @@ test('package.json matches shared extension constants', () => {
     packageJson.contributes.commands.slice(14).map((entry) => entry.command),
     [
       OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
+      OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
       OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
       OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND,
       OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND,
@@ -214,6 +216,10 @@ test('package.json matches shared extension constants', () => {
   assert.equal(
     packageNls['omegaEdit.command.getEditorState.title'],
     'OmegaEdit: Get Editor State'
+  )
+  assert.equal(
+    packageNls['omegaEdit.command.getAssistantContext.title'],
+    'OmegaEdit: Get Assistant Context'
   )
   assert.equal(
     packageNls['omegaEdit.command.setExternalHighlights.title'],
@@ -309,6 +315,7 @@ test('package.json matches shared extension constants', () => {
   assert.deepEqual(
     [
       OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
+      OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
       OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
       OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND,
     ].map((command) =>
@@ -318,6 +325,7 @@ test('package.json matches shared extension constants', () => {
     ),
     [
       { command: OMEGA_EDIT_GET_EDITOR_STATE_COMMAND, when: 'false' },
+      { command: OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND, when: 'false' },
       { command: OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND, when: 'false' },
       { command: OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND, when: 'false' },
     ]
@@ -1632,11 +1640,13 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(extensionJs, /OMEGA_EDIT_ROLLBACK_CHECKPOINT_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_CREATE_CHECKPOINT_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_GET_EDITOR_STATE_COMMAND/)
+  assert.match(extensionJs, /OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND/)
   assert.match(extensionJs, /OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND/)
   assert.match(extensionJs, /getEditorState/)
+  assert.match(extensionJs, /getAssistantContext/)
   assert.match(extensionJs, /setExternalHighlights/)
   assert.match(extensionJs, /clearExternalHighlights/)
   assert.match(extensionJs, /loadRangeMap/)

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -66,6 +66,103 @@ function parseTransformDataHex(data) {
   return JSON.parse(Buffer.from(data, 'hex').toString('utf8'))
 }
 
+function assertSamePath(actual, expected) {
+  const normalizedActual = path.resolve(actual)
+  const normalizedExpected = path.resolve(expected)
+  if (process.platform === 'win32') {
+    assert.equal(
+      normalizedActual.toLowerCase(),
+      normalizedExpected.toLowerCase()
+    )
+    return
+  }
+  assert.equal(normalizedActual, normalizedExpected)
+}
+
+function assertAssistantCommandSurface(commands) {
+  assert.ok(Array.isArray(commands), 'expected assistant commands array')
+  assert.ok(commands.length > 0, 'expected assistant command entries')
+
+  for (const entry of commands) {
+    assert.equal(typeof entry.action, 'string', 'entry action is named')
+    assert.equal(typeof entry.result, 'string', `${entry.action}.result`)
+
+    for (const legacyField of [
+      'vscodeCommand',
+      'extensionApi',
+      'cli',
+      'mcpTool',
+    ]) {
+      assert.equal(
+        Object.hasOwn(entry, legacyField),
+        false,
+        `${entry.action}.${legacyField} must not leak legacy singular field`
+      )
+    }
+
+    for (const arrayField of [
+      'vscodeCommands',
+      'extensionApis',
+      'cliCommands',
+      'mcpTools',
+    ]) {
+      if (!Object.hasOwn(entry, arrayField)) {
+        continue
+      }
+
+      assert.ok(
+        Array.isArray(entry[arrayField]),
+        `${entry.action}.${arrayField}`
+      )
+      assert.ok(
+        entry[arrayField].length > 0,
+        `${entry.action}.${arrayField} not empty`
+      )
+      for (const value of entry[arrayField]) {
+        assert.equal(typeof value, 'string', `${entry.action}.${arrayField}`)
+        assert.equal(
+          value.includes(' / '),
+          false,
+          `${entry.action}.${arrayField} must use separate array values`
+        )
+      }
+    }
+  }
+
+  const byAction = new Map(commands.map((entry) => [entry.action, entry]))
+  assert.deepEqual(byAction.get('assistantContext')?.vscodeCommands, [
+    OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
+  ])
+  assert.deepEqual(byAction.get('assistantContext')?.extensionApis, [
+    'getAssistantContext',
+  ])
+  assert.deepEqual(byAction.get('assistantContext')?.cliCommands, [
+    'oe session-context --session <id> [--file <path>]',
+  ])
+  assert.deepEqual(byAction.get('assistantContext')?.mcpTools, [
+    'omega_edit_session_context',
+  ])
+  assert.deepEqual(byAction.get('undoRedo')?.vscodeCommands, [
+    'omegaEdit.undo',
+    'omegaEdit.redo',
+  ])
+  assert.deepEqual(byAction.get('undoRedo')?.cliCommands, [
+    'oe undo --session <id>',
+    'oe redo --session <id>',
+  ])
+  assert.deepEqual(byAction.get('undoRedo')?.mcpTools, [
+    'omega_edit_undo',
+    'omega_edit_redo',
+  ])
+}
+
+function assertAssistantContextPayloadBudget(context) {
+  assert.ok(
+    Buffer.byteLength(JSON.stringify(context), 'utf8') < 32 * 1024,
+    'assistant context should stay compact for small sessions'
+  )
+}
+
 suite('OmegaEdit VS Code extension', () => {
   let testPort
   let extensionApi
@@ -175,7 +272,7 @@ suite('OmegaEdit VS Code extension', () => {
       assert.equal(assistantContext.version, 1)
       assert.equal(assistantContext.session.id, session.sessionId)
       assert.equal(assistantContext.session.uri, uri.toString())
-      assert.equal(assistantContext.session.filePath, samplePath)
+      assertSamePath(assistantContext.session.filePath, samplePath)
       assert.equal(assistantContext.sizes.computed, 6)
       assert.equal(assistantContext.sizes.original, 6)
       assert.deepEqual(assistantContext.selection, {
@@ -190,14 +287,11 @@ suite('OmegaEdit VS Code extension', () => {
       )
       assert.equal(assistantContext.history.undoCount, 0)
       assert.equal(assistantContext.history.redoCount, 0)
+      assert.equal(assistantContext.history.undoStackDepth, 0)
+      assert.equal(assistantContext.history.redoStackDepth, 0)
       assert.equal(assistantContext.changeLog.format, 'omega-edit.change-log')
-      assert.ok(
-        assistantContext.commands.some(
-          (entry) =>
-            entry.vscodeCommand === OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND &&
-            entry.extensionApi === 'getAssistantContext'
-        )
-      )
+      assertAssistantCommandSurface(assistantContext.commands)
+      assertAssistantContextPayloadBudget(assistantContext)
 
       const highlightedState = await extensionApi.setExternalHighlights({
         uri,
@@ -500,21 +594,31 @@ suite('OmegaEdit VS Code extension', () => {
       )
       assert.equal(revealState.uri, uri.toString())
       assert.equal(typeof revealState.visibleOffset, 'number')
+      const numericRevealState = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+        3
+      )
+      assert.equal(numericRevealState.uri, uri.toString())
+      const offsetOnlyRevealState = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+        undefined,
+        4
+      )
+      assert.equal(offsetOnlyRevealState.uri, uri.toString())
 
       const initialContext = await vscode.commands.executeCommand(
         OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
         { uri }
       )
       assert.equal(initialContext.session.id, session.sessionId)
-      assert.equal(initialContext.session.filePath, samplePath)
+      assertSamePath(initialContext.session.filePath, samplePath)
       assert.equal(initialContext.sizes.computed, 8)
       assert.equal(initialContext.selection, null)
       assert.equal(initialContext.history.pendingChanges, false)
-      assert.ok(
-        initialContext.commands.some(
-          (entry) => entry.mcpTool === 'omega_edit_session_context'
-        )
-      )
+      assert.equal(initialContext.history.undoStackDepth, 0)
+      assert.equal(initialContext.history.redoStackDepth, 0)
+      assertAssistantCommandSurface(initialContext.commands)
+      assertAssistantContextPayloadBudget(initialContext)
 
       const applyResult = await vscode.commands.executeCommand(
         OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
@@ -562,6 +666,9 @@ suite('OmegaEdit VS Code extension', () => {
       )
       assert.equal(changedContext.history.undoCount, 2)
       assert.equal(changedContext.history.redoCount, 0)
+      assert.equal(changedContext.history.undoStackDepth, 2)
+      assert.equal(changedContext.history.redoStackDepth, 0)
+      assertAssistantContextPayloadBudget(changedContext)
       assert.equal(
         changedContext.changeLog.sourceChangeCount,
         changedContext.history.changeCount
@@ -579,6 +686,14 @@ suite('OmegaEdit VS Code extension', () => {
       )
       assert.equal(state.undoCount, 1)
       assert.equal(state.redoCount, 1)
+      const onceUndoneContext = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
+        { uri }
+      )
+      assert.equal(onceUndoneContext.history.undoCount, 1)
+      assert.equal(onceUndoneContext.history.redoCount, 1)
+      assert.equal(onceUndoneContext.history.undoStackDepth, 1)
+      assert.equal(onceUndoneContext.history.redoStackDepth, 1)
 
       await provider.dispatchWebviewMessageForTesting(uri, { type: 'undo' })
       await assertSessionText(session.sessionId, 'ABCDEFGH')
@@ -588,6 +703,14 @@ suite('OmegaEdit VS Code extension', () => {
       )
       assert.equal(state.undoCount, 0)
       assert.equal(state.redoCount, 2)
+      const fullyUndoneContext = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
+        { uri }
+      )
+      assert.equal(fullyUndoneContext.history.undoCount, 0)
+      assert.equal(fullyUndoneContext.history.redoCount, 2)
+      assert.equal(fullyUndoneContext.history.undoStackDepth, 0)
+      assert.equal(fullyUndoneContext.history.redoStackDepth, 2)
 
       await provider.dispatchWebviewMessageForTesting(uri, { type: 'redo' })
       await assertSessionText(session.sessionId, replaced)

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -23,6 +23,8 @@ const {
   OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND,
   OMEGA_EDIT_OPEN_IN_HEX_EDITOR_COMMAND,
   OMEGA_EDIT_ROLLBACK_SESSION_COMMAND,
+  OMEGA_EDIT_SEARCH_NEXT_COMMAND,
+  OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
   OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND,
   OMEGA_EDIT_UNLOAD_RANGE_MAP_COMMAND,
   OMEGA_EDIT_VIEW_TYPE,
@@ -141,6 +143,10 @@ function assertAssistantCommandSurface(commands) {
   ])
   assert.deepEqual(byAction.get('assistantContext')?.mcpTools, [
     'omega_edit_session_context',
+  ])
+  assert.deepEqual(byAction.get('patchRange')?.mcpTools, [
+    'omega_edit_preview_patch',
+    'omega_edit_apply_patch',
   ])
   assert.deepEqual(byAction.get('undoRedo')?.vscodeCommands, [
     'omegaEdit.undo',
@@ -587,6 +593,16 @@ suite('OmegaEdit VS Code extension', () => {
       )
       assert.equal(initialState.uri, uri.toString())
       assert.equal(initialState.fileSize, 8)
+      assert.equal(
+        await vscode.commands.executeCommand(OMEGA_EDIT_SEARCH_NEXT_COMMAND),
+        undefined
+      )
+      assert.equal(
+        await vscode.commands.executeCommand(
+          OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND
+        ),
+        undefined
+      )
 
       const revealState = await vscode.commands.executeCommand(
         OMEGA_EDIT_GO_TO_OFFSET_COMMAND,

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -144,6 +144,10 @@ function assertAssistantCommandSurface(commands) {
   assert.deepEqual(byAction.get('assistantContext')?.mcpTools, [
     'omega_edit_session_context',
   ])
+  assert.deepEqual(byAction.get('search')?.vscodeCommands, [
+    OMEGA_EDIT_SEARCH_NEXT_COMMAND,
+    OMEGA_EDIT_SEARCH_PREVIOUS_COMMAND,
+  ])
   assert.deepEqual(byAction.get('patchRange')?.mcpTools, [
     'omega_edit_preview_patch',
     'omega_edit_apply_patch',
@@ -2182,6 +2186,10 @@ suite('OmegaEdit VS Code extension', () => {
       isDirty: false,
       savedChangeDepth: 1,
     })
+    const savedAssistantContext = provider.getAssistantContext(document.uri)
+    assert.equal(savedAssistantContext.history.changeCount, 4)
+    assert.equal(savedAssistantContext.history.pendingChanges, false)
+    assert.equal(savedAssistantContext.dirty, false)
 
     const saved = await fs.readFile(samplePath, 'utf8')
     assert.equal(saved, 'qux qux qux qux')

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -17,6 +17,7 @@ const {
   OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
   OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND,
   OMEGA_EDIT_EXPORT_CHANGE_LOG_COMMAND,
+  OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
   OMEGA_EDIT_GET_EDITOR_STATE_COMMAND,
   OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
   OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND,
@@ -91,6 +92,7 @@ suite('OmegaEdit VS Code extension', () => {
     assert.equal(typeof extensionApi.open, 'function')
     assert.equal(typeof extensionApi.reveal, 'function')
     assert.equal(typeof extensionApi.getEditorState, 'function')
+    assert.equal(typeof extensionApi.getAssistantContext, 'function')
     assert.equal(typeof extensionApi.setExternalHighlights, 'function')
     assert.equal(typeof extensionApi.clearExternalHighlights, 'function')
     assert.equal(typeof extensionApi.loadRangeMap, 'function')
@@ -115,6 +117,7 @@ suite('OmegaEdit VS Code extension', () => {
     assert.ok(commands.includes(OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND))
     assert.ok(commands.includes(OMEGA_EDIT_ROLLBACK_SESSION_COMMAND))
     assert.ok(commands.includes(OMEGA_EDIT_GET_EDITOR_STATE_COMMAND))
+    assert.ok(commands.includes(OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND))
     assert.ok(commands.includes(OMEGA_EDIT_SET_EXTERNAL_HIGHLIGHTS_COMMAND))
     assert.ok(commands.includes(OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND))
     assert.ok(commands.includes(OMEGA_EDIT_LOAD_RANGE_MAP_COMMAND))
@@ -166,6 +169,34 @@ suite('OmegaEdit VS Code extension', () => {
       assert.equal(selectedState.editMode, 'insert')
       assert.equal(selectedState.selectionStart, 1)
       assert.equal(selectedState.selectionEnd, 3)
+
+      const assistantContext = extensionApi.getAssistantContext({ uri })
+      assert.equal(assistantContext.version, 1)
+      assert.equal(assistantContext.session.id, session.sessionId)
+      assert.equal(assistantContext.session.uri, uri.toString())
+      assert.equal(assistantContext.session.filePath, samplePath)
+      assert.equal(assistantContext.sizes.computed, 6)
+      assert.equal(assistantContext.sizes.original, 6)
+      assert.deepEqual(assistantContext.selection, {
+        offset: 1,
+        start: 1,
+        end: 3,
+        length: 3,
+      })
+      assert.equal(
+        assistantContext.viewport.activeViewportId,
+        session.viewportId
+      )
+      assert.equal(assistantContext.history.undoCount, 0)
+      assert.equal(assistantContext.history.redoCount, 0)
+      assert.equal(assistantContext.changeLog.format, 'omega-edit.change-log')
+      assert.ok(
+        assistantContext.commands.some(
+          (entry) =>
+            entry.vscodeCommand === OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND &&
+            entry.extensionApi === 'getAssistantContext'
+        )
+      )
 
       const highlightedState = await extensionApi.setExternalHighlights({
         uri,
@@ -462,13 +493,37 @@ suite('OmegaEdit VS Code extension', () => {
       assert.equal(initialState.uri, uri.toString())
       assert.equal(initialState.fileSize, 8)
 
-      await vscode.commands.executeCommand(
+      const revealState = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GO_TO_OFFSET_COMMAND,
+        { uri, offset: 2 }
+      )
+      assert.equal(revealState.uri, uri.toString())
+      assert.equal(typeof revealState.visibleOffset, 'number')
+
+      const initialContext = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
+        { uri }
+      )
+      assert.equal(initialContext.session.id, session.sessionId)
+      assert.equal(initialContext.session.filePath, samplePath)
+      assert.equal(initialContext.sizes.computed, 8)
+      assert.equal(initialContext.selection, null)
+      assert.equal(initialContext.history.pendingChanges, false)
+      assert.ok(
+        initialContext.commands.some(
+          (entry) => entry.mcpTool === 'omega_edit_session_context'
+        )
+      )
+
+      const applyResult = await vscode.commands.executeCommand(
         OMEGA_EDIT_APPLY_CHANGE_LOG_COMMAND,
         {
           uri,
           sourceUri: vscode.Uri.file(changeLogPath),
         }
       )
+      assert.equal(applyResult.changeCount, 5)
+      assert.equal(applyResult.state.uri, uri.toString())
       await assertSessionText(session.sessionId, transformed)
 
       const highlightedState = await vscode.commands.executeCommand(
@@ -500,6 +555,20 @@ suite('OmegaEdit VS Code extension', () => {
       ])
       assert.equal(highlightedState.undoCount, 2)
       assert.equal(highlightedState.redoCount, 0)
+      const changedContext = await vscode.commands.executeCommand(
+        OMEGA_EDIT_GET_ASSISTANT_CONTEXT_COMMAND,
+        { uri }
+      )
+      assert.equal(changedContext.history.undoCount, 2)
+      assert.equal(changedContext.history.redoCount, 0)
+      assert.equal(
+        changedContext.changeLog.sourceChangeCount,
+        changedContext.history.changeCount
+      )
+      assert.ok(
+        changedContext.changeLog.sourceChangeCount >=
+          applyResult.sourceChangeCount
+      )
 
       await provider.dispatchWebviewMessageForTesting(uri, { type: 'undo' })
       await assertSessionText(session.sessionId, replaced)


### PR DESCRIPTION
## Summary
- add a stable assistant-readable session context for VS Code command/API callers plus CLI and MCP tooling
- return structured results from existing VS Code command handlers where provider results already exist
- document UI, VS Code command/API, CLI, and MCP command parity while keeping the extension API version pinned at 2

## Testing
- yarn workspace @omega-edit/ai build:esm
- yarn workspace @omega-edit/ai build:cjs
- yarn workspace @omega-edit/ai exec vitest run --config vitest.config.ts tests/specs/cli.spec.ts tests/specs/mcp.spec.ts
- npm --prefix vscode-extension run compile
- npm --prefix vscode-extension run test:unit
- npm --prefix vscode-extension run test:integration

Note: the package-level AI test wrapper hit an existing local CMake cache path mismatch before Vitest: server/cpp/build was created from d:/GitHub/... and refused to rebuild from /mnt/d/GitHub/.... The direct focused Vitest run above passed against the built artifacts.

Closes #1489
Closes #1493