### PR TITLE
test: add brutal test harness coverage and fuzz driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ venv/
 .venv-conan/
 package-lock.json
 
+# clang
+.clangd
+
 # log files
 *.log
 

--- a/CHANGELOG-OPTIMIZER.md
+++ b/CHANGELOG-OPTIMIZER.md
@@ -1,0 +1,1167 @@
+# Change-Log Optimizer
+
+**Status:** Approved design. Supersedes `CHANGELOG-OPTIMIZER.md` and
+`CHANGELOG-OPTIMIZER-REVISED.md`.
+
+**Audience:** A software engineer implementing this with AI coding assistants.
+Every section that matters for implementation names the real files, functions,
+and invariants in this repository so an assistant can be pointed at them
+directly. Verify any line numbers before relying on them — the code moves.
+
+---
+
+## 1. What this document is
+
+Two prior designs existed:
+
+- `CHANGELOG-OPTIMIZER.md` (original) proposed an in-core compactor built on
+  adjacent-entry pattern matching and an "interruptible scan with atomic vector
+  swap". **Do not implement it.** Section 12 explains, with concrete examples,
+  why its optimization rules are semantically wrong and why its concurrency
+  model doesn't match the core.
+- `CHANGELOG-OPTIMIZER-REVISED.md` corrected the model: a coordinate-aware
+  planner shared by a non-mutating export mode (ship first) and a later online
+  compaction mode. Its constraints section is accurate.
+
+This document keeps the revised architecture, tightens the API, adds the
+implementation hints and pitfalls an engineer (and their AI assistant) needs,
+and lays out a phased execution plan where every phase lands independently
+with tests.
+
+## 2. Problem and use cases
+
+The change-log export pipeline (`packages/ai/src/service.ts`,
+`exportChangeLog` / `applyChangeLog`) serializes one `ChangeLogEntry` per
+change serial into a JSON `ChangeLogDocument` (hex payloads). Sessions with
+tens of thousands of tiny edits (per-keystroke inserts, repeated rewrites of
+the same range) produce logs where per-entry overhead dominates, and replay
+costs one round of work per entry.
+
+Two use cases, in delivery order:
+
+1. **Optimized export (non-mutating).** Produce a smaller, replayable change
+   log that reaches the same final content. Nothing about the session changes.
+2. **Online compaction (mutating history, not content).** Reduce a live
+   session's in-memory change history — fewer change records, less payload
+   retention, shorter undo replay — without changing the current document
+   content.
+
+Both are powered by **one shared planner** in the core C++ library. The
+TypeScript layer stays thin: routing, JSON formatting, fingerprints,
+presentation. No optimization logic in TS.
+
+## 3. Ground truth: how the core actually stores history
+
+These are facts about the current code, not design choices. The design must
+respect all of them. (All paths relative to repo root.)
+
+### 3.1 History is split across models
+
+`omega_session_t` (`core/src/lib/impl_/session_def.hpp`) owns `models_`, a
+vector of `omega_model_t`. Each model has:
+
+- `change_serial_base` — cumulative change count when the model was created
+- `changes` — active changes (`std::vector<const_omega_change_ptr_t>`,
+  i.e. `shared_ptr<const omega_change_t>`)
+- `changes_undone` — undone changes (redo stack)
+- `model_segments` — the piece list the session reads through
+- `model_snapshots` — deep clones of `model_segments`, keyed by **change
+  count**, taken every `undo_snapshot_interval_` changes
+- `file_ptr` / `file_path` — the model's backing content (original snapshot
+  copy for the front model, checkpoint file for others)
+
+`models_.back()` is the live model. Every read (`populate_data_segment_` in
+`core/src/lib/impl_/internal_fun.cpp`) goes through the back model only.
+
+### 3.2 Serial lookup is index arithmetic
+
+`omega_session_get_change` (`core/src/lib/session.cpp`) resolves a serial via
+`index = serial - 1 - model->change_serial_base` against each model's
+`changes` vector. **Compaction cannot leave sparse serials.** Compacted
+changes must be renumbered contiguously and clients must be told their cached
+serials are invalid.
+
+### 3.3 Model segments reference change objects
+
+`omega_model_segment_t` holds a `shared_ptr` to its parent change and reads
+payload bytes through it (`omega_change_copy_payload_bytes_` in
+`core/src/lib/impl_/change_def.hpp`). Snapshots clone segments and retain the
+same change references. **You cannot swap only the `changes` vector.** Online
+compaction must install, together and atomically: replacement changes,
+replacement segments, cleared/rebuilt snapshots, renumbered serials, and
+updated counts.
+
+### 3.4 Undo/redo state is separate, and payloads carry undo data
+
+Undo (`omega_edit_undo_last_change`, `core/src/lib/edit.cpp`) pops active
+changes, flips `serial` negative, and pushes them onto `changes_undone`. There
+are **no negative serials inside the active vector**. A new change with a
+positive serial frees the redo stack (`free_session_changes_undone_`), which
+also deletes undone transforms' checkpoint files.
+
+DELETE changes carry the deleted bytes as a payload (inline or file-backed);
+OVERWRITE carries the replaced bytes as `inverse_data`. That payload is what
+makes undo possible. Any synthesized change that should remain undoable must
+have a correct payload — see the shadow-replay hint in §9.3.
+
+### 3.5 Payload destructors delete files
+
+`omega_byte_payload_struct::reset()` (`core/src/lib/impl_/change_def.hpp`)
+**removes the payload file from disk** when storage is file-backed. Dropping
+the last `shared_ptr` to a change destroys its payloads. Consequences:
+
+- Discarding a change during compaction correctly cleans up its payload file —
+  but only after the last reference (old segments, old snapshots) is gone.
+- A synthesized merged change must own its own payload (new inline buffer or
+  new payload file). Never alias another change's payload file path.
+
+### 3.6 TRANSFORM is a checkpoint-backed model boundary
+
+Transforms materialize their output into a checkpoint file and push a new
+model whose first change is the TRANSFORM record
+(`promote_checkpoint_file_`, `core/src/lib/edit.cpp`). `update_model_` skips
+TRANSFORM changes entirely — they never splice segments. Transforms are
+**hard barriers**: never merged, deduplicated, reordered, or synthesized. (Two
+"identical" transforms are not provably idempotent; plugin behavior is opaque.)
+
+Plain checkpoints (`omega_edit_create_checkpoint`) also create model
+boundaries but add **no** change record.
+
+### 3.7 REPLACE is not a stored change kind
+
+Internal kinds are DELETE(0), INSERT(1), OVERWRITE(2), TRANSFORM(3)
+(`core/src/lib/impl_/change_def.hpp`). REPLACE exists only as a script/export
+operation (`omega_edit_script_op_t`, applied by `omega_edit_apply_script` as
+delete+insert in a transaction). Export may emit REPLACE entries; online
+compaction must lower them to the existing kinds.
+
+### 3.8 The core is single-threaded per session
+
+The gRPC server serializes all access to a session through
+`SessionInfo::core_mutex` (`server/cpp/src/session_manager.h`), plus
+`try_begin_mutation` / `try_begin_transform` operation guards. There is no
+concurrent mutation to be "interruptible" against. Online compaction v1 runs
+fully serialized like any other mutation RPC. (A low-lock variant is a listed
+future extension, §11 — it requires deep-copying change metadata under the
+lock, because change objects are mutated in place by undo/redo.)
+
+### 3.9 `omega_visit_changes` only visits the back model
+
+`core/src/lib/visit.cpp` iterates `models_.back()->changes`. Export
+enumeration must walk **all models in serial order** to see the full history
+(including TRANSFORM records at model boundaries). This is a new internal
+helper, not a change to the existing public visitor.
+
+### 3.10 Offsets are state-relative
+
+A change's `offset` is a coordinate in the document **as it existed when the
+change was applied**. Later changes shift earlier coordinates. This single
+fact invalidates all adjacent-entry pattern matching — see §12.
+
+## 4. Design overview
+
+```
+                       ┌────────────────────────────┐
+                       │  History enumerator        │
+                       │  (all models, serial order)│
+                       └─────────────┬──────────────┘
+                                     │ raw changes + barriers
+                                     ▼
+                       ┌────────────────────────────┐
+                       │  Span partitioner          │
+                       │  barriers: TRANSFORM,      │
+                       │  model boundary, high-water│
+                       │  tail (compaction only)    │
+                       └─────────────┬──────────────┘
+                                     │ spans of plain edits
+                                     ▼
+                       ┌────────────────────────────┐
+                       │  Coordinate-aware planner  │
+                       │  (piece table per span)    │
+                       └───────┬───────────┬────────┘
+                               │           │
+                 plan entries  │           │  plan entries
+                               ▼           ▼
+                ┌──────────────────┐  ┌───────────────────────┐
+                │ EXPORT consumer  │  │ COMPACTION consumer   │
+                │ visitor callback │  │ candidate model build │
+                │ (non-mutating)   │  │ + validate + install  │
+                └──────────────────┘  └───────────────────────┘
+```
+
+One planner, two consumers. Export ships first and de-risks the planner; the
+compaction consumer reuses it unchanged.
+
+### 4.1 Spans
+
+An **optimization span** is a maximal run of active, non-transform changes
+that may be planned together. Spans never cross:
+
+- TRANSFORM entries (preserved exactly, emitted as-is)
+- model boundaries (v1; content-equivalent merging across plain-checkpoint
+  boundaries is a future extension)
+- the protected high-water tail (online compaction only)
+- redo state (compaction v1 requires empty redo)
+
+### 4.2 The planner
+
+Per span, replay the span's changes **in order** into a lightweight piece
+table over the span's input document:
+
+- Pieces are either *base* (range of the span input) or *insert* (payload
+  bytes of a raw change, referenced not copied).
+- INSERT splices an insert piece at the current-coordinate offset.
+- DELETE removes a current-coordinate range (splitting pieces as needed).
+- OVERWRITE is planned as delete + equal-length insert.
+
+At span end, **diff the piece sequence against identity**: walk the pieces,
+and for every region that is not "base piece i covering exactly its original
+range in order", emit a minimal op. Trim common prefixes/suffixes of
+replacement regions against base bytes (this needs actual base bytes — read
+them lazily and only for candidate regions). Emission produces a compact
+script in replay coordinates (offsets valid at replay time, front to back):
+
+- nothing, when the span nets out to identity
+- DELETE when the replacement is empty
+- INSERT when the removed range is empty
+- OVERWRITE when lengths match (optional; callers may prefer REPLACE form)
+- REPLACE otherwise
+
+Complexity: piece count is O(#changes in span), not O(file size). Memory is
+bounded by piece metadata plus payload references; `max_span_bytes` splits
+oversized spans into subspans as a safety valve (correct, just less optimal).
+
+### 4.3 What each consumer does with plan entries
+
+- **Export** serializes them through a visitor callback; TS wraps them into
+  the existing `ChangeLogDocument` format. Non-mutating; borrowed pointers
+  valid only during the callback.
+- **Compaction** lowers them into real core changes, rebuilds the model, and
+  atomically installs the candidate (§7).
+
+## 5. Correctness rules (the invariants tests must pin)
+
+1. **Content identity.** After replaying an optimized export into a fresh
+   session over the same base content — or after online compaction of a live
+   session — the computed file size and content bytes are identical to the
+   unoptimized result. Verify with `omega_edit_save_segment_to_bytes` for
+   small tests and the fingerprint digest for large ones.
+2. **Transform preservation.** TRANSFORM entries appear in the output exactly
+   once each, unmodified, in order, with all metadata
+   (`transform_id`, `options_json`, `replacement_length`,
+   `computed_file_size_before/after`).
+3. **Serial honesty.** Synthetic export entries carry **no** `serial` (or
+   explicit provenance metadata later); they must not impersonate original
+   serials. After online compaction, active serials in the compacted model
+   are contiguous from `change_serial_base + 1`, and the compaction event
+   reports `first_invalid_serial`.
+4. **Undo safety (compaction).** The high-water tail (last N active changes)
+   keeps its exact change records — same granularity, same payloads. Changes
+   older than the tail may be coalesced into fewer, coarser undo units, but
+   undo through them must still restore correct content (guaranteed by the
+   shadow-replay lowering, §9.3).
+5. **No mutation on export.** Export takes a `const omega_session_t *` and
+   must compile that way.
+6. **Failure atomicity (compaction).** Any failure — allocation, validation,
+   precondition — leaves the session exactly as it was.
+
+## 6. Public core API
+
+New header: `core/src/include/omega_edit/changelog.h`. New source:
+`core/src/lib/changelog.cpp` (planner + consumers; split into
+`changelog_planner.cpp` if it grows). Follow the existing header conventions
+(C linkage, Doxygen comments, `omega_edit_` prefix, status-code returns —
+note `omega_edit_status_result_is_success` treats `0` as success).
+
+### 6.1 Plan entry (shared by export visitor)
+
+```c
+typedef enum {
+    OMEGA_CHANGELOG_PLAN_DELETE = 1,
+    OMEGA_CHANGELOG_PLAN_INSERT = 2,
+    OMEGA_CHANGELOG_PLAN_OVERWRITE = 3,
+    OMEGA_CHANGELOG_PLAN_REPLACE = 4,
+    OMEGA_CHANGELOG_PLAN_TRANSFORM = 5
+} omega_changelog_plan_kind_t;
+
+typedef struct {
+    omega_changelog_plan_kind_t kind;
+    int64_t offset;              /* replay-time document offset */
+    int64_t length;              /* delete/overwrite/remove length */
+    const omega_byte_t *bytes;   /* borrowed; valid only during callback */
+    int64_t bytes_length;        /* insert/overwrite/replacement length */
+
+    /* TRANSFORM only; borrowed during callback. */
+    const char *transform_id;
+    const char *options_json;
+    int64_t replacement_length;
+    int64_t computed_file_size_before;
+    int64_t computed_file_size_after;
+} omega_changelog_plan_entry_t;
+```
+
+### 6.2 Optimized export (Phase 1)
+
+```c
+typedef int (*omega_changelog_plan_visitor_cbk_t)(
+    const omega_changelog_plan_entry_t *entry, void *user_data);
+
+typedef struct {
+    uint32_t flags;              /* reserved; 0 for v1 */
+    int64_t max_span_bytes;      /* 0 = default; splits oversized spans */
+    int64_t max_entries;         /* 0 = uncapped */
+    int prefer_overwrite_form;   /* emit OVERWRITE instead of equal-length REPLACE */
+} omega_changelog_export_options_t;
+
+/** Non-mutating. Returns 0 on success, non-zero on error or when the
+ *  visitor callback returns non-zero (propagated). */
+int omega_edit_export_changelog_optimized(
+    const omega_session_t *session_ptr,
+    const omega_changelog_export_options_t *options, /* NULL = defaults */
+    omega_changelog_plan_visitor_cbk_t cbk,
+    void *user_data);
+```
+
+### 6.3 Online compaction (Phase 3)
+
+```c
+typedef struct {
+    uint32_t high_water_count;      /* protected tail; default 20 */
+    uint32_t flags;                 /* reserved */
+} omega_changelog_compact_options_t;
+
+typedef struct {
+    int64_t change_count_before;
+    int64_t change_count_after;
+    int64_t removed_change_count;
+    int64_t first_invalid_serial;   /* clients invalidate serials >= this */
+    int64_t preserved_tail_count;
+} omega_changelog_compact_result_t;
+
+/** Compacts active history of the current (back) model only, preserving the
+ *  high-water tail. Content is unchanged. Returns:
+ *    0  success (including no-op)
+ *   -1  invalid argument / internal error (session preserved)
+ *   -2  blocked: open transaction, redo state present, changes paused,
+ *       or nothing eligible
+ *   -3  candidate validation failed (session preserved)          */
+int omega_edit_compact_changes(
+    omega_session_t *session_ptr,
+    const omega_changelog_compact_options_t *options, /* NULL = defaults */
+    omega_changelog_compact_result_t *result);        /* NULL ok */
+```
+
+### 6.4 Session event (Phase 3)
+
+Add to `omega_session_event_t` in `core/src/include/omega_edit/fwd_defs.h`.
+The highest bit currently used is `SESSION_EVT_RESTORE_CHECKPOINT = 1 << 18`,
+so:
+
+```c
+SESSION_EVT_CHANGELOG_COMPACTED = 1 << 19
+```
+
+Event payload is `omega_changelog_compact_result_t` (same struct; passed as
+the notify pointer). Emit exactly **one** event after install — no EDIT/UNDO
+events, because content did not change. Mark all viewports dirty via the
+existing `mark_all_viewports_changed_` helper pattern (offsets unchanged).
+
+Client obligations on receipt: re-read change count; invalidate cached serials
+`>= first_invalid_serial`; fingerprints and content-derived caches are
+unaffected.
+
+## 7. Online compaction commit model (Phase 3)
+
+Compaction is a **mutation of history, not content**, executed fully
+serialized like any other mutation.
+
+**Preconditions (return `-2` when violated):**
+
+- no transaction open or in progress (`omega_session_get_transaction_state`)
+- no redoable changes in the back model (`changes_undone` empty)
+- changes not paused (`omega_session_changes_paused`)
+- at least one eligible change beyond the high-water tail
+
+**Build candidate (no session mutation yet):**
+
+1. Partition the back model's active changes: `[0, scan_limit)` eligible,
+   `[scan_limit, end)` protected tail, where
+   `scan_limit = changes.size() - high_water_count` (skip the leading
+   TRANSFORM record if the model is a transform checkpoint — it stays as-is).
+2. Run the planner over the eligible range (single span in practice, since
+   transforms end models).
+3. **Lower via shadow replay** (§9.3): apply the plan through the normal edit
+   primitives against a scratch model seeded from the back model's backing
+   file. This produces correct changes (with undo payloads), segments, and
+   serials for free.
+4. Replay the protected tail's existing change records on top (reusing the
+   same `shared_ptr`s; their `serial` fields get renumbered during install).
+5. Validate: computed file size equals pre-compaction size;
+   `omega_check_model`-style integrity on the candidate; optional content
+   fingerprint in paranoid/debug builds. On failure return `-3`, discard.
+
+**Atomic install:**
+
+1. Re-check preconditions (cheap; nothing ran concurrently, but guard against
+   event-handler reentrancy).
+2. Move candidate `changes`, `model_segments` into the back model; clear
+   `model_snapshots` (they are keyed by change count, which just changed —
+   let the normal snapshot interval rebuild them).
+3. Renumber serials contiguously from `change_serial_base + 1` (tail change
+   objects are mutated in place, mirroring how undo flips signs).
+4. Mark viewports dirty; emit `SESSION_EVT_CHANGELOG_COMPACTED`.
+
+Old change objects (and their file-backed payloads) are released when the
+last references from the old segments/snapshots drop — which is exactly at
+install. That is the desired cleanup (§3.5).
+
+## 8. Server and TypeScript integration
+
+### 8.1 gRPC (service `EditorService`, `proto/omega_edit/v1/omega_edit.proto`)
+
+Export must be **server-streaming** — the server never configures message-size
+limits and currently inherits gRPC's 4 MiB inbound default and unlimited
+outbound (see `SHORTCOMINGS.md` item 15); a unary export response is exactly
+the kind of unbounded message that document flags.
+
+```protobuf
+rpc ExportChangeLog(ExportChangeLogRequest)
+    returns (stream ExportChangeLogResponse);
+
+message ExportChangeLogRequest {
+    string session_id = 1;
+    bool optimize = 2;
+}
+
+message ExportChangeLogResponse {
+    ChangeLogEntry entry = 1;   // new message mirroring plan entries
+}
+
+rpc CompactChanges(CompactChangesRequest) returns (CompactChangesResponse);
+
+message CompactChangesRequest {
+    string session_id = 1;
+    optional uint32 high_water_count = 2;
+}
+
+message CompactChangesResponse {
+    string session_id = 1;
+    int64 change_count_before = 2;
+    int64 change_count_after = 3;
+    int64 removed_change_count = 4;
+    int64 first_invalid_serial = 5;
+    int64 preserved_tail_count = 6;
+}
+```
+
+Server implementation notes (`server/cpp/src/editor_service.cpp`):
+
+- `CompactChanges` follows the standard mutation prologue used by
+  `UndoLastChange`/`ClearChanges`: `session_manager_.try_begin_mutation(...)`,
+  then `lock_session(...)`, then the core call, mapping `-2` to
+  `FAILED_PRECONDITION` and `-1`/`-3` to `INTERNAL`.
+- `ExportChangeLog` is read-only: `lock_session` only. The visitor writes one
+  streamed response per entry; honor `context->IsCancelled()` between writes.
+  Note the core lock is held for the duration — the same availability caveat
+  as other whole-content reads (`SHORTCOMINGS.md` items 3/16 apply; keep the
+  per-entry work small and let the stream apply backpressure).
+- Forward `SESSION_EVT_CHANGELOG_COMPACTED` through the existing session event
+  subscription plumbing (`session_event_callback` in
+  `server/cpp/src/session_manager.cpp` — add the payload fields to
+  `SessionEventData` the same way transform progress was added).
+
+### 8.2 TypeScript (`packages/ai/src/service.ts`, `packages/ai/src/mcp.ts`)
+
+The TS layer keeps its current responsibilities: `ChangeLogDocument` JSON
+shape (`packages/ai/src/types.ts`), streaming to file, before/after
+fingerprints, replay validation, CLI/MCP presentation.
+
+- `exportChangeLog(...)` (service.ts) gains `optimize?: boolean`; when set it
+  consumes the streaming RPC instead of per-serial `getChangeDetails`.
+  Synthetic entries are written **without** `serial`.
+- `applyChangeLog(...)` keeps its behavior: transactional batches for plain
+  entries, plugin replay for transforms. It already replays entries in order
+  with replay-time offsets, which is exactly what the planner emits. (A batch
+  `ApplyScript` RPC is a separate optimization, out of scope here.)
+- MCP: `omega_edit_export_change_log` gains an `optimize` parameter; add
+  `omega_edit_compact_changes` returning the compact result fields.
+
+## 9. Implementation hints (read before writing code)
+
+### 9.1 Reuse map — functions that already do what you need
+
+| Need | Reuse | Where |
+| ---- | ----- | ----- |
+| Enumerate all history in serial order | iterate `session_ptr->models_`, each model's `changes` (bases are ordered) | `session_def.hpp`, `model_def.hpp` |
+| Read change payload bytes safely | `omega_change_copy_payload_bytes_` / `omega_change_write_payload_bytes_` | `impl_/change_def.hpp` |
+| Change kind / transaction bit | `omega_change_get_kind_`, `omega_change_get_transaction_bit_` | `impl_/change_def.hpp` |
+| Read base content ranges (for prefix/suffix trim) | `omega_session_get_segment` on a scratch `omega_segment_t`, or `omega_util_read_file_segment` against the model's backing file | `session.cpp`, `filesystem.cpp` |
+| Build changes with correct payload capture | `omega_edit_insert_bytes` / `omega_edit_delete` / `omega_edit_overwrite_bytes` (they call `capture_session_range_payload_` internally) | `edit.cpp` |
+| Batch-apply a script in one transaction | `omega_edit_apply_script` | `edit.cpp` |
+| Rebuild segments by replaying changes | pattern in `rebuild_model_to_change_count_` (`initialize_model_segments_` + `update_model_` loop) | `edit.cpp` |
+| Validate candidate integrity | `omega_check_model` (session-level; adapt its checks for a single candidate model) | `check.cpp` |
+| Mark viewports dirty + notify | `mark_all_viewports_changed_` pattern | `edit.cpp` |
+| Overflow-safe arithmetic | `safe_add_int64_`, `valid_nonnegative_range_` | `impl_/safe_math.hpp` |
+| Content fingerprint for tests | `GetSessionFingerprint` RPC / digest plugin, or `omega_edit_save_segment_to_bytes` + any hash for unit tests | server + `edit.cpp` |
+
+### 9.2 Gotchas — each of these has bitten a prior design
+
+1. **Same-offset inserts reverse.** `INSERT@5 "AB"` then `INSERT@5 "CD"`
+   yields `CDAB` at offset 5, not `ABCD`. Any "concatenate adjacent inserts"
+   shortcut is wrong; only the piece-table replay is safe.
+2. **Payload file deletion on destruction** (§3.5). Never construct a
+   candidate change that stores another change's `file_path`. When a merged
+   change needs file-backed storage, write a **new** payload file in the
+   session's checkpoint directory (`create_payload_file_` pattern in
+   `edit.cpp`).
+3. **Snapshots are keyed by change count.** After renumbering, every existing
+   snapshot key is wrong. Clear them; do not try to remap.
+4. **`omega_visit_changes` sees only the back model.** Write a new internal
+   enumerator; do not "fix" the public visitor (its semantics are relied on).
+5. **Transform records are inside checkpoint models** as `changes.front()`
+   (see `checkpoint_snapshot_change_count_`). When compacting the back model
+   of a transform checkpoint, the TRANSFORM record is not eligible history —
+   skip index 0.
+6. **`update_` frees redo state** on any new positive-serial change. The
+   shadow replay must run against a *scratch* model, never the live one, or
+   you will destroy the user's redo stack before the install decision.
+7. **Event interest is a signed 32-bit mask** combined in
+   `session_manager.cpp` (`combine_event_interest`); `1 << 19` is fine, but
+   update any `ALL_EVENTS`-style masks and the proto `SessionEventKind`
+   mapping together.
+8. **Inline payload limit.** Changes above
+   `OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT` (64 MiB default, `config.h`) are
+   file-backed. Merged spans can cross that threshold in either direction;
+   let the edit primitives decide storage (another reason for shadow replay).
+9. **`0` is success for status APIs** (`omega_edit_status_result_is_success`).
+   Do not return positive "count" values from the status-returning compact
+   API; counts go in the result struct.
+10. **The scratch/shadow session must not fire events.** Create it with a
+    null event callback and zero interest, and give it the same checkpoint
+    directory so payload files land in the managed location.
+
+### 9.3 The shadow-replay lowering trick (strongly recommended)
+
+Hand-constructing `omega_change_t` records, segments, serials, and undo
+payloads is the highest-risk part of compaction. Avoid all of it:
+
+1. Open the back model's backing file (`model->file_path`) read-only in a
+   scratch model/session (same code path as `create_session_with_backing_file_`,
+   or a private helper that builds a bare `omega_model_t`).
+2. Apply the plan entries through the ordinary edit primitives
+   (`omega_edit_delete` / `insert_bytes` / `overwrite_bytes`, REPLACE via
+   delete+insert) — each op gets correct payload capture (undo data), correct
+   segment splicing, and sequential serials automatically.
+3. Replay the protected tail: for each preserved change record, re-apply it
+   via `update_model_`-style splicing using the *existing* change object (the
+   candidate's `changes` vector pushes the same `shared_ptr`).
+4. Steal the scratch model's `changes` + `model_segments` as the candidate;
+   fix up `change_serial_base` and renumber.
+
+This reduces "lowering" to a replay loop over machinery that is already
+heavily tested, and it makes validation almost tautological (the scratch
+session's computed size/content *is* the candidate's).
+
+### 9.4 Working with AI assistants on this codebase
+
+- **Feed the constraints, not just the task.** When prompting for planner or
+  compaction code, paste §3 (ground truth) and §9.2 (gotchas) into context;
+  most plausible-looking generated code violates gotchas 1, 2, or 6.
+- **Test-first per rule.** Have the assistant write the Catch2 cases from
+  §10.1–§10.2 before the planner logic; the same-offset-insert case in particular
+  kills the naive implementation immediately.
+- **Small, landable diffs.** Each phase below is one PR-sized unit with its
+  own tests; do not let a session sprawl across phases.
+- **Verify against the real headers.** Assistants will invent field names
+  (`session_ptr->changes_` from the superseded doc is wrong — history lives
+  under `models_`). Ground every struct access in
+  `impl_/session_def.hpp` / `impl_/model_def.hpp` / `impl_/change_def.hpp`.
+- **Build/test loop:** configure with the existing CMake presets; core tests
+  are Catch2 under `core/src/tests/` (`omegaEdit_tests.cpp` shows the
+  conventions — `MAKE_PATH`, fixture files, session lifecycle patterns).
+
+## 10. Testing strategy (brutal by design)
+
+The optimizer rewrites history behind the user's back. The bar is therefore
+not "the tests pass" — it is **bulletproof and invisible**. Pin the
+visibility contract first; every test below enforces some clause of it.
+
+**The invisibility contract.** After optimized export replay or online
+compaction, an end user may observe exactly two things:
+
+1. A smaller change count / renumbered serials (announced via
+   `SESSION_EVT_CHANGELOG_COMPACTED`).
+2. Coarser undo/redo steps for history **older than `highWaterCount`** —
+   undoing past the protected tail jumps in span-sized units instead of
+   per-edit units.
+
+Everything else is a bug. Concretely, a user must **never** observe:
+
+- any content difference, at any offset, at any file size
+- viewport data changes or offset shifts at the moment of compaction
+- undo/redo behaving differently **within** the protected tail
+- undo producing content that never existed in the pre-compaction timeline
+- spurious EDIT/UNDO/TRANSFORM events, missing or duplicated COMPACTED events
+- stalls of unrelated RPCs, crashes, leaked or prematurely deleted
+  payload/checkpoint files, or error-log noise during routine compaction
+
+### 10.1 Harness first: oracles and invariant checkers
+
+Build these as reusable helpers in `core/src/tests/changelog_test_support.hpp`
+**before** any optimizer code. Every subsequent test composes them; an AI
+assistant should be asked to write and review these first, because every
+other test inherits their strictness.
+
+| Oracle | Checks | How |
+| ------ | ------ | --- |
+| `assert_content_equal(a, b)` | byte-identical content | `omega_edit_save_segment_to_bytes` compare for small sessions; `omega_edit_save` to temp + `omega_util_compare_files` above `OMEGA_MEMORY_BUFFER_LIMIT` |
+| `assert_model_valid(s)` | segment contiguity, change-ref integrity, size consistency | `omega_check_model` (`core/src/lib/check.cpp`) — run after **every** mutation in fuzz runs |
+| `capture_undo_trajectory(s)` | full undo timeline | undo to zero, hashing content at each step; restore via redo; used by §10.4 |
+| `EventRecorder` | exact event sequence | session/viewport callbacks appending `(event, payload)` to a vector; assert against expected traces |
+| `CheckpointDirAudit` | filesystem hygiene | snapshot file list of `omega_session_get_checkpoint_directory()` before/after; diff must match expectation exactly (no strays, no missing) |
+| `assert_serials_contiguous(s)` | serial arithmetic | walk models; verify `omega_session_get_change(serial)` round-trips for every serial |
+
+Two cheap knobs make the harness vastly more punishing — set them in most
+tests:
+
+- `omega_session_set_change_inline_payload_limit(session, 8)` forces
+  file-backed payloads for nearly every edit, exercising payload-file
+  ownership (§3.5) constantly instead of only in rare >64 MiB tests.
+- `omega_session_set_undo_snapshot_interval(session, k)` with k ∈ {0, 1, 7}
+  shakes snapshot interactions (disabled / every change / prime stride).
+
+### 10.2 Planner unit tests (`core/src/tests/changelog_tests.cpp`)
+
+Pin the coordinate semantics first:
+
+| Case | Expected optimized output |
+| ---- | ------------------------- |
+| empty session / single change | passthrough (0 or 1 entries) |
+| `INSERT@5 "AB"`, `INSERT@5 "CD"` | one INSERT@5 `"CDAB"` |
+| `INSERT@5 "AB"`, `INSERT@7 "CD"` | one INSERT@5 `"ABCD"` |
+| `INSERT@0 "abc"`, `DELETE@0 len 3` | nothing (identity span) |
+| `DELETE@10 len 3`, `DELETE@10 len 2` | one DELETE@10 len 5 |
+| `OVERWRITE@4 "xxxx"`, `OVERWRITE@4 "yyyy"` | one OVERWRITE@4 `"yyyy"` |
+| `DELETE@8 len 4`, `INSERT@8 "zz"` | one REPLACE@8 remove 4 insert `"zz"` |
+| overlapping rewrites of the same region N times | single op bounded to the net-changed range (prefix/suffix trimmed) |
+| edits interleaved around a TRANSFORM | two independent spans; TRANSFORM preserved verbatim between them |
+| span exceeding `max_span_bytes` | split into subspans; content still correct |
+
+Then the adversarial edge matrix — every row runs against empty, 1-byte,
+odd-sized, and multi-gigabyte-sparse base documents:
+
+- ops at offset 0, at EOF, and spanning the exact EOF boundary
+- whole-document delete followed by rebuild from empty
+- inserts into an empty session; delete-everything as the only history
+- payload sizes exactly at, one below, and one above the inline/file-backed
+  threshold (use the lowered limit from §10.1)
+- spans that begin/end exactly at a TRANSFORM or model boundary
+- a span whose net effect is identity except for one byte in the middle
+  (prefix/suffix trim must not over-trim)
+- degenerate `max_span_bytes` (1) — pathological subspan splitting must
+  still be correct, merely unoptimal
+- **determinism**: same input planned twice (and on Windows/Linux/macOS CI)
+  yields byte-identical output
+- **idempotence**: exporting, replaying, and re-exporting optimized output
+  reproduces the same entries (a fixpoint after one pass)
+
+### 10.3 Differential fuzzing (the workhorse)
+
+```text
+for seed in many:
+    base   = random bytes (0..N)
+    ses_a  = session(base); apply script = generate(seed, k ops)
+    log    = export(ses_a, optimize=true)
+    ses_b  = session(base); replay(log)
+    assert_content_equal(ses_a, ses_b)
+    assert entries(log) <= raw_entries(ses_a)
+    assert_model_valid(ses_a); assert_model_valid(ses_b)
+```
+
+**Generator spec** (weights per profile; all sizes/offsets from mixed
+distributions — clustered hot-spot, sequential "typing", uniform random):
+
+| Op | typing | bulk | adversarial |
+| -- | ------ | ---- | ----------- |
+| small INSERT (1–16 B) | 60% | 10% | 20% |
+| DELETE (1 B–128 KiB) | 15% | 20% | 20% |
+| OVERWRITE | 10% | 30% | 20% |
+| undo / redo burst (1–50) | 10% | 2% | 20% |
+| transaction begin/end pair | 3% | 5% | 10% |
+| builtin TRANSFORM | 1% | 3% | 5% |
+| checkpoint create/destroy | 1% | 0% | 5% |
+
+Rules of engagement:
+
+- The op script is **serialized to a replay file** (JSON, one op per line)
+  in the scratch directory whenever an assertion fails, and the seed is
+  printed; a test-binary flag replays a saved script verbatim. A fuzz
+  failure that cannot be reproduced deterministically is a harness bug.
+- Shrinking: on failure, bisect the op script (drop halves, then individual
+  ops) until minimal; assistants are good at writing this — demand it.
+- Three modes: **PR** (≈2 min, fixed seed set + last N regression scripts),
+  **nightly** (≈1 h, random seeds), **soak** (≥24 h before any attestation,
+  zero failures required). Iterations controlled by env var.
+- Every historical failure's minimized script is committed as a named
+  regression case. The fuzz corpus only grows.
+
+### 10.4 Undo/redo equivalence (the one permitted visible change)
+
+This is the clause users will actually notice if we get it wrong, so it gets
+its own oracle. For a session with `C` changes compacted with tail `H`:
+
+1. **Within the tail — bit-exact.** Record `capture_undo_trajectory` for the
+   last `H` steps before compaction. After compaction, the first `H` undo
+   steps must produce the **identical content sequence**, step by step.
+2. **Past the tail — coarse but truthful.** Each further undo step must land
+   exactly on a content state that existed in the pre-compaction trajectory
+   (assert membership in the recorded hash set), in the same order; the
+   final full-undo state equals the span input / base content.
+3. **Round-trip.** Undo all the way down, redo all the way up: content
+   equals the pre-compaction tip; `omega_session_get_num_changes` and
+   `num_undone_changes` are consistent at every step; `assert_model_valid`
+   passes at every step.
+4. **Branching.** Undo past the tail, apply a fresh edit (this frees redo
+   state — §3.4), continue editing, compact again. All oracles hold.
+5. **Transform boundaries.** Undo across a TRANSFORM after compaction still
+   routes through `undo_transform_checkpoint_` correctly (checkpoint model
+   pop, file retained for redo).
+
+### 10.5 Compaction correctness, fault injection, and resource abuse
+
+Baseline (every case ends with all §10.1 oracles):
+
+- no-op when everything is inside the high-water tail; `-2` for open
+  transaction / redo present / paused changes; result struct accurate
+- serial contiguity and lookup after install; snapshots cleared and later
+  rebuilt at the normal interval
+- compaction twice in a row: second pass removes ~nothing and is harmless
+
+Fault injection — add an internal, test-only failure-point hook to the
+candidate builder (enumerated points, settable from tests): planner
+allocation, scratch-model creation, payload-file creation, tail replay,
+validation compare, pre-install precondition recheck. For **every** point:
+
+- the session is byte-identical to before the attempt (content, change
+  count, undo trajectory, serials)
+- no event was emitted; no viewport was dirtied
+- `CheckpointDirAudit` shows zero new files left behind
+
+Environmental abuse, in the same spirit:
+
+- checkpoint directory made read-only (payload/scratch creation fails
+  cleanly); on Linux, a near-full tmpfs quota for genuine disk-full
+- an old change's payload file deleted out from under the session before
+  compaction (must fail cleanly, not crash, session still readable)
+- histories of 100k and 1M changes (soak tier); a single span whose merged
+  payload crosses the file-backed threshold both directions
+- compaction of a session whose history is 100% incompressible (removal
+  ratio ≈ 0) — correct no-op-ish result, no pathological memory
+
+### 10.6 Invisibility at the server boundary
+
+- **Viewport freeze-frame.** Create viewports across the document (including
+  one floating, one at EOF), snapshot `omega_viewport_get_data` bytes and
+  offsets, compact, re-fetch: offsets identical, bytes identical, exactly one
+  `VIEWPORT_EVT`-level dirtying cycle, no data churn.
+- **Event discipline.** `EventRecorder` over a compaction: exactly one
+  `SESSION_EVT_CHANGELOG_COMPACTED` with a correct payload; zero EDIT, UNDO,
+  TRANSFORM, or CLEAR events; subscribed gRPC event streams receive exactly
+  one message.
+- **Concurrency hammer (TSan build mandatory).** While a driver thread
+  compacts in a loop, N client threads hammer viewport reads, `GetSegment`,
+  `SearchSession`, and heartbeats on the *same and different* sessions. Pass
+  criteria: no deadlock, no data race reported, every read returns either
+  the (identical) content, and p99 stall of unrelated-session RPCs stays
+  under a set budget (this doubles as a regression test for the
+  global-mutex findings in `SHORTCOMINGS.md` item 3).
+- **Destruction races.** `DestroySession` issued while the sweeper holds the
+  compaction guard; sweeper ticking during server shutdown; both must
+  resolve without crash, leak, or orphaned checkpoint directory.
+- gRPC mapping: `-2` → `FAILED_PRECONDITION`, `-1`/`-3` → `INTERNAL`, result
+  fields faithfully copied.
+- TS round-trip: `exportChangeLog({optimize:true})` → `applyChangeLog` →
+  fingerprints match; synthetic entries carry no `serial`.
+
+### 10.7 Filesystem hygiene and platform matrix
+
+`CheckpointDirAudit` runs in every compaction test: after compaction, the
+only file-count changes permitted are payload files belonging to dropped
+changes disappearing and new candidate payload files appearing; after
+session destroy, the managed directory is empty. Platform notes to encode as
+CI matrix legs, not comments:
+
+- **Windows:** open files cannot be deleted — payload cleanup order matters;
+  CRLF-rich content in the fuzz corpus; path length near `FILENAME_MAX`.
+- **macOS/Linux:** clonefile/FICLONE snapshot paths; case-sensitive vs
+  insensitive checkout of fixture files.
+- All three run the PR fuzz tier; nightly soak runs at least Linux + Windows.
+
+### 10.8 Performance gates (hard CI thresholds)
+
+| Metric | Gate |
+| ------ | ---- |
+| plan + export, 100k-change session | < 1 s |
+| online compaction, 100k changes (incl. validation) | < 2 s |
+| export memory | O(#changes); measured peak < 2× raw-entry metadata size |
+| edit-path overhead with policy **disabled** | zero (compiled-out or single branch); benchmarked, not asserted by eye |
+| edit-path overhead with sweeper enabled | < 1% on the keystroke benchmark |
+| streaming export of a 1M-entry log | bounded resident memory (no full-log buffering) |
+
+### 10.9 CI matrix and the definition of bulletproof
+
+Sanitizer legs: ASan+UBSan on all core tests; TSan on the server concurrency
+hammer; debug builds run the paranoid content-fingerprint validation inside
+the differential fuzz loop. Coverage gate on `changelog*.cpp`: no merge
+below agreed branch coverage; every fuzz-found bug lands with its minimized
+regression script.
+
+Ship/attestation checklist (all must be true):
+
+- [ ] all §10.2 unit + edge matrices green on all three platforms
+- [ ] 24 h soak fuzz (typing + bulk + adversarial profiles), zero failures
+- [ ] undo/redo equivalence suite green with tail ∈ {0, 1, 20, > history}
+- [ ] every fault-injection point proves atomic rollback + zero file litter
+- [ ] TSan hammer clean; unrelated-RPC stall budget met
+- [ ] performance gates met; disabled-path overhead confirmed zero
+- [ ] a human has diffed a real edited file: raw export replay vs optimized
+      export replay vs compacted session — three identical files
+
+## 11. Phased execution plan
+
+Each phase is independently landable with tests; later phases do not modify
+earlier public APIs.
+
+### Phase 1 — Planner + optimized export (non-mutating)
+
+*Scope:* `changelog.h`, `changelog.cpp` (enumerator, span partitioner,
+piece-table planner, diff emitter), `omega_edit_export_changelog_optimized`,
+streaming `ExportChangeLog` RPC, TS `exportChangeLog optimize` flag, MCP
+parameter.
+
+*Tests:* §10.1 harness helpers land here, then the §10.2 unit/edge matrices
+and the §10.3 differential fuzz in export mode, TS round-trip, streaming RPC
+cancellation.
+
+*Exit:* optimized export is never larger than raw export, replays to an
+identical fingerprint, and provably performs no session mutation
+(const-correct API + a test asserting change count/content unchanged).
+
+### Phase 2 — Candidate builder (no install)
+
+*Scope:* internal candidate engine — shadow-replay lowering (§9.3), tail
+replay, serial renumbering, validation helpers. No public API change; exposed
+only to tests via an internal header.
+
+*Tests:* §10.5 candidate-only subset (content equality, serial contiguity,
+integrity checks, every fault-injection point) without ever installing.
+
+*Exit:* the same planner output drives both export and a validated candidate
+model; failure paths leave the source session untouched.
+
+### Phase 3 — Online compaction
+
+*Scope:* `omega_edit_compact_changes`, `SESSION_EVT_CHANGELOG_COMPACTED`,
+atomic install, `CompactChanges` RPC with mutation guard, event forwarding
+through the server subscription plumbing, TS/MCP/CLI surface.
+
+*Tests:* full §10.4 (undo/redo equivalence), §10.5 (fault injection), §10.6
+(server-boundary invisibility, TSan hammer), §10.7 (hygiene audits); the
+§10.9 attestation checklist gates the release.
+
+*Exit:* a live session compacts old history with unchanged content, valid
+model integrity, working undo/redo semantics, and correct client
+invalidation signaling.
+
+### Phase 4 (optional) — Compaction policy
+
+Automatic triggering is **policy, not core mechanism**. The core has no
+timers and is single-threaded per session, so "quiet period" logic does not
+belong there. Phase 4 ships a server-side policy engine that decides *when*
+to call the Phase 3 mechanism (`omega_edit_compact_changes`), plus the same
+policy shape exposed to clients that prefer to drive compaction themselves.
+Ship only if Phase 3 usage shows real demand; measure first. Everything in
+this subsection is additive — the core API does not change.
+
+#### Phase 4.1 Where policy runs: a sweeper thread, not the edit path
+
+Run policy in a background **compaction sweeper** thread inside
+`EditorServiceImpl`, mirroring the existing `reaper_loop`
+(`server/cpp/src/editor_service.cpp`) — same start/stop lifecycle, same
+condition-variable shutdown. Rejected alternatives, for the record:
+
+- *In-core trigger on change insertion* (the original doc's design): the core
+  has no clock or threads, and compacting synchronously inside
+  `omega_edit_insert_bytes` would add unbounded latency to an interactive
+  keystroke. Rejected.
+- *Post-RPC inline trigger* (compact at the end of a mutation RPC): simple,
+  but the triggering RPC pays the full compaction latency, and the "quiet
+  period" cannot be observed from inside the burst that crossed the
+  threshold. Acceptable fallback; the sweeper is better.
+
+Sweeper loop shape (per tick, default every `sweepIntervalMs`):
+
+```text
+ids = session_manager.snapshot_session_ids()        // under mutex_, copy, release
+for sid in ids (bounded by maxSessionsPerSweep):
+    if !should_compact(policy, counters[sid], now): continue
+    guard = session_manager.try_begin_mutation(sid) // same guard as any edit RPC
+    if !guard: continue                             // busy — try next sweep
+    locked = session_manager.lock_session(sid)
+    if !locked: continue
+    rc = omega_edit_compact_changes(session, opts, &result)
+    record_outcome(counters[sid], rc, result, now)  // feeds thrash guard
+```
+
+Hard rules, tied to earlier findings:
+
+- The sweeper must **never** hold the global `SessionManager::mutex_` while
+  waiting on a per-session `core_mutex` or while compacting (that is exactly
+  the stall pattern flagged in `SHORTCOMINGS.md` item 3). Snapshot ids, then
+  operate per session with the normal guard + lock sequence.
+- A `-2` (blocked) result is not an error — the session was busy or had redo
+  state; the counters stay armed and the next sweep retries.
+- Policy needs a **mutation clock, not an activity clock**. `last_activity`
+  on `SessionInfo` is touched by reads (viewport polling would keep the quiet
+  period from ever expiring). Add a separate `last_mutation_time`, updated
+  only where `try_begin_mutation`/`try_begin_transform` succeed, and an
+  `eligible_change_hint` refreshed from `omega_session_get_num_changes` at
+  guard release.
+
+#### Phase 4.2 Proposed policy schema
+
+One canonical shape, surfaced at three layers that override in order:
+**server defaults (flags/env) → policy file → per-session override (RPC)**.
+All layers use the same field names so an AI assistant can generate the
+plumbing mechanically.
+
+Canonical JSON (this is also the `--compact-policy-file` format):
+
+```jsonc
+{
+  "enabled": false,             // master switch; default OFF
+  "minEligibleChanges": 5000,   // eligible = active changes − highWaterCount
+  "quietPeriodMs": 2000,        // no mutation for this long before compacting
+  "sweepIntervalMs": 1000,      // sweeper tick
+  "highWaterCount": 20,         // forwarded to omega_changelog_compact_options_t
+  "minRemovalRatio": 0.10,      // thrash guard threshold (see 4.3)
+  "cooldownMs": 30000,          // minimum time between compactions per session
+  "maxCooldownMs": 600000,      // backoff cap for the thrash guard
+  "maxSessionsPerSweep": 1      // bound sweep work per tick
+}
+```
+
+Field reference and validation (reject the whole file on violation — the
+server already fails fast on bad flag values in `main.cpp`):
+
+| Field | Type | Default | Constraint | Meaning |
+| ----- | ---- | ------- | ---------- | ------- |
+| `enabled` | bool | `false` | — | Nothing runs unless true. |
+| `minEligibleChanges` | int64 | `5000` | `>= 1` | Minimum changes past the high-water tail before a session is considered. |
+| `quietPeriodMs` | int64 | `2000` | `>= 0` | Required mutation-free interval. `0` = compact even mid-burst (bulk-load profile). |
+| `sweepIntervalMs` | int64 | `1000` | `>= 100` | Sweeper tick period. |
+| `highWaterCount` | uint32 | `20` | `>= 0` | Protected undo tail; passed straight to the core options. |
+| `minRemovalRatio` | double | `0.10` | `[0.0, 1.0]` | If a compaction removes less than this fraction of eligible changes, engage backoff. |
+| `cooldownMs` | int64 | `30000` | `>= 0` | Per-session floor between compaction attempts. |
+| `maxCooldownMs` | int64 | `600000` | `>= cooldownMs` | Cap for exponential backoff. |
+| `maxSessionsPerSweep` | int | `1` | `>= 1` | At most this many compactions per tick, so sweeps never monopolize the server. |
+
+CLI / environment mapping (follows the existing `main.cpp` conventions —
+every flag has an `OMEGA_EDIT_*` env twin, flags win over env, both win over
+the policy file):
+
+| Flag | Env | Maps to |
+| ---- | --- | ------- |
+| `--auto-compact` | `OMEGA_EDIT_AUTO_COMPACT` | `enabled = true` |
+| `--auto-compact-min-changes <n>` | `OMEGA_EDIT_AUTO_COMPACT_MIN_CHANGES` | `minEligibleChanges` |
+| `--auto-compact-quiet-ms <ms>` | `OMEGA_EDIT_AUTO_COMPACT_QUIET_MS` | `quietPeriodMs` |
+| `--auto-compact-high-water <n>` | `OMEGA_EDIT_AUTO_COMPACT_HIGH_WATER` | `highWaterCount` |
+| `--auto-compact-cooldown-ms <ms>` | `OMEGA_EDIT_AUTO_COMPACT_COOLDOWN_MS` | `cooldownMs` |
+| `--compact-policy-file <path>` | `OMEGA_EDIT_COMPACT_POLICY_FILE` | whole document |
+
+Per-session override RPC (optional, second PR of the phase; lets a client
+like the VS Code extension tune one session without redeploying the server):
+
+```protobuf
+message CompactionPolicy {
+    optional bool enabled = 1;
+    optional int64 min_eligible_changes = 2;
+    optional int64 quiet_period_ms = 3;
+    optional uint32 high_water_count = 4;
+    optional double min_removal_ratio = 5;
+    optional int64 cooldown_ms = 6;
+}
+
+rpc GetCompactionPolicy(GetCompactionPolicyRequest)
+    returns (GetCompactionPolicyResponse);   // effective (merged) policy
+rpc SetCompactionPolicy(SetCompactionPolicyRequest)
+    returns (SetCompactionPolicyResponse);   // per-session override; unset
+                                             // fields inherit server policy
+```
+
+All fields `optional` so an override sets only what it means to set; the
+effective policy is server defaults overlaid with the session override.
+`SetCompactionPolicy` is a metadata write — guard it like other lightweight
+session RPCs (`lock_session` only; it does not mutate history).
+
+#### Phase 4.3 Decision function and thrash guard
+
+Per-session sweeper state:
+`last_mutation_time`, `last_compact_time`, `current_cooldown_ms`
+(starts at `cooldownMs`), `last_removal_ratio`.
+
+```text
+should_compact(policy, s, now):
+    if !policy.enabled:                                   return false
+    eligible = num_changes(session) - policy.highWaterCount
+    if eligible < policy.minEligibleChanges:              return false
+    if now - s.last_mutation_time < policy.quietPeriodMs: return false
+    if now - s.last_compact_time  < s.current_cooldown_ms: return false
+    return true
+
+record_outcome(s, rc, result, now):
+    s.last_compact_time = now
+    if rc == -2:  return                       // busy; keep cooldown as-is
+    if rc != 0:   log warn; s.current_cooldown_ms = policy.maxCooldownMs; return
+    removed  = result.removed_change_count
+    eligible = result.change_count_before - result.preserved_tail_count
+    s.last_removal_ratio = eligible > 0 ? removed / eligible : 0
+    if s.last_removal_ratio < policy.minRemovalRatio:
+        // History doesn't compress (e.g. random-offset edits): back off
+        // exponentially instead of rescanning every threshold crossing.
+        s.current_cooldown_ms = min(s.current_cooldown_ms * 2, policy.maxCooldownMs)
+    else:
+        s.current_cooldown_ms = policy.cooldownMs          // reset on success
+```
+
+The thrash guard matters because compaction cost is O(history) even when it
+removes nothing: a session of random single-byte overwrites across a large
+file compresses poorly, and without backoff the sweeper would re-plan the
+same history every `minEligibleChanges` changes.
+
+Telemetry: log one structured line per compaction
+(`session, before, after, removed, ratio, duration_ms, rc`) and consider a
+`compaction_count`/`compacted_changes_total` pair on `GetHeartbeat` later.
+
+#### Phase 4.4 Worked examples
+
+**Example A — interactive editor (VS Code), default profile.** User types
+~12,000 single-byte inserts into a log file over ten minutes, mostly
+appending, occasionally correcting. Policy: defaults with `enabled: true`.
+
+| t | Event | Sweeper decision |
+| --- | ----- | ---------------- |
+| 0–600 s | Keystroke mutations arrive | `quietPeriodMs` never satisfied → defer (matches the "user actively editing" row of the old design, without any core involvement) |
+| 602 s | User pauses; 12,014 active changes, 20 protected | eligible = 11,994 ≥ 5,000, quiet ≥ 2 s → compact |
+| 602 s | `omega_edit_compact_changes` | typed runs coalesce; result: `before=12,014`, `after=31` (≈10 net REPLACE/INSERT ops + tail 20 + transform record), `removed=11,983`, ratio ≈ 1.0 |
+| 602 s | `SESSION_EVT_CHANGELOG_COMPACTED` | extension drops cached serials ≥ `first_invalid_serial`, re-reads change count; undo still steps through the last 20 keystrokes one by one |
+
+**Example B — agent bulk import, aggressive profile.** An MCP agent replays a
+50k-entry change log via `applyChangeLog`. Interactivity doesn't matter;
+memory does. Policy file:
+
+```json
+{
+  "enabled": true,
+  "minEligibleChanges": 20000,
+  "quietPeriodMs": 0,
+  "cooldownMs": 5000,
+  "minRemovalRatio": 0.25,
+  "highWaterCount": 0
+}
+```
+
+`quietPeriodMs: 0` lets the sweeper compact between transaction batches
+mid-import (the mutation guard makes each attempt safe — if a batch is in
+flight, `try_begin_mutation` fails and the sweeper just retries next tick);
+`highWaterCount: 0` because nobody will interactively undo an agent import.
+
+**Example C — thrash guard engaging.** A fuzzing client scatters random
+single-byte overwrites across a 4 GiB session. First compaction: eligible =
+5,000, removed = 130, ratio 0.026 < 0.10 → cooldown doubles 30 s → 60 s →
+120 s → … capped at 600 s. The session keeps working; the server stops
+burning CPU re-planning incompressible history. One later compaction with
+ratio ≥ 0.10 resets the cooldown to 30 s.
+
+**Example D — client-side policy instead of server policy.** A deployment
+leaves the server sweeper disabled and lets the VS Code extension decide:
+
+```jsonc
+// VS Code settings.json
+"omegaEdit.autoCompact": {
+  "enabled": true,
+  "minEligibleChanges": 5000,
+  "quietPeriodMs": 2000        // evaluated against the extension's own
+}                               // edit stream, then calls CompactChanges
+```
+
+The extension already knows when the user is idle; it simply calls the
+public `CompactChanges` RPC. Both modes can coexist — the mutation guard and
+cooldown make duplicate triggers a cheap no-op (`-2` or ratio ≈ 0).
+
+*Scope:* sweeper thread + counters in `EditorServiceImpl`/`SessionInfo`,
+policy parsing (flags/env/file) in `main.cpp` following its existing
+`parse_*` helpers, optional `Get/SetCompactionPolicy` RPCs, telemetry log
+line, VS Code setting.
+
+*Tests:* policy unit tests for `should_compact`/`record_outcome` (threshold,
+quiet period, cooldown, backoff sequence, ratio math); a server test that a
+busy session (guard held) is skipped and retried; a config test rejecting
+invalid policy files; an end-to-end test that a quiet session above threshold
+gets compacted exactly once and emits one event.
+
+*Exit:* with policy disabled, zero behavior change; with defaults enabled,
+Example A's timeline reproduces in an integration test, and Example C's
+backoff is observable in the telemetry log.
+
+## 12. Why the original design was rejected (do not resurrect)
+
+Kept short, with the concrete counterexamples an implementer needs:
+
+1. **Adjacent pattern rules ignore coordinate shift.** Its merge table said
+   `INSERT@O A` + `INSERT@O B` → `INSERT@O AB`; the document actually contains
+   `BA` (§9.2#1). Its "dead-write" rule for same-offset INSERTs deletes user
+   data (both inserts' bytes remain in the document). Its no-op rule
+   (`INSERT D` then `DELETE |D|` at `offset+|D|`) deletes the *wrong range* —
+   the inserted bytes live at `[offset, offset+|D|)`.
+2. **"Interruptible scan + atomic vector swap" solves a nonexistent problem.**
+   The core is single-threaded per session (§3.8); nothing can dirty the
+   vector mid-scan, and the server's `core_mutex` already serializes. The
+   design's retry loop, `-2` livelock code, and microsecond "read-only
+   window" analysis modeled concurrency the core does not have.
+3. **Swapping only `changes` corrupts the session.** Segments and snapshots
+   hold `shared_ptr`s into the change vector (§3.3); serial lookup is index
+   arithmetic (§3.2); undone changes live in a separate vector (§3.4). A
+   changes-only swap breaks reads, undo, and `omega_session_get_change`.
+4. **Transform dedup is unsafe.** Plugins are opaque; two identical-looking
+   transforms are not provably idempotent. Transforms are barriers, period.
+5. **It assumed a stored REPLACE kind and a flat `session_ptr->changes_`
+   member.** Neither exists (§3.7, §3.1).
+
+The revised document fixed all of the above; this document additionally
+specifies the emission diff, the shadow-replay lowering, payload-file
+ownership rules, the concrete server/TS integration points, and the
+test-first execution plan.
+
+## 13. Open decisions (defaults chosen)
+
+| Decision | Default |
+| -------- | ------- |
+| Synthetic export serials | Omit `serial` entirely on synthetic entries. |
+| Compaction scope | Back model only in v1. |
+| Transform handling | Hard barrier; preserved exactly; no dedup. |
+| Redo state | Blocks compaction (`-2`). |
+| Snapshots after compaction | Cleared; rebuilt by the normal interval. |
+| Event | `SESSION_EVT_CHANGELOG_COMPACTED = 1 << 19`, one per compaction. |
+| OVERWRITE vs REPLACE emission | `prefer_overwrite_form` option; default REPLACE. |
+| Auto-compaction | Phase 4 server sweeper + policy schema (§Phase 4.2); disabled by default. |
+
+## 14. Out of scope for initial delivery
+
+- Transform deduplication or replay-based transform folding.
+- Compaction across model/checkpoint boundaries.
+- Sparse-serial lookup redesign (compaction renumbers instead).
+- Low-lock compaction via deep-copied history snapshots (design sketch lives
+  in the revised doc §7.4; revisit only if serialized compaction shows up in
+  profiles).
+- A batch `ApplyScript` RPC for cheaper replay (worthwhile, but independent).

--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -9,7 +9,9 @@ particular, the transform/change-log/checkpoint audit items that now have
 regression coverage are not repeated here. The recent VS Code extension issues
 around the initial Find toggle state, auto bytes-per-row overfitting, and the
 duplicate Ctrl-Z undo toast are also treated as fixed by the current extension
-branch/PR and are not listed as open.
+branch/PR and are not listed as open. The redo preservation bug across
+transform undo boundaries found by the brutal-testing harness is also fixed by
+the current core test branch/PR and is no longer listed as open.
 
 Recent core/server/plugin review findings have been folded into the priority
 list below rather than kept as a second appended review. A fresh core/server

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -617,16 +617,22 @@ namespace {
         model_ptr->changes.clear();
     }
 
-    inline void free_model_changes_undone_(omega_model_struct *model_ptr) {
-        for (const auto &change_ptr : model_ptr->changes_undone) {
+    inline void free_changes_undone_(omega_changes_t &changes_undone) {
+        for (const auto &change_ptr : changes_undone) {
             if (omega_change_get_kind_(change_ptr.get()) == change_kind_t::CHANGE_TRANSFORM &&
-                change_ptr->transform_data && !change_ptr->transform_data->checkpoint_file_path.empty()) {
-                if (0 != omega_util_remove_file(change_ptr->transform_data->checkpoint_file_path.c_str())) {
+                change_ptr->transform_data) {
+                free_changes_undone_(change_ptr->transform_data->preserved_changes_undone);
+                if (!change_ptr->transform_data->checkpoint_file_path.empty() &&
+                    0 != omega_util_remove_file(change_ptr->transform_data->checkpoint_file_path.c_str())) {
                     LOG_ERRNO();
                 }
             }
         }
-        model_ptr->changes_undone.clear();
+        changes_undone.clear();
+    }
+
+    inline void free_model_changes_undone_(omega_model_struct *model_ptr) {
+        free_changes_undone_(model_ptr->changes_undone);
     }
 
     inline void free_session_changes_(const omega_session_t *session_ptr) {
@@ -1534,13 +1540,14 @@ namespace {
         if (transform_model_ptr->changes.empty()) { return 0; }
         const auto change_ptr = transform_model_ptr->changes.back();
         if (omega_change_get_kind_(change_ptr.get()) != change_kind_t::CHANGE_TRANSFORM) { return 0; }
+        if (!change_ptr->transform_data) { return -1; }
         auto *const previous_model_ptr = session_ptr->models_[session_ptr->models_.size() - 2].get();
         try {
             previous_model_ptr->changes_undone.reserve(previous_model_ptr->changes_undone.size() + 1);
         } catch (const std::bad_alloc &) { return -1; }
 
         transform_model_ptr->changes.pop_back();
-        free_model_changes_undone_(transform_model_ptr);
+        change_ptr->transform_data->preserved_changes_undone.swap(transform_model_ptr->changes_undone);
         FCLOSE(transform_model_ptr->file_ptr);
         session_ptr->models_.pop_back();
         session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
@@ -1591,6 +1598,7 @@ namespace {
             return -1;
         }
 
+        session_ptr->models_.back()->changes_undone.swap(redone_change_ptr->transform_data->preserved_changes_undone);
         redone_change_ptr->serial = redone_serial;
         undone_changes.pop_back();
         session_ptr->num_changes_adjustment_ = change_serial_base;

--- a/core/src/lib/impl_/change_def.hpp
+++ b/core/src/lib/impl_/change_def.hpp
@@ -18,12 +18,14 @@
 #include "../../include/omega_edit/change.h"
 #include "../../include/omega_edit/filesystem.h"
 #include "data_def.hpp"
+#include "internal_fwd_defs.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace omega_edit::internal {
 
@@ -85,6 +87,7 @@ struct omega_transform_change_data_struct {
     std::string transform_id{};
     std::string options_json{};
     std::string checkpoint_file_path{};
+    std::vector<const_omega_change_ptr_t> preserved_changes_undone{};
     int64_t replacement_length{};
     int64_t computed_file_size_before{};
     int64_t computed_file_size_after{};

--- a/core/src/tests/differential_fuzz_tests.cpp
+++ b/core/src/tests/differential_fuzz_tests.cpp
@@ -1,0 +1,873 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+ * implied.  See the License for the specific language governing permissions and limitations under the License.       *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+/**
+ * @file differential_fuzz_tests.cpp
+ * @brief Section 10.3 differential fuzz driver built on the shared core test harness.
+ */
+
+#include "omega_edit.h"
+#include "omega_edit/stl_string_adaptor.hpp"
+
+#include "test_harness.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using omega_test::check_serials_contiguous;
+using omega_test::compare_content;
+using omega_test::model_valid;
+using omega_test::ScratchDir;
+using omega_test::TestSession;
+using omega_test::verify_undo_redo_round_trip;
+
+namespace {
+    enum class fuzz_profile_t { typing, bulk, adversarial };
+
+    enum class fuzz_op_kind_t {
+        insert,
+        delete_bytes,
+        overwrite,
+        undo_burst,
+        redo_burst,
+        begin_transaction,
+        end_transaction,
+        transform,
+        create_checkpoint,
+        destroy_checkpoint
+    };
+
+    struct fuzz_op_t {
+        fuzz_op_kind_t kind{};
+        int64_t offset{};
+        int64_t length{};
+        int64_t count{};
+        omega_edit_transform_t transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+        std::vector<omega_byte_t> bytes;
+    };
+
+    struct fuzz_script_t {
+        uint64_t seed{};
+        fuzz_profile_t profile{fuzz_profile_t::typing};
+        std::vector<omega_byte_t> base;
+        std::vector<fuzz_op_t> ops;
+    };
+
+    struct fuzz_run_result_t {
+        bool ok{true};
+        size_t step{};
+        std::string message;
+    };
+
+    const char *profile_name(fuzz_profile_t profile) {
+        switch (profile) {
+            case fuzz_profile_t::typing:
+                return "typing";
+            case fuzz_profile_t::bulk:
+                return "bulk";
+            case fuzz_profile_t::adversarial:
+                return "adversarial";
+        }
+        return "unknown";
+    }
+
+    fuzz_profile_t profile_from_name(const std::string &name) {
+        if (name == "bulk") { return fuzz_profile_t::bulk; }
+        if (name == "adversarial") { return fuzz_profile_t::adversarial; }
+        return fuzz_profile_t::typing;
+    }
+
+    const char *op_name(fuzz_op_kind_t kind) {
+        switch (kind) {
+            case fuzz_op_kind_t::insert:
+                return "insert";
+            case fuzz_op_kind_t::delete_bytes:
+                return "delete";
+            case fuzz_op_kind_t::overwrite:
+                return "overwrite";
+            case fuzz_op_kind_t::undo_burst:
+                return "undo";
+            case fuzz_op_kind_t::redo_burst:
+                return "redo";
+            case fuzz_op_kind_t::begin_transaction:
+                return "begin_transaction";
+            case fuzz_op_kind_t::end_transaction:
+                return "end_transaction";
+            case fuzz_op_kind_t::transform:
+                return "transform";
+            case fuzz_op_kind_t::create_checkpoint:
+                return "create_checkpoint";
+            case fuzz_op_kind_t::destroy_checkpoint:
+                return "destroy_checkpoint";
+        }
+        return "unknown";
+    }
+
+    uint64_t parse_u64(const char *value, uint64_t fallback) {
+        if (!value || !*value) { return fallback; }
+        errno = 0;
+        char *end = nullptr;
+        const auto parsed = std::strtoull(value, &end, 0);
+        return errno == 0 && end && *end == '\0' ? static_cast<uint64_t>(parsed) : fallback;
+    }
+
+    int64_t parse_i64(const char *value, int64_t fallback, int64_t min_value, int64_t max_value) {
+        if (!value || !*value) { return fallback; }
+        errno = 0;
+        char *end = nullptr;
+        const auto parsed = std::strtoll(value, &end, 0);
+        if (errno != 0 || !end || *end != '\0') { return fallback; }
+        return std::max(min_value, std::min<int64_t>(parsed, max_value));
+    }
+
+    int64_t random_i64(std::mt19937_64 &rng, int64_t min_value, int64_t max_value) {
+        if (max_value <= min_value) { return min_value; }
+        std::uniform_int_distribution<int64_t> dist(min_value, max_value);
+        return dist(rng);
+    }
+
+    bool chance(std::mt19937_64 &rng, int percent) { return random_i64(rng, 1, 100) <= percent; }
+
+    int64_t clamp_offset(int64_t value, int64_t max_value) {
+        if (max_value <= 0) { return 0; }
+        return std::max<int64_t>(0, std::min(value, max_value));
+    }
+
+    int64_t choose_offset(std::mt19937_64 &rng, int64_t size, bool allow_eof, fuzz_profile_t profile, int64_t cursor,
+                          int64_t hot_spot) {
+        const auto max_offset = allow_eof ? size : size - 1;
+        if (max_offset <= 0) { return 0; }
+
+        const auto mode = random_i64(rng, 0, 99);
+        if (profile == fuzz_profile_t::typing && mode < 55) { return clamp_offset(cursor, max_offset); }
+        if (mode < 75) { return clamp_offset(hot_spot + random_i64(rng, -16, 16), max_offset); }
+        return random_i64(rng, 0, max_offset);
+    }
+
+    int64_t choose_span_length(std::mt19937_64 &rng, fuzz_profile_t profile) {
+        if (profile == fuzz_profile_t::adversarial && chance(rng, 8)) { return 128 * 1024; }
+        if (profile == fuzz_profile_t::bulk) { return random_i64(rng, 1, 4096); }
+        return random_i64(rng, 1, 128);
+    }
+
+    int64_t choose_byte_count(std::mt19937_64 &rng, fuzz_profile_t profile, bool small_insert) {
+        if (small_insert) { return random_i64(rng, 1, 16); }
+        if (profile == fuzz_profile_t::bulk) { return random_i64(rng, 1, 512); }
+        return random_i64(rng, 1, 96);
+    }
+
+    std::vector<omega_byte_t> random_bytes(std::mt19937_64 &rng, int64_t length, fuzz_profile_t profile) {
+        std::vector<omega_byte_t> bytes(static_cast<size_t>(std::max<int64_t>(0, length)));
+        for (auto &byte : bytes) {
+            if (profile == fuzz_profile_t::typing && chance(rng, 85)) {
+                static constexpr char alphabet[] =
+                        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 \n\t.,;:_-";
+                byte = static_cast<omega_byte_t>(
+                        alphabet[random_i64(rng, 0, static_cast<int64_t>(sizeof(alphabet) - 2))]);
+            } else {
+                byte = static_cast<omega_byte_t>(random_i64(rng, 0, 255));
+            }
+        }
+        return bytes;
+    }
+
+    fuzz_op_kind_t choose_weighted_op(std::mt19937_64 &rng, fuzz_profile_t profile) {
+        struct weighted_op_t {
+            fuzz_op_kind_t kind;
+            int weight;
+        };
+
+        const std::array<weighted_op_t, 7> typing{{
+                {fuzz_op_kind_t::insert, 60},
+                {fuzz_op_kind_t::delete_bytes, 15},
+                {fuzz_op_kind_t::overwrite, 10},
+                {fuzz_op_kind_t::undo_burst, 10},
+                {fuzz_op_kind_t::begin_transaction, 3},
+                {fuzz_op_kind_t::transform, 1},
+                {fuzz_op_kind_t::create_checkpoint, 1},
+        }};
+        const std::array<weighted_op_t, 7> bulk{{
+                {fuzz_op_kind_t::insert, 10},
+                {fuzz_op_kind_t::delete_bytes, 20},
+                {fuzz_op_kind_t::overwrite, 30},
+                {fuzz_op_kind_t::undo_burst, 2},
+                {fuzz_op_kind_t::begin_transaction, 5},
+                {fuzz_op_kind_t::transform, 3},
+                {fuzz_op_kind_t::create_checkpoint, 0},
+        }};
+        const std::array<weighted_op_t, 7> adversarial{{
+                {fuzz_op_kind_t::insert, 20},
+                {fuzz_op_kind_t::delete_bytes, 20},
+                {fuzz_op_kind_t::overwrite, 20},
+                {fuzz_op_kind_t::undo_burst, 20},
+                {fuzz_op_kind_t::begin_transaction, 10},
+                {fuzz_op_kind_t::transform, 5},
+                {fuzz_op_kind_t::create_checkpoint, 5},
+        }};
+
+        const auto &weights =
+                profile == fuzz_profile_t::typing ? typing : (profile == fuzz_profile_t::bulk ? bulk : adversarial);
+        int total = 0;
+        for (const auto &entry : weights) { total += entry.weight; }
+        auto pick = static_cast<int>(random_i64(rng, 1, total));
+        for (const auto &entry : weights) {
+            pick -= entry.weight;
+            if (pick <= 0) { return entry.kind; }
+        }
+        return fuzz_op_kind_t::insert;
+    }
+
+    omega_edit_transform_t choose_transform(std::mt19937_64 &rng) {
+        switch (random_i64(rng, 0, 4)) {
+            case 0:
+                return {OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+            case 1:
+                return {OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER, 0};
+            case 2:
+                return {OMEGA_EDIT_TRANSFORM_BITWISE_AND, static_cast<omega_byte_t>(random_i64(rng, 0, 255))};
+            case 3:
+                return {OMEGA_EDIT_TRANSFORM_BITWISE_OR, static_cast<omega_byte_t>(random_i64(rng, 0, 255))};
+            default:
+                return {OMEGA_EDIT_TRANSFORM_BITWISE_XOR, static_cast<omega_byte_t>(random_i64(rng, 0, 255))};
+        }
+    }
+
+    int64_t apply_one(omega_session_t *session_ptr, const fuzz_op_t &op) {
+        switch (op.kind) {
+            case fuzz_op_kind_t::insert:
+                return omega_edit_insert_bytes(session_ptr, op.offset, op.bytes.empty() ? nullptr : op.bytes.data(),
+                                               static_cast<int64_t>(op.bytes.size()));
+            case fuzz_op_kind_t::delete_bytes:
+                return omega_edit_delete(session_ptr, op.offset, op.length);
+            case fuzz_op_kind_t::overwrite:
+                return omega_edit_overwrite_bytes(session_ptr, op.offset, op.bytes.empty() ? nullptr : op.bytes.data(),
+                                                  static_cast<int64_t>(op.bytes.size()));
+            case fuzz_op_kind_t::undo_burst: {
+                int64_t applied = 0;
+                for (int64_t i = 0; i < op.count; ++i) {
+                    const auto rc = omega_edit_undo_last_change(session_ptr);
+                    if (rc < 0) {
+                        ++applied;
+                    } else {
+                        break;
+                    }
+                }
+                return applied;
+            }
+            case fuzz_op_kind_t::redo_burst: {
+                int64_t applied = 0;
+                for (int64_t i = 0; i < op.count; ++i) {
+                    const auto rc = omega_edit_redo_last_undo(session_ptr);
+                    if (rc > 0) {
+                        ++applied;
+                    } else {
+                        break;
+                    }
+                }
+                return applied;
+            }
+            case fuzz_op_kind_t::begin_transaction:
+                return omega_session_begin_transaction(session_ptr);
+            case fuzz_op_kind_t::end_transaction:
+                return omega_session_end_transaction(session_ptr);
+            case fuzz_op_kind_t::transform:
+                return omega_edit_apply_builtin_transform(session_ptr, op.transform, op.offset, op.length);
+            case fuzz_op_kind_t::create_checkpoint:
+                return omega_edit_create_checkpoint(session_ptr);
+            case fuzz_op_kind_t::destroy_checkpoint:
+                return omega_edit_destroy_last_checkpoint(session_ptr);
+        }
+        return -1;
+    }
+
+    void update_generation_cursor(const omega_session_t *session_ptr, const fuzz_op_t &op, int64_t &cursor,
+                                  int64_t &hot_spot) {
+        const auto size = std::max<int64_t>(0, omega_session_get_computed_file_size(session_ptr));
+        switch (op.kind) {
+            case fuzz_op_kind_t::insert:
+            case fuzz_op_kind_t::overwrite:
+                hot_spot = clamp_offset(op.offset, size);
+                cursor = clamp_offset(op.offset + static_cast<int64_t>(op.bytes.size()), size);
+                break;
+            case fuzz_op_kind_t::delete_bytes:
+            case fuzz_op_kind_t::transform:
+                hot_spot = clamp_offset(op.offset, size);
+                cursor = hot_spot;
+                break;
+            default:
+                cursor = clamp_offset(cursor, size);
+                hot_spot = clamp_offset(hot_spot, size);
+                break;
+        }
+    }
+
+    fuzz_op_t make_edit_op(std::mt19937_64 &rng, omega_session_t *session_ptr, fuzz_profile_t profile,
+                           fuzz_op_kind_t kind, int64_t cursor, int64_t hot_spot, bool small_insert = false) {
+        const auto size = std::max<int64_t>(0, omega_session_get_computed_file_size(session_ptr));
+        fuzz_op_t op;
+        op.kind = kind;
+        switch (kind) {
+            case fuzz_op_kind_t::insert:
+                op.offset = choose_offset(rng, size, true, profile, cursor, hot_spot);
+                op.bytes = random_bytes(rng, choose_byte_count(rng, profile, small_insert), profile);
+                break;
+            case fuzz_op_kind_t::delete_bytes:
+                op.offset = choose_offset(rng, size, false, profile, cursor, hot_spot);
+                op.length = choose_span_length(rng, profile);
+                break;
+            case fuzz_op_kind_t::overwrite:
+                op.offset = choose_offset(rng, size, true, profile, cursor, hot_spot);
+                op.bytes = random_bytes(rng, choose_byte_count(rng, profile, false), profile);
+                break;
+            default:
+                break;
+        }
+        return op;
+    }
+
+    void record_and_apply(fuzz_script_t &script, TestSession &planning_session, const fuzz_op_t &op, int64_t &cursor,
+                          int64_t &hot_spot) {
+        script.ops.push_back(op);
+        apply_one(planning_session.get(), op);
+        update_generation_cursor(planning_session.get(), op, cursor, hot_spot);
+    }
+
+    fuzz_script_t generate_script(uint64_t seed, fuzz_profile_t profile, int64_t op_count) {
+        std::mt19937_64 rng(seed);
+        fuzz_script_t script;
+        script.seed = seed;
+        script.profile = profile;
+
+        const auto max_base_size =
+                profile == fuzz_profile_t::bulk ? 1024 : (profile == fuzz_profile_t::typing ? 48 : 256);
+        script.base = random_bytes(rng, random_i64(rng, 0, max_base_size), profile);
+
+        const ScratchDir planning_scratch;
+        auto planning_session =
+                TestSession::from_bytes(script.base.empty() ? nullptr : script.base.data(),
+                                        static_cast<int64_t>(script.base.size()), planning_scratch.c_str());
+        planning_session.make_brutal(8, 1);
+
+        int64_t cursor = omega_session_get_computed_file_size(planning_session.get());
+        int64_t hot_spot = cursor / 2;
+        for (int64_t i = 0; i < op_count; ++i) {
+            auto kind = choose_weighted_op(rng, profile);
+            const auto size = omega_session_get_computed_file_size(planning_session.get());
+            if ((kind == fuzz_op_kind_t::delete_bytes || kind == fuzz_op_kind_t::transform) && size <= 0) {
+                kind = fuzz_op_kind_t::insert;
+            }
+            if (kind == fuzz_op_kind_t::undo_burst && chance(rng, 18)) { kind = fuzz_op_kind_t::redo_burst; }
+
+            if (kind == fuzz_op_kind_t::begin_transaction) {
+                fuzz_op_t begin;
+                begin.kind = fuzz_op_kind_t::begin_transaction;
+                record_and_apply(script, planning_session, begin, cursor, hot_spot);
+
+                const auto transaction_ops = random_i64(rng, 1, profile == fuzz_profile_t::adversarial ? 7 : 4);
+                for (int64_t j = 0; j < transaction_ops; ++j) {
+                    const auto edit_pick = random_i64(rng, 0, 2);
+                    auto edit_kind = edit_pick == 0 ? fuzz_op_kind_t::insert
+                                                    : (edit_pick == 1 ? fuzz_op_kind_t::delete_bytes
+                                                                      : fuzz_op_kind_t::overwrite);
+                    if (edit_kind == fuzz_op_kind_t::delete_bytes &&
+                        omega_session_get_computed_file_size(planning_session.get()) <= 0) {
+                        edit_kind = fuzz_op_kind_t::insert;
+                    }
+                    const auto edit_op = make_edit_op(rng, planning_session.get(), profile, edit_kind, cursor, hot_spot,
+                                                      edit_kind == fuzz_op_kind_t::insert);
+                    record_and_apply(script, planning_session, edit_op, cursor, hot_spot);
+                }
+
+                fuzz_op_t end;
+                end.kind = fuzz_op_kind_t::end_transaction;
+                record_and_apply(script, planning_session, end, cursor, hot_spot);
+                continue;
+            }
+
+            fuzz_op_t op;
+            op.kind = kind;
+            switch (kind) {
+                case fuzz_op_kind_t::insert:
+                case fuzz_op_kind_t::delete_bytes:
+                case fuzz_op_kind_t::overwrite:
+                    op = make_edit_op(rng, planning_session.get(), profile, kind, cursor, hot_spot,
+                                      kind == fuzz_op_kind_t::insert);
+                    break;
+                case fuzz_op_kind_t::undo_burst:
+                case fuzz_op_kind_t::redo_burst:
+                    op.count = random_i64(rng, 1, 50);
+                    break;
+                case fuzz_op_kind_t::transform:
+                    op.transform = choose_transform(rng);
+                    op.offset = choose_offset(rng, size, false, profile, cursor, hot_spot);
+                    op.length = chance(rng, 20) ? 0 : choose_span_length(rng, profile);
+                    break;
+                case fuzz_op_kind_t::create_checkpoint:
+                    if (profile == fuzz_profile_t::adversarial &&
+                        omega_session_get_num_checkpoints(planning_session.get()) > 0 && chance(rng, 45)) {
+                        op.kind = fuzz_op_kind_t::destroy_checkpoint;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            record_and_apply(script, planning_session, op, cursor, hot_spot);
+        }
+        return script;
+    }
+
+    char hex_digit(unsigned value) { return static_cast<char>(value < 10 ? '0' + value : 'a' + (value - 10)); }
+
+    std::string hex_encode(const std::vector<omega_byte_t> &bytes) {
+        std::string encoded;
+        encoded.reserve(bytes.size() * 2);
+        for (const auto byte : bytes) {
+            encoded.push_back(hex_digit((byte >> 4U) & 0x0FU));
+            encoded.push_back(hex_digit(byte & 0x0FU));
+        }
+        return encoded;
+    }
+
+    int hex_value(char ch) {
+        if (ch >= '0' && ch <= '9') { return ch - '0'; }
+        if (ch >= 'a' && ch <= 'f') { return ch - 'a' + 10; }
+        if (ch >= 'A' && ch <= 'F') { return ch - 'A' + 10; }
+        return -1;
+    }
+
+    bool hex_decode(const std::string &encoded, std::vector<omega_byte_t> &bytes) {
+        if ((encoded.size() % 2) != 0) { return false; }
+        bytes.clear();
+        bytes.reserve(encoded.size() / 2);
+        for (size_t i = 0; i < encoded.size(); i += 2) {
+            const auto high = hex_value(encoded[i]);
+            const auto low = hex_value(encoded[i + 1]);
+            if (high < 0 || low < 0) { return false; }
+            bytes.push_back(static_cast<omega_byte_t>((high << 4U) | low));
+        }
+        return true;
+    }
+
+    bool extract_string(const std::string &line, const std::string &key, std::string &value) {
+        const auto needle = "\"" + key + "\":\"";
+        const auto begin = line.find(needle);
+        if (begin == std::string::npos) { return false; }
+        const auto value_begin = begin + needle.size();
+        const auto value_end = line.find('"', value_begin);
+        if (value_end == std::string::npos) { return false; }
+        value = line.substr(value_begin, value_end - value_begin);
+        return true;
+    }
+
+    bool extract_int64(const std::string &line, const std::string &key, int64_t &value) {
+        const auto needle = "\"" + key + "\":";
+        const auto begin = line.find(needle);
+        if (begin == std::string::npos) { return false; }
+        const auto value_begin = begin + needle.size();
+        const auto value_end = line.find_first_of(",}", value_begin);
+        if (value_end == std::string::npos) { return false; }
+        const auto text = line.substr(value_begin, value_end - value_begin);
+        errno = 0;
+        char *end = nullptr;
+        const auto parsed = std::strtoll(text.c_str(), &end, 10);
+        if (errno != 0 || !end || *end != '\0') { return false; }
+        value = parsed;
+        return true;
+    }
+
+    bool extract_uint64(const std::string &line, const std::string &key, uint64_t &value) {
+        int64_t signed_value = 0;
+        if (!extract_int64(line, key, signed_value) || signed_value < 0) { return false; }
+        value = static_cast<uint64_t>(signed_value);
+        return true;
+    }
+
+    bool parse_op(const std::string &line, fuzz_op_t &op, std::string &error) {
+        std::string name;
+        if (!extract_string(line, "op", name)) {
+            error = "missing op field";
+            return false;
+        }
+
+        if (name == "insert") {
+            op.kind = fuzz_op_kind_t::insert;
+            std::string bytes;
+            if (!extract_int64(line, "offset", op.offset) || !extract_string(line, "bytes", bytes) ||
+                !hex_decode(bytes, op.bytes)) {
+                error = "invalid insert op";
+                return false;
+            }
+            return true;
+        }
+        if (name == "delete") {
+            op.kind = fuzz_op_kind_t::delete_bytes;
+            if (!extract_int64(line, "offset", op.offset) || !extract_int64(line, "length", op.length)) {
+                error = "invalid delete op";
+                return false;
+            }
+            return true;
+        }
+        if (name == "overwrite") {
+            op.kind = fuzz_op_kind_t::overwrite;
+            std::string bytes;
+            if (!extract_int64(line, "offset", op.offset) || !extract_string(line, "bytes", bytes) ||
+                !hex_decode(bytes, op.bytes)) {
+                error = "invalid overwrite op";
+                return false;
+            }
+            return true;
+        }
+        if (name == "undo" || name == "redo") {
+            op.kind = name == "undo" ? fuzz_op_kind_t::undo_burst : fuzz_op_kind_t::redo_burst;
+            if (!extract_int64(line, "count", op.count)) {
+                error = "invalid undo/redo op";
+                return false;
+            }
+            return true;
+        }
+        if (name == "begin_transaction") {
+            op.kind = fuzz_op_kind_t::begin_transaction;
+            return true;
+        }
+        if (name == "end_transaction") {
+            op.kind = fuzz_op_kind_t::end_transaction;
+            return true;
+        }
+        if (name == "transform") {
+            int64_t transform_kind = 0;
+            int64_t operand = 0;
+            op.kind = fuzz_op_kind_t::transform;
+            if (!extract_int64(line, "kind", transform_kind) || !extract_int64(line, "operand", operand) ||
+                !extract_int64(line, "offset", op.offset) || !extract_int64(line, "length", op.length)) {
+                error = "invalid transform op";
+                return false;
+            }
+            op.transform = {static_cast<omega_edit_transform_kind_t>(transform_kind),
+                            static_cast<omega_byte_t>(operand)};
+            return true;
+        }
+        if (name == "create_checkpoint") {
+            op.kind = fuzz_op_kind_t::create_checkpoint;
+            return true;
+        }
+        if (name == "destroy_checkpoint") {
+            op.kind = fuzz_op_kind_t::destroy_checkpoint;
+            return true;
+        }
+
+        error = "unknown op '" + name + "'";
+        return false;
+    }
+
+    bool load_script(const std::filesystem::path &path, fuzz_script_t &script, std::string &error) {
+        std::ifstream input(path);
+        if (!input) {
+            error = "failed to open replay file";
+            return false;
+        }
+
+        std::string line;
+        if (!std::getline(input, line)) {
+            error = "replay file is empty";
+            return false;
+        }
+
+        std::string name;
+        std::string profile;
+        std::string base_hex;
+        if (!extract_string(line, "op", name) || name != "base" || !extract_uint64(line, "seed", script.seed) ||
+            !extract_string(line, "profile", profile) || !extract_string(line, "bytes", base_hex) ||
+            !hex_decode(base_hex, script.base)) {
+            error = "invalid base record";
+            return false;
+        }
+        script.profile = profile_from_name(profile);
+
+        size_t line_number = 1;
+        while (std::getline(input, line)) {
+            ++line_number;
+            if (line.empty()) { continue; }
+            fuzz_op_t op;
+            if (!parse_op(line, op, error)) {
+                std::ostringstream message;
+                message << "line " << line_number << ": " << error;
+                error = message.str();
+                return false;
+            }
+            script.ops.push_back(std::move(op));
+        }
+        return true;
+    }
+
+    std::filesystem::path fuzz_failure_directory() {
+        auto path = std::filesystem::temp_directory_path() / "omega-edit-differential-fuzz-failures";
+        std::error_code ec;
+        std::filesystem::create_directories(path, ec);
+        return path;
+    }
+
+    void write_script(const std::filesystem::path &path, const fuzz_script_t &script) {
+        std::ofstream output(path);
+        output << "{\"op\":\"base\",\"seed\":" << script.seed << ",\"profile\":\"" << profile_name(script.profile)
+               << "\",\"bytes\":\"" << hex_encode(script.base) << "\"}\n";
+        for (const auto &op : script.ops) {
+            output << "{\"op\":\"" << op_name(op.kind) << "\"";
+            switch (op.kind) {
+                case fuzz_op_kind_t::insert:
+                case fuzz_op_kind_t::overwrite:
+                    output << ",\"offset\":" << op.offset << ",\"bytes\":\"" << hex_encode(op.bytes) << "\"";
+                    break;
+                case fuzz_op_kind_t::delete_bytes:
+                    output << ",\"offset\":" << op.offset << ",\"length\":" << op.length;
+                    break;
+                case fuzz_op_kind_t::undo_burst:
+                case fuzz_op_kind_t::redo_burst:
+                    output << ",\"count\":" << op.count;
+                    break;
+                case fuzz_op_kind_t::transform:
+                    output << ",\"kind\":" << static_cast<int>(op.transform.kind)
+                           << ",\"operand\":" << static_cast<int>(op.transform.operand) << ",\"offset\":" << op.offset
+                           << ",\"length\":" << op.length;
+                    break;
+                default:
+                    break;
+            }
+            output << "}\n";
+        }
+    }
+
+    std::filesystem::path dump_script(const fuzz_script_t &script, const std::string &suffix) {
+        const auto directory = fuzz_failure_directory();
+        std::ostringstream file_name;
+        file_name << "seed-" << script.seed << "-" << profile_name(script.profile) << "-" << suffix << ".jsonl";
+        const auto path = directory / file_name.str();
+        write_script(path, script);
+        return path;
+    }
+
+    bool transactions_balanced(const std::vector<fuzz_op_t> &ops) {
+        int depth = 0;
+        for (const auto &op : ops) {
+            if (op.kind == fuzz_op_kind_t::begin_transaction) {
+                if (depth != 0) { return false; }
+                depth = 1;
+            } else if (op.kind == fuzz_op_kind_t::end_transaction) {
+                if (depth != 1) { return false; }
+                depth = 0;
+            }
+        }
+        return depth == 0;
+    }
+
+    bool safe_for_full_round_trip(const std::vector<fuzz_op_t> &ops) {
+        bool transform_seen = false;
+        for (const auto &op : ops) {
+            if (op.kind == fuzz_op_kind_t::transform) {
+                transform_seen = true;
+                continue;
+            }
+            if (transform_seen && (op.kind == fuzz_op_kind_t::insert || op.kind == fuzz_op_kind_t::delete_bytes ||
+                                   op.kind == fuzz_op_kind_t::overwrite)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    fuzz_run_result_t fail_at(size_t step, const std::string &message) {
+        fuzz_run_result_t result;
+        result.ok = false;
+        result.step = step;
+        result.message = message;
+        return result;
+    }
+
+    fuzz_run_result_t run_script(const fuzz_script_t &script) {
+        const ScratchDir scratch_a;
+        const ScratchDir scratch_b;
+        auto session_a = TestSession::from_bytes(script.base.empty() ? nullptr : script.base.data(),
+                                                 static_cast<int64_t>(script.base.size()), scratch_a.c_str());
+        auto session_b = TestSession::from_bytes(script.base.empty() ? nullptr : script.base.data(),
+                                                 static_cast<int64_t>(script.base.size()), scratch_b.c_str());
+        if (!session_a || !session_b) { return fail_at(0, "failed to create fuzz sessions"); }
+
+        static constexpr std::array<int64_t, 3> snapshot_a{{0, 1, 7}};
+        static constexpr std::array<int64_t, 3> snapshot_b{{7, 0, 1}};
+        static constexpr std::array<int64_t, 3> payload_a{{8, 32, 96}};
+        static constexpr std::array<int64_t, 3> payload_b{{96, 8, 32}};
+        const auto knob_index = static_cast<size_t>(script.seed % snapshot_a.size());
+        omega_session_set_undo_snapshot_interval(session_a.get(), snapshot_a[knob_index]);
+        omega_session_set_undo_snapshot_interval(session_b.get(), snapshot_b[knob_index]);
+        omega_session_set_change_inline_payload_limit(session_a.get(), payload_a[knob_index]);
+        omega_session_set_change_inline_payload_limit(session_b.get(), payload_b[knob_index]);
+
+        for (size_t i = 0; i < script.ops.size(); ++i) {
+            const auto &op = script.ops[i];
+            const auto rc_a = apply_one(session_a.get(), op);
+            const auto rc_b = apply_one(session_b.get(), op);
+            if (rc_a != rc_b) {
+                std::ostringstream message;
+                message << "return mismatch after " << op_name(op.kind) << ": " << rc_a << " vs " << rc_b;
+                return fail_at(i + 1, message.str());
+            }
+
+            const auto compare = compare_content(session_a.get(), session_b.get());
+            if (!compare.equal) {
+                std::ostringstream message;
+                message << "content mismatch after " << op_name(op.kind) << ", sizes " << compare.size_a << " vs "
+                        << compare.size_b << ", first diff " << compare.first_diff_offset;
+                return fail_at(i + 1, message.str());
+            }
+            if (!model_valid(session_a.get()) || !model_valid(session_b.get())) {
+                return fail_at(i + 1, std::string("model invalid after ") + op_name(op.kind));
+            }
+
+            const auto serials_a = check_serials_contiguous(session_a.get());
+            const auto serials_b = check_serials_contiguous(session_b.get());
+            if (!serials_a.contiguous || !serials_b.contiguous) {
+                std::ostringstream message;
+                message << "serial lookup gap after " << op_name(op.kind) << ": " << serials_a.first_bad_serial
+                        << " vs " << serials_b.first_bad_serial;
+                return fail_at(i + 1, message.str());
+            }
+        }
+
+        if (omega_session_get_transaction_state(session_a.get()) != 0 ||
+            omega_session_get_transaction_state(session_b.get()) != 0) {
+            return fail_at(script.ops.size(), "script ended with an open transaction");
+        }
+
+        if (safe_for_full_round_trip(script.ops)) {
+            const auto round_trip_a = verify_undo_redo_round_trip(session_a.get());
+            const auto round_trip_b = verify_undo_redo_round_trip(session_b.get());
+            if (!round_trip_a.ok || !round_trip_a.model_valid_throughout || !round_trip_b.ok ||
+                !round_trip_b.model_valid_throughout) {
+                std::ostringstream message;
+                message << "undo/redo round trip failed: mismatch steps " << round_trip_a.mismatch_step << " and "
+                        << round_trip_b.mismatch_step;
+                return fail_at(script.ops.size(), message.str());
+            }
+            const auto compare = compare_content(session_a.get(), session_b.get());
+            if (!compare.equal) { return fail_at(script.ops.size(), "sessions diverged after undo/redo round trip"); }
+        }
+
+        return {};
+    }
+
+    std::vector<fuzz_op_t> without_range(const std::vector<fuzz_op_t> &ops, size_t begin, size_t count) {
+        std::vector<fuzz_op_t> result;
+        result.reserve(ops.size() - count);
+        result.insert(result.end(), ops.begin(), ops.begin() + static_cast<std::ptrdiff_t>(begin));
+        result.insert(result.end(), ops.begin() + static_cast<std::ptrdiff_t>(begin + count), ops.end());
+        return result;
+    }
+
+    fuzz_script_t shrink_script(const fuzz_script_t &script) {
+        fuzz_script_t candidate = script;
+        if (candidate.ops.size() < 2) { return candidate; }
+
+        for (auto chunk = candidate.ops.size() / 2; chunk > 0;) {
+            bool removed = false;
+            for (size_t begin = 0; begin + chunk <= candidate.ops.size(); ++begin) {
+                auto trial = candidate;
+                trial.ops = without_range(candidate.ops, begin, chunk);
+                if (trial.ops.empty() || !transactions_balanced(trial.ops)) { continue; }
+                if (!run_script(trial).ok) {
+                    candidate = std::move(trial);
+                    removed = true;
+                    break;
+                }
+            }
+            if (removed) {
+                chunk = std::max<size_t>(1, candidate.ops.size() / 2);
+            } else {
+                chunk /= 2;
+            }
+        }
+        return candidate;
+    }
+
+    std::vector<uint64_t> fixed_seeds() {
+        return {
+                0x5EED0001ULL,     0x5EED0002ULL,     0x5EED0003ULL,     0xC0FFEE1234ULL,
+                0xBAD5EEDULL,      0x0D1FF5EEDULL,    0xA11CEB00CULL,    0xF00DCAFEULL,
+                0x123456789ABCULL, 0x9876543210ULL,   0x102030405060ULL, 0xFFEEDDCCBBAAULL,
+                0x314159265358ULL, 0x271828182845ULL, 0xABCDEF010203ULL, 0xDEADBEEF0042ULL,
+        };
+    }
+}// namespace
+
+TEST_CASE("Differential fuzz driver replays generated scripts", "[DifferentialFuzz][Harness]") {
+    if (const auto *replay_path = std::getenv("OMEGA_EDIT_FUZZ_REPLAY"); replay_path && *replay_path) {
+        fuzz_script_t replay;
+        std::string error;
+        REQUIRE(load_script(replay_path, replay, error));
+        const auto result = run_script(replay);
+        INFO("replay " << replay_path << " seed " << replay.seed << " step " << result.step << ": " << result.message);
+        REQUIRE(result.ok);
+        return;
+    }
+
+    const auto iterations = parse_i64(std::getenv("OMEGA_EDIT_FUZZ_ITERATIONS"), 12, 1, 1000000);
+    const auto op_count = parse_i64(std::getenv("OMEGA_EDIT_FUZZ_OPS"), 96, 1, 1000000);
+    const auto one_seed = std::getenv("OMEGA_EDIT_FUZZ_SEED");
+    auto seeds = fixed_seeds();
+
+    for (int64_t i = 0; i < iterations; ++i) {
+        const auto seed = one_seed && *one_seed
+                                  ? parse_u64(one_seed, seeds[0])
+                                  : (i < static_cast<int64_t>(seeds.size())
+                                             ? seeds[static_cast<size_t>(i)]
+                                             : seeds.back() + static_cast<uint64_t>(i * 0x9E3779B97F4A7C15ULL));
+        const auto profile = static_cast<fuzz_profile_t>(i % 3);
+        const auto script = generate_script(seed, profile, op_count);
+        if (i == 0) {
+            const ScratchDir replay_scratch;
+            const auto replay_path = std::filesystem::path(replay_scratch.str()) / "replay-smoke.jsonl";
+            write_script(replay_path, script);
+            fuzz_script_t loaded;
+            std::string error;
+            REQUIRE(load_script(replay_path, loaded, error));
+            REQUIRE(loaded.seed == script.seed);
+            REQUIRE(loaded.ops.size() == script.ops.size());
+            const auto replay_result = run_script(loaded);
+            INFO("serialized replay smoke " << replay_path << " seed " << loaded.seed << " step " << replay_result.step
+                                            << ": " << replay_result.message);
+            REQUIRE(replay_result.ok);
+        }
+
+        const auto result = run_script(script);
+        if (!result.ok) {
+            const auto original_path = dump_script(script, "original");
+            const auto minimized = shrink_script(script);
+            const auto minimized_path = dump_script(minimized, "minimized");
+            INFO("seed " << script.seed << " profile " << profile_name(script.profile) << " step " << result.step
+                         << ": " << result.message << "; original replay " << original_path << "; minimized replay "
+                         << minimized_path);
+        }
+        REQUIRE(result.ok);
+    }
+}

--- a/core/src/tests/harness_tests.cpp
+++ b/core/src/tests/harness_tests.cpp
@@ -1,0 +1,318 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+ * implied.  See the License for the specific language governing permissions and limitations under the License.       *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+/**
+ * Self-tests for the shared brutal-testing harness (test_harness.hpp). These prove each oracle
+ * catches what it must, using only known-good core behavior — if the harness itself is lax, every
+ * suite built on it inherits the weakness.
+ */
+
+#include "omega_edit.h"
+#include "omega_edit/stl_string_adaptor.hpp"
+
+#include "test_harness.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+using namespace omega_test;
+
+namespace {
+    std::string session_content(const omega_session_t *session_ptr) { return content_string(session_ptr); }
+}// namespace
+
+TEST_CASE("Harness: content oracles agree and pinpoint divergence", "[Harness][ContentOracle]") {
+    TestSession session_a;
+    TestSession session_b;
+    REQUIRE(session_a);
+    REQUIRE(session_b);
+
+    SECTION("empty sessions are equal and hash alike") {
+        const auto compare = compare_content(session_a.get(), session_b.get());
+        REQUIRE(compare.equal);
+        REQUIRE(compare.first_diff_offset == -1);
+        REQUIRE(content_hash(session_a.get()) == content_hash(session_b.get()));
+    }
+
+    SECTION("identical edit scripts produce equal content") {
+        for (auto *session : {session_a.get(), session_b.get()}) {
+            REQUIRE(0 < omega_edit_insert_string(session, 0, "the quick brown fox"));
+            REQUIRE(0 < omega_edit_overwrite_string(session, 4, "QUICK"));
+            REQUIRE(0 < omega_edit_delete(session, 0, 4));
+        }
+        const auto compare = compare_content(session_a.get(), session_b.get());
+        REQUIRE(compare.equal);
+        REQUIRE(content_hash(session_a.get()) == content_hash(session_b.get()));
+        REQUIRE(session_content(session_a.get()) == "QUICK brown fox");
+    }
+
+    SECTION("a single divergent byte is caught at the exact offset") {
+        REQUIRE(0 < omega_edit_insert_string(session_a.get(), 0, "0123456789"));
+        REQUIRE(0 < omega_edit_insert_string(session_b.get(), 0, "0123456789"));
+        REQUIRE(0 < omega_edit_overwrite_string(session_b.get(), 7, "X"));
+
+        const auto compare = compare_content(session_a.get(), session_b.get());
+        REQUIRE_FALSE(compare.equal);
+        REQUIRE(compare.first_diff_offset == 7);
+        REQUIRE(content_hash(session_a.get()) != content_hash(session_b.get()));
+    }
+
+    SECTION("size mismatch is unequal without a byte diff") {
+        REQUIRE(0 < omega_edit_insert_string(session_a.get(), 0, "abc"));
+        REQUIRE(0 < omega_edit_insert_string(session_b.get(), 0, "abcd"));
+        const auto compare = compare_content(session_a.get(), session_b.get());
+        REQUIRE_FALSE(compare.equal);
+        REQUIRE(compare.size_a == 3);
+        REQUIRE(compare.size_b == 4);
+        REQUIRE(compare.first_diff_offset == -1);
+    }
+}
+
+TEST_CASE("Harness: content oracles stream beyond a single chunk", "[Harness][ContentOracle]") {
+    // Content larger than HARNESS_CHUNK_SIZE forces the streamed (multi-segment) code paths.
+    const std::string block(HARNESS_CHUNK_SIZE / 4, 'A');
+    TestSession session_a;
+    TestSession session_b;
+    for (int i = 0; i < 6; ++i) {
+        REQUIRE(0 < omega_edit_insert_string(session_a.get(), 0, block));
+        REQUIRE(0 < omega_edit_insert_string(session_b.get(), 0, block));
+    }
+    REQUIRE(omega_session_get_computed_file_size(session_a.get()) > HARNESS_CHUNK_SIZE);
+    REQUIRE(compare_content(session_a.get(), session_b.get()).equal);
+
+    // Flip one byte deep in the second chunk and require exact localization.
+    const int64_t poke_offset = HARNESS_CHUNK_SIZE + 42;
+    REQUIRE(0 < omega_edit_overwrite_string(session_b.get(), poke_offset, "z"));
+    const auto compare = compare_content(session_a.get(), session_b.get());
+    REQUIRE_FALSE(compare.equal);
+    REQUIRE(compare.first_diff_offset == poke_offset);
+}
+
+TEST_CASE("Harness: model validity and serial contiguity", "[Harness][ModelOracle][SerialOracle]") {
+    TestSession session;
+    REQUIRE(session);
+    REQUIRE(model_valid(session.get()));
+
+    REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "serial test payload"));
+    REQUIRE(0 < omega_edit_overwrite_string(session.get(), 0, "SERIAL"));
+    REQUIRE(0 < omega_edit_delete(session.get(), 6, 5));
+    REQUIRE(model_valid(session.get()));
+
+    auto serials = check_serials_contiguous(session.get());
+    REQUIRE(serials.contiguous);
+    REQUIRE(serials.num_changes == 3);
+
+    SECTION("contiguity holds through undo and redo") {
+        REQUIRE(0 > omega_edit_undo_last_change(session.get()));
+        serials = check_serials_contiguous(session.get());
+        REQUIRE(serials.contiguous);
+        REQUIRE(serials.num_changes == 2);
+
+        REQUIRE(0 < omega_edit_redo_last_undo(session.get()));
+        serials = check_serials_contiguous(session.get());
+        REQUIRE(serials.contiguous);
+        REQUIRE(serials.num_changes == 3);
+        REQUIRE(model_valid(session.get()));
+    }
+}
+
+TEST_CASE("Harness: undo/redo trajectory oracle round-trips", "[Harness][UndoOracle]") {
+    SECTION("empty session is a trivial trajectory") {
+        TestSession session;
+        const auto result = verify_undo_redo_round_trip(session.get());
+        REQUIRE(result.ok);
+        REQUIRE(result.undo_steps == 0);
+        REQUIRE(result.trajectory.size() == 1);
+        REQUIRE(result.model_valid_throughout);
+    }
+
+    SECTION("scripted edits, including a transaction, round-trip bit-exact") {
+        TestSession session;
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "hello world"));
+        REQUIRE(0 < omega_edit_overwrite_string(session.get(), 0, "HELLO"));
+        // replace runs delete+insert inside one transaction: one undo step, one redo step
+        REQUIRE(0 < omega_edit_replace(session.get(), 6, 5, "OMEGA", 5));
+        REQUIRE(0 < omega_edit_delete(session.get(), 5, 1));
+
+        const auto tip_content = session_content(session.get());
+        const auto tip_changes = omega_session_get_num_changes(session.get());
+
+        const auto result = verify_undo_redo_round_trip(session.get());
+        REQUIRE(result.ok);
+        REQUIRE(result.mismatch_step == -1);
+        REQUIRE(result.model_valid_throughout);
+        REQUIRE(result.undo_steps == 4);// insert, overwrite, replace-transaction, delete
+        REQUIRE(result.trajectory.size() == 5);
+
+        // The oracle must leave the session exactly at the tip.
+        REQUIRE(session_content(session.get()) == tip_content);
+        REQUIRE(omega_session_get_num_changes(session.get()) == tip_changes);
+    }
+
+    SECTION("round-trip holds under every snapshot-interval brutality knob") {
+        for (const int64_t interval : {int64_t{0}, int64_t{1}, int64_t{7}}) {
+            TestSession session;
+            omega_session_set_undo_snapshot_interval(session.get(), interval);
+            for (int i = 0; i < 25; ++i) {
+                REQUIRE(0 < omega_edit_insert_string(session.get(), i, std::string(1, 'a' + (i % 26))));
+            }
+            REQUIRE(0 < omega_edit_delete(session.get(), 5, 10));
+            const auto result = verify_undo_redo_round_trip(session.get());
+            INFO("snapshot interval " << interval);
+            REQUIRE(result.ok);
+            REQUIRE(result.model_valid_throughout);
+        }
+    }
+
+    SECTION("round-trip crosses a builtin transform checkpoint boundary") {
+        TestSession session;
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "mixed Case content"));
+        REQUIRE(0 < omega_edit_overwrite_string(session.get(), 6, "CASE"));
+        const omega_edit_transform_t to_upper{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session.get(), to_upper, 0, 5));
+        REQUIRE(0 < omega_edit_overwrite_string(session.get(), 6, "case"));
+        REQUIRE(session_content(session.get()) == "MIXED case content");
+
+        const auto result = verify_undo_redo_round_trip(session.get());
+        REQUIRE(result.ok);
+        REQUIRE(result.mismatch_step == -1);
+        REQUIRE(result.model_valid_throughout);
+        REQUIRE(result.undo_steps == 4);// post-transform overwrite, transform checkpoint, overwrite, insert
+        REQUIRE(session_content(session.get()) == "MIXED case content");
+    }
+}
+
+TEST_CASE("Harness: undo past a transform preserves later redo state", "[Harness][UndoOracle][Transform]") {
+    TestSession session;
+    REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "abc"));
+    const omega_edit_transform_t to_upper{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session.get(), to_upper, 0, 0));
+    REQUIRE(0 < omega_edit_overwrite_string(session.get(), 0, "X"));
+    REQUIRE(session_content(session.get()) == "XBC");
+
+    REQUIRE(0 > omega_edit_undo_last_change(session.get()));// undo overwrite
+    REQUIRE(0 > omega_edit_undo_last_change(session.get()));// undo transform
+    REQUIRE(session_content(session.get()) == "abc");
+
+    REQUIRE(0 < omega_edit_redo_last_undo(session.get()));// redo transform
+    REQUIRE(session_content(session.get()) == "ABC");
+    REQUIRE(0 < omega_edit_redo_last_undo(session.get()));// redo overwrite
+    REQUIRE(session_content(session.get()) == "XBC");
+    REQUIRE(omega_session_get_num_changes(session.get()) == 3);
+    REQUIRE(model_valid(session.get()));
+}
+
+TEST_CASE("Harness: event recorder captures exact sequences", "[Harness][EventOracle]") {
+    TestSession session;
+    REQUIRE(session);
+    REQUIRE(session.events().count(SESSION_EVT_CREATE) == 1);
+    session.events().clear();
+
+    SECTION("plain edits emit one EDIT each, with serials") {
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "one"));
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 3, "two"));
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 6, "three"));
+        REQUIRE(session.events().count(SESSION_EVT_EDIT) == 3);
+        REQUIRE(session.events().events()[0].serial == 1);
+        REQUIRE(session.events().events()[2].serial == 3);
+    }
+
+    SECTION("undo and redo emit UNDO and EDIT") {
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "payload"));
+        session.events().clear();
+        REQUIRE(0 > omega_edit_undo_last_change(session.get()));
+        REQUIRE(session.events().count(SESSION_EVT_UNDO) == 1);
+        REQUIRE(session.events().events().front().serial == -1);
+        REQUIRE(0 < omega_edit_redo_last_undo(session.get()));
+        REQUIRE(session.events().count(SESSION_EVT_EDIT) == 1);
+    }
+
+    SECTION("transactions bracket batched edits") {
+        static const omega_byte_t text[] = "batched";
+        const omega_edit_script_op_t ops[] = {
+                {0, 0, OMEGA_EDIT_SCRIPT_INSERT, text, 7},
+                {0, 3, OMEGA_EDIT_SCRIPT_DELETE, nullptr, 0},
+        };
+        REQUIRE(0 == omega_edit_apply_script(session.get(), ops, 2));
+        REQUIRE(session.events().count(SESSION_EVT_TRANSACTION_STARTED) == 1);
+        REQUIRE(session.events().count(SESSION_EVT_TRANSACTION_ENDED) == 1);
+        REQUIRE(session.events().count(SESSION_EVT_EDIT) >= 1);
+    }
+
+    SECTION("builtin transforms emit checkpoint and transform events, never EDIT") {
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "abcdef"));
+        session.events().clear();
+        const omega_edit_transform_t to_upper{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session.get(), to_upper, 0, 0));
+        REQUIRE(session.events().count(SESSION_EVT_CREATE_CHECKPOINT) == 1);
+        REQUIRE(session.events().count(SESSION_EVT_TRANSFORM) == 1);
+        REQUIRE(session.events().count(SESSION_EVT_EDIT) == 0);
+    }
+}
+
+TEST_CASE("Harness: checkpoint directory audit polices file hygiene", "[Harness][HygieneOracle]") {
+    const ScratchDir scratch;
+    DirAudit audit(scratch.str());
+    REQUIRE(audit.unchanged());
+
+    static const omega_byte_t seed[] = "0123456789ABCDEF0123456789ABCDEF";
+    {
+        auto session = TestSession::from_bytes(seed, sizeof(seed) - 1, scratch.c_str());
+        REQUIRE(session);
+        // Force the file-backed payload path on a small delete: limit 4, delete 16 bytes.
+        session.make_brutal(4, 1);
+
+        // The memory-backed session snapshot lives in the checkpoint directory.
+        REQUIRE_FALSE(audit.added().empty());
+
+        const auto before_delete = DirAudit::list(scratch.str());
+        REQUIRE(0 < omega_edit_delete(session.get(), 0, 16));
+        const auto after_delete = DirAudit::list(scratch.str());
+        REQUIRE(after_delete.size() == before_delete.size() + 1);// captured payload file appeared
+
+        // Undo keeps the payload file alive (it backs the redo state), redo keeps it referenced.
+        REQUIRE(0 > omega_edit_undo_last_change(session.get()));
+        REQUIRE(DirAudit::list(scratch.str()).size() == after_delete.size());
+        REQUIRE(0 < omega_edit_redo_last_undo(session.get()));
+        REQUIRE(session_content(session.get()) == "0123456789ABCDEF");
+        REQUIRE(model_valid(session.get()));
+    }
+    // Destroying the session must return the directory to its exact baseline: no leaked
+    // snapshot, checkpoint, or payload files.
+    REQUIRE(audit.added().empty());
+    REQUIRE(audit.removed().empty());
+    REQUIRE(audit.unchanged());
+}
+
+TEST_CASE("Harness: brutal payload knob exercises file-backed undo data end to end",
+          "[Harness][HygieneOracle][UndoOracle]") {
+    const ScratchDir scratch;
+    DirAudit audit(scratch.str());
+    {
+        TestSession session(nullptr, scratch.c_str());
+        REQUIRE(session);
+        session.make_brutal(8, 1);
+
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "the five boxing wizards jump quickly"));
+        REQUIRE(0 < omega_edit_overwrite_string(session.get(), 4, "FIVE BOXING WIZARDS"));// > 8 bytes captured
+        REQUIRE(0 < omega_edit_delete(session.get(), 0, 24));                             // > 8 bytes captured
+
+        const auto result = verify_undo_redo_round_trip(session.get());
+        REQUIRE(result.ok);
+        REQUIRE(result.model_valid_throughout);
+        REQUIRE(session_content(session.get()) == "jump quickly");
+    }
+    REQUIRE(audit.unchanged());
+}

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -20,6 +20,8 @@
 #include "omega_edit/stl_string_adaptor.hpp"
 #include "omega_edit/utility.h"
 
+#include "test_harness.hpp"
+
 #include <test_util.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -40,6 +42,14 @@ namespace fs = std::filesystem;
 using Catch::Matchers::Contains;
 using Catch::Matchers::EndsWith;
 using Catch::Matchers::Equals;
+
+using omega_test::check_serials_contiguous;
+using omega_test::content_string;
+using omega_test::DirAudit;
+using omega_test::model_valid;
+using omega_test::ScratchDir;
+using omega_test::TestSession;
+using omega_test::verify_undo_redo_round_trip;
 
 
 TEST_CASE("Size Tests", "[SizeTests]") {
@@ -109,13 +119,14 @@ TEST_CASE("Apply Script", "[EditScript]") {
 }
 
 TEST_CASE("Overwrite undo restores captured inverse bytes", "[UndoTests][PayloadTests]") {
-    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    TestSession session(nullptr, nullptr, NO_EVENTS);
+    REQUIRE(session);
+    auto *session_ptr = session.get();
 
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "0123456789"));
     REQUIRE(0 < omega_edit_overwrite_string(session_ptr, 8, "ABCDE"));
-    REQUIRE("01234567ABCDE" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("01234567ABCDE" == content_string(session_ptr));
+    REQUIRE(model_valid(session_ptr));
 
     const auto *change_ptr = omega_session_get_last_change(session_ptr);
     REQUIRE(change_ptr);
@@ -124,17 +135,18 @@ TEST_CASE("Overwrite undo restores captured inverse bytes", "[UndoTests][Payload
     REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(change_ptr));
 
     REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
-    REQUIRE("0123456789" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("0123456789" == content_string(session_ptr));
+    REQUIRE(model_valid(session_ptr));
     REQUIRE(2 == omega_edit_redo_last_undo(session_ptr));
-    REQUIRE("01234567ABCDE" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
-
-    omega_edit_destroy_session(session_ptr);
+    REQUIRE("01234567ABCDE" == content_string(session_ptr));
+    const auto serials = check_serials_contiguous(session_ptr);
+    REQUIRE(serials.contiguous);
 }
 
 TEST_CASE("Large delete payloads are file backed", "[UndoTests][PayloadTests]") {
-    const auto file_path = (DATA_DIR / "large-delete-payload.dat").string();
+    const ScratchDir data_scratch;
+    const ScratchDir checkpoint_scratch;
+    const auto file_path = (fs::path(data_scratch.str()) / "large-delete-payload.dat").string();
     const auto payload_limit = int64_t{32};
     const auto file_byte_count = payload_limit - 1;
     const std::string pattern = "OmegaEditPayload";
@@ -153,42 +165,48 @@ TEST_CASE("Large delete payloads are file backed", "[UndoTests][PayloadTests]") 
     REQUIRE(file_ptr);
     FCLOSE(file_ptr);
 
-    const auto session_ptr = omega_edit_create_session(file_path.c_str(), nullptr, nullptr, NO_EVENTS, nullptr);
-    REQUIRE(session_ptr);
-    REQUIRE(payload_limit == omega_session_set_change_inline_payload_limit(session_ptr, payload_limit));
-    REQUIRE(payload_limit == omega_session_get_change_inline_payload_limit(session_ptr));
+    DirAudit audit(checkpoint_scratch.str());
+    {
+        TestSession session(file_path.c_str(), checkpoint_scratch.c_str(), NO_EVENTS);
+        REQUIRE(session);
+        auto *session_ptr = session.get();
+        REQUIRE(payload_limit == omega_session_set_change_inline_payload_limit(session_ptr, payload_limit));
+        REQUIRE(payload_limit == omega_session_get_change_inline_payload_limit(session_ptr));
 
-    REQUIRE(0 < omega_edit_insert_string(session_ptr, insert_offset, inserted.c_str()));
-    REQUIRE(delete_byte_count == omega_session_get_computed_file_size(session_ptr));
-    REQUIRE(0 < omega_edit_delete(session_ptr, 0, delete_byte_count));
-    const auto *change_ptr = omega_session_get_last_change(session_ptr);
-    REQUIRE(change_ptr);
-    REQUIRE('D' == omega_change_get_kind_as_char(change_ptr));
-    REQUIRE(delete_byte_count == omega_change_get_length(change_ptr));
-    REQUIRE(delete_byte_count == omega_change_get_data_length(change_ptr));
-    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED == omega_change_get_data_storage(change_ptr));
-    const auto *deleted_bytes = omega_change_get_bytes(change_ptr);
-    REQUIRE(deleted_bytes);
-    REQUIRE(static_cast<omega_byte_t>(pattern.front()) == deleted_bytes[0]);
-    REQUIRE(static_cast<omega_byte_t>(inserted.front()) == deleted_bytes[insert_offset]);
-    REQUIRE(static_cast<omega_byte_t>(pattern.front()) ==
-            deleted_bytes[insert_offset + static_cast<int64_t>(inserted.size())]);
-    REQUIRE(static_cast<omega_byte_t>(
-                    pattern[static_cast<size_t>((file_byte_count - 1) % static_cast<int64_t>(pattern.size()))]) ==
-            deleted_bytes[delete_byte_count - 1]);
+        REQUIRE(0 < omega_edit_insert_string(session_ptr, insert_offset, inserted.c_str()));
+        REQUIRE(delete_byte_count == omega_session_get_computed_file_size(session_ptr));
+        REQUIRE(0 < omega_edit_delete(session_ptr, 0, delete_byte_count));
+        const auto *change_ptr = omega_session_get_last_change(session_ptr);
+        REQUIRE(change_ptr);
+        REQUIRE('D' == omega_change_get_kind_as_char(change_ptr));
+        REQUIRE(delete_byte_count == omega_change_get_length(change_ptr));
+        REQUIRE(delete_byte_count == omega_change_get_data_length(change_ptr));
+        REQUIRE(OMEGA_CHANGE_DATA_STORAGE_FILE_BACKED == omega_change_get_data_storage(change_ptr));
+        const auto *deleted_bytes = omega_change_get_bytes(change_ptr);
+        REQUIRE(deleted_bytes);
+        REQUIRE(static_cast<omega_byte_t>(pattern.front()) == deleted_bytes[0]);
+        REQUIRE(static_cast<omega_byte_t>(inserted.front()) == deleted_bytes[insert_offset]);
+        REQUIRE(static_cast<omega_byte_t>(pattern.front()) ==
+                deleted_bytes[insert_offset + static_cast<int64_t>(inserted.size())]);
+        REQUIRE(static_cast<omega_byte_t>(
+                        pattern[static_cast<size_t>((file_byte_count - 1) % static_cast<int64_t>(pattern.size()))]) ==
+                deleted_bytes[delete_byte_count - 1]);
 
-    REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
-    REQUIRE(delete_byte_count == omega_session_get_computed_file_size(session_ptr));
-    REQUIRE(expected_content == omega_session_get_segment_string(session_ptr, 0, delete_byte_count));
-    REQUIRE(2 == omega_edit_redo_last_undo(session_ptr));
-    REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
-
-    omega_edit_destroy_session(session_ptr);
-    omega_util_remove_file(file_path.c_str());
+        REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
+        REQUIRE(delete_byte_count == omega_session_get_computed_file_size(session_ptr));
+        REQUIRE(expected_content == content_string(session_ptr));
+        REQUIRE(model_valid(session_ptr));
+        REQUIRE(2 == omega_edit_redo_last_undo(session_ptr));
+        REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
+        REQUIRE(model_valid(session_ptr));
+    }
+    REQUIRE(audit.unchanged());
 }
 
 TEST_CASE("Large overwrite inverse payloads are file backed", "[UndoTests][PayloadTests]") {
-    const auto file_path = (DATA_DIR / "large-overwrite-inverse-payload.dat").string();
+    const ScratchDir data_scratch;
+    const ScratchDir checkpoint_scratch;
+    const auto file_path = (fs::path(data_scratch.str()) / "large-overwrite-inverse-payload.dat").string();
     const auto payload_limit = int64_t{32};
     const auto byte_count = payload_limit + 1;
     const std::string pattern = "OriginalPayload";
@@ -201,99 +219,131 @@ TEST_CASE("Large overwrite inverse payloads are file backed", "[UndoTests][Paylo
         replacement[static_cast<size_t>(i)] = static_cast<omega_byte_t>('A' + (i % 26));
     }
 
-    const auto session_ptr = omega_edit_create_session(file_path.c_str(), nullptr, nullptr, NO_EVENTS, nullptr);
-    REQUIRE(session_ptr);
-    REQUIRE(payload_limit == omega_session_set_change_inline_payload_limit(session_ptr, payload_limit));
-    REQUIRE(payload_limit == omega_session_get_change_inline_payload_limit(session_ptr));
+    DirAudit audit(checkpoint_scratch.str());
+    {
+        TestSession session(file_path.c_str(), checkpoint_scratch.c_str(), NO_EVENTS);
+        REQUIRE(session);
+        auto *session_ptr = session.get();
+        REQUIRE(payload_limit == omega_session_set_change_inline_payload_limit(session_ptr, payload_limit));
+        REQUIRE(payload_limit == omega_session_get_change_inline_payload_limit(session_ptr));
 
-    REQUIRE(0 < omega_edit_overwrite_bytes(session_ptr, 0, replacement.data(), byte_count));
-    const auto *change_ptr = omega_session_get_last_change(session_ptr);
-    REQUIRE(change_ptr);
-    REQUIRE('O' == omega_change_get_kind_as_char(change_ptr));
-    REQUIRE(byte_count == omega_change_get_length(change_ptr));
-    REQUIRE(byte_count == omega_change_get_data_length(change_ptr));
-    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(change_ptr));
-    REQUIRE(std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == omega_session_get_segment_string(session_ptr, 0, 26));
+        REQUIRE(0 < omega_edit_overwrite_bytes(session_ptr, 0, replacement.data(), byte_count));
+        const auto *change_ptr = omega_session_get_last_change(session_ptr);
+        REQUIRE(change_ptr);
+        REQUIRE('O' == omega_change_get_kind_as_char(change_ptr));
+        REQUIRE(byte_count == omega_change_get_length(change_ptr));
+        REQUIRE(byte_count == omega_change_get_data_length(change_ptr));
+        REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(change_ptr));
+        REQUIRE(std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == omega_session_get_segment_string(session_ptr, 0, 26));
 
-    REQUIRE(-1 == omega_edit_undo_last_change(session_ptr));
-    REQUIRE(byte_count == omega_session_get_computed_file_size(session_ptr));
-    REQUIRE(pattern == omega_session_get_segment_string(session_ptr, 0, static_cast<int64_t>(pattern.size())));
-    REQUIRE(std::string(1, pattern[static_cast<size_t>((byte_count - 1) % static_cast<int64_t>(pattern.size()))]) ==
-            omega_session_get_segment_string(session_ptr, byte_count - 1, 1));
+        REQUIRE(-1 == omega_edit_undo_last_change(session_ptr));
+        REQUIRE(byte_count == omega_session_get_computed_file_size(session_ptr));
+        REQUIRE(pattern == content_string(session_ptr).substr(0, pattern.size()));
+        REQUIRE(std::string(1, pattern[static_cast<size_t>((byte_count - 1) % static_cast<int64_t>(pattern.size()))]) ==
+                omega_session_get_segment_string(session_ptr, byte_count - 1, 1));
+        REQUIRE(model_valid(session_ptr));
 
-    REQUIRE(1 == omega_edit_redo_last_undo(session_ptr));
-    REQUIRE(byte_count == omega_session_get_computed_file_size(session_ptr));
-    REQUIRE(std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == omega_session_get_segment_string(session_ptr, 0, 26));
-    REQUIRE(std::string(1, static_cast<char>(replacement.back())) ==
-            omega_session_get_segment_string(session_ptr, byte_count - 1, 1));
-
-    omega_edit_destroy_session(session_ptr);
-    omega_util_remove_file(file_path.c_str());
+        REQUIRE(1 == omega_edit_redo_last_undo(session_ptr));
+        REQUIRE(byte_count == omega_session_get_computed_file_size(session_ptr));
+        REQUIRE(std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == omega_session_get_segment_string(session_ptr, 0, 26));
+        REQUIRE(std::string(1, static_cast<char>(replacement.back())) ==
+                omega_session_get_segment_string(session_ptr, byte_count - 1, 1));
+        REQUIRE(model_valid(session_ptr));
+    }
+    REQUIRE(audit.unchanged());
 }
 
 TEST_CASE("Apply Builtin Transform", "[EditTransform]") {
-    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    const ScratchDir scratch;
+    DirAudit audit(scratch.str());
+    {
+        TestSession session(nullptr, scratch.c_str());
+        REQUIRE(session);
+        auto *session_ptr = session.get();
 
-    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "Abc xyz 09!"));
+        REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "Abc xyz 09!"));
+        session.events().clear();
 
-    const omega_edit_transform_t lower_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER, 0};
-    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, lower_transform, 0, 3));
-    REQUIRE("abc xyz 09!" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
-    auto change_ptr = omega_session_get_last_change(session_ptr);
-    REQUIRE(change_ptr);
-    REQUIRE('T' == omega_change_get_kind_as_char(change_ptr));
-    REQUIRE(2 == omega_change_get_serial(change_ptr));
-    REQUIRE(0 == omega_change_get_offset(change_ptr));
-    REQUIRE(3 == omega_change_get_length(change_ptr));
-    REQUIRE(std::string("builtin:ascii-to-lower") == omega_change_get_transform_id(change_ptr));
-    REQUIRE(3 == omega_change_get_transform_replacement_length(change_ptr));
-    REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(change_ptr));
-    REQUIRE(std::string(R"({"transformId":"builtin:ascii-to-lower","args":{}})") ==
-            std::string(reinterpret_cast<const char *>(omega_change_get_data(change_ptr)),
-                        static_cast<size_t>(omega_change_get_data_length(change_ptr))));
-    REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
-    REQUIRE("Abc xyz 09!" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
-    REQUIRE(2 == omega_edit_redo_last_undo(session_ptr));
-    REQUIRE("abc xyz 09!" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+        const omega_edit_transform_t lower_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_LOWER, 0};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, lower_transform, 0, 3));
+        REQUIRE("abc xyz 09!" == content_string(session_ptr));
+        REQUIRE(1 == session.events().count(SESSION_EVT_CREATE_CHECKPOINT));
+        REQUIRE(1 == session.events().count(SESSION_EVT_TRANSFORM));
+        REQUIRE(model_valid(session_ptr));
+        auto change_ptr = omega_session_get_last_change(session_ptr);
+        REQUIRE(change_ptr);
+        REQUIRE('T' == omega_change_get_kind_as_char(change_ptr));
+        REQUIRE(2 == omega_change_get_serial(change_ptr));
+        REQUIRE(0 == omega_change_get_offset(change_ptr));
+        REQUIRE(3 == omega_change_get_length(change_ptr));
+        REQUIRE(std::string("builtin:ascii-to-lower") == omega_change_get_transform_id(change_ptr));
+        REQUIRE(3 == omega_change_get_transform_replacement_length(change_ptr));
+        REQUIRE(OMEGA_CHANGE_DATA_STORAGE_INLINE == omega_change_get_data_storage(change_ptr));
+        REQUIRE(std::string(R"({"transformId":"builtin:ascii-to-lower","args":{}})") ==
+                std::string(reinterpret_cast<const char *>(omega_change_get_data(change_ptr)),
+                            static_cast<size_t>(omega_change_get_data_length(change_ptr))));
+        REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
+        REQUIRE("Abc xyz 09!" == content_string(session_ptr));
+        REQUIRE(model_valid(session_ptr));
+        REQUIRE(2 == omega_edit_redo_last_undo(session_ptr));
+        REQUIRE("abc xyz 09!" == content_string(session_ptr));
 
-    const omega_edit_transform_t upper_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
-    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, upper_transform, 4, 3));
-    REQUIRE("abc XYZ 09!" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+        const omega_edit_transform_t upper_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, upper_transform, 4, 3));
+        REQUIRE("abc XYZ 09!" == content_string(session_ptr));
+        REQUIRE(model_valid(session_ptr));
+        const auto serials = check_serials_contiguous(session_ptr);
+        REQUIRE(serials.contiguous);
 
-    const omega_edit_transform_t invalid_transform{static_cast<omega_edit_transform_kind_t>(999), 0};
-    REQUIRE(-1 == omega_edit_apply_builtin_transform(session_ptr, invalid_transform, 0, 0));
-    REQUIRE(-1 == omega_edit_apply_builtin_transform(nullptr, upper_transform, 0, 0));
+        const omega_edit_transform_t invalid_transform{static_cast<omega_edit_transform_kind_t>(999), 0};
+        REQUIRE(-1 == omega_edit_apply_builtin_transform(session_ptr, invalid_transform, 0, 0));
+        REQUIRE(-1 == omega_edit_apply_builtin_transform(nullptr, upper_transform, 0, 0));
 
-    omega_edit_destroy_session(session_ptr);
+        REQUIRE(-3 == omega_edit_undo_last_change(session_ptr));
+        REQUIRE("abc xyz 09!" == content_string(session_ptr));
+        REQUIRE(model_valid(session_ptr));
+        REQUIRE(3 == omega_edit_redo_last_undo(session_ptr));
+        REQUIRE("abc XYZ 09!" == content_string(session_ptr));
+    }
+    REQUIRE(audit.unchanged());
 }
 
 TEST_CASE("Apply Builtin Bitwise Transform", "[EditTransform]") {
+    const ScratchDir scratch;
+    DirAudit audit(scratch.str());
     const omega_byte_t input[] = {0x0F, 0xF0, 0x55};
-    const auto session_ptr = omega_edit_create_session_from_bytes(input, static_cast<int64_t>(sizeof(input)), nullptr,
-                                                                  nullptr, NO_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    {
+        auto session = TestSession::from_bytes(input, static_cast<int64_t>(sizeof(input)), scratch.c_str(), NO_EVENTS);
+        REQUIRE(session);
+        auto *session_ptr = session.get();
 
-    const omega_edit_transform_t xor_transform{OMEGA_EDIT_TRANSFORM_BITWISE_XOR, 0xFF};
-    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, xor_transform, 0, 2));
-    REQUIRE(std::string({static_cast<char>(0xF0), static_cast<char>(0x0F), static_cast<char>(0x55)}) ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+        const omega_edit_transform_t xor_transform{OMEGA_EDIT_TRANSFORM_BITWISE_XOR, 0xFF};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, xor_transform, 0, 2));
+        REQUIRE(std::string({static_cast<char>(0xF0), static_cast<char>(0x0F), static_cast<char>(0x55)}) ==
+                omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
 
-    const omega_edit_transform_t and_transform{OMEGA_EDIT_TRANSFORM_BITWISE_AND, 0x0F};
-    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, and_transform, 0, 0));
-    REQUIRE(std::string({static_cast<char>(0x00), static_cast<char>(0x0F), static_cast<char>(0x05)}) ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+        const omega_edit_transform_t and_transform{OMEGA_EDIT_TRANSFORM_BITWISE_AND, 0x0F};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, and_transform, 0, 0));
+        REQUIRE(std::string({static_cast<char>(0x00), static_cast<char>(0x0F), static_cast<char>(0x05)}) ==
+                omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
 
-    const omega_edit_transform_t or_transform{OMEGA_EDIT_TRANSFORM_BITWISE_OR, 0xA0};
-    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, or_transform, 1, 2));
-    REQUIRE(std::string({static_cast<char>(0x00), static_cast<char>(0xAF), static_cast<char>(0xA5)}) ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+        const omega_edit_transform_t or_transform{OMEGA_EDIT_TRANSFORM_BITWISE_OR, 0xA0};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, or_transform, 1, 2));
+        REQUIRE(std::string({static_cast<char>(0x00), static_cast<char>(0xAF), static_cast<char>(0xA5)}) ==
+                omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
 
-    omega_edit_destroy_session(session_ptr);
+        REQUIRE(model_valid(session_ptr));
+        const auto serials = check_serials_contiguous(session_ptr);
+        REQUIRE(serials.contiguous);
+        REQUIRE(-3 == omega_edit_undo_last_change(session_ptr));
+        REQUIRE(std::string({static_cast<char>(0x00), static_cast<char>(0x0F), static_cast<char>(0x05)}) ==
+                omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+        REQUIRE(model_valid(session_ptr));
+        REQUIRE(3 == omega_edit_redo_last_undo(session_ptr));
+        REQUIRE(std::string({static_cast<char>(0x00), static_cast<char>(0xAF), static_cast<char>(0xA5)}) ==
+                omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    }
+    REQUIRE(audit.unchanged());
 }
 
 TEST_CASE("Model Tests", "[ModelTests]") {
@@ -1346,8 +1396,9 @@ TEST_CASE("Segment Small Data Optimization", "[SegmentTests]") {
 
 TEST_CASE("Undo Snapshot Optimization", "[UndoTests]") {
     // Create a session with a small snapshot interval to exercise snapshot-accelerated undo
-    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    TestSession session;
+    REQUIRE(session);
+    auto *session_ptr = session.get();
 
     // Default interval should be 100
     REQUIRE(100 == omega_session_get_undo_snapshot_interval(session_ptr));
@@ -1364,14 +1415,20 @@ TEST_CASE("Undo Snapshot Optimization", "[UndoTests]") {
     }
     REQUIRE(10 == omega_session_get_num_changes(session_ptr));
     REQUIRE(10 == omega_session_get_computed_file_size(session_ptr));
-    REQUIRE(0 == omega_check_model(session_ptr));
+    REQUIRE(model_valid(session_ptr));
+
+    const auto round_trip = verify_undo_redo_round_trip(session_ptr);
+    REQUIRE(round_trip.ok);
+    REQUIRE(round_trip.model_valid_throughout);
+    REQUIRE(10 == omega_session_get_num_changes(session_ptr));
+    REQUIRE("ABCDEFGHIJ" == content_string(session_ptr));
 
     // Undo all changes one at a time, verifying model integrity at each step
     for (int i = 10; i > 0; --i) {
         REQUIRE(i * -1 == omega_edit_undo_last_change(session_ptr));
         REQUIRE(i - 1 == omega_session_get_num_changes(session_ptr));
         REQUIRE(i - 1 == omega_session_get_computed_file_size(session_ptr));
-        REQUIRE(0 == omega_check_model(session_ptr));
+        REQUIRE(model_valid(session_ptr));
     }
     REQUIRE(0 == omega_session_get_num_changes(session_ptr));
     REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
@@ -1379,23 +1436,21 @@ TEST_CASE("Undo Snapshot Optimization", "[UndoTests]") {
     // Redo all changes
     for (int i = 0; i < 10; ++i) {
         REQUIRE(0 < omega_edit_redo_last_undo(session_ptr));
-        REQUIRE(0 == omega_check_model(session_ptr));
+        REQUIRE(model_valid(session_ptr));
     }
     REQUIRE(10 == omega_session_get_num_changes(session_ptr));
     REQUIRE(10 == omega_session_get_computed_file_size(session_ptr));
-    REQUIRE(0 == omega_check_model(session_ptr));
+    REQUIRE(model_valid(session_ptr));
 
     // Disable snapshots and verify undo still works (falls back to full replay)
     REQUIRE(0 == omega_session_set_undo_snapshot_interval(session_ptr, 0));
     REQUIRE(0 == omega_session_get_undo_snapshot_interval(session_ptr));
     REQUIRE(-10 == omega_edit_undo_last_change(session_ptr));
-    REQUIRE(0 == omega_check_model(session_ptr));
+    REQUIRE(model_valid(session_ptr));
 
     // Invalid interval should be rejected
     REQUIRE(0 == omega_session_set_undo_snapshot_interval(nullptr, 100));
     REQUIRE(0 == omega_session_set_undo_snapshot_interval(session_ptr, -1));
-
-    omega_edit_destroy_session(session_ptr);
 }
 
 TEST_CASE("Edit result predicates distinguish serial and status conventions", "[EditResult]") {
@@ -1409,57 +1464,53 @@ TEST_CASE("Edit result predicates distinguish serial and status conventions", "[
 }
 
 TEST_CASE("Restore To Change Count Discards Later Changes And Redo", "[UndoTests]") {
-    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    TestSession session;
+    REQUIRE(session);
+    auto *session_ptr = session.get();
 
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
     const auto keep_count = omega_session_get_num_changes(session_ptr);
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 3, "def"));
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 6, "ghi"));
-    REQUIRE("abcdefghi" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("abcdefghi" == content_string(session_ptr));
     REQUIRE(0 > omega_edit_undo_last_change(session_ptr));
     REQUIRE(1 == omega_session_get_num_undone_changes(session_ptr));
-    REQUIRE("abcdef" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("abcdef" == content_string(session_ptr));
 
     REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, keep_count));
     REQUIRE(keep_count == omega_session_get_num_changes(session_ptr));
     REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
-    REQUIRE("abc" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
-    REQUIRE(0 == omega_check_model(session_ptr));
+    REQUIRE("abc" == content_string(session_ptr));
+    REQUIRE(model_valid(session_ptr));
+    REQUIRE(check_serials_contiguous(session_ptr).contiguous);
 
     REQUIRE(0 == omega_edit_redo_last_undo(session_ptr));
     REQUIRE(-1 == omega_edit_restore_to_change_count(session_ptr, keep_count + 1));
-
-    omega_edit_destroy_session(session_ptr);
 }
 
 TEST_CASE("Restore To Change Count Validates Inputs And No-Ops Current Count", "[UndoTests]") {
-    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    TestSession session;
+    REQUIRE(session);
+    auto *session_ptr = session.get();
 
     REQUIRE(-1 == omega_edit_restore_to_change_count(nullptr, 0));
     REQUIRE(-1 == omega_edit_restore_to_change_count(session_ptr, -1));
     REQUIRE(-1 == omega_edit_restore_to_change_count(session_ptr, 1));
     REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, 0));
-    REQUIRE(0 == omega_check_model(session_ptr));
+    REQUIRE(model_valid(session_ptr));
 
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
     const auto current_count = omega_session_get_num_changes(session_ptr);
     REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, current_count));
     REQUIRE(current_count == omega_session_get_num_changes(session_ptr));
-    REQUIRE("abc" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
-    REQUIRE(0 == omega_check_model(session_ptr));
-
-    omega_edit_destroy_session(session_ptr);
+    REQUIRE("abc" == content_string(session_ptr));
+    REQUIRE(model_valid(session_ptr));
 }
 
 TEST_CASE("Restore To Change Count Discards Redo Without Dropping Active Changes", "[UndoTests]") {
-    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    TestSession session;
+    REQUIRE(session);
+    auto *session_ptr = session.get();
 
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
     REQUIRE(0 < omega_edit_insert_string(session_ptr, 3, "def"));
@@ -1470,17 +1521,16 @@ TEST_CASE("Restore To Change Count Discards Redo Without Dropping Active Changes
     REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, current_count));
     REQUIRE(current_count == omega_session_get_num_changes(session_ptr));
     REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
-    REQUIRE("abc" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("abc" == content_string(session_ptr));
     REQUIRE(0 == omega_edit_redo_last_undo(session_ptr));
-    REQUIRE(0 == omega_check_model(session_ptr));
-
-    omega_edit_destroy_session(session_ptr);
+    REQUIRE(model_valid(session_ptr));
+    REQUIRE(check_serials_contiguous(session_ptr).contiguous);
 }
 
 TEST_CASE("Restore To Change Count Rebuilds From Retained Undo Snapshot", "[UndoTests]") {
-    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    TestSession session;
+    REQUIRE(session);
+    auto *session_ptr = session.get();
 
     REQUIRE(2 == omega_session_set_undo_snapshot_interval(session_ptr, 2));
     for (auto i = 0; i < 7; ++i) {
@@ -1488,67 +1538,72 @@ TEST_CASE("Restore To Change Count Rebuilds From Retained Undo Snapshot", "[Undo
         REQUIRE(0 < omega_edit_insert_string(session_ptr, omega_session_get_computed_file_size(session_ptr), bytes));
     }
     REQUIRE(7 == omega_session_get_num_changes(session_ptr));
-    REQUIRE("ABCDEFG" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("ABCDEFG" == content_string(session_ptr));
+    REQUIRE(model_valid(session_ptr));
 
     REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, 5));
     REQUIRE(5 == omega_session_get_num_changes(session_ptr));
     REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
-    REQUIRE("ABCDE" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+    REQUIRE("ABCDE" == content_string(session_ptr));
     REQUIRE(0 == omega_edit_redo_last_undo(session_ptr));
-    REQUIRE(0 == omega_check_model(session_ptr));
-
-    omega_edit_destroy_session(session_ptr);
+    REQUIRE(model_valid(session_ptr));
+    REQUIRE(check_serials_contiguous(session_ptr).contiguous);
 }
 
 TEST_CASE("Restore To Change Count Discards Explicit Checkpoint Models", "[UndoTests]") {
-    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    const ScratchDir scratch;
+    DirAudit audit(scratch.str());
+    {
+        TestSession session(nullptr, scratch.c_str());
+        REQUIRE(session);
+        auto *session_ptr = session.get();
 
-    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
-    const auto checkpoint_count = omega_session_get_num_changes(session_ptr);
-    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
-    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
-    REQUIRE(0 < omega_edit_insert_string(session_ptr, 3, "def"));
+        REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+        const auto checkpoint_count = omega_session_get_num_changes(session_ptr);
+        REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+        REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+        REQUIRE(0 < omega_edit_insert_string(session_ptr, 3, "def"));
 
-    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, checkpoint_count));
-    REQUIRE(checkpoint_count == omega_session_get_num_changes(session_ptr));
-    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
-    REQUIRE("abc" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
-    REQUIRE(0 == omega_check_model(session_ptr));
+        REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, checkpoint_count));
+        REQUIRE(checkpoint_count == omega_session_get_num_changes(session_ptr));
+        REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+        REQUIRE("abc" == content_string(session_ptr));
+        REQUIRE(model_valid(session_ptr));
 
-    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, 0));
-    REQUIRE(0 == omega_session_get_num_changes(session_ptr));
-    REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
-    REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
-    REQUIRE(0 == omega_check_model(session_ptr));
-
-    omega_edit_destroy_session(session_ptr);
+        REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, 0));
+        REQUIRE(0 == omega_session_get_num_changes(session_ptr));
+        REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
+        REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
+        REQUIRE(model_valid(session_ptr));
+    }
+    REQUIRE(audit.unchanged());
 }
 
 TEST_CASE("Restore To Change Count Discards Transform Checkpoint Model", "[UndoTests][Transform]") {
-    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, ALL_EVENTS, nullptr);
-    REQUIRE(session_ptr);
+    const ScratchDir scratch;
+    DirAudit audit(scratch.str());
+    {
+        TestSession session(nullptr, scratch.c_str());
+        REQUIRE(session);
+        auto *session_ptr = session.get();
 
-    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
-    const auto keep_count = omega_session_get_num_changes(session_ptr);
+        REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abc"));
+        const auto keep_count = omega_session_get_num_changes(session_ptr);
 
-    const omega_edit_transform_t upper_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
-    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, upper_transform, 0, 3));
-    REQUIRE(keep_count + 1 == omega_session_get_num_changes(session_ptr));
-    REQUIRE("ABC" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
-    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+        const omega_edit_transform_t upper_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, upper_transform, 0, 3));
+        REQUIRE(keep_count + 1 == omega_session_get_num_changes(session_ptr));
+        REQUIRE("ABC" == content_string(session_ptr));
+        REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+        REQUIRE(model_valid(session_ptr));
 
-    REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, keep_count));
-    REQUIRE(keep_count == omega_session_get_num_changes(session_ptr));
-    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
-    REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
-    REQUIRE("abc" ==
-            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
-    REQUIRE(0 == omega_check_model(session_ptr));
-
-    omega_edit_destroy_session(session_ptr);
+        REQUIRE(0 == omega_edit_restore_to_change_count(session_ptr, keep_count));
+        REQUIRE(keep_count == omega_session_get_num_changes(session_ptr));
+        REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+        REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
+        REQUIRE("abc" == content_string(session_ptr));
+        REQUIRE(model_valid(session_ptr));
+        REQUIRE(check_serials_contiguous(session_ptr).contiguous);
+    }
+    REQUIRE(audit.unchanged());
 }

--- a/core/src/tests/test_harness.hpp
+++ b/core/src/tests/test_harness.hpp
@@ -1,0 +1,448 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed under the License is            *
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                   *
+ * implied.  See the License for the specific language governing permissions and limitations under the License.       *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+/**
+ * @file test_harness.hpp
+ * @brief Shared "brutal testing" oracles and invariant checkers for OmegaEdit core tests.
+ *
+ * This is the reusable harness described in CHANGELOG-OPTIMIZER-Fable5.md section 10.1. It is
+ * deliberately independent of any single feature: every core test that mutates a session should be
+ * able to compose these checks cheaply. Design rules:
+ *
+ *  - Oracles return structured results (first divergence offset, mismatch step, ...) instead of
+ *    bare bools wherever a failure needs a useful diagnostic.
+ *  - Nothing here asserts directly; tests wrap results in REQUIRE/CHECK so failures point at the
+ *    calling test line. Use INFO(...) with the returned diagnostics.
+ *  - All content oracles stream through bounded segments, so they work on sessions of any size
+ *    (no OMEGA_MEMORY_BUFFER_LIMIT dependence).
+ */
+
+#ifndef OMEGA_EDIT_TEST_HARNESS_HPP
+#define OMEGA_EDIT_TEST_HARNESS_HPP
+
+#include "omega_edit.h"
+#include "omega_edit/change.h"
+#include "omega_edit/check.h"
+#include "omega_edit/config.h"
+#include "omega_edit/filesystem.h"
+#include "omega_edit/segment.h"
+#include "omega_edit/session.h"
+#include "omega_edit/viewport.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace omega_test {
+
+    /**********************************************************************************************************************
+     * Content oracles
+     **********************************************************************************************************************/
+
+    constexpr int64_t HARNESS_CHUNK_SIZE = 64 * 1024;
+
+    /** Stream the session content through a visitor: visit(const omega_byte_t*, int64_t) -> bool (false aborts). */
+    template<typename Visitor>
+    inline bool visit_session_content(const omega_session_t *session_ptr, Visitor &&visit) {
+        if (!session_ptr) { return false; }
+        const auto size = omega_session_get_computed_file_size(session_ptr);
+        if (size < 0) { return false; }
+        auto *segment = omega_segment_create(std::min<int64_t>(std::max<int64_t>(size, 1), HARNESS_CHUNK_SIZE));
+        if (!segment) { return false; }
+        bool ok = true;
+        int64_t offset = 0;
+        while (offset < size) {
+            if (0 != omega_session_get_segment(session_ptr, segment, offset)) {
+                ok = false;
+                break;
+            }
+            const auto length = omega_segment_get_length(segment);
+            if (length <= 0) {
+                ok = false;// would spin forever; a read hole is an oracle failure, not "done"
+                break;
+            }
+            if (!visit(omega_segment_get_data(segment), length)) {
+                ok = false;
+                break;
+            }
+            offset += length;
+        }
+        omega_segment_destroy(segment);
+        return ok;
+    }
+
+    /** FNV-1a 64-bit content hash, streamed. Distinct sizes always hash distinct (size is mixed in). */
+    inline uint64_t content_hash(const omega_session_t *session_ptr) {
+        uint64_t hash = 14695981039346656037ULL;
+        auto mix = [&hash](const omega_byte_t *data, int64_t length) {
+            for (int64_t i = 0; i < length; ++i) {
+                hash ^= data[i];
+                hash *= 1099511628211ULL;
+            }
+            return true;
+        };
+        if (!visit_session_content(session_ptr, mix)) { return 0; }// 0 = "unhashable", never a valid content hash here
+        const auto size = static_cast<uint64_t>(omega_session_get_computed_file_size(session_ptr));
+        for (int shift = 0; shift < 64; shift += 8) {
+            hash ^= (size >> shift) & 0xFFU;
+            hash *= 1099511628211ULL;
+        }
+        return hash;
+    }
+
+    /** Full content as a string (small sessions only; intended for readable Catch2 diffs). */
+    inline std::string content_string(const omega_session_t *session_ptr) {
+        std::string result;
+        const auto size = omega_session_get_computed_file_size(session_ptr);
+        if (size > 0) { result.reserve(static_cast<size_t>(size)); }
+        visit_session_content(session_ptr, [&result](const omega_byte_t *data, int64_t length) {
+            result.append(reinterpret_cast<const char *>(data), static_cast<size_t>(length));
+            return true;
+        });
+        return result;
+    }
+
+    struct content_compare_result_t {
+        bool equal{};
+        int64_t size_a{-1};
+        int64_t size_b{-1};
+        int64_t first_diff_offset{-1};///< -1 when equal or when sizes differ before any byte diff
+    };
+
+    /** Byte-exact comparison of two sessions, streamed; reports the first divergent offset. */
+    inline content_compare_result_t compare_content(const omega_session_t *session_a,
+                                                    const omega_session_t *session_b) {
+        content_compare_result_t result;
+        result.size_a = omega_session_get_computed_file_size(session_a);
+        result.size_b = omega_session_get_computed_file_size(session_b);
+        if (result.size_a < 0 || result.size_b < 0 || result.size_a != result.size_b) { return result; }
+
+        auto *segment_a = omega_segment_create(HARNESS_CHUNK_SIZE);
+        auto *segment_b = omega_segment_create(HARNESS_CHUNK_SIZE);
+        if (!segment_a || !segment_b) {
+            omega_segment_destroy(segment_a);
+            omega_segment_destroy(segment_b);
+            return result;
+        }
+        result.equal = true;
+        int64_t offset = 0;
+        while (offset < result.size_a) {
+            if (0 != omega_session_get_segment(session_a, segment_a, offset) ||
+                0 != omega_session_get_segment(session_b, segment_b, offset)) {
+                result.equal = false;
+                result.first_diff_offset = offset;
+                break;
+            }
+            const auto length = std::min(omega_segment_get_length(segment_a), omega_segment_get_length(segment_b));
+            if (length <= 0) {
+                result.equal = false;
+                result.first_diff_offset = offset;
+                break;
+            }
+            const auto *data_a = omega_segment_get_data(segment_a);
+            const auto *data_b = omega_segment_get_data(segment_b);
+            if (0 != std::memcmp(data_a, data_b, static_cast<size_t>(length))) {
+                for (int64_t i = 0; i < length; ++i) {
+                    if (data_a[i] != data_b[i]) {
+                        result.first_diff_offset = offset + i;
+                        break;
+                    }
+                }
+                result.equal = false;
+                break;
+            }
+            offset += length;
+        }
+        omega_segment_destroy(segment_a);
+        omega_segment_destroy(segment_b);
+        return result;
+    }
+
+    /**********************************************************************************************************************
+     * Model integrity
+     **********************************************************************************************************************/
+
+    /** Wraps omega_check_model: segment contiguity, change-reference integrity, size consistency. */
+    inline bool model_valid(const omega_session_t *session_ptr) { return 0 == omega_check_model(session_ptr); }
+
+    /**********************************************************************************************************************
+     * Serial contiguity
+     **********************************************************************************************************************/
+
+    struct serial_check_result_t {
+        bool contiguous{};
+        int64_t num_changes{};
+        int64_t first_bad_serial{};///< 0 when contiguous
+    };
+
+    /**
+     * Every serial 1..num_changes must resolve via omega_session_get_change and round-trip its
+     * serial value; num_changes + 1 must not resolve.
+     */
+    inline serial_check_result_t check_serials_contiguous(const omega_session_t *session_ptr) {
+        serial_check_result_t result;
+        result.num_changes = omega_session_get_num_changes(session_ptr);
+        for (int64_t serial = 1; serial <= result.num_changes; ++serial) {
+            const auto *change = omega_session_get_change(session_ptr, serial);
+            if (!change || omega_change_get_serial(change) != serial) {
+                result.first_bad_serial = serial;
+                return result;
+            }
+        }
+        if (nullptr != omega_session_get_change(session_ptr, result.num_changes + 1)) {
+            result.first_bad_serial = result.num_changes + 1;
+            return result;
+        }
+        result.contiguous = true;
+        return result;
+    }
+
+    /**********************************************************************************************************************
+     * Undo/redo trajectory oracle
+     **********************************************************************************************************************/
+
+    struct undo_redo_result_t {
+        bool ok{};
+        int64_t undo_steps{};
+        int64_t redo_steps{};
+        int64_t mismatch_step{-1};       ///< redo step index whose content hash diverged (-1 = none)
+        bool model_valid_throughout{};   ///< omega_check_model held at every step
+        std::vector<uint64_t> trajectory;///< content hash per state: [0] = tip, back() = deepest undo
+    };
+
+    /**
+     * Capture the full undo trajectory (undo to exhaustion, hashing content at each state), then
+     * redo back to the tip verifying every intermediate state hash in reverse order. Leaves the
+     * session at the tip on success. This is the "one permitted visible change" oracle: any code
+     * that rewrites history must keep every state on this trajectory truthful.
+     *
+     * Note: undo stops at plain (non-transform) checkpoint boundaries by core design; the
+     * trajectory covers what the user can actually reach.
+     */
+    inline undo_redo_result_t verify_undo_redo_round_trip(omega_session_t *session_ptr) {
+        undo_redo_result_t result;
+        result.model_valid_throughout = model_valid(session_ptr);
+        result.trajectory.push_back(content_hash(session_ptr));
+
+        while (omega_edit_undo_last_change(session_ptr) < 0) {
+            result.trajectory.push_back(content_hash(session_ptr));
+            result.model_valid_throughout = result.model_valid_throughout && model_valid(session_ptr);
+            ++result.undo_steps;
+        }
+
+        for (auto step = static_cast<int64_t>(result.trajectory.size()) - 2; step >= 0; --step) {
+            if (omega_edit_redo_last_undo(session_ptr) <= 0) {
+                result.mismatch_step = step;
+                return result;
+            }
+            ++result.redo_steps;
+            result.model_valid_throughout = result.model_valid_throughout && model_valid(session_ptr);
+            if (content_hash(session_ptr) != result.trajectory[static_cast<size_t>(step)]) {
+                result.mismatch_step = step;
+                return result;
+            }
+        }
+        result.ok = result.undo_steps == result.redo_steps;
+        return result;
+    }
+
+    /**********************************************************************************************************************
+     * Event recording
+     **********************************************************************************************************************/
+
+    struct recorded_session_event_t {
+        omega_session_event_t event{};
+        int64_t serial{};///< change serial for EDIT/UNDO/TRANSFORM payloads; 0 otherwise
+    };
+
+    /**
+     * Records the exact session event sequence. Pass callback() and this instance as user data at
+     * session creation (core callbacks are fixed at create time — see TestSession).
+     */
+    class SessionEventRecorder {
+    public:
+        static void callback(const omega_session_t *session_ptr, omega_session_event_t event, const void *event_ptr) {
+            auto *recorder = static_cast<SessionEventRecorder *>(omega_session_get_user_data_ptr(session_ptr));
+            if (!recorder) { return; }
+            recorded_session_event_t record{event, 0};
+            switch (event) {
+                case SESSION_EVT_EDIT:// deliberate fall-through
+                case SESSION_EVT_UNDO:
+                case SESSION_EVT_TRANSFORM:
+                    if (event_ptr) {
+                        record.serial = omega_change_get_serial(static_cast<const omega_change_t *>(event_ptr));
+                    }
+                    break;
+                default:
+                    break;
+            }
+            recorder->events_.push_back(record);
+        }
+
+        const std::vector<recorded_session_event_t> &events() const { return events_; }
+
+        int64_t count(omega_session_event_t event) const {
+            int64_t total = 0;
+            for (const auto &record : events_) {
+                if (record.event == event) { ++total; }
+            }
+            return total;
+        }
+
+        void clear() { events_.clear(); }
+
+    private:
+        std::vector<recorded_session_event_t> events_;
+    };
+
+    /**********************************************************************************************************************
+     * Filesystem hygiene audit
+     **********************************************************************************************************************/
+
+    /**
+     * Snapshot a directory's file names at construction; report additions/removals on demand.
+     * Point it at omega_session_get_checkpoint_directory() to police payload/checkpoint litter.
+     */
+    class DirAudit {
+    public:
+        explicit DirAudit(std::string directory) : directory_(std::move(directory)), baseline_(list(directory_)) {}
+
+        std::vector<std::string> added() const { return difference(list(directory_), baseline_); }
+        std::vector<std::string> removed() const { return difference(baseline_, list(directory_)); }
+        bool unchanged() const { return added().empty() && removed().empty(); }
+        const std::string &directory() const { return directory_; }
+        void rebase() { baseline_ = list(directory_); }
+
+        static std::vector<std::string> list(const std::string &directory) {
+            std::vector<std::string> names;
+            std::error_code ec;
+            for (std::filesystem::directory_iterator iter(directory, ec), end; !ec && iter != end; iter.increment(ec)) {
+                names.push_back(iter->path().filename().string());
+            }
+            std::sort(names.begin(), names.end());
+            return names;
+        }
+
+    private:
+        static std::vector<std::string> difference(const std::vector<std::string> &lhs,
+                                                   const std::vector<std::string> &rhs) {
+            std::vector<std::string> result;
+            std::set_difference(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), std::back_inserter(result));
+            return result;
+        }
+
+        std::string directory_;
+        std::vector<std::string> baseline_;
+    };
+
+    /** RAII scratch directory (unique per instance) removed recursively on destruction. */
+    class ScratchDir {
+    public:
+        ScratchDir() {
+            static std::mt19937_64 rng{std::random_device{}()};
+            const auto base = std::filesystem::temp_directory_path() / "omega-edit-test-harness";
+            std::error_code ec;
+            std::filesystem::create_directories(base, ec);
+            do { path_ = base / ("scratch-" + std::to_string(rng())); } while (std::filesystem::exists(path_, ec));
+            std::filesystem::create_directories(path_, ec);
+        }
+
+        ~ScratchDir() {
+            std::error_code ec;
+            std::filesystem::remove_all(path_, ec);
+        }
+
+        ScratchDir(const ScratchDir &) = delete;
+        auto operator=(const ScratchDir &) -> ScratchDir & = delete;
+
+        const std::string &str() const {
+            if (cached_.empty()) { cached_ = path_.string(); }
+            return cached_;
+        }
+        const char *c_str() const { return str().c_str(); }
+
+    private:
+        std::filesystem::path path_;
+        mutable std::string cached_;
+    };
+
+    /**********************************************************************************************************************
+     * Session wrapper with recorder and brutality knobs
+     **********************************************************************************************************************/
+
+    /**
+     * RAII session with a SessionEventRecorder wired at creation (the core only accepts callbacks
+     * at create time) and an isolated checkpoint directory when one is supplied. The recorder is
+     * heap-owned so its address — registered with the core as user data — stays stable across
+     * moves of the wrapper.
+     */
+    class TestSession {
+    public:
+        explicit TestSession(const char *file_path = nullptr, const char *checkpoint_directory = nullptr,
+                             int32_t event_interest = SESSION_EVENTS_ALL)
+            : recorder_(std::make_unique<SessionEventRecorder>()),
+              session_(omega_edit_create_session(file_path, SessionEventRecorder::callback, recorder_.get(),
+                                                 event_interest, checkpoint_directory)) {}
+
+        static TestSession from_bytes(const omega_byte_t *data, int64_t length,
+                                      const char *checkpoint_directory = nullptr,
+                                      int32_t event_interest = SESSION_EVENTS_ALL) {
+            TestSession wrapper(tag_t{});
+            wrapper.session_ =
+                    omega_edit_create_session_from_bytes(data, length, SessionEventRecorder::callback,
+                                                         wrapper.recorder_.get(), event_interest, checkpoint_directory);
+            return wrapper;
+        }
+
+        ~TestSession() {
+            if (session_) { omega_edit_destroy_session(session_); }
+        }
+
+        TestSession(const TestSession &) = delete;
+        auto operator=(const TestSession &) -> TestSession & = delete;
+
+        TestSession(TestSession &&other) noexcept : recorder_(std::move(other.recorder_)), session_(other.session_) {
+            other.session_ = nullptr;
+        }
+
+        omega_session_t *get() const { return session_; }
+        explicit operator bool() const { return session_ != nullptr; }
+        SessionEventRecorder &events() { return *recorder_; }
+
+        /**
+         * The brutality knobs from CHANGELOG-OPTIMIZER-Fable5.md section 10.1: a tiny inline
+         * payload limit forces the file-backed payload-ownership paths on nearly every edit, and
+         * an aggressive snapshot interval shakes snapshot interactions.
+         */
+        void make_brutal(int64_t inline_payload_limit = 8, int64_t undo_snapshot_interval = 1) {
+            omega_session_set_change_inline_payload_limit(session_, inline_payload_limit);
+            omega_session_set_undo_snapshot_interval(session_, undo_snapshot_interval);
+        }
+
+    private:
+        struct tag_t {};
+        explicit TestSession(tag_t) : recorder_(std::make_unique<SessionEventRecorder>()) {}
+
+        std::unique_ptr<SessionEventRecorder> recorder_;
+        omega_session_t *session_{};
+    };
+
+}// namespace omega_test
+
+#endif//OMEGA_EDIT_TEST_HARNESS_HPP


### PR DESCRIPTION
## Summary

- Add the shared brutal-testing harness and self-tests for content, model, serial, undo/redo, event, and checkpoint-directory oracles.
- Adopt the harness in omegaEdit test hot spots around undo payloads, builtin transforms, undo snapshots, restore-to-change-count, and checkpoint paths.
- Add a Section 10.3 differential fuzz driver with JSONL replay, deterministic seed controls, minimization-on-failure, and env knobs for iterations/op counts/replay.
- Ignore local `.clangd` files.

## Validation

- `cmake -S . -B _build-codex -G Ninja -DBUILD_SHARED_LIBS=YES -DBUILD_DOCS=NO -DBUILD_EXAMPLES=NO -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build _build-codex --target omegaEdit_tests differential_fuzz_tests`
- `./differential_fuzz_tests`
- `./omegaEdit_tests`