### PR TITLE
fix: shortcomings hardening batch

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -11,6 +11,9 @@ around the initial Find toggle state, auto bytes-per-row overfitting, and the
 duplicate Ctrl-Z undo toast are also treated as fixed by the current extension
 branch/PR and are not listed as open.
 
+Recent core/server/plugin review findings have been folded into the priority
+list below rather than kept as a second appended review.
+
 Priority guide:
 - **P0**: correctness, data integrity, or behavior that can mislead callers.
 - **P1**: high-impact product, performance, or robustness work.
@@ -26,46 +29,61 @@ Risk guide:
 
 ## Start Here
 
-1. **Undo performance batch**: implement the low-risk undo pieces first
-   (transaction extents, redo batching, snapshot telemetry), then tackle
-   in-place inverse undo.
-2. **Streaming import**: pair existing streaming export with a streaming/chunked
+1. **Critical deployment boundary**: add optional TLS/mTLS and an authorization
+   hook before making any "hardened for production" attestation.
+2. **Massive-file pressure caps**: bound or stream `replace_matches`, and apply
+   a configurable segment-size cap to read/classification RPCs.
+3. **Plugin input hardening**: cap zlib decompression output and add cooperative
+   cancellation to the C++ codec plugins.
+4. **Undo performance batch**: implement the remaining low-risk undo pieces
+   (transaction extents, redo batching, snapshot telemetry).
+5. **Streaming import**: pair existing streaming export with a streaming/chunked
    import path.
-3. **Checkpoint caps/dedupe**: add server/API guardrails for unbounded checkpoint
+6. **Checkpoint caps/dedupe**: add server/API guardrails for unbounded checkpoint
    creation.
 
-The first batch gives a useful blend: high user-visible impact from undo work,
-plus lower-risk cleanup that reduces future surprises.
+The first batch now favors deployment hardening, resource caps, and remaining
+input-hardening work before larger undo/import architecture changes.
 
-## P1 High-Impact Work
+## P0 Critical Hardening
 
-### 1. Undo still rebuilds the model instead of applying inverse edits
+### 1. Server transport has no TLS or authentication path
 
-**Impact:** High
-**Risk:** High
-**Area:** Core undo/redo
+**Impact:** High for critical or non-local deployments
+**Risk:** Medium to High
+**Area:** C++ server security/deployment, AI/MCP toolkit
 
-Undo pops the trailing change transaction, then rebuilds the computed model to
-the remaining change count with `rebuild_model_to_change_count_`. That routine
-clones the nearest snapshot and replays forward from it. The current default
-snapshot interval is non-zero (`100`), so the worst case is bounded by snapshot
-spacing, but a single undo can still replay many changes and full snapshots are
-deep clones of the segment tree.
+The C++ server only registers insecure gRPC credentials. The loopback-only
+default and explicit non-loopback opt-in are good guardrails, but the API can
+read and write files with the server process privileges. Critical deployments
+need at least optional TLS/mTLS and ideally a narrow authorization hook.
+
+The AI/MCP toolkit surface extends the same trust boundary to the connected
+agent: `create_session(filePath)`, `save_session`/`export_range(outputPath)`,
+and `apply_change_log(inputPath)` pass caller-supplied paths straight through to
+the server/filesystem with no allowlist or workspace confinement. That is
+inherent to a file-editing agent tool, but for a hardened deployment it needs the
+same explicit trust-boundary decision as the transport.
 
 Relevant code:
-- `core/src/lib/edit.cpp:655`
-- `core/src/lib/edit.cpp:719`
-- `core/src/lib/edit.cpp:2162`
-- `core/src/lib/impl_/session_def.hpp:45`
+- `server/cpp/src/main.cpp:597`
+- `server/cpp/src/main.cpp:615`
+- `server/cpp/src/main.cpp:622`
+- `packages/ai/src/mcp.ts:713`
+- `packages/ai/src/service.ts:947`
 
 Suggested fix:
-- Implement in-place inverse application for ordinary changes:
-  delete inverse for insert, insert inverse for delete, restore original bytes
-  for overwrite/replace.
-- Keep checkpoint-backed transform undo on its existing checkpoint path unless
-  or until transform changes get a dedicated inverse/replay primitive.
-- Use model integrity tests around mixed insert/delete/overwrite/replace
-  sequences before replacing the rebuild path.
+- Add optional TLS and mTLS server credential configuration.
+- Preserve the loopback-only insecure default for local tooling.
+- Add an authorization hook for file/session operations, or define the
+  supported deployment trust boundary explicitly.
+- Decide whether the MCP/AI toolkit should confine file paths to an allowlist or
+  workspace root, or document that it grants the agent the process's full
+  filesystem access.
+- Cover secure and insecure startup paths in server tests or integration smoke
+  tests.
+
+## P1 High-Impact Work
 
 ### 2. Undo snapshot strategy is count-only and memory-blind
 
@@ -89,7 +107,53 @@ Suggested fix:
   cheap references instead of deep clones.
 - Surface basic metrics for snapshot count/bytes in tests or debug logs.
 
-### 3. Change-log import is still full-document JSON parsing
+### 3. `replace_matches` buffers every match in memory
+
+**Impact:** High for very large files and common patterns
+**Risk:** Medium
+**Area:** Core replace/search, C++ server replace RPC
+
+`omega_edit_replace_matches_bytes` accumulates all accepted match offsets in a
+vector, builds a full operation script, then applies one change record per
+operation. The default limit can be unlimited, so replacing a common pattern in a
+large file can consume memory proportional to match count. The streaming,
+checkpointed `omega_edit_replace_all_bytes` path avoids this shape.
+
+Relevant code:
+- `core/src/lib/edit.cpp:1822`
+- `core/src/lib/edit.cpp:1852`
+- `core/src/lib/edit.cpp:1877`
+- `core/src/lib/edit.cpp:1895`
+
+Suggested fix:
+- Add an internal match-count or operation-count ceiling for the current script
+  path.
+- Prefer a streaming/checkpointed implementation when the caller requests
+  unbounded replacement.
+- Add scale tests that assert bounded memory or a clear graceful failure.
+
+### 4. Read/classification RPCs allocate unbounded segments
+
+**Impact:** High for server robustness
+**Risk:** Low to Medium
+**Area:** C++ server read APIs
+
+`GetSegment`, `GetContentType`, and `GetLanguage` allocate a segment directly
+from `request->length()` without a policy ceiling. `bad_alloc` is caught as an
+internal error, but the RPCs remain an easy memory-pressure lever. Viewports
+already have a capacity limit, so this should use a similar policy.
+
+Relevant code:
+- `server/cpp/src/editor_service.cpp:1526`
+- `server/cpp/src/editor_service.cpp:1570`
+- `server/cpp/src/editor_service.cpp:2032`
+
+Suggested fix:
+- Add a configurable maximum read/classification segment size.
+- Return `INVALID_ARGUMENT` or `RESOURCE_EXHAUSTED` when callers exceed it.
+- Align defaults with viewport limits or document why they differ.
+
+### 5. Change-log import is still full-document JSON parsing
 
 **Impact:** High
 **Risk:** Medium to High
@@ -110,7 +174,7 @@ Suggested fix:
 - Validate document header/fingerprint before reading all entries.
 - Replay entries incrementally while preserving atomic rollback semantics.
 
-### 4. TypeScript live client still has a 2^53 int64 ceiling
+### 6. TypeScript live client still has a 2^53 int64 ceiling
 
 **Impact:** High for the "massive files" promise
 **Risk:** High
@@ -133,11 +197,59 @@ Suggested fix:
   or expose parallel BigInt methods.
 - Keep safe-number wrappers for legacy callers during the transition.
 
+### 7. Zlib decompression has no output-size or ratio cap
+
+**Impact:** High (decompression-bomb memory exhaustion)
+**Risk:** Low to Medium
+**Area:** Transform plugins (zlib)
+
+`zlib_decompress` grows the output buffer by doubling with only a `SIZE_MAX/2`
+ceiling, so a few kilobytes of compressible input can inflate to gigabytes of
+resident memory. The loop does poll cancellation, but there is no maximum output
+size or compression-ratio guard.
+
+Relevant code:
+- `plugins/src/zlib.c:142`
+- `plugins/src/zlib.c:178`
+
+Suggested fix:
+- Add a configurable maximum decompressed-output size (and/or ratio) and fail
+  with a clear error when exceeded.
+- Keep the existing per-iteration cancellation polling.
+- Add a decompression-bomb test that asserts the cap is enforced.
+
+### 8. Bundled plugins run in-process with server privileges
+
+**Impact:** High for any hardening attestation
+**Risk:** Medium
+**Area:** Core transform plugin loading, deployment trust boundary
+
+Transform plugins are loaded with `dlopen`/`LoadLibrary` and execute in-process
+with the server's full privileges; there is no sandbox. Plugin directories are
+operator-controlled at startup rather than client-selectable, so this is a
+supply-chain/trust matter, not a client RCE. The `omega.example.*` naming implies
+samples, yet at least `openssl_digests` is wired into a production feature
+(`GetSessionFingerprint`), so the "example" plugins already inherit production
+trust.
+
+Relevant code:
+- `core/src/lib/transform.cpp:62`
+- `core/src/lib/transform.cpp:1044`
+- `server/cpp/src/editor_service.cpp:81`
+
+Suggested fix:
+- Decide and document which bundled plugins are supported/production versus
+  samples, and treat supported ones at the server's trust level.
+- Define the plugin trust boundary for the attestation (operator-provided,
+  reviewed, signed, or sandboxed).
+- Consider process/permission isolation for untrusted plugins if that becomes a
+  requirement.
+
 ---
 
 ## P2 Medium-Impact / Medium-Risk Work
 
-### 5. Transform change replay is metadata-aware but not native-first
+### 9. Transform change replay is metadata-aware but not native-first
 
 **Impact:** Medium to High
 **Risk:** Medium to High
@@ -154,27 +266,7 @@ Suggested fix:
   operation end to end.
 - Keep verifying replayed size/replacement metadata after import.
 
-### 6. File-backed plugin allocation tracking is process-global
-
-**Impact:** Medium
-**Risk:** Medium
-**Area:** Core transform plugin allocation
-
-Large plugin allocations are tracked in a process-wide map protected by a single
-mutex. Unrelated sessions and plugins therefore contend on one global lock, and
-ownership boundaries are less clear than they could be.
-
-Relevant code:
-- `core/src/lib/transform.cpp:800`
-
-Suggested fix:
-- Move allocation ownership to a per-operation, per-session, or per-registry
-  structure.
-- Keep a narrow compatibility shim for response cleanup.
-- Add stress coverage for concurrent transforms that allocate file-backed
-  buffers.
-
-### 7. Server checkpoint creation has no cap or dedupe policy
+### 10. Server checkpoint creation has no cap or dedupe policy
 
 **Impact:** Medium
 **Risk:** Medium
@@ -194,7 +286,7 @@ Suggested fix:
 - Consider dedupe when the computed content equals the latest checkpoint.
 - Return explicit "not needed" or "limit reached" results where appropriate.
 
-### 8. C-string and byte edit APIs encode different zero-length semantics
+### 11. C-string and byte edit APIs encode different zero-length semantics
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -213,7 +305,7 @@ Suggested fix:
 - Keep byte APIs explicit-only.
 - Add examples that steer binary callers to `_bytes` variants.
 
-### 9. Long positional argument lists remain hard to use safely
+### 12. Long positional argument lists remain hard to use safely
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -232,7 +324,7 @@ Suggested fix:
 - Preserve existing positional APIs for ABI compatibility.
 - Use enum/boolean-like typed fields in the options structs.
 
-### 10. Viewport dirty state uses a negative-capacity sentinel
+### 13. Viewport dirty state uses a negative-capacity sentinel
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -253,11 +345,56 @@ Suggested fix:
 - Keep capacity non-negative internally.
 - Update tests that currently force dirty state by negating capacity.
 
+### 14. C++ codec plugins lack cancellation, and base58 is quadratic
+
+**Impact:** Medium to High (CPU hang on large selections)
+**Risk:** Low
+**Area:** Transform plugins (text/decimal codecs)
+
+The C++ REPLACE codecs pull the whole selection into memory via `selected_bytes`
+and then run their encode/decode loops with no cancellation polling, unlike the C
+plugins which poll roughly every 4096 bytes. base58 encode/decode are also
+`O(n^2)` over the selection, so a large selection becomes an uninterruptible
+multi-second-to-minutes CPU hang.
+
+Relevant code:
+- `plugins/src/plugin_options.hpp:185`
+- `plugins/src/text_codecs.cpp:195`
+- `plugins/src/text_codecs.cpp:224`
+
+Suggested fix:
+- Poll `omega_transform_plugin_sdk_is_cancelled` inside the C++ codec loops.
+- Cap base58 selection size or document it as a short-field codec.
+- Add cancellation and large-input tests for the C++ codecs.
+
+### 15. OpenSSL cipher plugin does not zeroize key material
+
+**Impact:** Medium
+**Risk:** Low
+**Area:** Transform plugins (crypto hygiene)
+
+`cipher_parse_options` holds the raw key/IV in a stack `omega_cipher_options_t`
+(and the hex key in a stack buffer during parsing) and never scrubs them with
+`OPENSSL_cleanse` before returning, so key bytes linger in freed stack memory.
+Transform output is also persisted to checkpoint files in the clear, which is
+inherent to how transforms materialize but worth stating for a crypto-grade
+attestation.
+
+Relevant code:
+- `plugins/src/openssl_ciphers.c:166`
+- `plugins/src/openssl_ciphers.c:355`
+
+Suggested fix:
+- `OPENSSL_cleanse` the key/IV buffers (and the parsing scratch buffer) before
+  returning from apply.
+- Document that transform output, including ciphertext, is written to checkpoint
+  files unencrypted.
+
 ---
 
 ## P3 Low-Risk / Opportunistic Work
 
-### 11. Snapshot allocation failure silently degrades undo speed
+### 16. Snapshot allocation failure silently degrades undo speed
 
 **Impact:** Low to Medium
 **Risk:** Low
@@ -273,7 +410,7 @@ Suggested fix:
 - Emit a debug/warn log or session diagnostic event when snapshot capture fails.
 - Add a test hook or allocator-failure test if the existing harness supports it.
 
-### 12. Transaction-boundary scan is linear per undo
+### 17. Transaction-boundary scan is linear per undo
 
 **Impact:** Low to Medium
 **Risk:** Low to Medium
@@ -289,7 +426,7 @@ Suggested fix:
 - Store transaction extents or cached transaction change counts.
 - Reuse the same metadata for redo batching.
 
-### 13. Redo still replays one change at a time
+### 18. Redo still replays one change at a time
 
 **Impact:** Low to Medium
 **Risk:** Low to Medium
@@ -304,6 +441,116 @@ Relevant code:
 Suggested fix:
 - Batch redo by transaction.
 - Reuse notification batching and viewport-update coalescing where possible.
+
+### 19. C transform plugins each reimplement the same JSON parser
+
+**Impact:** Low
+**Risk:** Low
+**Area:** Transform plugins (C option parsing)
+
+base64, zlib, cipher, digest, and the bitmask header each carry their own
+`*_skip_ws` / `*_parse_json_string` / `*_parse_options` scaffolding. The C++
+plugins already share `plugin_options.hpp`; the C plugins have no equivalent, so
+the same parser is duplicated and independently maintained.
+
+Relevant code:
+- `plugins/src/base64.c:34`
+- `plugins/src/zlib.c:48`
+- `plugins/src/openssl_ciphers.c:84`
+- `plugins/src/openssl_digests.c:61`
+- `plugins/src/bitmask_options.h:53`
+
+Suggested fix:
+- Extract a shared C options header mirroring `plugin_options.hpp`.
+- Consolidate to a single audited JSON-options parser to shrink the attack
+  surface.
+- Keep per-plugin schema validation.
+
+### 20. Utility string helpers have minor robustness gaps
+
+**Impact:** Low
+**Risk:** Low
+**Area:** Core C utility helpers
+
+`omega_util_strndup` does not null-check `s` before `memcpy`, so a null source
+with a non-zero length would crash; current callers pass valid pointers.
+`omega_util_strncmp` compares with signed `char` subtraction, so its ordering
+result differs from `strcmp` for bytes `>= 0x80` (equality is unaffected).
+
+Relevant code:
+- `core/src/lib/utility.c:214`
+- `core/src/lib/utility.c:232`
+
+Suggested fix:
+- Guard `omega_util_strndup` against a null source.
+- Compare bytes as `unsigned char` in `omega_util_strncmp` if strcmp-compatible
+  ordering is expected.
+
+### 21. Content detection feeds untrusted bytes to third-party parsers
+
+**Impact:** Low to Medium
+**Risk:** Low
+**Area:** C++ server content/language detection
+
+`GetContentType` and `GetLanguage` hand segment bytes to libmagic and CLD3.
+libmagic has a long history of parser CVEs, and both run in-process. Access is
+serialized and bounded to the requested segment, so this is a dependency-currency
+and isolation concern rather than a code defect.
+
+Relevant code:
+- `server/cpp/src/libmagic_content_detector.cpp:129`
+- `server/cpp/src/cld3_language_detector.cpp:132`
+
+Suggested fix:
+- Track and update libmagic/CLD3 versions as part of the release process.
+- Consider isolating or resource-limiting content detection for untrusted input.
+- Document the third-party parser exposure in the deployment trust boundary.
+
+---
+
+## Testing Gaps For Attestation
+
+These are not separate product shortcomings, but they are worth closing before
+claiming production hardening:
+
+- Save durability: add fault-injection coverage around interrupted saves beyond
+  the current atomic/durable publishing coverage.
+- Remaining overflow paths: helper and edit-range tests exist, but add more
+  near-`INT64_MAX` coverage through public APIs and server RPC boundaries.
+- `replace_matches` scale: assert bounded memory use or clear failure on huge
+  match counts.
+- Transform/mutation concurrency: add real-thread coverage for
+  `try_begin_transform` returning `MUTATION_IN_PROGRESS` and for transform vs.
+  mutation mutual exclusion.
+- Source mutation immunity: assert sessions continue reading from their private
+  original snapshot after the user truncates or rewrites the source file.
+- Plugin fuzzing: fuzz the format inspectors and text/decimal codecs, especially
+  base58, for hangs, unbounded output, and decode round-trips.
+- Decompression caps: assert zlib decompression enforces its output-size/ratio
+  ceiling and stays cancellable.
+- Plugin cancellation: assert every bundled plugin honors cooperative
+  cancellation partway through a large selection.
+
+---
+
+## Reviewed And Not Open
+
+- The stack-allocated `omega_segment_t data_segment` in
+  `omega_search_next_match` is not an uninitialized-read issue; the struct uses
+  non-static data member initializers, so default initialization covers the
+  fields read by `populate_data_segment_`.
+- The C transform plugins' hand-rolled JSON string parsers use fixed stack
+  buffers with strict `length + 1 >= out_size` guards; no buffer overflow was
+  found across the base64/zlib/cipher/digest/bitmask parsers.
+- The xxhash streaming ring-buffer arithmetic in `common_checksums.cpp` is
+  bounds-safe, and the streaming checksums honor cancellation via
+  `for_each_chunk`.
+- `omega_find` (Boyer-Moore-Horspool) and its 256-entry skip table are
+  byte-indexed and bounds-checked; the search core operates on segment buffers
+  bounded by the max segment length.
+- `omega_session_*` count/segment/BOM entry points validate offset/length via
+  `safe_add_int64_` and tolerate null segments; `ABORT` is `std::abort()`
+  (noreturn), so switch defaults that reach it are not fall-through UB.
 
 ---
 

--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -12,7 +12,10 @@ duplicate Ctrl-Z undo toast are also treated as fixed by the current extension
 branch/PR and are not listed as open.
 
 Recent core/server/plugin review findings have been folded into the priority
-list below rather than kept as a second appended review.
+list below rather than kept as a second appended review. A fresh core/server
+review pass (edit/session/viewport/search/transform/filesystem/utility plus the
+gRPC service, session manager, and server main) added the items marked as new
+in this revision.
 
 Priority guide:
 - **P0**: correctness, data integrity, or behavior that can mislead callers.
@@ -66,9 +69,9 @@ inherent to a file-editing agent tool, but for a hardened deployment it needs th
 same explicit trust-boundary decision as the transport.
 
 Relevant code:
-- `server/cpp/src/main.cpp:597`
-- `server/cpp/src/main.cpp:615`
-- `server/cpp/src/main.cpp:622`
+- `server/cpp/src/main.cpp:568`
+- `server/cpp/src/main.cpp:586`
+- `server/cpp/src/main.cpp:593`
 - `packages/ai/src/mcp.ts:713`
 - `packages/ai/src/service.ts:947`
 
@@ -85,7 +88,62 @@ Suggested fix:
 
 ## P1 High-Impact Work
 
-### 2. Undo snapshot strategy is count-only and memory-blind
+### 2. Change-detail RPCs materialize file-backed payloads into memory
+
+**Impact:** High for massive files
+**Risk:** Low to Medium
+**Area:** C++ server change details, core change payload accessor
+
+Deletes and overwrites larger than the inline payload limit (default 64 MiB)
+store their captured bytes in a payload file. `fill_change_details` (used by
+`GetChangeDetails`, `GetLastChange`, and `GetLastUndo`) calls
+`omega_change_get_bytes`, which loads the *entire* file-backed payload into a
+heap buffer — and keeps it cached on the change until the change is destroyed.
+A single RPC against a multi-gigabyte delete allocates the full payload in
+memory, copies it again into the protobuf response, and leaves the cache
+resident. There is no size check anywhere on this path, and the server never
+configures a send-side message limit (see item 13).
+
+Relevant code:
+- `server/cpp/src/editor_service.cpp:842`
+- `core/src/lib/change.cpp:45`
+- `core/src/lib/change.cpp:56`
+
+Suggested fix:
+- Cap the change data returned by detail RPCs (truncate with an explicit
+  "data omitted/truncated" indicator, or return storage kind + length only for
+  file-backed payloads).
+- Avoid populating the permanent payload cache from a one-shot RPC; stream from
+  the payload file or use a bounded read.
+- Add a test that requests details for a change larger than the inline limit
+  and asserts bounded memory/response size.
+
+### 3. SearchSession buffers unbounded match lists
+
+**Impact:** High for common patterns on massive files
+**Risk:** Low
+**Area:** C++ server search RPC
+
+`SearchSession` with the default `limit = 0` accumulates every match offset in
+a vector and then copies them all into a single response message. A short or
+single-byte pattern over a large session can produce billions of matches
+(memory proportional to match count, then a proportionally huge response). The
+search loop also advances by 1 byte per match, so overlapping matches multiply
+the count. This is the search-side sibling of the `replace_matches` finding
+below.
+
+Relevant code:
+- `server/cpp/src/editor_service.cpp:2008`
+- `server/cpp/src/editor_service.cpp:2032`
+
+Suggested fix:
+- Impose a server-side default/maximum match cap when the caller passes
+  `limit = 0`, and report truncation explicitly (flag or status detail).
+- Consider a streaming search RPC for callers that genuinely need all matches.
+- Add a scale test with a high-frequency pattern asserting bounded memory and
+  response size.
+
+### 4. Undo snapshot strategy is count-only and memory-blind
 
 **Impact:** High
 **Risk:** Medium to High
@@ -97,7 +155,7 @@ current default interval is useful, but the policy is still crude for very large
 files or very dense edit histories.
 
 Relevant code:
-- `core/src/lib/edit.cpp:719`
+- `core/src/lib/edit.cpp:923`
 - `core/src/lib/impl_/session_def.hpp:45`
 
 Suggested fix:
@@ -107,7 +165,7 @@ Suggested fix:
   cheap references instead of deep clones.
 - Surface basic metrics for snapshot count/bytes in tests or debug logs.
 
-### 3. `replace_matches` buffers every match in memory
+### 5. `replace_matches` buffers every match in memory
 
 **Impact:** High for very large files and common patterns
 **Risk:** Medium
@@ -120,10 +178,10 @@ large file can consume memory proportional to match count. The streaming,
 checkpointed `omega_edit_replace_all_bytes` path avoids this shape.
 
 Relevant code:
-- `core/src/lib/edit.cpp:1822`
-- `core/src/lib/edit.cpp:1852`
-- `core/src/lib/edit.cpp:1877`
-- `core/src/lib/edit.cpp:1895`
+- `core/src/lib/edit.cpp:1886`
+- `core/src/lib/edit.cpp:1916`
+- `core/src/lib/edit.cpp:1941`
+- `core/src/lib/edit.cpp:1959`
 
 Suggested fix:
 - Add an internal match-count or operation-count ceiling for the current script
@@ -132,7 +190,7 @@ Suggested fix:
   unbounded replacement.
 - Add scale tests that assert bounded memory or a clear graceful failure.
 
-### 4. Read/classification RPCs allocate unbounded segments
+### 6. Read/classification RPCs allocate unbounded segments
 
 **Impact:** High for server robustness
 **Risk:** Low to Medium
@@ -144,16 +202,16 @@ internal error, but the RPCs remain an easy memory-pressure lever. Viewports
 already have a capacity limit, so this should use a similar policy.
 
 Relevant code:
-- `server/cpp/src/editor_service.cpp:1526`
-- `server/cpp/src/editor_service.cpp:1570`
-- `server/cpp/src/editor_service.cpp:2032`
+- `server/cpp/src/editor_service.cpp:1566`
+- `server/cpp/src/editor_service.cpp:1609`
+- `server/cpp/src/editor_service.cpp:1986`
 
 Suggested fix:
 - Add a configurable maximum read/classification segment size.
 - Return `INVALID_ARGUMENT` or `RESOURCE_EXHAUSTED` when callers exceed it.
 - Align defaults with viewport limits or document why they differ.
 
-### 5. Change-log import is still full-document JSON parsing
+### 7. Change-log import is still full-document JSON parsing
 
 **Impact:** High
 **Risk:** Medium to High
@@ -174,7 +232,7 @@ Suggested fix:
 - Validate document header/fingerprint before reading all entries.
 - Replay entries incrementally while preserving atomic rollback semantics.
 
-### 6. TypeScript live client still has a 2^53 int64 ceiling
+### 8. TypeScript live client still has a 2^53 int64 ceiling
 
 **Impact:** High for the "massive files" promise
 **Risk:** High
@@ -197,7 +255,7 @@ Suggested fix:
   or expose parallel BigInt methods.
 - Keep safe-number wrappers for legacy callers during the transition.
 
-### 7. Zlib decompression has no output-size or ratio cap
+### 9. Zlib decompression has no output-size or ratio cap
 
 **Impact:** High (decompression-bomb memory exhaustion)
 **Risk:** Low to Medium
@@ -218,7 +276,7 @@ Suggested fix:
 - Keep the existing per-iteration cancellation polling.
 - Add a decompression-bomb test that asserts the cap is enforced.
 
-### 8. Bundled plugins run in-process with server privileges
+### 10. Bundled plugins run in-process with server privileges
 
 **Impact:** High for any hardening attestation
 **Risk:** Medium
@@ -234,7 +292,7 @@ trust.
 
 Relevant code:
 - `core/src/lib/transform.cpp:62`
-- `core/src/lib/transform.cpp:1044`
+- `core/src/lib/transform.cpp:1068`
 - `server/cpp/src/editor_service.cpp:81`
 
 Suggested fix:
@@ -249,7 +307,7 @@ Suggested fix:
 
 ## P2 Medium-Impact / Medium-Risk Work
 
-### 9. Transform change replay is metadata-aware but not native-first
+### 11. Transform change replay is metadata-aware but not native-first
 
 **Impact:** Medium to High
 **Risk:** Medium to High
@@ -266,7 +324,7 @@ Suggested fix:
   operation end to end.
 - Keep verifying replayed size/replacement metadata after import.
 
-### 10. Server checkpoint creation has no cap or dedupe policy
+### 12. Server checkpoint creation has no cap or dedupe policy
 
 **Impact:** Medium
 **Risk:** Medium
@@ -277,16 +335,151 @@ server/core API still allows unbounded checkpoint creation. Repeated checkpoint
 calls can grow state without a cost signal or cap.
 
 Relevant code:
-- `core/src/lib/edit.cpp:2235`
+- `core/src/lib/edit.cpp:2620`
 - `proto/omega_edit/v1/omega_edit.proto`
-- `server/cpp/src/editor_service.cpp`
+- `server/cpp/src/editor_service.cpp:2284`
 
 Suggested fix:
 - Add configurable checkpoint count/bytes caps.
 - Consider dedupe when the computed content equals the latest checkpoint.
 - Return explicit "not needed" or "limit reached" results where appropriate.
 
-### 11. C-string and byte edit APIs encode different zero-length semantics
+### 13. gRPC message-size limits are unconfigured and inconsistent
+
+**Impact:** Medium
+**Risk:** Low
+**Area:** C++ server transport configuration
+
+`main.cpp` never calls `SetMaxReceiveMessageSize`/`SetMaxSendMessageSize`, so
+the server runs with gRPC defaults: a 4 MiB inbound message cap and an
+effectively unlimited outbound cap. Two consequences:
+
+- The advertised `--max-change-bytes` default of 64 MiB is unreachable — any
+  `SubmitChange` above ~4 MiB is rejected at the transport layer with a
+  generic gRPC error before the service's own limit or error message applies.
+- Outbound responses are unbounded, which is what makes items 4 and 5 (and
+  large `GetSegment` reads) able to produce multi-gigabyte responses.
+
+Relevant code:
+- `server/cpp/src/main.cpp:556`
+- `server/cpp/src/session_manager.h:43`
+
+Suggested fix:
+- Configure receive/send message sizes explicitly and derive them from (or
+  validate them against) `max_change_bytes` and the segment/search caps.
+- Fail startup or log prominently when the configured limits are mutually
+  inconsistent.
+- Add an integration test that submits a change just under and just over the
+  effective limit and asserts the intended error text.
+
+### 14. Whole-content operations hold the per-session core lock for their full duration
+
+**Impact:** Medium (per-session availability on massive files)
+**Risk:** Medium
+**Area:** C++ server fingerprint/inspection/transform paths
+
+`GetSessionFingerprint` and `InspectSessionContent` over *computed* content, and
+`ApplyTransformPlugin` generally, hold the session's `core_mutex` while
+streaming the entire session content through the digest/inspect/transform
+plugin. On a massive file that is minutes of wall-clock time during which every
+other RPC on that session (viewport reads, heartbeat-adjacent calls, saves)
+blocks — and, combined with item 3, can escalate to a server-wide stall. The
+file-snapshot paths already avoid this by reading the snapshot outside the
+lock.
+
+Relevant code:
+- `server/cpp/src/editor_service.cpp:1765`
+- `server/cpp/src/editor_service.cpp:1911`
+- `server/cpp/src/editor_service.cpp:2341`
+
+Suggested fix:
+- For computed-content digests/inspections, materialize a temporary snapshot
+  (or reuse the checkpoint machinery) under the lock, then stream from the
+  snapshot outside the lock, as the original/checkpoint paths do.
+- Document that transforms intentionally serialize the session, and rely on the
+  existing transform/mutation guards for mutual exclusion rather than the core
+  lock alone where possible.
+- Add a test that runs a digest over a large session and asserts a concurrent
+  viewport read completes promptly.
+
+### 15. Profile and character-count scans read in `BUFSIZ` chunks
+
+**Impact:** Medium (massive-file scan throughput, especially on Windows)
+**Risk:** Low
+**Area:** Core session statistics
+
+`omega_session_byte_frequency_profile` and `omega_session_character_counts`
+iterate the session in `BUFSIZ`-sized segments. `BUFSIZ` is 512 bytes on MSVC
+(8 KiB on glibc), so profiling a 10 GiB session on Windows performs ~20 million
+`populate_data_segment_` calls, each doing an `upper_bound` over the segment
+list plus a seek/read. The rest of the codebase uses a 64 KiB
+`OMEGA_IO_BUFFER_SIZE` for streaming.
+
+Relevant code:
+- `core/src/lib/session.cpp:385`
+- `core/src/lib/session.cpp:422`
+
+Suggested fix:
+- Use `OMEGA_IO_BUFFER_SIZE` (or a dedicated scan buffer constant) instead of
+  `BUFSIZ` for both scans.
+- Null-check the `omega_segment_create` result explicitly.
+- Add a benchmark or perf regression note for full-file profiling.
+
+### 16. Temp files are created, closed, then reopened by path
+
+**Impact:** Medium (local symlink-swap hardening)
+**Risk:** Low
+**Area:** Core checkpoint/payload/save temp-file handling
+
+The common pattern is `omega_util_mkstemp` (0600, `O_EXCL`) followed by
+`close(fd)` and a later `FOPEN(path, "wb")` — in checkpoint creation, payload
+capture, save's temp file, and `reserve_output_path_`. Between the close and
+the reopen, a local attacker with write access to the directory (for example a
+shared `/tmp` checkpoint directory) can swap the file for a symlink and the
+subsequent open-for-write follows it. The exclusive create wins the name, but
+the identity guarantee is dropped when the fd is closed.
+
+Relevant code:
+- `core/src/lib/edit.cpp:987`
+- `core/src/lib/edit.cpp:1011`
+- `core/src/lib/edit.cpp:2259`
+- `core/src/lib/edit.cpp:291`
+
+Suggested fix:
+- Keep the descriptor from `mkstemp` and wrap it with `fdopen` instead of
+  closing and reopening by name.
+- Where reopening is unavoidable, verify identity (`O_NOFOLLOW`, or
+  fstat/st_ino comparison) before writing.
+- Document that checkpoint directories should not be world-writable shared
+  directories.
+
+### 17. Search treats read failures as "no match"
+
+**Impact:** Medium (silently wrong results on I/O errors)
+**Risk:** Low
+**Area:** Core search, C++ server search RPC
+
+`omega_search_next_match` ignores the return value of
+`populate_data_segment_`; on a read failure the segment length is zero, the
+window loop ends, and the context reports "no more matches". A transient I/O
+error therefore looks identical to a legitimate miss. On the server side,
+`SearchSession` also returns `OK` with an empty match list when context
+creation fails (invalid offset/length/pattern), so callers cannot distinguish
+"no matches" from "search never ran".
+
+Relevant code:
+- `core/src/lib/search.cpp:221`
+- `server/cpp/src/editor_service.cpp:2025`
+
+Suggested fix:
+- Propagate populate failures out of `omega_search_next_match` (distinct error
+  return) and surface them as RPC errors.
+- Return `INVALID_ARGUMENT` from `SearchSession` when the search context cannot
+  be created.
+- Add a test with an out-of-range offset asserting an error rather than an
+  empty result.
+
+### 18. C-string and byte edit APIs encode different zero-length semantics
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -305,7 +498,7 @@ Suggested fix:
 - Keep byte APIs explicit-only.
 - Add examples that steer binary callers to `_bytes` variants.
 
-### 12. Long positional argument lists remain hard to use safely
+### 19. Long positional argument lists remain hard to use safely
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -324,7 +517,7 @@ Suggested fix:
 - Preserve existing positional APIs for ABI compatibility.
 - Use enum/boolean-like typed fields in the options structs.
 
-### 13. Viewport dirty state uses a negative-capacity sentinel
+### 20. Viewport dirty state uses a negative-capacity sentinel
 
 **Impact:** Medium
 **Risk:** Low to Medium
@@ -332,20 +525,27 @@ Suggested fix:
 
 Viewport data dirtiness is encoded by negating `data_segment.capacity`, while
 public capacity reads hide that with `abs`. This couples a state flag to a size
-field and requires every internal user to remember the convention.
+field and requires every internal user to remember the convention. The
+"negate capacity + notify" idiom is also copy-pasted at six call sites
+(`update_viewports_`, `notify_checkpoint_restore_`, `promote_checkpoint_file_`,
+`mark_all_viewports_changed_`, `omega_edit_clear_changes`,
+`omega_edit_destroy_last_checkpoint`) even though
+`mark_all_viewports_changed_` exists for exactly this purpose.
 
 Relevant code:
-- `core/src/lib/edit.cpp:1443`
-- `core/src/lib/edit.cpp:2155`
-- `core/src/lib/edit.cpp:2259`
+- `core/src/lib/edit.cpp:588`
+- `core/src/lib/edit.cpp:950`
+- `core/src/lib/edit.cpp:1070`
+- `core/src/lib/edit.cpp:1522`
 - `core/src/lib/viewport.cpp:122`
 
 Suggested fix:
 - Add an explicit dirty flag to the viewport/data-segment structure.
 - Keep capacity non-negative internally.
+- Route all mark-dirty-and-notify call sites through one helper.
 - Update tests that currently force dirty state by negating capacity.
 
-### 14. C++ codec plugins lack cancellation, and base58 is quadratic
+### 21. C++ codec plugins lack cancellation, and base58 is quadratic
 
 **Impact:** Medium to High (CPU hang on large selections)
 **Risk:** Low
@@ -367,7 +567,7 @@ Suggested fix:
 - Cap base58 selection size or document it as a short-field codec.
 - Add cancellation and large-input tests for the C++ codecs.
 
-### 15. OpenSSL cipher plugin does not zeroize key material
+### 22. OpenSSL cipher plugin does not zeroize key material
 
 **Impact:** Medium
 **Risk:** Low
@@ -394,7 +594,7 @@ Suggested fix:
 
 ## P3 Low-Risk / Opportunistic Work
 
-### 16. Snapshot allocation failure silently degrades undo speed
+### 23. Snapshot allocation failure silently degrades undo speed
 
 **Impact:** Low to Medium
 **Risk:** Low
@@ -404,13 +604,13 @@ When snapshot allocation fails, the snapshot is erased and undo performance can
 fall back to longer replay distances without any visible signal.
 
 Relevant code:
-- `core/src/lib/edit.cpp:724`
+- `core/src/lib/edit.cpp:928`
 
 Suggested fix:
 - Emit a debug/warn log or session diagnostic event when snapshot capture fails.
 - Add a test hook or allocator-failure test if the existing harness supports it.
 
-### 17. Transaction-boundary scan is linear per undo
+### 24. Transaction-boundary scan is linear per undo
 
 **Impact:** Low to Medium
 **Risk:** Low to Medium
@@ -420,13 +620,13 @@ Undo scans backward to find the current transaction extent each time. For very
 large transactions this is a repeated tail scan.
 
 Relevant code:
-- `core/src/lib/edit.cpp:2176`
+- `core/src/lib/edit.cpp:2551`
 
 Suggested fix:
 - Store transaction extents or cached transaction change counts.
 - Reuse the same metadata for redo batching.
 
-### 18. Redo still replays one change at a time
+### 25. Redo still replays one change at a time
 
 **Impact:** Low to Medium
 **Risk:** Low to Medium
@@ -436,13 +636,13 @@ Redo loops through `changes_undone` and calls `update_` one change at a time,
 paying repeated checks and per-change update overhead.
 
 Relevant code:
-- `core/src/lib/edit.cpp:2220`
+- `core/src/lib/edit.cpp:2596`
 
 Suggested fix:
 - Batch redo by transaction.
 - Reuse notification batching and viewport-update coalescing where possible.
 
-### 19. C transform plugins each reimplement the same JSON parser
+### 26. C transform plugins each reimplement the same JSON parser
 
 **Impact:** Low
 **Risk:** Low
@@ -466,7 +666,45 @@ Suggested fix:
   surface.
 - Keep per-plugin schema validation.
 
-### 20. Utility string helpers have minor robustness gaps
+### 27. Core/server duplication that should be consolidated
+
+**Impact:** Low (maintainability, divergence risk)
+**Risk:** Low
+**Area:** Core edit internals, C++ server RPC scaffolding
+
+Several near-identical code blocks are maintained in parallel and have already
+started to drift:
+
+- `create_checkpoint_file_` and `create_payload_file_` differ only in the
+  filename template (`core/src/lib/edit.cpp:972`, `core/src/lib/edit.cpp:996`).
+- `update_model_helper_` and `insert_payload_segment_` duplicate the
+  segment-split/walk scaffolding (~40 lines) around different insert bodies
+  (`core/src/lib/edit.cpp:640`, `core/src/lib/edit.cpp:738`).
+- `rebuild_model_to_change_count_` repeats the "reinitialize from backing file"
+  block in two branches (`core/src/lib/edit.cpp:859`).
+- `omega_session_get_num_change_transactions` and
+  `omega_session_get_num_undone_change_transactions` are copy-pasted loops over
+  different vectors (`core/src/lib/session.cpp:270`,
+  `core/src/lib/session.cpp:295`).
+- `GetSessionFingerprint` and `InspectSessionContent` each duplicate the entire
+  snapshot-vs-computed branch pair, including two ten-argument
+  `inspect_with_streaming_plugin` calls that differ only in messages
+  (`server/cpp/src/editor_service.cpp:1702`,
+  `server/cpp/src/editor_service.cpp:1856`); `GetContentType` and `GetLanguage`
+  are likewise structural twins (`server/cpp/src/editor_service.cpp:1546`,
+  `server/cpp/src/editor_service.cpp:1589`).
+- Nearly every RPC repeats the same guard/lock/NOT_FOUND prologue by hand.
+
+Suggested fix:
+- Extract a single temp-file-in-checkpoint-dir helper parameterized by prefix.
+- Factor the model segment split/walk into one helper used by both insert
+  paths.
+- Introduce a small `resolve_content_source(...)` helper (and an error-message
+  struct for `inspect_with_streaming_plugin`) so fingerprint/inspect share one
+  body.
+- Add a `with_locked_session(request_id, handler)` helper for the RPC prologue.
+
+### 28. Utility string helpers have minor robustness gaps
 
 **Impact:** Low
 **Risk:** Low
@@ -486,7 +724,39 @@ Suggested fix:
 - Compare bytes as `unsigned char` in `omega_util_strncmp` if strcmp-compatible
   ordering is expected.
 
-### 21. Content detection feeds untrusted bytes to third-party parsers
+### 29. Failure-signaling edges can mislead callers or operators
+
+**Impact:** Low to Medium
+**Risk:** Low
+**Area:** Core edit results, server startup/CLI
+
+A collection of small signaling gaps, individually rare but relevant to a
+reliability attestation:
+
+- `replace_bytes_impl_` returns `0` (the "nothing changed" value) when the
+  insert fails *and* the compensating undo of the already-applied delete also
+  fails, so in that allocation-failure corner the session content changed while
+  the caller is told it did not (`core/src/lib/edit.cpp:396`).
+- `omega_edit_save_segment` returns `-12` when `sync_parent_directory_` fails
+  *after* the atomic rename has already published the file, so a completed save
+  is reported as a failure with no way to distinguish post-commit durability
+  warnings from real failures (`core/src/lib/edit.cpp:2376`).
+- `main.cpp` silently ignores unknown CLI options, so a typo in a resource-cap
+  or security-relevant flag leaves defaults in effect without any warning
+  (`server/cpp/src/main.cpp:509`).
+- `CreateSession` maps "file does not exist" to `INTERNAL` rather than
+  `NOT_FOUND`/`INVALID_ARGUMENT` (`server/cpp/src/main.cpp` comment says this
+  matches previous behavior) (`server/cpp/src/editor_service.cpp:917`).
+
+Suggested fix:
+- Return a distinct negative error when the replace rollback itself fails, and
+  a distinct post-commit code (or success-with-warning) for the directory-sync
+  case.
+- Reject unknown CLI options (or at least log a warning listing them).
+- Use `NOT_FOUND` for missing session files, keeping the old message text if
+  compatibility matters.
+
+### 30. Content detection feeds untrusted bytes to third-party parsers
 
 **Impact:** Low to Medium
 **Risk:** Low
@@ -519,6 +789,16 @@ claiming production hardening:
   near-`INT64_MAX` coverage through public APIs and server RPC boundaries.
 - `replace_matches` scale: assert bounded memory use or clear failure on huge
   match counts.
+- Change-detail payload bounds: request details for a change larger than the
+  inline payload limit and assert bounded memory/response behavior.
+- Same-session availability under long scans: run a slow operation (large
+  transform or computed-content fingerprint) and assert non-mutating RPCs on
+  that session complete promptly once the long scan paths release `core_mutex`
+  more aggressively.
+- gRPC message-size boundaries: submit changes just under/over the effective
+  transport and `max_change_bytes` limits and assert the intended error paths.
+- Search error paths: assert I/O failures and invalid ranges surface as errors,
+  not empty match lists.
 - Transform/mutation concurrency: add real-thread coverage for
   `try_begin_transform` returning `MUTATION_IN_PROGRESS` and for transform vs.
   mutation mutual exclusion.
@@ -551,6 +831,22 @@ claiming production hardening:
 - `omega_session_*` count/segment/BOM entry points validate offset/length via
   `safe_add_int64_` and tolerate null segments; `ABORT` is `std::abort()`
   (noreturn), so switch defaults that reach it are not fall-through UB.
+- The floating-viewport offset-adjustment arithmetic clamps on `int64`
+  overflow via `safe_add_int64_` rather than wrapping, and dirty-read
+  repopulation re-validates lengths.
+- The transform plugin allocator's file-backed (mmap) allocations are tracked
+  in an allocation store; unclaimed allocations are released after apply and
+  response-owned buffers are promoted to the global store and freed by
+  `omega_transform_plugin_response_clear`, so no leak path was found.
+- The server event queues are bounded (drop-oldest with logged drop counts),
+  closed on unsubscribe/destroy, and cleared to release retained payloads;
+  subscriber streams exit on cancellation or queue closure.
+- The schema-regex safety pre-check plus 4 KiB pattern cap and bounded cache in
+  `transform.cpp` reasonably mitigate ReDoS in plugin option validation, and
+  the hand-rolled JSON parser enforces a 256-level nesting cap.
+- Session/viewport ID validation (charset + 128-byte cap), path control-byte
+  rejection, and shared-session attachment counting in the session manager are
+  sound; UUIDv7 generation is mutex-guarded and monotonic.
 
 ---
 
@@ -573,6 +869,11 @@ These areas were in the old document but are no longer open backlog items:
   APIs now have explicit success predicates.
 - Undo-based change-log rollback; AI and VS Code imports now use a native
   restore-to-change-count primitive that discards redo.
+- Clear-changes now discards stacked checkpoint/transform models, resets change
+  serial bookkeeping to the original model, and marks viewports dirty.
+- Session creation and session/viewport subscription paths now avoid holding the
+  global session-map mutex across core session creation or per-session
+  `core_mutex` acquisition.
 - Session/viewport subscription lock ordering, handoff, queue closure, and
   ordered callback delivery.
 - Desired ID/path validation and default host/port duplication.

--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -874,6 +874,9 @@ These areas were in the old document but are no longer open backlog items:
 - Session creation and session/viewport subscription paths now avoid holding the
   global session-map mutex across core session creation or per-session
   `core_mutex` acquisition.
+- Shared file-backed session creation now reserves the file-path mapping in the
+  same critical section that observes no existing session, so concurrent authors
+  attach to one session instead of racing into adjacent reservations.
 - Session/viewport subscription lock ordering, handoff, queue closure, and
   ordered callback delivery.
 - Desired ID/path validation and default host/port duplication.

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -122,7 +122,7 @@ namespace {
         const auto flushed = FlushFileBuffers(directory_handle) != 0;
         const auto flush_error = GetLastError();
         CloseHandle(directory_handle);
-        return flushed || flush_error == ERROR_INVALID_FUNCTION;
+        return flushed || flush_error == ERROR_INVALID_FUNCTION || flush_error == ERROR_ACCESS_DENIED;
 #else
         char directory[FILENAME_MAX + 1];
         omega_util_dirname(path, directory);
@@ -2484,14 +2484,17 @@ int omega_edit_clear_changes(omega_session_t *session_ptr) {
     if (session_ptr->models_.front()->file_ptr != nullptr) {
         if (0 != FSEEK(session_ptr->models_.front()->file_ptr, 0L, SEEK_END)) { return -1; }
         length = FTELL(session_ptr->models_.front()->file_ptr);
+        if (length < 0) { return -1; }
     }
-    if (!initialize_model_segments_(session_ptr->models_.front()->model_segments, length)) { return -1; }
+
+    omega_model_segments_t reset_segments;
+    if (!initialize_model_segments_(reset_segments, length)) { return -1; }
+    while (session_ptr->models_.size() > 1) { discard_top_model_(session_ptr); }
+    session_ptr->models_.front()->model_segments = std::move(reset_segments);
     free_session_changes_(session_ptr);
     free_session_changes_undone_(session_ptr);
-    for (const auto &viewport_ptr : session_ptr->viewports_) {
-        viewport_ptr->data_segment.capacity = -1 * std::abs(viewport_ptr->data_segment.capacity);// indicate dirty read
-        omega_viewport_notify(viewport_ptr.get(), VIEWPORT_EVT_CLEAR, nullptr);
-    }
+    session_ptr->num_changes_adjustment_ = 0;
+    mark_all_viewports_changed_(session_ptr, VIEWPORT_EVT_CLEAR, nullptr);
     omega_session_notify(session_ptr, SESSION_EVT_CLEAR, nullptr);
     return 0;
 }

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -29,6 +29,7 @@
 #include "impl_/viewport_def.hpp"
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <cstddef>
 #include <cstdlib>
 #include <limits>
@@ -71,6 +72,7 @@ using omega_edit::internal::valid_nonnegative_range_;
 #ifdef OMEGA_BUILD_WINDOWS
 
 #include <io.h>
+#include <windows.h>
 
 #define close _close
 #ifdef min
@@ -81,6 +83,7 @@ using omega_edit::internal::valid_nonnegative_range_;
 #endif
 #else
 
+#include <fcntl.h>
 #include <unistd.h>
 
 #endif
@@ -90,6 +93,67 @@ namespace {
     constexpr int OMEGA_OUTPUT_PATH_SUFFIX_ATTEMPTS = 1000000;
 
     auto initialize_model_segments_(omega_model_segments_t &model_segments, int64_t length) -> bool;
+
+    auto flush_file_to_disk_(FILE *file_ptr) -> bool {
+        if (!file_ptr) { return false; }
+        if (fflush(file_ptr) != 0) { return false; }
+#ifdef OMEGA_BUILD_WINDOWS
+        const auto fd = _fileno(file_ptr);
+        if (fd < 0) { return false; }
+        const auto os_handle = _get_osfhandle(fd);
+        if (os_handle == -1) { return false; }
+        return FlushFileBuffers(reinterpret_cast<HANDLE>(os_handle)) != 0;
+#else
+        const auto fd = fileno(file_ptr);
+        return fd >= 0 && fsync(fd) == 0;
+#endif
+    }
+
+    auto sync_parent_directory_(const char *path) -> bool {
+        if (!path || !*path) { return false; }
+#ifdef OMEGA_BUILD_WINDOWS
+        char directory[FILENAME_MAX + 1];
+        omega_util_dirname(path, directory);
+        if (!directory[0] && !omega_util_get_current_dir(directory)) { return false; }
+        const auto directory_handle =
+                CreateFileA(directory, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                            nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+        if (directory_handle == INVALID_HANDLE_VALUE) { return true; }
+        const auto flushed = FlushFileBuffers(directory_handle) != 0;
+        const auto flush_error = GetLastError();
+        CloseHandle(directory_handle);
+        return flushed || flush_error == ERROR_INVALID_FUNCTION;
+#else
+        char directory[FILENAME_MAX + 1];
+        omega_util_dirname(path, directory);
+        if (!directory[0] && !omega_util_get_current_dir(directory)) { return false; }
+        auto flags = O_RDONLY;
+#ifdef O_DIRECTORY
+        flags |= O_DIRECTORY;
+#endif
+        const auto dir_fd = OPEN(directory, flags, 0);
+        if (dir_fd < 0) { return true; }
+        const auto rc = fsync(dir_fd);
+        const auto saved_errno = errno;
+        CLOSE(dir_fd);
+#ifdef ENOTSUP
+        if (rc != 0 && saved_errno == ENOTSUP) { return true; }
+#endif
+#ifdef EOPNOTSUPP
+        if (rc != 0 && saved_errno == EOPNOTSUPP) { return true; }
+#endif
+        return rc == 0 || saved_errno == EINVAL;
+#endif
+    }
+
+    auto atomic_replace_file_(const char *from_path, const char *to_path) -> bool {
+        if (!from_path || !*from_path || !to_path || !*to_path) { return false; }
+#ifdef OMEGA_BUILD_WINDOWS
+        return MoveFileExA(from_path, to_path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0;
+#else
+        return rename(from_path, to_path) == 0;
+#endif
+    }
 
     struct captured_change_payload_t {
         omega_byte_t *bytes{};
@@ -2286,7 +2350,17 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
             return -8;
         }
     }
-    FCLOSE(temp_fptr);
+    if (!flush_file_to_disk_(temp_fptr)) {
+        LOG_ERRNO();
+        close_and_cleanup_output();
+        return -8;
+    }
+    if (FCLOSE(temp_fptr) != 0) {
+        LOG_ERRNO();
+        temp_fptr = nullptr;
+        if (cleanup_output) { omega_util_remove_file(output_path); }
+        return -8;
+    }
     temp_fptr = nullptr;
     if (bytes_written != adjusted_length) {
         LOG_ERROR("failed to write all requested bytes, expected: " << adjusted_length << ", got: " << bytes_written);
@@ -2299,18 +2373,18 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
         close_and_cleanup_output();
         return -9;
     }
-    if (overwrite && omega_util_file_exists(file_path)) {
-        if (overwrite) {
-            if (0 != omega_util_remove_file(file_path)) {
-                LOG_ERRNO();
-                omega_util_remove_file(temp_filename);
-                return -10;
-            }
+    if (overwrite) {
+        if (!atomic_replace_file_(temp_filename, file_path)) {
+            LOG_ERRNO();
+            omega_util_remove_file(temp_filename);
+            return -12;
         }
-    }
-    if (overwrite && rename(temp_filename, file_path) != 0) {
+        if (!sync_parent_directory_(file_path)) {
+            LOG_ERRNO();
+            return -12;
+        }
+    } else if (!sync_parent_directory_(output_path)) {
         LOG_ERRNO();
-        omega_util_remove_file(temp_filename);
         return -12;
     }
     cleanup_output = false;

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -256,6 +256,8 @@ namespace {
         return regex && std::regex_match(value, *regex);
     }
 
+    constexpr size_t JSON_MAX_NESTING_DEPTH = 256U;
+
     struct json_value_t {
         enum class kind_t { null_value, object, array, string, number, boolean };
 
@@ -273,7 +275,7 @@ namespace {
 
         auto parse(json_value_t &value) -> bool {
             skip_ws();
-            if (!parse_value(value)) { return false; }
+            if (!parse_value(value, 0)) { return false; }
             skip_ws();
             return input_[pos_] == '\0';
         }
@@ -293,13 +295,14 @@ namespace {
             return true;
         }
 
-        auto parse_value(json_value_t &value) -> bool {
+        auto parse_value(json_value_t &value, size_t depth) -> bool {
+            if (depth > JSON_MAX_NESTING_DEPTH) { return false; }
             skip_ws();
             switch (input_[pos_]) {
                 case '{':
-                    return parse_object(value);
+                    return parse_object(value, depth);
                 case '[':
-                    return parse_array(value);
+                    return parse_array(value, depth);
                 case '"':
                     value.kind = json_value_t::kind_t::string;
                     return parse_string(value.string_value);
@@ -368,7 +371,7 @@ namespace {
             return false;
         }
 
-        auto parse_object(json_value_t &value) -> bool {
+        auto parse_object(json_value_t &value, size_t depth) -> bool {
             if (!consume('{')) { return false; }
             value = {};
             value.kind = json_value_t::kind_t::object;
@@ -379,7 +382,7 @@ namespace {
                 skip_ws();
                 if (!parse_string(key) || !consume(':')) { return false; }
                 json_value_t member;
-                if (!parse_value(member)) { return false; }
+                if (!parse_value(member, depth + 1)) { return false; }
                 value.object_value[key] = std::move(member);
                 skip_ws();
                 if (consume('}')) { return true; }
@@ -388,7 +391,7 @@ namespace {
             return false;
         }
 
-        auto parse_array(json_value_t &value) -> bool {
+        auto parse_array(json_value_t &value, size_t depth) -> bool {
             if (!consume('[')) { return false; }
             value = {};
             value.kind = json_value_t::kind_t::array;
@@ -396,7 +399,7 @@ namespace {
             if (consume(']')) { return true; }
             while (input_[pos_] != '\0') {
                 json_value_t item;
-                if (!parse_value(item)) { return false; }
+                if (!parse_value(item, depth + 1)) { return false; }
                 value.array_value.push_back(std::move(item));
                 skip_ws();
                 if (consume(']')) { return true; }
@@ -510,7 +513,8 @@ namespace {
         return true;
     }
 
-    auto json_values_equal_(const json_value_t &left, const json_value_t &right) -> bool {
+    auto json_values_equal_(const json_value_t &left, const json_value_t &right, size_t depth = 0) -> bool {
+        if (depth > JSON_MAX_NESTING_DEPTH) { return false; }
         if (left.kind != right.kind) { return false; }
         switch (left.kind) {
             case json_value_t::kind_t::null_value:
@@ -524,7 +528,9 @@ namespace {
             case json_value_t::kind_t::array:
                 if (left.array_value.size() != right.array_value.size()) { return false; }
                 for (size_t index = 0; index < left.array_value.size(); ++index) {
-                    if (!json_values_equal_(left.array_value[index], right.array_value[index])) { return false; }
+                    if (!json_values_equal_(left.array_value[index], right.array_value[index], depth + 1)) {
+                        return false;
+                    }
                 }
                 return true;
             case json_value_t::kind_t::object:
@@ -532,7 +538,7 @@ namespace {
                 for (const auto &[key, left_value] : left.object_value) {
                     const auto right_iter = right.object_value.find(key);
                     if (right_iter == right.object_value.end()) { return false; }
-                    if (!json_values_equal_(left_value, right_iter->second)) { return false; }
+                    if (!json_values_equal_(left_value, right_iter->second, depth + 1)) { return false; }
                 }
                 return true;
         }
@@ -554,7 +560,8 @@ namespace {
         return number == static_cast<double>(out);
     }
 
-    auto validate_schema_value_(const json_value_t &value, const json_value_t &schema) -> bool {
+    auto validate_schema_value_(const json_value_t &value, const json_value_t &schema, size_t depth = 0) -> bool {
+        if (depth > JSON_MAX_NESTING_DEPTH) { return false; }
         if (schema.kind != json_value_t::kind_t::object) { return false; }
 
         const auto *one_of = json_object_member_(schema, "oneOf");
@@ -562,19 +569,19 @@ namespace {
             if (one_of->kind != json_value_t::kind_t::array) { return false; }
             auto matches = 0;
             for (const auto &candidate : one_of->array_value) {
-                if (validate_schema_value_(value, candidate)) { ++matches; }
+                if (validate_schema_value_(value, candidate, depth + 1)) { ++matches; }
             }
             if (matches != 1) { return false; }
         }
 
         const auto *not_schema = json_object_member_(schema, "not");
-        if (not_schema && validate_schema_value_(value, *not_schema)) { return false; }
+        if (not_schema && validate_schema_value_(value, *not_schema, depth + 1)) { return false; }
 
         if (const auto *enum_values = json_object_member_(schema, "enum")) {
             if (enum_values->kind != json_value_t::kind_t::array) { return false; }
             auto matches = false;
             for (const auto &candidate : enum_values->array_value) {
-                if (json_values_equal_(value, candidate)) {
+                if (json_values_equal_(value, candidate, depth + 1)) {
                     matches = true;
                     break;
                 }
@@ -627,7 +634,7 @@ namespace {
                         if (!additional_properties) { return false; }
                         continue;
                     }
-                    if (!validate_schema_value_(member, property_iter->second)) { return false; }
+                    if (!validate_schema_value_(member, property_iter->second, depth + 1)) { return false; }
                 }
             } else if (!additional_properties && !value.object_value.empty()) {
                 return false;
@@ -642,7 +649,7 @@ namespace {
             }
             if (const auto *items = json_object_member_(schema, "items")) {
                 for (const auto &item : value.array_value) {
-                    if (!validate_schema_value_(item, *items)) { return false; }
+                    if (!validate_schema_value_(item, *items, depth + 1)) { return false; }
                 }
             }
         }
@@ -814,25 +821,42 @@ namespace {
 #endif
     };
 
-    std::mutex g_file_backed_allocations_mutex;
-    std::unordered_map<void *, std::shared_ptr<file_backed_buffer_t>> g_file_backed_allocations;
+    class plugin_allocation_store_t {
+    public:
+        void add(void *ptr, std::shared_ptr<file_backed_buffer_t> allocation) {
+            if (!ptr || !allocation) { return; }
+            std::lock_guard<std::mutex> lock(mutex_);
+            file_backed_allocations_[ptr] = std::move(allocation);
+        }
 
-    void release_plugin_allocation_(void *ptr) {
+        auto take(void *ptr, std::shared_ptr<file_backed_buffer_t> &allocation_out) -> bool {
+            if (!ptr) { return false; }
+            std::lock_guard<std::mutex> lock(mutex_);
+            const auto iter = file_backed_allocations_.find(ptr);
+            if (iter == file_backed_allocations_.end()) { return false; }
+            allocation_out = std::move(iter->second);
+            file_backed_allocations_.erase(iter);
+            return true;
+        }
+
+    private:
+        std::mutex mutex_;
+        std::unordered_map<void *, std::shared_ptr<file_backed_buffer_t>> file_backed_allocations_;
+    };
+
+    plugin_allocation_store_t g_response_file_backed_allocations;
+
+    void release_plugin_allocation_(plugin_allocation_store_t *allocation_store, void *ptr) {
         if (!ptr) { return; }
         std::shared_ptr<file_backed_buffer_t> file_backed;
-        {
-            std::lock_guard<std::mutex> lock(g_file_backed_allocations_mutex);
-            const auto iter = g_file_backed_allocations.find(ptr);
-            if (iter != g_file_backed_allocations.end()) {
-                file_backed = std::move(iter->second);
-                g_file_backed_allocations.erase(iter);
-            }
-        }
+        if (allocation_store) { allocation_store->take(ptr, file_backed); }
+        if (!file_backed) { g_response_file_backed_allocations.take(ptr, file_backed); }
         if (!file_backed) { std::free(ptr); }
     }
 
     struct plugin_allocator_state_t {
         const char *checkpoint_directory{};
+        plugin_allocation_store_t *allocation_store{};
         std::vector<void *> allocations;
     };
 
@@ -840,13 +864,12 @@ namespace {
         auto *state = static_cast<plugin_allocator_state_t *>(user_data_ptr);
         const auto requested_size = size == 0 ? 1 : size;
         void *ptr = nullptr;
-        if (requested_size > TRANSFORM_PLUGIN_FILE_BACKED_ALLOC_LIMIT_BYTES && state) {
+        if (requested_size > TRANSFORM_PLUGIN_FILE_BACKED_ALLOC_LIMIT_BYTES && state && state->allocation_store) {
             auto file_backed =
                     file_backed_buffer_t::create(state->checkpoint_directory, "OmegaEdit-xform-alloc", requested_size);
             if (file_backed) {
                 ptr = file_backed->data();
-                std::lock_guard<std::mutex> lock(g_file_backed_allocations_mutex);
-                g_file_backed_allocations[ptr] = std::move(file_backed);
+                state->allocation_store->add(ptr, std::move(file_backed));
             }
         } else {
             ptr = std::malloc(requested_size);
@@ -864,9 +887,34 @@ namespace {
     void release_unclaimed_plugin_allocations_(plugin_allocator_state_t &state,
                                                const omega_transform_plugin_response_t &response) {
         for (auto *ptr : state.allocations) {
-            if (!response_owns_allocation_(response, ptr)) { release_plugin_allocation_(ptr); }
+            if (!response_owns_allocation_(response, ptr)) { release_plugin_allocation_(state.allocation_store, ptr); }
         }
         state.allocations.clear();
+    }
+
+    void promote_response_allocation_(plugin_allocator_state_t &state, void *ptr) {
+        if (!ptr || !state.allocation_store) { return; }
+        std::shared_ptr<file_backed_buffer_t> file_backed;
+        if (state.allocation_store->take(ptr, file_backed)) {
+            g_response_file_backed_allocations.add(ptr, std::move(file_backed));
+        }
+    }
+
+    void promote_response_allocations_(plugin_allocator_state_t &state,
+                                       const omega_transform_plugin_response_t &response) {
+        promote_response_allocation_(state, response.replacement_bytes);
+        promote_response_allocation_(state, response.result_bytes);
+        promote_response_allocation_(state, response.result_label);
+        promote_response_allocation_(state, response.result_mime_type);
+    }
+
+    void clear_plugin_response_(plugin_allocator_state_t &state, omega_transform_plugin_response_t *response_ptr) {
+        if (!response_ptr) { return; }
+        release_plugin_allocation_(state.allocation_store, response_ptr->replacement_bytes);
+        release_plugin_allocation_(state.allocation_store, response_ptr->result_bytes);
+        release_plugin_allocation_(state.allocation_store, response_ptr->result_label);
+        release_plugin_allocation_(state.allocation_store, response_ptr->result_mime_type);
+        *response_ptr = {};
     }
 
     struct session_range_reader_t {
@@ -896,13 +944,14 @@ namespace {
 
     // Transfers plugin-owned response buffers to the caller. If no caller response is supplied,
     // the temporary response is cleared here so plugins never leak allocator-owned memory.
-    void move_plugin_response_(omega_transform_plugin_response_t *response_ptr,
+    void move_plugin_response_(plugin_allocator_state_t &state, omega_transform_plugin_response_t *response_ptr,
                                omega_transform_plugin_response_t &plugin_response) {
         if (!response_ptr) {
-            omega_transform_plugin_response_clear(&plugin_response);
+            clear_plugin_response_(state, &plugin_response);
             return;
         }
         omega_transform_plugin_response_clear(response_ptr);
+        promote_response_allocations_(state, plugin_response);
         *response_ptr = plugin_response;
         plugin_response = {};
     }
@@ -1007,6 +1056,7 @@ namespace {
 
 struct omega_transform_plugin_registry_struct {
     std::vector<std::unique_ptr<loaded_plugin_t>> plugins;
+    plugin_allocation_store_t allocation_store;
 };
 
 omega_transform_plugin_registry_t *omega_transform_plugin_registry_create(void) {
@@ -1144,7 +1194,9 @@ int omega_transform_plugin_registry_apply_to_session_with_progress_cancel_and_se
     session_range_reader_t reader{
             session_ptr,         offset, requested_length, 0, progress, progress_user_data_ptr, is_cancelled,
             cancel_user_data_ptr};
-    plugin_allocator_state_t allocator_state{omega_session_get_checkpoint_directory(session_ptr), {}};
+    plugin_allocator_state_t allocator_state{omega_session_get_checkpoint_directory(session_ptr),
+                                             &registry_ptr->allocation_store,
+                                             {}};
 
     omega_transform_plugin_request_t request{};
     request.input_bytes = input.data();
@@ -1166,24 +1218,24 @@ int omega_transform_plugin_registry_apply_to_session_with_progress_cancel_and_se
     if (is_cancelled && is_cancelled(cancel_user_data_ptr) != 0) { return -1; }
     if (0 != (*iter)->apply(&request, &plugin_response)) {
         release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-        omega_transform_plugin_response_clear(&plugin_response);
+        clear_plugin_response_(allocator_state, &plugin_response);
         return -1;
     }
     if (is_cancelled && is_cancelled(cancel_user_data_ptr) != 0) {
         release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-        omega_transform_plugin_response_clear(&plugin_response);
+        clear_plugin_response_(allocator_state, &plugin_response);
         return -1;
     }
     if (!plugin_buffer_is_valid_(plugin_response.replacement_bytes, plugin_response.replacement_length) ||
         !plugin_buffer_is_valid_(plugin_response.result_bytes, plugin_response.result_length)) {
         release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-        omega_transform_plugin_response_clear(&plugin_response);
+        clear_plugin_response_(allocator_state, &plugin_response);
         return -1;
     }
     if (plugin_response_has_no_content_change_(plugin_response) &&
         (plugin_response.replacement_bytes != nullptr || plugin_response.replacement_length != 0)) {
         release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-        omega_transform_plugin_response_clear(&plugin_response);
+        clear_plugin_response_(allocator_state, &plugin_response);
         return -1;
     }
 
@@ -1192,7 +1244,7 @@ int omega_transform_plugin_registry_apply_to_session_with_progress_cancel_and_se
         const auto no_content_change = plugin_response_has_no_content_change_(plugin_response);
         if (!no_content_change && requested_length == 0 && plugin_response.replacement_length == 0) {
             release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-            omega_transform_plugin_response_clear(&plugin_response);
+            clear_plugin_response_(allocator_state, &plugin_response);
             return -1;
         }
         if (no_content_change) {
@@ -1203,7 +1255,7 @@ int omega_transform_plugin_registry_apply_to_session_with_progress_cancel_and_se
                     plugin_response.replacement_length, plugin_id, options_json);
             if (change_serial <= 0) {
                 release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-                omega_transform_plugin_response_clear(&plugin_response);
+                clear_plugin_response_(allocator_state, &plugin_response);
                 return -1;
             }
             if (change_serial_out) { *change_serial_out = change_serial; }
@@ -1211,7 +1263,7 @@ int omega_transform_plugin_registry_apply_to_session_with_progress_cancel_and_se
     }
 
     release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-    move_plugin_response_(response_ptr, plugin_response);
+    move_plugin_response_(allocator_state, response_ptr, plugin_response);
     return 0;
 }
 
@@ -1247,7 +1299,7 @@ int omega_transform_plugin_registry_inspect_reader_with_cancel(
     if (((*iter)->info.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) { return -1; }
     if (0 != omega_transform_plugin_options_match_args_schema(options_json, (*iter)->info.args_schema)) { return -1; }
 
-    plugin_allocator_state_t allocator_state{checkpoint_directory, {}};
+    plugin_allocator_state_t allocator_state{checkpoint_directory, &registry_ptr->allocation_store, {}};
 
     omega_transform_plugin_request_t request{};
     request.input_length = 0;
@@ -1270,32 +1322,32 @@ int omega_transform_plugin_registry_inspect_reader_with_cancel(
     if (is_cancelled && is_cancelled(cancel_user_data_ptr) != 0) { return -1; }
     if (0 != (*iter)->apply(&request, &plugin_response)) {
         release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-        omega_transform_plugin_response_clear(&plugin_response);
+        clear_plugin_response_(allocator_state, &plugin_response);
         return -1;
     }
     if (is_cancelled && is_cancelled(cancel_user_data_ptr) != 0) {
         release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-        omega_transform_plugin_response_clear(&plugin_response);
+        clear_plugin_response_(allocator_state, &plugin_response);
         return -1;
     }
     if (!plugin_buffer_is_valid_(plugin_response.replacement_bytes, plugin_response.replacement_length) ||
         !plugin_buffer_is_valid_(plugin_response.result_bytes, plugin_response.result_length) ||
         plugin_response.replacement_bytes != nullptr || plugin_response.replacement_length != 0) {
         release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-        omega_transform_plugin_response_clear(&plugin_response);
+        clear_plugin_response_(allocator_state, &plugin_response);
         return -1;
     }
 
     release_unclaimed_plugin_allocations_(allocator_state, plugin_response);
-    move_plugin_response_(response_ptr, plugin_response);
+    move_plugin_response_(allocator_state, response_ptr, plugin_response);
     return 0;
 }
 
 void omega_transform_plugin_response_clear(omega_transform_plugin_response_t *response_ptr) {
     if (!response_ptr) { return; }
-    release_plugin_allocation_(response_ptr->replacement_bytes);
-    release_plugin_allocation_(response_ptr->result_bytes);
-    release_plugin_allocation_(response_ptr->result_label);
-    release_plugin_allocation_(response_ptr->result_mime_type);
+    release_plugin_allocation_(nullptr, response_ptr->replacement_bytes);
+    release_plugin_allocation_(nullptr, response_ptr->result_bytes);
+    release_plugin_allocation_(nullptr, response_ptr->result_label);
+    release_plugin_allocation_(nullptr, response_ptr->result_mime_type);
     *response_ptr = {};
 }

--- a/core/src/lib/utility.c
+++ b/core/src/lib/utility.c
@@ -452,10 +452,11 @@ void omega_util_count_characters(const unsigned char *data, size_t length, omega
         case BOM_UTF32BE:
             while (i + 3 < length) {
                 // Swap the bytes if the BOM is little endian
-                const uint32_t char32 =
-                        counts_ptr->bom == BOM_UTF32LE
-                                ? (data[i] | (data[i + 1] << 8) | (data[i + 2] << 16) | (data[i + 3] << 24))
-                                : ((data[i] << 24) | (data[i + 1] << 16) | (data[i + 2] << 8) | data[i + 3]);
+                const uint32_t char32 = counts_ptr->bom == BOM_UTF32LE
+                                                ? ((uint32_t) data[i] | ((uint32_t) data[i + 1] << 8) |
+                                                   ((uint32_t) data[i + 2] << 16) | ((uint32_t) data[i + 3] << 24))
+                                                : (((uint32_t) data[i] << 24) | ((uint32_t) data[i + 1] << 16) |
+                                                   ((uint32_t) data[i + 2] << 8) | (uint32_t) data[i + 3]);
 
                 if ((char32 >= 0xD800 && char32 <= 0xDFFF) || char32 > 0x10FFFF) {
                     ++counts_ptr->invalidBytes;// surrogate pairs and characters above 0x10FFFF are invalid in UTF-32

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -568,6 +568,34 @@ TEST_CASE("Character Counts", "[CharCounts]") {
     REQUIRE(0 == omega_character_counts_invalid_bytes(char_counts_ptr));
     omega_edit_destroy_session(session_ptr);
 
+    const omega_byte_t utf32le_high_byte_data[] = {0xFF, 0xFE, 0x00, 0x00,
+                                                   0x00, 0x00, 0x00, static_cast<omega_byte_t>(0x80)};
+    session_ptr = omega_edit_create_session_from_bytes(utf32le_high_byte_data,
+                                                       static_cast<int64_t>(sizeof(utf32le_high_byte_data)), nullptr,
+                                                       nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 == omega_session_character_counts(session_ptr, char_counts_ptr, 0, 0,
+                                                omega_session_detect_BOM(session_ptr, 0)));
+    REQUIRE(BOM_UTF32LE == omega_character_counts_get_BOM(char_counts_ptr));
+    REQUIRE(4 == omega_character_counts_bom_bytes(char_counts_ptr));
+    REQUIRE(0 == omega_character_counts_quad_byte_chars(char_counts_ptr));
+    REQUIRE(4 == omega_character_counts_invalid_bytes(char_counts_ptr));
+    omega_edit_destroy_session(session_ptr);
+
+    const omega_byte_t utf32be_high_byte_data[] = {0x00, 0x00, 0xFE, 0xFF, static_cast<omega_byte_t>(0x80),
+                                                   0x00, 0x00, 0x00};
+    session_ptr = omega_edit_create_session_from_bytes(utf32be_high_byte_data,
+                                                       static_cast<int64_t>(sizeof(utf32be_high_byte_data)), nullptr,
+                                                       nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 == omega_session_character_counts(session_ptr, char_counts_ptr, 0, 0,
+                                                omega_session_detect_BOM(session_ptr, 0)));
+    REQUIRE(BOM_UTF32BE == omega_character_counts_get_BOM(char_counts_ptr));
+    REQUIRE(4 == omega_character_counts_bom_bytes(char_counts_ptr));
+    REQUIRE(0 == omega_character_counts_quad_byte_chars(char_counts_ptr));
+    REQUIRE(4 == omega_character_counts_invalid_bytes(char_counts_ptr));
+    omega_edit_destroy_session(session_ptr);
+
     session_ptr = omega_edit_create_session(MAKE_PATH("ascii_1.dat"), nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(session_ptr);
     REQUIRE(0 == omega_session_character_counts(session_ptr, char_counts_ptr, 0, 0,

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -216,6 +216,61 @@ TEST_CASE("Restore Last Transform Checkpoint Preserves Transform Change",
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Clear Changes Discards Checkpoint Stack", "[SessionCheckpointTests][ClearChanges]") {
+    const auto input = reinterpret_cast<const omega_byte_t *>("abcdef");
+    const auto session_ptr = omega_edit_create_session_from_bytes(input, 6, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(1 == omega_edit_overwrite_string(session_ptr, 1, "Z"));
+    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(1 == omega_session_get_num_changes(session_ptr));
+    const std::string checkpoint_path = omega_session_get_latest_checkpoint_file_path(session_ptr);
+    REQUIRE(0 != omega_util_file_exists(checkpoint_path.c_str()));
+
+    REQUIRE(2 == omega_edit_insert_string(session_ptr, 2, "YY"));
+    REQUIRE("aZYYcdef" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    REQUIRE(0 == omega_edit_clear_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE("abcdef" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(nullptr == omega_session_get_latest_checkpoint_file_path(session_ptr));
+    REQUIRE(0 == omega_util_file_exists(checkpoint_path.c_str()));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Clear Changes Discards Transform Checkpoint Stack", "[SessionCheckpointTests][ClearChanges]") {
+    const auto input = reinterpret_cast<const omega_byte_t *>("abcXYZ");
+    const auto session_ptr = omega_edit_create_session_from_bytes(input, 6, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 == omega_edit_apply_transform(session_ptr, to_lower, nullptr, 0, 0));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(1 == omega_session_get_num_changes(session_ptr));
+    const std::string checkpoint_path = omega_session_get_latest_checkpoint_file_path(session_ptr);
+    REQUIRE(0 != omega_util_file_exists(checkpoint_path.c_str()));
+
+    REQUIRE(2 == omega_edit_insert_string(session_ptr, 3, "--"));
+    REQUIRE("abc--xyz" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    REQUIRE(0 == omega_edit_clear_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE("abcXYZ" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE(nullptr == omega_session_get_latest_checkpoint_file_path(session_ptr));
+    REQUIRE(0 == omega_util_file_exists(checkpoint_path.c_str()));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Session owned snapshot file accessors expose original and latest checkpoint",
           "[SessionCheckpointTests][SnapshotFiles]") {
     const auto input = reinterpret_cast<const omega_byte_t *>("abcdef");

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -1369,7 +1369,7 @@ async function writeStreamText(
 }
 
 async function syncFileToDisk(path: string): Promise<void> {
-  const handle = await fs.open(path, 'r')
+  const handle = await fs.open(path, 'r+')
   try {
     await handle.sync()
   } finally {

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -1368,6 +1368,30 @@ async function writeStreamText(
   }
 }
 
+async function syncFileToDisk(path: string): Promise<void> {
+  const handle = await fs.open(path, 'r')
+  try {
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+async function syncParentDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') {
+    return
+  }
+  let handle: fs.FileHandle | undefined
+  try {
+    handle = await fs.open(dirname(path), 'r')
+    await handle.sync()
+  } catch {
+    // Some filesystems/platforms do not support directory fsync through Node.
+  } finally {
+    await handle?.close().catch(() => undefined)
+  }
+}
+
 async function writeChangeLogDocumentFile(
   outputPath: string,
   overwriteExisting: boolean,
@@ -1435,8 +1459,10 @@ async function writeChangeLogDocumentFile(
     await finished(stream)
 
     assertCompleteChangeLog('export', collected.unavailableChangeSerials)
+    await syncFileToDisk(tempPath)
     await verifyBeforeCommit?.()
     await fs.rename(tempPath, outputPath)
+    await syncParentDirectory(outputPath)
     committed = true
     return collected
   } finally {

--- a/plugins/src/format_inspectors.cpp
+++ b/plugins/src/format_inspectors.cpp
@@ -30,16 +30,19 @@ namespace {
             "\"default\":1,\"enum\":[1,2,3,4]},\"endian\":{\"type\":\"string\",\"title\":\"Byte order\","
             "\"default\":\"big\",\"enum\":[\"big\",\"little\"]}},\"additionalProperties\":false}";
 
-    std::string inspect_protobuf_varints(const std::vector<omega_byte_t> &input) {
+    std::string inspect_protobuf_varints(const omega_transform_plugin_request_t *request_ptr,
+                                         const std::vector<omega_byte_t> &input) {
         std::ostringstream out;
         size_t offset = 0;
         int index = 0;
         while (offset < input.size()) {
+            if (omega_transform_plugin_sdk_is_cancelled(request_ptr)) { return {}; }
             const size_t start = offset;
             uint64_t value = 0;
             int shift = 0;
             bool terminated = false;
             while (offset < input.size() && shift < 64) {
+                if (omega_transform_plugin_sdk_is_cancelled(request_ptr)) { return {}; }
                 const omega_byte_t byte = input[offset++];
                 value |= static_cast<uint64_t>(byte & 0x7FU) << shift;
                 if ((byte & 0x80U) == 0) {
@@ -74,11 +77,13 @@ namespace {
         return "unknown";
     }
 
-    std::string inspect_asn1(const std::vector<omega_byte_t> &input) {
+    std::string inspect_asn1(const omega_transform_plugin_request_t *request_ptr,
+                             const std::vector<omega_byte_t> &input) {
         std::ostringstream out;
         size_t offset = 0;
         int index = 0;
         while (offset < input.size()) {
+            if (omega_transform_plugin_sdk_is_cancelled(request_ptr)) { return {}; }
             const size_t start = offset;
             const omega_byte_t first = input[offset++];
             const unsigned int tag_class = (first >> 6U) & 0x03U;
@@ -88,6 +93,7 @@ namespace {
                 tag = 0;
                 bool done = false;
                 while (offset < input.size()) {
+                    if (omega_transform_plugin_sdk_is_cancelled(request_ptr)) { return {}; }
                     const omega_byte_t byte = input[offset++];
                     tag = (tag << 7U) | (byte & 0x7FU);
                     if ((byte & 0x80U) == 0) {
@@ -113,7 +119,7 @@ namespace {
                 const unsigned int length_bytes = length_byte & 0x7FU;
                 if (length_bytes == 0) {
                     indefinite = true;
-                } else if (length_bytes > 8 || offset + length_bytes > input.size()) {
+                } else if (length_bytes > 8 || length_bytes > input.size() - offset) {
                     out << "tlv[" << index << "] offset=" << start << " tag=" << tag << " error=invalid-length\n";
                     break;
                 } else {
@@ -129,7 +135,7 @@ namespace {
                 break;
             }
             out << " length=" << length;
-            if (offset + length > input.size()) {
+            if (length > static_cast<uint64_t>(input.size() - offset)) {
                 out << " error=value-truncated\n";
                 break;
             }
@@ -150,14 +156,15 @@ namespace {
         return value;
     }
 
-    std::string inspect_tlv(const std::vector<omega_byte_t> &input, int64_t tag_bytes, int64_t length_bytes,
-                            bool little_endian) {
+    std::string inspect_tlv(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                            int64_t tag_bytes, int64_t length_bytes, bool little_endian) {
         std::ostringstream out;
         size_t offset = 0;
         int index = 0;
         const auto header = static_cast<size_t>(tag_bytes + length_bytes);
         while (offset < input.size()) {
-            if (offset + header > input.size()) {
+            if (omega_transform_plugin_sdk_is_cancelled(request_ptr)) { return {}; }
+            if (header > input.size() - offset) {
                 out << "tlv[" << index << "] offset=" << offset << " error=truncated-header\n";
                 break;
             }
@@ -166,7 +173,7 @@ namespace {
                     read_uint(input, offset + static_cast<size_t>(tag_bytes), length_bytes, little_endian);
             const size_t value_offset = offset + header;
             out << "tlv[" << index++ << "] offset=" << offset << " tag=" << tag << " length=" << length;
-            if (value_offset + length > input.size()) {
+            if (length > static_cast<uint64_t>(input.size() - value_offset)) {
                 out << " error=value-truncated\n";
                 break;
             }
@@ -206,17 +213,18 @@ omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr
     const std::string format = omega_edit::plugin::option_or(options, "format", "protobuf-varint");
     std::string result;
     if (format == "protobuf-varint") {
-        result = inspect_protobuf_varints(input);
+        result = inspect_protobuf_varints(request_ptr, input);
     } else if (format == "asn1-ber" || format == "asn1-der") {
-        result = inspect_asn1(input);
+        result = inspect_asn1(request_ptr, input);
     } else if (format == "tlv") {
         const int64_t tag_bytes = omega_edit::plugin::option_int_or(options, "tagBytes", 1);
         const int64_t length_bytes = omega_edit::plugin::option_int_or(options, "lengthBytes", 1);
         if (tag_bytes < 1 || tag_bytes > 4 || length_bytes < 1 || length_bytes > 4) { return -1; }
-        result = inspect_tlv(input, tag_bytes, length_bytes,
+        result = inspect_tlv(request_ptr, input, tag_bytes, length_bytes,
                              omega_edit::plugin::option_or(options, "endian", "big") == "little");
     } else {
         return -1;
     }
+    if (omega_transform_plugin_sdk_is_cancelled(request_ptr)) { return -1; }
     return omega_edit::plugin::set_text_result(request_ptr, response_ptr, format, result);
 }

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -130,6 +130,10 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     const char *unsupported_number_schema =
             "{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"number\"}},\"additionalProperties\":false}";
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"value\":1.5}", unsupported_number_schema));
+    std::string deeply_nested_options;
+    deeply_nested_options.append(300, '[');
+    deeply_nested_options.append(300, ']');
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(deeply_nested_options.c_str(), empty_object_schema));
     for (int64_t index = 0; index < omega_transform_plugin_registry_get_count(registry_ptr); ++index) {
         const auto *info = omega_transform_plugin_registry_get_info(registry_ptr, index);
         REQUIRE(info);
@@ -811,6 +815,20 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                     .find("value=150") != std::string::npos);
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(format_session_ptr);
+
+    const auto asn1_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(asn1_session_ptr);
+    const omega_byte_t asn1_overflow_length[] = {0x04, 0x88, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    REQUIRE(0 < omega_edit_insert_bytes(asn1_session_ptr, 0, asn1_overflow_length,
+                                        static_cast<int64_t>(sizeof(asn1_overflow_length))));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.format_inspectors",
+                                                                  asn1_session_ptr, 0, 0, "{\"format\":\"asn1-ber\"}",
+                                                                  &response));
+    REQUIRE(std::string(reinterpret_cast<const char *>(response.result_bytes),
+                        static_cast<size_t>(response.result_length))
+                    .find("error=value-truncated") != std::string::npos);
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(asn1_session_ptr);
 
     const auto record_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(record_session_ptr);

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -975,6 +975,9 @@ namespace omega_edit {
         grpc::Status EditorServiceImpl::SaveSession(grpc::ServerContext * /*context*/,
                                                     const ::omega_edit::v1::SaveSessionRequest *request,
                                                     ::omega_edit::v1::SaveSessionResponse *response) {
+            if (request->file_path().empty()) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "file_path must not be empty");
+            }
             const auto path_status = validate_path_argument(request->file_path(), "file_path");
             if (!path_status.ok()) { return path_status; }
 

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -319,6 +319,43 @@ namespace omega_edit {
             return metadata;
         }
 
+        static int grpc_context_is_cancelled(void *user_data_ptr);
+
+        static grpc::Status inspect_with_streaming_plugin(
+                grpc::ServerContext *context, omega_transform_plugin_registry_t *registry, std::mutex &registry_mutex,
+                const std::string &plugin_id, const char *options_json, const char *checkpoint_directory,
+                int64_t session_offset, int64_t session_length, omega_transform_plugin_read_t read,
+                void *reader_user_data_ptr, grpc::StatusCode not_found_code, const std::string &not_found_message,
+                const std::string &wrong_operation_message, const std::string &invalid_options_message,
+                const std::string &cancelled_message, grpc::StatusCode failed_code, const std::string &failed_message,
+                omega_transform_plugin_response_t *response) {
+            transform_plugin_metadata plugin_metadata;
+            {
+                std::lock_guard<std::mutex> plugin_lock(registry_mutex);
+                plugin_metadata = snapshot_transform_plugin_metadata(registry, plugin_id);
+            }
+            if (!plugin_metadata.found) { return grpc::Status(not_found_code, not_found_message); }
+            if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
+                (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
+                return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, wrong_operation_message);
+            }
+            if (0 !=
+                omega_transform_plugin_options_match_args_schema(options_json, plugin_metadata.args_schema_ptr())) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, invalid_options_message);
+            }
+
+            if (0 != omega_transform_plugin_registry_inspect_reader_with_cancel(
+                             registry, plugin_id.c_str(), session_offset, session_length, options_json,
+                             checkpoint_directory, read, reader_user_data_ptr, SESSION_CONTENT_INSPECTION_CHUNK_SIZE,
+                             nullptr, nullptr, grpc_context_is_cancelled, context, response)) {
+                if (context && context->IsCancelled()) {
+                    return grpc::Status(grpc::StatusCode::CANCELLED, cancelled_message);
+                }
+                return grpc::Status(failed_code, failed_message);
+            }
+            return grpc::Status::OK;
+        }
+
         struct transform_progress_context {
             SessionManager *session_manager{};
             grpc::ServerContext *grpc_context{};
@@ -938,6 +975,9 @@ namespace omega_edit {
         grpc::Status EditorServiceImpl::SaveSession(grpc::ServerContext * /*context*/,
                                                     const ::omega_edit::v1::SaveSessionRequest *request,
                                                     ::omega_edit::v1::SaveSessionResponse *response) {
+            const auto path_status = validate_path_argument(request->file_path(), "file_path");
+            if (!path_status.ok()) { return path_status; }
+
             auto locked_session = session_manager_.lock_session(request->session_id());
             if (!locked_session) {
                 return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
@@ -1706,42 +1746,21 @@ namespace omega_edit {
                 }
 
                 session_content_file_reader reader{snapshot_file_path, 0, byte_length};
-                transform_plugin_metadata plugin_metadata;
-                {
-                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
-                    plugin_metadata = snapshot_transform_plugin_metadata(transform_plugin_registry_,
-                                                                         SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
-                }
-                if (!plugin_metadata.found) {
-                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                        "session fingerprint digest plugin is not registered: " +
-                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                }
-                if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-                    (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                        "session fingerprint digest plugin must be a streaming inspect plugin");
-                }
-                if (0 != omega_transform_plugin_options_match_args_schema(options_json.c_str(),
-                                                                          plugin_metadata.args_schema_ptr())) {
-                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                        "unsupported fingerprint digest algorithm: " + algorithm);
-                }
-
-                if (0 != omega_transform_plugin_registry_inspect_reader_with_cancel(
-                                 transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
-                                 options_json.c_str(), checkpoint_directory.c_str(), read_session_content_file_chunk,
-                                 &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE, nullptr, nullptr,
-                                 grpc_context_is_cancelled, context, &plugin_response.response)) {
-                    if (context && context->IsCancelled()) {
-                        return grpc::Status(grpc::StatusCode::CANCELLED,
-                                            "session fingerprint digest plugin cancelled: " +
-                                                    std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                    }
-                    return grpc::Status(grpc::StatusCode::ABORTED,
-                                        "session fingerprint digest plugin failed: " +
-                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                }
+                const auto inspect_status = inspect_with_streaming_plugin(
+                        context, transform_plugin_registry_, transform_plugin_registry_mutex_,
+                        SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, options_json.c_str(), checkpoint_directory.c_str(), 0,
+                        byte_length, read_session_content_file_chunk, &reader, grpc::StatusCode::FAILED_PRECONDITION,
+                        "session fingerprint digest plugin is not registered: " +
+                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                        "session fingerprint digest plugin must be a streaming inspect plugin",
+                        "unsupported fingerprint digest algorithm: " + algorithm,
+                        "session fingerprint digest plugin cancelled: " +
+                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                        grpc::StatusCode::ABORTED,
+                        "session fingerprint digest plugin failed: " +
+                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                        &plugin_response.response);
+                if (!inspect_status.ok()) { return inspect_status; }
             } else {
                 auto locked_session = session_manager_.lock_session(request->session_id());
                 if (!locked_session) {
@@ -1754,43 +1773,23 @@ namespace omega_edit {
                                         "session content length unavailable for fingerprint");
                 }
 
-                transform_plugin_metadata plugin_metadata;
-                {
-                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
-                    plugin_metadata = snapshot_transform_plugin_metadata(transform_plugin_registry_,
-                                                                         SESSION_FINGERPRINT_DIGEST_PLUGIN_ID);
-                }
-                if (!plugin_metadata.found) {
-                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                        "session fingerprint digest plugin is not registered: " +
-                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                }
-                if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-                    (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                        "session fingerprint digest plugin must be a streaming inspect plugin");
-                }
-                if (0 != omega_transform_plugin_options_match_args_schema(options_json.c_str(),
-                                                                          plugin_metadata.args_schema_ptr())) {
-                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                        "unsupported fingerprint digest algorithm: " + algorithm);
-                }
-
                 session_content_reader reader{session, inspection_content, 0, byte_length};
-                if (0 != omega_transform_plugin_registry_inspect_reader_with_cancel(
-                                 transform_plugin_registry_, SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, 0, byte_length,
-                                 options_json.c_str(), omega_session_get_checkpoint_directory(session),
-                                 read_session_content_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE, nullptr,
-                                 nullptr, grpc_context_is_cancelled, context, &plugin_response.response)) {
-                    if (context && context->IsCancelled()) {
-                        return grpc::Status(grpc::StatusCode::CANCELLED,
-                                            "session fingerprint digest plugin cancelled: " +
-                                                    std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                    }
-                    return grpc::Status(grpc::StatusCode::INTERNAL,
-                                        "session fingerprint digest plugin failed: " +
-                                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID));
-                }
+                const auto inspect_status = inspect_with_streaming_plugin(
+                        context, transform_plugin_registry_, transform_plugin_registry_mutex_,
+                        SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, options_json.c_str(),
+                        omega_session_get_checkpoint_directory(session), 0, byte_length, read_session_content_chunk,
+                        &reader, grpc::StatusCode::FAILED_PRECONDITION,
+                        "session fingerprint digest plugin is not registered: " +
+                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                        "session fingerprint digest plugin must be a streaming inspect plugin",
+                        "unsupported fingerprint digest algorithm: " + algorithm,
+                        "session fingerprint digest plugin cancelled: " +
+                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                        grpc::StatusCode::ABORTED,
+                        "session fingerprint digest plugin failed: " +
+                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                        &plugin_response.response);
+                if (!inspect_status.ok()) { return inspect_status; }
             }
 
             if (plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
@@ -1873,6 +1872,7 @@ namespace omega_edit {
             int64_t effective_length = 0;
             std::string checkpoint_directory;
             transform_plugin_response_guard plugin_response;
+            const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
 
             if (session_content_source_uses_file_snapshot(content)) {
                 std::string snapshot_file_path;
@@ -1898,39 +1898,16 @@ namespace omega_edit {
                 }
 
                 session_content_file_reader reader{snapshot_file_path, effective_offset, effective_length};
-                transform_plugin_metadata plugin_metadata;
-                {
-                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
-                    plugin_metadata =
-                            snapshot_transform_plugin_metadata(transform_plugin_registry_, request->plugin_id());
-                }
-                if (!plugin_metadata.found) {
-                    return grpc::Status(grpc::StatusCode::NOT_FOUND,
-                                        "transform plugin not found: " + request->plugin_id());
-                }
-                if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-                    (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                        "session content inspection requires a streaming inspect plugin");
-                }
-                const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
-                if (0 !=
-                    omega_transform_plugin_options_match_args_schema(options_json, plugin_metadata.args_schema_ptr())) {
-                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                        "transform options do not match schema: " + request->plugin_id());
-                }
-                if (0 != omega_transform_plugin_registry_inspect_reader_with_cancel(
-                                 transform_plugin_registry_, request->plugin_id().c_str(), effective_offset,
-                                 effective_length, options_json, checkpoint_directory.c_str(),
-                                 read_session_content_file_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE,
-                                 nullptr, nullptr, grpc_context_is_cancelled, context, &plugin_response.response)) {
-                    if (context && context->IsCancelled()) {
-                        return grpc::Status(grpc::StatusCode::CANCELLED,
-                                            "session content inspection cancelled: " + request->plugin_id());
-                    }
-                    return grpc::Status(grpc::StatusCode::ABORTED,
-                                        "session content inspection failed: " + request->plugin_id());
-                }
+                const auto inspect_status = inspect_with_streaming_plugin(
+                        context, transform_plugin_registry_, transform_plugin_registry_mutex_, request->plugin_id(),
+                        options_json, checkpoint_directory.c_str(), effective_offset, effective_length,
+                        read_session_content_file_chunk, &reader, grpc::StatusCode::NOT_FOUND,
+                        "transform plugin not found: " + request->plugin_id(),
+                        "session content inspection requires a streaming inspect plugin",
+                        "transform options do not match schema: " + request->plugin_id(),
+                        "session content inspection cancelled: " + request->plugin_id(), grpc::StatusCode::ABORTED,
+                        "session content inspection failed: " + request->plugin_id(), &plugin_response.response);
+                if (!inspect_status.ok()) { return inspect_status; }
             } else {
                 auto locked_session = session_manager_.lock_session(request->session_id());
                 if (!locked_session) {
@@ -1943,39 +1920,16 @@ namespace omega_edit {
                 if (!range_status.ok()) { return range_status; }
 
                 session_content_reader reader{session, content, effective_offset, effective_length};
-                transform_plugin_metadata plugin_metadata;
-                {
-                    std::lock_guard<std::mutex> plugin_lock(transform_plugin_registry_mutex_);
-                    plugin_metadata =
-                            snapshot_transform_plugin_metadata(transform_plugin_registry_, request->plugin_id());
-                }
-                if (!plugin_metadata.found) {
-                    return grpc::Status(grpc::StatusCode::NOT_FOUND,
-                                        "transform plugin not found: " + request->plugin_id());
-                }
-                if (plugin_metadata.operation != OMEGA_TRANSFORM_PLUGIN_OPERATION_INSPECT ||
-                    (plugin_metadata.flags & OMEGA_TRANSFORM_PLUGIN_FLAG_STREAMING) == 0U) {
-                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                        "session content inspection requires a streaming inspect plugin");
-                }
-                const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
-                if (0 !=
-                    omega_transform_plugin_options_match_args_schema(options_json, plugin_metadata.args_schema_ptr())) {
-                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                        "transform options do not match schema: " + request->plugin_id());
-                }
-                if (0 != omega_transform_plugin_registry_inspect_reader_with_cancel(
-                                 transform_plugin_registry_, request->plugin_id().c_str(), effective_offset,
-                                 effective_length, options_json, omega_session_get_checkpoint_directory(session),
-                                 read_session_content_chunk, &reader, SESSION_CONTENT_INSPECTION_CHUNK_SIZE, nullptr,
-                                 nullptr, grpc_context_is_cancelled, context, &plugin_response.response)) {
-                    if (context && context->IsCancelled()) {
-                        return grpc::Status(grpc::StatusCode::CANCELLED,
-                                            "session content inspection cancelled: " + request->plugin_id());
-                    }
-                    return grpc::Status(grpc::StatusCode::INTERNAL,
-                                        "session content inspection failed: " + request->plugin_id());
-                }
+                const auto inspect_status = inspect_with_streaming_plugin(
+                        context, transform_plugin_registry_, transform_plugin_registry_mutex_, request->plugin_id(),
+                        options_json, omega_session_get_checkpoint_directory(session), effective_offset,
+                        effective_length, read_session_content_chunk, &reader, grpc::StatusCode::NOT_FOUND,
+                        "transform plugin not found: " + request->plugin_id(),
+                        "session content inspection requires a streaming inspect plugin",
+                        "transform options do not match schema: " + request->plugin_id(),
+                        "session content inspection cancelled: " + request->plugin_id(), grpc::StatusCode::ABORTED,
+                        "session content inspection failed: " + request->plugin_id(), &plugin_response.response);
+                if (!inspect_status.ok()) { return inspect_status; }
             }
 
             if (!inspect_plugin_response_is_valid(plugin_response.response)) {

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -115,6 +115,12 @@ static bool parse_log_level(const std::string &value, const std::string &name, L
     return true;
 }
 
+static bool require_option_value(const std::string &key, const std::string &value) {
+    if (!value.empty()) { return true; }
+    std::cerr << "Error: " << key << " requires a value\n";
+    return false;
+}
+
 static bool env_value_is_true(const char *value) {
     if (!value) { return false; }
     std::string normalized;
@@ -199,12 +205,11 @@ static bool apply_log_config_file(const std::string &config_path, std::string &l
     return true;
 }
 
-/// Parse a string as an integer in [min_val, max_val], writing the result to out.
-/// Returns true on success; on failure prints a message to stderr and returns false.
-static bool parse_int(const std::string &str, const std::string &name, long min_val, long max_val, int &out) {
+static bool parse_signed_integer(const std::string &str, const std::string &name, long long min_val, long long max_val,
+                                 long long &out) {
     try {
         size_t pos = 0;
-        long v = std::stol(str, &pos);
+        const auto v = std::stoll(str, &pos);
         if (pos != str.size()) {
             std::cerr << "Error: " << name << " must be a valid integer, got: " << str << "\n";
             return false;
@@ -214,59 +219,67 @@ static bool parse_int(const std::string &str, const std::string &name, long min_
                       << "\n";
             return false;
         }
-        out = static_cast<int>(v);
+        out = v;
         return true;
     } catch (const std::exception &) {
         std::cerr << "Error: " << name << " must be a valid integer, got: " << str << "\n";
         return false;
     }
+}
+
+static bool parse_unsigned_integer(const std::string &str, const std::string &name, unsigned long long min_val,
+                                   unsigned long long max_val, unsigned long long &out) {
+    try {
+        size_t pos = 0;
+        const auto v = std::stoull(str, &pos);
+        if (pos != str.size()) {
+            std::cerr << "Error: " << name << " must be a valid integer, got: " << str << "\n";
+            return false;
+        }
+        if (v < min_val || v > max_val) {
+            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val << ", got: " << v
+                      << "\n";
+            return false;
+        }
+        out = v;
+        return true;
+    } catch (const std::exception &) {
+        std::cerr << "Error: " << name << " must be a valid integer, got: " << str << "\n";
+        return false;
+    }
+}
+
+/// Parse a string as an integer in [min_val, max_val], writing the result to out.
+/// Returns true on success; on failure prints a message to stderr and returns false.
+static bool parse_int(const std::string &str, const std::string &name, long min_val, long max_val, int &out) {
+    long long parsed = 0;
+    if (!parse_signed_integer(str, name, min_val, max_val, parsed)) { return false; }
+    out = static_cast<int>(parsed);
+    return true;
 }
 
 /// Parse a string as an int64 in [min_val, max_val], writing the result to out.
 /// Returns true on success; on failure prints a message to stderr and returns false.
 static bool parse_int64(const std::string &str, const std::string &name, int64_t min_val, int64_t max_val,
                         int64_t &out) {
-    try {
-        size_t pos = 0;
-        long long v = std::stoll(str, &pos);
-        if (pos != str.size()) {
-            std::cerr << "Error: " << name << " must be a valid integer, got: " << str << "\n";
-            return false;
-        }
-        if (v < min_val || v > max_val) {
-            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val << ", got: " << v
-                      << "\n";
-            return false;
-        }
-        out = static_cast<int64_t>(v);
-        return true;
-    } catch (const std::exception &) {
-        std::cerr << "Error: " << name << " must be a valid integer, got: " << str << "\n";
+    long long parsed = 0;
+    if (!parse_signed_integer(str, name, static_cast<long long>(min_val), static_cast<long long>(max_val), parsed)) {
         return false;
     }
+    out = static_cast<int64_t>(parsed);
+    return true;
 }
 
 /// Parse a string as a size_t in [min_val, max_val], writing the result to out.
 /// Returns true on success; on failure prints a message to stderr and returns false.
 static bool parse_size_t(const std::string &str, const std::string &name, size_t min_val, size_t max_val, size_t &out) {
-    try {
-        size_t pos = 0;
-        unsigned long long v = std::stoull(str, &pos);
-        if (pos != str.size()) {
-            std::cerr << "Error: " << name << " must be a valid integer, got: " << str << "\n";
-            return false;
-        }
-        if (v < min_val || v > max_val) {
-            std::cerr << "Error: " << name << " must be between " << min_val << " and " << max_val << ", got: " << v
-                      << "\n";
-            return false;
-        }
-        out = static_cast<size_t>(v);
-        return true;
-    } catch (const std::exception &) {
-        std::cerr << "Error: " << name << " must be a valid integer, got: " << str << "\n";
+    unsigned long long parsed = 0;
+    if (!parse_unsigned_integer(str, name, static_cast<unsigned long long>(min_val),
+                                static_cast<unsigned long long>(max_val), parsed)) {
         return false;
     }
+    out = static_cast<size_t>(parsed);
+    return true;
 }
 
 static void append_transform_plugin_directories(const std::string &directories, std::vector<std::string> &out) {
@@ -427,46 +440,25 @@ int main(int argc, char **argv) {
             }
 
             if (key == "-i" || key == "--interface") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 interface_addr = value;
             } else if (key == "-p" || key == "--port") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 if (!parse_int(value, "--port", 1, 65535, port)) return 1;
             } else if (key == "-f" || key == "--pidfile") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 pidfile = value;
             } else if (key == "-u" || key == "--unix-socket") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 unix_socket = value;
             } else if (key == "--log-file") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 log_file = value;
             } else if (key == "--log-level") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 if (!parse_log_level(value, "--log-level", log_level)) return 1;
             } else if (key == "--log-config") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 log_config_file = value;
                 // Pre-scan for explicit --log-file / --log-level flags so that they
                 // always win over the config file regardless of argument order.
@@ -486,53 +478,32 @@ int main(int argc, char **argv) {
                 if (!has_explicit_log_file) { log_file = config_log_file; }
                 if (!has_explicit_log_level) { log_level = config_log_level; }
             } else if (key == "--session-timeout") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 if (!parse_int(value, "--session-timeout", 0, INT_MAX, session_timeout_ms)) return 1;
             } else if (key == "--cleanup-interval") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 if (!parse_int(value, "--cleanup-interval", 0, INT_MAX, cleanup_interval_ms)) return 1;
             } else if (key == "--session-event-queue-capacity") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 if (!parse_size_t(value, "--session-event-queue-capacity", 0, std::numeric_limits<size_t>::max(),
                                   session_event_queue_capacity))
                     return 1;
             } else if (key == "--viewport-event-queue-capacity") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 if (!parse_size_t(value, "--viewport-event-queue-capacity", 0, std::numeric_limits<size_t>::max(),
                                   viewport_event_queue_capacity))
                     return 1;
             } else if (key == "--max-change-bytes") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 if (!parse_int64(value, "--max-change-bytes", 0, std::numeric_limits<int64_t>::max(), max_change_bytes))
                     return 1;
             } else if (key == "--max-viewports-per-session") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 if (!parse_size_t(value, "--max-viewports-per-session", 0, std::numeric_limits<size_t>::max(),
                                   max_viewports_per_session))
                     return 1;
             } else if (key == "--transform-plugin-dir") {
-                if (value.empty()) {
-                    std::cerr << "Error: " << key << " requires a value\n";
-                    return 1;
-                }
+                if (!require_option_value(key, value)) { return 1; }
                 transform_plugin_directories.push_back(value);
             }
             // Silently ignore unknown options.

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -169,6 +169,14 @@ namespace omega_edit {
                 for (const auto &subscriber : subscribers) { subscriber->push(event); }
             }
 
+            void complete_session_initialization(const std::shared_ptr<SessionInfo> &info) {
+                {
+                    std::lock_guard<std::mutex> initialization_lock(info->initialization_mutex);
+                    info->initialization_complete = true;
+                }
+                info->initialization_cv.notify_all();
+            }
+
             bool normalize_existing_file_path(const std::string &file_path, std::string &normalized_path_out) {
                 char normalized_path[FILENAME_MAX] = {};
                 char *result = omega_util_normalize_path(file_path.c_str(), normalized_path);
@@ -539,6 +547,13 @@ namespace omega_edit {
                 }
 
                 if (existing_info) {
+                    {
+                        std::unique_lock<std::mutex> initialization_lock(existing_info->initialization_mutex);
+                        existing_info->initialization_cv.wait(initialization_lock, [&existing_info] {
+                            return existing_info->initialization_complete;
+                        });
+                    }
+
                     std::unique_lock<std::mutex> core_lock(existing_info->core_mutex);
                     if (!existing_info->session) {
                         if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
@@ -638,6 +653,7 @@ namespace omega_edit {
                     std::lock_guard<std::mutex> lock(mutex_);
                     cleanup_managed_server_root_if_empty();
                 }
+                complete_session_initialization(info);
                 if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
                 return "";// Failed to create
             }
@@ -654,9 +670,9 @@ namespace omega_edit {
                 if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
                 {
                     std::lock_guard<std::mutex> lock(mutex_);
-                    release_reserved_file_session();
                     cleanup_managed_server_root_if_empty();
                 }
+                complete_session_initialization(info);
                 if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
                 return "";
             }
@@ -686,15 +702,18 @@ namespace omega_edit {
                     std::lock_guard<std::mutex> lock(mutex_);
                     cleanup_managed_server_root_if_empty();
                 }
+                complete_session_initialization(info);
                 if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
                 return "";
             }
 
+            complete_session_initialization(info);
             return session_id;
         }
 
         void SessionManager::destroy_session_info(const std::shared_ptr<SessionInfo> &info) {
             if (!info) { return; }
+            complete_session_initialization(info);
             std::lock_guard<std::mutex> core_lock(info->core_mutex);
 
             // Close event queues

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -499,8 +499,6 @@ namespace omega_edit {
                                                    const std::string &checkpoint_directory,
                                                    const std::string *initial_data, int64_t &file_size_out,
                                                    std::string &checkpoint_dir_out, SessionCreateError *error_out) {
-            std::lock_guard<std::mutex> lock(mutex_);
-
             if (error_out) { *error_out = SessionCreateError::SUCCESS; }
 
             if (!file_path.empty() && !is_valid_external_path(file_path)) {
@@ -522,71 +520,99 @@ namespace omega_edit {
             const bool share_existing_file_session = desired_id.empty() && has_file_backing;
 
             if (share_existing_file_session) {
-                auto existing_file_session = file_sessions_by_path_.find(canonical_file_path);
-                if (existing_file_session != file_sessions_by_path_.end()) {
-                    auto existing = sessions_.find(existing_file_session->second);
-                    if (existing == sessions_.end()) {
-                        file_sessions_by_path_.erase(existing_file_session);
-                    } else if (checkpoint_directory.empty() ||
-                               checkpoint_directory == existing->second->checkpoint_directory) {
-                        auto &info = existing->second;
-                        std::lock_guard<std::mutex> core_lock(info->core_mutex);
-                        const auto computed_size =
-                                info->session ? omega_session_get_computed_file_size(info->session) : 0;
-                        if (computed_size < 0) {
-                            if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                std::shared_ptr<SessionInfo> existing_info;
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    auto existing_file_session = file_sessions_by_path_.find(canonical_file_path);
+                    if (existing_file_session != file_sessions_by_path_.end()) {
+                        auto existing = sessions_.find(existing_file_session->second);
+                        if (existing == sessions_.end()) {
+                            file_sessions_by_path_.erase(existing_file_session);
+                        } else if (checkpoint_directory.empty() ||
+                                   checkpoint_directory == existing->second->checkpoint_directory) {
+                            existing_info = existing->second;
+                        } else {
+                            if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
                             return "";
                         }
-                        ++info->attachment_count;
-                        info->last_activity = std::chrono::steady_clock::now();
-                        file_size_out = computed_size;
-                        checkpoint_dir_out = info->checkpoint_directory;
-                        return info->session_id;
-                    } else {
-                        if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
-                        return "";
                     }
                 }
+
+                if (existing_info) {
+                    std::unique_lock<std::mutex> core_lock(existing_info->core_mutex);
+                    if (!existing_info->session) {
+                        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                        return "";
+                    }
+                    const auto computed_size = omega_session_get_computed_file_size(existing_info->session);
+                    if (computed_size < 0) {
+                        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                        return "";
+                    }
+                    core_lock.unlock();
+
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    auto current = sessions_.find(existing_info->session_id);
+                    if (current == sessions_.end() || current->second != existing_info) {
+                        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                        return "";
+                    }
+                    ++existing_info->attachment_count;
+                    existing_info->last_activity = std::chrono::steady_clock::now();
+                    file_size_out = computed_size;
+                    checkpoint_dir_out = existing_info->checkpoint_directory;
+                    return existing_info->session_id;
+                }
             }
 
-            // Session ID priority: desired_id > generated opaque session ID
             std::string session_id;
-            if (!desired_id.empty()) {
-                if (!is_valid_external_id(desired_id)) {
-                    if (error_out) { *error_out = SessionCreateError::INVALID_ID; }
-                    return "";
-                }
-                session_id = desired_id;
-                if (sessions_.count(session_id) != 0) {
-                    if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
-                    return "";// Already exists
-                }
-            } else {
-                do { session_id = generate_session_id(); } while (sessions_.count(session_id) != 0);
-            }
-
             auto info = std::make_shared<SessionInfo>();
-            info->session_id = session_id;
-            info->canonical_file_path = canonical_file_path;
-            info->attachment_count = 1;
-            info->last_activity = std::chrono::steady_clock::now();
-
-            // Store info first so the callback can find it
-            sessions_[session_id] = info;
-
             std::string effective_checkpoint_directory = checkpoint_directory;
-            if (effective_checkpoint_directory.empty()) {
-                effective_checkpoint_directory = create_managed_checkpoint_directory();
-                if (effective_checkpoint_directory.empty()) {
-                    sessions_.erase(session_id);
-                    cleanup_managed_server_root_if_empty();
-                    if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
-                    return "";
+            auto release_reserved_file_session = [&]() {
+                if (!share_existing_file_session) { return; }
+                auto mapped = file_sessions_by_path_.find(canonical_file_path);
+                if (mapped != file_sessions_by_path_.end() && mapped->second == session_id) {
+                    file_sessions_by_path_.erase(mapped);
                 }
-                info->owns_checkpoint_directory = true;
+            };
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                // Session ID priority: desired_id > generated opaque session ID
+                if (!desired_id.empty()) {
+                    if (!is_valid_external_id(desired_id)) {
+                        if (error_out) { *error_out = SessionCreateError::INVALID_ID; }
+                        return "";
+                    }
+                    session_id = desired_id;
+                    if (sessions_.count(session_id) != 0) {
+                        if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
+                        return "";// Already exists
+                    }
+                } else {
+                    do { session_id = generate_session_id(); } while (sessions_.count(session_id) != 0);
+                }
+
+                info->session_id = session_id;
+                info->canonical_file_path = canonical_file_path;
+                info->attachment_count = 1;
+                info->last_activity = std::chrono::steady_clock::now();
+
+                if (effective_checkpoint_directory.empty()) {
+                    effective_checkpoint_directory = create_managed_checkpoint_directory();
+                    if (effective_checkpoint_directory.empty()) {
+                        cleanup_managed_server_root_if_empty();
+                        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                        return "";
+                    }
+                    info->owns_checkpoint_directory = true;
+                }
+
+                info->checkpoint_directory = effective_checkpoint_directory;
+                sessions_[session_id] = info;
+                if (share_existing_file_session) { file_sessions_by_path_[canonical_file_path] = session_id; }
             }
 
-            info->checkpoint_directory = effective_checkpoint_directory;
             const char *chkpt_dir =
                     effective_checkpoint_directory.empty() ? nullptr : effective_checkpoint_directory.c_str();
 
@@ -601,30 +627,68 @@ namespace omega_edit {
             }
 
             if (!session) {
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    auto current = sessions_.find(session_id);
+                    if (current != sessions_.end() && current->second == info) { sessions_.erase(current); }
+                    release_reserved_file_session();
+                }
                 if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
-                sessions_.erase(session_id);
-                cleanup_managed_server_root_if_empty();
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    cleanup_managed_server_root_if_empty();
+                }
                 if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
                 return "";// Failed to create
             }
 
-            info->session = session;
-            file_size_out = omega_session_get_computed_file_size(session);
-            if (file_size_out < 0) {
+            const auto computed_size = omega_session_get_computed_file_size(session);
+            if (computed_size < 0) {
                 omega_edit_destroy_session(session);
-                info->session = nullptr;
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    auto current = sessions_.find(session_id);
+                    if (current != sessions_.end() && current->second == info) { sessions_.erase(current); }
+                    release_reserved_file_session();
+                }
                 if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
-                sessions_.erase(session_id);
-                cleanup_managed_server_root_if_empty();
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    release_reserved_file_session();
+                    cleanup_managed_server_root_if_empty();
+                }
                 if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
                 return "";
             }
 
             const char *chkpt = omega_session_get_checkpoint_directory(session);
             checkpoint_dir_out = chkpt ? chkpt : "";
-            if (!checkpoint_dir_out.empty()) { info->checkpoint_directory = checkpoint_dir_out; }
-
-            if (share_existing_file_session) { file_sessions_by_path_[canonical_file_path] = session_id; }
+            bool publish_failed = false;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                auto current = sessions_.find(session_id);
+                if (current == sessions_.end() || current->second != info) {
+                    publish_failed = true;
+                } else {
+                    {
+                        std::lock_guard<std::mutex> core_lock(info->core_mutex);
+                        info->session = session;
+                    }
+                    file_size_out = computed_size;
+                    if (!checkpoint_dir_out.empty()) { info->checkpoint_directory = checkpoint_dir_out; }
+                    if (share_existing_file_session) { file_sessions_by_path_[canonical_file_path] = session_id; }
+                }
+            }
+            if (publish_failed) {
+                omega_edit_destroy_session(session);
+                if (info->owns_checkpoint_directory) { cleanup_directory_best_effort(info->checkpoint_directory); }
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    cleanup_managed_server_root_if_empty();
+                }
+                if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                return "";
+            }
 
             return session_id;
         }
@@ -830,49 +894,58 @@ namespace omega_edit {
         std::string SessionManager::create_viewport(const std::string &session_id, int64_t offset, int64_t capacity,
                                                     bool is_floating, const std::string &desired_viewport_id,
                                                     ViewportCreateError *error_out) {
-            std::lock_guard<std::mutex> lock(mutex_);
-
-            auto sit = sessions_.find(session_id);
-            if (sit == sessions_.end()) {
-                if (error_out) *error_out = ViewportCreateError::SESSION_NOT_FOUND;
-                return "";
-            }
-
-            if (!desired_viewport_id.empty() && !is_valid_external_id(desired_viewport_id)) {
-                if (error_out) *error_out = ViewportCreateError::INVALID_VIEWPORT_ID;
-                return "";
-            }
-
-            auto &session_info = sit->second;
-            session_info->last_activity = std::chrono::steady_clock::now();
-            std::string viewport_id = desired_viewport_id;
-            if (viewport_id.empty()) {
-                do { viewport_id = generate_viewport_id(); } while (session_info->viewports.count(viewport_id) != 0);
-            }
-
-            // Check for duplicate viewport
-            if (session_info->viewports.count(viewport_id)) {
-                if (error_out) *error_out = ViewportCreateError::DUPLICATE_VIEWPORT_ID;
-                return "";
-            }
-
-            if (limits_.max_viewports_per_session > 0 &&
-                session_info->viewports.size() >= limits_.max_viewports_per_session) {
-                if (error_out) *error_out = ViewportCreateError::TOO_MANY_VIEWPORTS;
-                return "";
-            }
-
+            std::shared_ptr<SessionInfo> session_info;
             auto vp_info = std::make_shared<ViewportInfo>();
             vp_info->session_id = session_id;
-            vp_info->viewport_id = viewport_id;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
 
-            // Store first so viewport callbacks can find subscription state. lock_viewport treats a null viewport as missing
-            // until omega_edit_create_viewport publishes the core pointer below.
-            session_info->viewports[viewport_id] = vp_info;
+                auto sit = sessions_.find(session_id);
+                if (sit == sessions_.end()) {
+                    if (error_out) *error_out = ViewportCreateError::SESSION_NOT_FOUND;
+                    return "";
+                }
+
+                if (!desired_viewport_id.empty() && !is_valid_external_id(desired_viewport_id)) {
+                    if (error_out) *error_out = ViewportCreateError::INVALID_VIEWPORT_ID;
+                    return "";
+                }
+
+                session_info = sit->second;
+                session_info->last_activity = std::chrono::steady_clock::now();
+                std::string viewport_id = desired_viewport_id;
+                if (viewport_id.empty()) {
+                    do {
+                        viewport_id = generate_viewport_id();
+                    } while (session_info->viewports.count(viewport_id) != 0);
+                }
+
+                // Check for duplicate viewport
+                if (session_info->viewports.count(viewport_id)) {
+                    if (error_out) *error_out = ViewportCreateError::DUPLICATE_VIEWPORT_ID;
+                    return "";
+                }
+
+                if (limits_.max_viewports_per_session > 0 &&
+                    session_info->viewports.size() >= limits_.max_viewports_per_session) {
+                    if (error_out) *error_out = ViewportCreateError::TOO_MANY_VIEWPORTS;
+                    return "";
+                }
+
+                vp_info->viewport_id = viewport_id;
+
+                // Store first so viewport callbacks can find subscription state. lock_viewport treats a null viewport as
+                // missing until omega_edit_create_viewport publishes the core pointer below.
+                session_info->viewports[viewport_id] = vp_info;
+            }
 
             std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
             if (session_info->session == nullptr) {
-                session_info->viewports.erase(viewport_id);
+                std::lock_guard<std::mutex> lock(mutex_);
+                auto current = sessions_.find(session_id);
+                if (current != sessions_.end() && current->second == session_info) {
+                    session_info->viewports.erase(vp_info->viewport_id);
+                }
                 if (error_out) *error_out = ViewportCreateError::SESSION_NOT_FOUND;
                 return "";
             }
@@ -881,28 +954,37 @@ namespace omega_edit {
                                                viewport_event_callback, vp_info.get(), 0);
 
             if (!viewport) {
-                session_info->viewports.erase(viewport_id);
+                std::lock_guard<std::mutex> lock(mutex_);
+                auto current = sessions_.find(session_id);
+                if (current != sessions_.end() && current->second == session_info) {
+                    session_info->viewports.erase(vp_info->viewport_id);
+                }
                 if (error_out) *error_out = ViewportCreateError::CORE_ERROR;
                 return "";
             }
 
             vp_info->viewport = viewport;
             if (error_out) *error_out = ViewportCreateError::SUCCESS;
-            return make_viewport_fqid(session_id, viewport_id);
+            return make_viewport_fqid(session_id, vp_info->viewport_id);
         }
 
         bool SessionManager::destroy_viewport(const std::string &session_id, const std::string &viewport_id) {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::shared_ptr<SessionInfo> session_info;
+            std::shared_ptr<ViewportInfo> vp_info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
 
-            auto sit = sessions_.find(session_id);
-            if (sit == sessions_.end()) return false;
+                auto sit = sessions_.find(session_id);
+                if (sit == sessions_.end()) return false;
 
-            auto &session_info = sit->second;
-            session_info->last_activity = std::chrono::steady_clock::now();
-            auto vit = session_info->viewports.find(viewport_id);
-            if (vit == session_info->viewports.end()) return false;
+                session_info = sit->second;
+                session_info->last_activity = std::chrono::steady_clock::now();
+                auto vit = session_info->viewports.find(viewport_id);
+                if (vit == session_info->viewports.end()) return false;
 
-            auto &vp_info = vit->second;
+                vp_info = vit->second;
+                session_info->viewports.erase(vit);
+            }
             std::lock_guard<std::mutex> core_lock(session_info->core_mutex);
             {
                 std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
@@ -914,7 +996,6 @@ namespace omega_edit {
 
             if (vp_info->viewport) { omega_edit_destroy_viewport(vp_info->viewport); }
             vp_info->viewport = nullptr;
-            session_info->viewports.erase(vit);
             return true;
         }
 
@@ -952,12 +1033,17 @@ namespace omega_edit {
 
         std::shared_ptr<EventQueue<SessionEventData>>
         SessionManager::subscribe_session_events(const std::string &session_id, int32_t interest) {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::shared_ptr<SessionInfo> info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
 
-            auto it = sessions_.find(session_id);
-            if (it == sessions_.end()) return nullptr;
+                auto it = sessions_.find(session_id);
+                if (it == sessions_.end()) return nullptr;
 
-            auto &info = it->second;
+                info = it->second;
+                info->last_activity = std::chrono::steady_clock::now();
+            }
+
             auto queue = std::make_shared<EventQueue<SessionEventData>>(limits_.session_event_queue_capacity,
                                                                         "session subscription '" + session_id + "#" +
                                                                                 generate_subscription_id() + "'");
@@ -967,18 +1053,36 @@ namespace omega_edit {
                 info->session_subscriptions.push_back({queue, interest});
                 combined_interest = combine_event_interest(info->session_subscriptions);
             }
-            std::lock_guard<std::mutex> core_lock(info->core_mutex);
-            if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
+            std::unique_lock<std::mutex> core_lock(info->core_mutex);
+            if (!info->session) {
+                core_lock.unlock();
+                {
+                    std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
+                    auto &subscriptions = info->session_subscriptions;
+                    subscriptions.erase(std::remove_if(subscriptions.begin(), subscriptions.end(),
+                                                       [&queue](const SessionEventSubscriptionInfo &subscription) {
+                                                           return subscription.event_queue == queue;
+                                                       }),
+                                        subscriptions.end());
+                }
+                queue->clear();
+                queue->close();
+                return nullptr;
+            }
+            omega_session_set_event_interest(info->session, combined_interest);
             return queue;
         }
 
         void SessionManager::unsubscribe_session_events(const std::string &session_id) {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::shared_ptr<SessionInfo> info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
 
-            auto it = sessions_.find(session_id);
-            if (it == sessions_.end()) return;
+                auto it = sessions_.find(session_id);
+                if (it == sessions_.end()) return;
 
-            auto &info = it->second;
+                info = it->second;
+            }
             std::vector<std::shared_ptr<EventQueue<SessionEventData>>> removed_queues;
             {
                 std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
@@ -998,12 +1102,17 @@ namespace omega_edit {
 
         void SessionManager::unsubscribe_session_events(const std::string &session_id,
                                                         const std::shared_ptr<EventQueue<SessionEventData>> &queue) {
-            std::lock_guard<std::mutex> lock(mutex_);
+            if (!queue) return;
 
-            auto it = sessions_.find(session_id);
-            if (it == sessions_.end() || !queue) return;
+            std::shared_ptr<SessionInfo> info;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
 
-            auto &info = it->second;
+                auto it = sessions_.find(session_id);
+                if (it == sessions_.end()) return;
+
+                info = it->second;
+            }
             bool removed = false;
             int32_t combined_interest = 0;
             {

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -135,7 +135,8 @@ namespace omega_edit {
 #endif
             }
 
-            int32_t combine_session_event_interest(const std::vector<SessionEventSubscriptionInfo> &subscriptions) {
+            template<typename SubscriptionInfo>
+            int32_t combine_event_interest(const std::vector<SubscriptionInfo> &subscriptions) {
                 uint32_t combined = 0;
                 for (const auto &subscription : subscriptions) {
                     combined |= static_cast<uint32_t>(subscription.interest);
@@ -143,12 +144,29 @@ namespace omega_edit {
                 return static_cast<int32_t>(combined);
             }
 
-            int32_t combine_viewport_event_interest(const std::vector<ViewportEventSubscriptionInfo> &subscriptions) {
-                uint32_t combined = 0;
-                for (const auto &subscription : subscriptions) {
-                    combined |= static_cast<uint32_t>(subscription.interest);
+            template<typename SubscriptionInfo, typename EventData>
+            std::vector<std::shared_ptr<EventQueue<EventData>>>
+            collect_event_subscribers(std::mutex &subscription_mutex,
+                                      const std::vector<SubscriptionInfo> &subscriptions, int32_t event_kind) {
+                const auto event_mask = static_cast<uint32_t>(event_kind);
+                std::vector<std::shared_ptr<EventQueue<EventData>>> subscribers;
+                {
+                    std::lock_guard<std::mutex> subscription_lock(subscription_mutex);
+                    subscribers.reserve(subscriptions.size());
+                    for (const auto &subscription : subscriptions) {
+                        if (subscription.event_queue &&
+                            ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
+                            subscribers.push_back(subscription.event_queue);
+                        }
+                    }
                 }
-                return static_cast<int32_t>(combined);
+                return subscribers;
+            }
+
+            template<typename EventData>
+            void publish_event_to_subscribers(const std::vector<std::shared_ptr<EventQueue<EventData>>> &subscribers,
+                                              const EventData &event) {
+                for (const auto &subscriber : subscribers) { subscriber->push(event); }
             }
 
             bool normalize_existing_file_path(const std::string &file_path, std::string &normalized_path_out) {
@@ -427,21 +445,9 @@ namespace omega_edit {
                     break;
             }
 
-            const auto event_kind = static_cast<int32_t>(event);
-            const auto event_mask = static_cast<uint32_t>(event_kind);
-            std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
-            {
-                std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-                subscribers.reserve(info->session_subscriptions.size());
-                for (const auto &subscription : info->session_subscriptions) {
-                    if (subscription.event_queue &&
-                        ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
-                        subscribers.push_back(subscription.event_queue);
-                    }
-                }
-            }
-
-            for (const auto &subscriber : subscribers) { subscriber->push(evt); }
+            const auto subscribers = collect_event_subscribers<SessionEventSubscriptionInfo, SessionEventData>(
+                    info->session_subscription_mutex, info->session_subscriptions, static_cast<int32_t>(event));
+            publish_event_to_subscribers(subscribers, evt);
         }
 
         void SessionManager::viewport_event_callback(const omega_viewport_t *viewport, omega_viewport_event_t event,
@@ -476,21 +482,9 @@ namespace omega_edit {
             const auto *data = omega_viewport_get_data(viewport);
             if (data && length > 0) { evt.data.assign(data, data + length); }
 
-            const auto event_kind = static_cast<int32_t>(event);
-            const auto event_mask = static_cast<uint32_t>(event_kind);
-            std::vector<std::shared_ptr<EventQueue<ViewportEventData>>> subscribers;
-            {
-                std::lock_guard<std::mutex> subscription_lock(info->viewport_subscription_mutex);
-                subscribers.reserve(info->viewport_subscriptions.size());
-                for (const auto &subscription : info->viewport_subscriptions) {
-                    if (subscription.event_queue &&
-                        ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
-                        subscribers.push_back(subscription.event_queue);
-                    }
-                }
-            }
-
-            for (const auto &subscriber : subscribers) { subscriber->push(evt); }
+            const auto subscribers = collect_event_subscribers<ViewportEventSubscriptionInfo, ViewportEventData>(
+                    info->viewport_subscription_mutex, info->viewport_subscriptions, static_cast<int32_t>(event));
+            publish_event_to_subscribers(subscribers, evt);
         }
 
         // ── Constructor / Destructor ─────────────────────────────────────────────────
@@ -809,20 +803,9 @@ namespace omega_edit {
             evt.transform_progress = progress;
             evt.has_transform_progress = true;
 
-            const auto event_mask = static_cast<uint32_t>(event_kind);
-            std::vector<std::shared_ptr<EventQueue<SessionEventData>>> subscribers;
-            {
-                std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
-                subscribers.reserve(info->session_subscriptions.size());
-                for (const auto &subscription : info->session_subscriptions) {
-                    if (subscription.event_queue &&
-                        ((static_cast<uint32_t>(subscription.interest) & event_mask) != 0U)) {
-                        subscribers.push_back(subscription.event_queue);
-                    }
-                }
-            }
-
-            for (const auto &subscriber : subscribers) { subscriber->push(evt); }
+            const auto subscribers = collect_event_subscribers<SessionEventSubscriptionInfo, SessionEventData>(
+                    info->session_subscription_mutex, info->session_subscriptions, event_kind);
+            publish_event_to_subscribers(subscribers, evt);
             return true;
         }
 
@@ -982,7 +965,7 @@ namespace omega_edit {
             {
                 std::lock_guard<std::mutex> subscription_lock(info->session_subscription_mutex);
                 info->session_subscriptions.push_back({queue, interest});
-                combined_interest = combine_session_event_interest(info->session_subscriptions);
+                combined_interest = combine_event_interest(info->session_subscriptions);
             }
             std::lock_guard<std::mutex> core_lock(info->core_mutex);
             if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
@@ -1034,7 +1017,7 @@ namespace omega_edit {
                                            return matches;
                                        }),
                         subscriptions.end());
-                combined_interest = combine_session_event_interest(subscriptions);
+                combined_interest = combine_event_interest(subscriptions);
             }
             std::lock_guard<std::mutex> core_lock(info->core_mutex);
             if (info->session) { omega_session_set_event_interest(info->session, combined_interest); }
@@ -1074,7 +1057,7 @@ namespace omega_edit {
             {
                 std::lock_guard<std::mutex> subscription_lock(vp_info->viewport_subscription_mutex);
                 vp_info->viewport_subscriptions.push_back({queue, interest});
-                combined_interest = combine_viewport_event_interest(vp_info->viewport_subscriptions);
+                combined_interest = combine_event_interest(vp_info->viewport_subscriptions);
             }
             omega_viewport_set_event_interest(vp_info->viewport, combined_interest);
             return queue;
@@ -1147,7 +1130,7 @@ namespace omega_edit {
                                            return matches;
                                        }),
                         subscriptions.end());
-                combined_interest = combine_viewport_event_interest(subscriptions);
+                combined_interest = combine_event_interest(subscriptions);
             }
             if (vp_info->viewport) { omega_viewport_set_event_interest(vp_info->viewport, combined_interest); }
 

--- a/server/cpp/src/session_manager.cpp
+++ b/server/cpp/src/session_manager.cpp
@@ -527,6 +527,48 @@ namespace omega_edit {
 
             const bool share_existing_file_session = desired_id.empty() && has_file_backing;
 
+            std::string session_id;
+            auto info = std::make_shared<SessionInfo>();
+            std::string effective_checkpoint_directory = checkpoint_directory;
+            bool reserved_new_session = false;
+            auto reserve_new_session_locked = [&]() -> bool {
+                // Session ID priority: desired_id > generated opaque session ID
+                if (!desired_id.empty()) {
+                    if (!is_valid_external_id(desired_id)) {
+                        if (error_out) { *error_out = SessionCreateError::INVALID_ID; }
+                        return false;
+                    }
+                    session_id = desired_id;
+                    if (sessions_.count(session_id) != 0) {
+                        if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
+                        return false;// Already exists
+                    }
+                } else {
+                    do { session_id = generate_session_id(); } while (sessions_.count(session_id) != 0);
+                }
+
+                info->session_id = session_id;
+                info->canonical_file_path = canonical_file_path;
+                info->attachment_count = 1;
+                info->last_activity = std::chrono::steady_clock::now();
+
+                if (effective_checkpoint_directory.empty()) {
+                    effective_checkpoint_directory = create_managed_checkpoint_directory();
+                    if (effective_checkpoint_directory.empty()) {
+                        cleanup_managed_server_root_if_empty();
+                        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
+                        return false;
+                    }
+                    info->owns_checkpoint_directory = true;
+                }
+
+                info->checkpoint_directory = effective_checkpoint_directory;
+                sessions_[session_id] = info;
+                if (share_existing_file_session) { file_sessions_by_path_[canonical_file_path] = session_id; }
+                reserved_new_session = true;
+                return true;
+            };
+
             if (share_existing_file_session) {
                 std::shared_ptr<SessionInfo> existing_info;
                 {
@@ -536,6 +578,7 @@ namespace omega_edit {
                         auto existing = sessions_.find(existing_file_session->second);
                         if (existing == sessions_.end()) {
                             file_sessions_by_path_.erase(existing_file_session);
+                            if (!reserve_new_session_locked()) { return ""; }
                         } else if (checkpoint_directory.empty() ||
                                    checkpoint_directory == existing->second->checkpoint_directory) {
                             existing_info = existing->second;
@@ -543,6 +586,8 @@ namespace omega_edit {
                             if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
                             return "";
                         }
+                    } else if (!reserve_new_session_locked()) {
+                        return "";
                     }
                 }
 
@@ -580,9 +625,6 @@ namespace omega_edit {
                 }
             }
 
-            std::string session_id;
-            auto info = std::make_shared<SessionInfo>();
-            std::string effective_checkpoint_directory = checkpoint_directory;
             auto release_reserved_file_session = [&]() {
                 if (!share_existing_file_session) { return; }
                 auto mapped = file_sessions_by_path_.find(canonical_file_path);
@@ -590,42 +632,9 @@ namespace omega_edit {
                     file_sessions_by_path_.erase(mapped);
                 }
             };
-            {
+            if (!reserved_new_session) {
                 std::lock_guard<std::mutex> lock(mutex_);
-
-                // Session ID priority: desired_id > generated opaque session ID
-                if (!desired_id.empty()) {
-                    if (!is_valid_external_id(desired_id)) {
-                        if (error_out) { *error_out = SessionCreateError::INVALID_ID; }
-                        return "";
-                    }
-                    session_id = desired_id;
-                    if (sessions_.count(session_id) != 0) {
-                        if (error_out) { *error_out = SessionCreateError::ALREADY_EXISTS; }
-                        return "";// Already exists
-                    }
-                } else {
-                    do { session_id = generate_session_id(); } while (sessions_.count(session_id) != 0);
-                }
-
-                info->session_id = session_id;
-                info->canonical_file_path = canonical_file_path;
-                info->attachment_count = 1;
-                info->last_activity = std::chrono::steady_clock::now();
-
-                if (effective_checkpoint_directory.empty()) {
-                    effective_checkpoint_directory = create_managed_checkpoint_directory();
-                    if (effective_checkpoint_directory.empty()) {
-                        cleanup_managed_server_root_if_empty();
-                        if (error_out) { *error_out = SessionCreateError::CORE_ERROR; }
-                        return "";
-                    }
-                    info->owns_checkpoint_directory = true;
-                }
-
-                info->checkpoint_directory = effective_checkpoint_directory;
-                sessions_[session_id] = info;
-                if (share_existing_file_session) { file_sessions_by_path_[canonical_file_path] = session_id; }
+                if (!reserve_new_session_locked()) { return ""; }
             }
 
             const char *chkpt_dir =

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -175,6 +175,7 @@ namespace omega_edit {
         /// Information about a session managed by the session manager
         struct SessionInfo {
             omega_session_t *session{};
+            bool initialization_complete{false};
             std::string session_id;
             std::string canonical_file_path;
             std::string checkpoint_directory;
@@ -188,6 +189,8 @@ namespace omega_edit {
             size_t active_mutations{0};
             // Serializes all access to the underlying non-thread-safe omega_session_t and its viewports.
             std::mutex core_mutex;
+            std::mutex initialization_mutex;
+            std::condition_variable initialization_cv;
             std::mutex session_subscription_mutex;
             std::vector<SessionEventSubscriptionInfo> session_subscriptions;
             std::chrono::steady_clock::time_point last_activity;


### PR DESCRIPTION
## Summary
- Harden save publishing with fsync/atomic replacement, including a Windows directory-sync fallback for CI where directory FlushFileBuffers reports access denied after a successful publish.
- Validate SaveSession paths, make AI change-log export flush before rename, and add plugin/parser/allocation hardening from the original shortcomings batch.
- Fix new SHORTCOMINGS #2/#3: clear-changes now discards checkpoint/transform model stacks and SessionManager no longer holds the global session-map mutex across core session creation or per-session core-lock acquisition on the listed paths.
- Fix the shared file-backed session creation races exposed by CI: concurrent authors now wait for a reserved session to initialize and the first creator reserves the file-path mapping atomically with the no-existing-session lookup.
- Remove the fixed items from SHORTCOMINGS.md, renumber the remaining backlog, and record the shared-session race closure in the fixed list.

## Testing
- cmake --build /tmp/omega-edit-codex-build
- cmake --build /tmp/omega-edit-codex-build --target session_tests
- ctest --test-dir /tmp/omega-edit-codex-build/core --output-on-failure
- ctest --test-dir /tmp/omega-edit-codex-build/plugins --output-on-failure
- /tmp/omega-edit-codex-build/core/src/tests/session_tests
- clang++ -std=c++17 -Icore/src/include -Iserver/cpp/src -fsyntax-only server/cpp/src/session_manager.cpp
- clang-format --dry-run --Werror server/cpp/src/session_manager.cpp server/cpp/src/session_manager.h
- ./node_modules/.bin/tsc -p packages/ai/tsconfig.esm.json
- ./node_modules/.bin/tsc -p packages/ai/tsconfig.cjs.json
- ./node_modules/.bin/biome check packages/ai/src/service.ts
- git diff --check

## Not run
- server/cpp CMake build from WSL: the existing build cache was created at d:/GitHub/omega-edit/server/cpp/build and points at C:/ProgramData/chocolatey/bin/ninja.exe, so CMake rejects it from /mnt/d/GitHub/omega-edit.
- Fresh standalone server/cpp configure: local configure is blocked because ProtobufConfig.cmake / protobuf-config.cmake is not installed in this environment.
- Local client UDS lifecycle test for the latest C++ fix: this checkout has no local Linux omega-edit-grpc-server binary to point CPP_SERVER_BINARY at; the available packages/server/out/bin binary is Windows-only.