### PR TITLE
 fix: bound read and search RPCs

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -36,8 +36,7 @@ Risk guide:
 
 1. **Critical deployment boundary**: add optional TLS/mTLS and an authorization
    hook before making any "hardened for production" attestation.
-2. **Massive-file pressure caps**: bound or stream `replace_matches`, and apply
-   a configurable segment-size cap to read/classification RPCs.
+2. **Massive-file pressure caps**: bound or stream `replace_matches`.
 3. **Plugin input hardening**: cap zlib decompression output and add cooperative
    cancellation to the C++ codec plugins.
 4. **Undo performance batch**: implement the remaining low-risk undo pieces
@@ -120,31 +119,6 @@ Suggested fix:
 - Add a test that requests details for a change larger than the inline limit
   and asserts bounded memory/response size.
 
-### 3. SearchSession buffers unbounded match lists
-
-**Impact:** High for common patterns on massive files
-**Risk:** Low
-**Area:** C++ server search RPC
-
-`SearchSession` with the default `limit = 0` accumulates every match offset in
-a vector and then copies them all into a single response message. A short or
-single-byte pattern over a large session can produce billions of matches
-(memory proportional to match count, then a proportionally huge response). The
-search loop also advances by 1 byte per match, so overlapping matches multiply
-the count. This is the search-side sibling of the `replace_matches` finding
-below.
-
-Relevant code:
-- `server/cpp/src/editor_service.cpp:2008`
-- `server/cpp/src/editor_service.cpp:2032`
-
-Suggested fix:
-- Impose a server-side default/maximum match cap when the caller passes
-  `limit = 0`, and report truncation explicitly (flag or status detail).
-- Consider a streaming search RPC for callers that genuinely need all matches.
-- Add a scale test with a high-frequency pattern asserting bounded memory and
-  response size.
-
 ### 4. Undo snapshot strategy is count-only and memory-blind
 
 **Impact:** High
@@ -191,27 +165,6 @@ Suggested fix:
 - Prefer a streaming/checkpointed implementation when the caller requests
   unbounded replacement.
 - Add scale tests that assert bounded memory or a clear graceful failure.
-
-### 6. Read/classification RPCs allocate unbounded segments
-
-**Impact:** High for server robustness
-**Risk:** Low to Medium
-**Area:** C++ server read APIs
-
-`GetSegment`, `GetContentType`, and `GetLanguage` allocate a segment directly
-from `request->length()` without a policy ceiling. `bad_alloc` is caught as an
-internal error, but the RPCs remain an easy memory-pressure lever. Viewports
-already have a capacity limit, so this should use a similar policy.
-
-Relevant code:
-- `server/cpp/src/editor_service.cpp:1566`
-- `server/cpp/src/editor_service.cpp:1609`
-- `server/cpp/src/editor_service.cpp:1986`
-
-Suggested fix:
-- Add a configurable maximum read/classification segment size.
-- Return `INVALID_ARGUMENT` or `RESOURCE_EXHAUSTED` when callers exceed it.
-- Align defaults with viewport limits or document why they differ.
 
 ### 7. Change-log import is still full-document JSON parsing
 
@@ -865,6 +818,12 @@ These areas were in the old document but are no longer open backlog items:
 - Change-log version enforcement, serial/group validation, completeness metadata,
   and status-code-based missing-detail handling.
 - Former hard change-log entry/byte caps on export/import.
+- Unbounded `SearchSession` unary responses; the server now enforces a
+  configurable `max_search_matches` policy and returns `RESOURCE_EXHAUSTED`
+  instead of silently truncating when a search would exceed it.
+- Unbounded `GetSegment`, `GetContentType`, and `GetLanguage` allocations; the
+  server now applies a configurable read/classification segment limit that
+  defaults to the viewport capacity and can be disabled with `0`.
 - Service-wide transform plugin execution locking; server plugin calls now
   snapshot registry metadata under a short lock and execute under session/content
   guards.

--- a/core/src/lib/transform.cpp
+++ b/core/src/lib/transform.cpp
@@ -1210,9 +1210,11 @@ namespace {
 
         STARTUPINFOA startup_info{};
         startup_info.cb = sizeof(startup_info);
+        startup_info.dwFlags = STARTF_USESHOWWINDOW;
+        startup_info.wShowWindow = SW_HIDE;
         PROCESS_INFORMATION process_info{};
-        if (!CreateProcessA(nullptr, mutable_command_line.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr,
-                            &startup_info, &process_info)) {
+        if (!CreateProcessA(nullptr, mutable_command_line.data(), nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr,
+                            nullptr, &startup_info, &process_info)) {
             return false;
         }
 

--- a/packages/client/src/shims/omega-edit-server.ts
+++ b/packages/client/src/shims/omega-edit-server.ts
@@ -36,6 +36,8 @@ export interface HeartbeatOptions {
   viewportEventQueueCapacity?: number
   maxChangeBytes?: number
   maxViewportsPerSession?: number
+  maxReadSegmentBytes?: number
+  maxSearchMatches?: number
   logFile?: string
   logLevel?: string
   logConfigFile?: string

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -25,6 +25,9 @@ import {
   destroySession,
   getComputedFileSize,
   getClient,
+  getContentType,
+  getLanguage,
+  getSegment,
   getServerHeartbeat,
   getSessionCount,
   getViewportCount,
@@ -35,6 +38,7 @@ import {
   replaceSession,
   replaceSessionCheckpointed,
   resetClient,
+  searchSession,
   setLogger,
   startServer,
   startServerUnixSocket,
@@ -541,6 +545,8 @@ describe('Server Resource Limits', () => {
 
   const heartbeat: HeartbeatOptions = {
     maxChangeBytes: 1,
+    maxReadSegmentBytes: 1,
+    maxSearchMatches: 2,
     maxViewportsPerSession: 1,
     sessionEventQueueCapacity: 1,
     viewportEventQueueCapacity: 1,
@@ -746,6 +752,73 @@ describe('Server Resource Limits', () => {
     }
 
     expect(await getViewportCount(session_id)).to.equal(1)
+  })
+
+  it(`on port ${serverTestPort} should reject segment reads larger than configured`, async () => {
+    await insert(session_id, 0, Uint8Array.from([0x41]))
+    expect(await getSegment(session_id, 0, 1)).deep.equals(
+      Uint8Array.from([0x41])
+    )
+
+    try {
+      await getSegment(session_id, 0, 2)
+      expect.fail(
+        'getSegment should reject lengths larger than maxReadSegmentBytes'
+      )
+    } catch (err) {
+      expectResourceExhausted(err, 'configured read segment limit of 1 bytes')
+    }
+  })
+
+  it(`on port ${serverTestPort} should reject content classification reads larger than configured`, async () => {
+    await insert(session_id, 0, Uint8Array.from([0x41]))
+    expect((await getContentType(session_id, 0, 1)).getContentType()).to.be.a(
+      'string'
+    )
+
+    try {
+      await getContentType(session_id, 0, 2)
+      expect.fail(
+        'getContentType should reject lengths larger than maxReadSegmentBytes'
+      )
+    } catch (err) {
+      expectResourceExhausted(err, 'configured read segment limit of 1 bytes')
+    }
+  })
+
+  it(`on port ${serverTestPort} should reject language detection reads larger than configured`, async () => {
+    await insert(session_id, 0, Uint8Array.from([0x41]))
+    expect((await getLanguage(session_id, 0, 1, 'none')).getLanguage()).to.be.a(
+      'string'
+    )
+
+    try {
+      await getLanguage(session_id, 0, 2, 'none')
+      expect.fail(
+        'getLanguage should reject lengths larger than maxReadSegmentBytes'
+      )
+    } catch (err) {
+      expectResourceExhausted(err, 'configured read segment limit of 1 bytes')
+    }
+  })
+
+  it(`on port ${serverTestPort} should reject unbounded searches above the configured match limit`, async () => {
+    await insert(session_id, 0, Uint8Array.from([0x61]))
+    await insert(session_id, 1, Uint8Array.from([0x61]))
+    await insert(session_id, 2, Uint8Array.from([0x61]))
+
+    expect(
+      await searchSession(session_id, 'a', false, false, 0, 0, 2)
+    ).deep.equals([0, 1])
+
+    try {
+      await searchSession(session_id, 'a', false, false, 0, 0, 0)
+      expect.fail(
+        'searchSession should reject responses larger than maxSearchMatches'
+      )
+    } catch (err) {
+      expectResourceExhausted(err, 'configured search match limit of 2')
+    }
   })
 
   it(`on port ${serverTestPort} should generate opaque sess_ IDs for unmanaged sessions`, async () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -47,6 +47,10 @@ export interface HeartbeatOptions {
   maxChangeBytes?: number
   /** Limit concurrently open viewports per session (0 = unbounded). */
   maxViewportsPerSession?: number
+  /** Limit materialized read/classification segment size in bytes (0 = unbounded). */
+  maxReadSegmentBytes?: number
+  /** Limit unary search matches returned by one RPC (0 = unbounded). */
+  maxSearchMatches?: number
   /** Append native server lifecycle logs to this file. */
   logFile?: string
   /** Native server log level. */
@@ -431,6 +435,12 @@ function heartbeatToArgs(
   }
   if (opts?.maxViewportsPerSession !== undefined) {
     args.push(`--max-viewports-per-session=${opts.maxViewportsPerSession}`)
+  }
+  if (opts?.maxReadSegmentBytes !== undefined) {
+    args.push(`--max-read-segment-bytes=${opts.maxReadSegmentBytes}`)
+  }
+  if (opts?.maxSearchMatches !== undefined) {
+    args.push(`--max-search-matches=${opts.maxSearchMatches}`)
   }
   if (opts?.logConfigFile !== undefined) {
     args.push(`--log-config=${opts.logConfigFile}`)

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -735,6 +735,37 @@ namespace omega_edit {
             return grpc::Status::OK;
         }
 
+        static grpc::Status validate_materialized_segment_request(const char *operation, int64_t offset, int64_t length,
+                                                                  int64_t max_read_segment_bytes) {
+            if (offset < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    std::string(operation) + " offset must be non-negative");
+            }
+            if (length < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    std::string(operation) + " length must be non-negative");
+            }
+            if (length > 0 && offset > (std::numeric_limits<int64_t>::max)() - length) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, std::string(operation) + " range is invalid");
+            }
+            if (max_read_segment_bytes > 0 && length > max_read_segment_bytes) {
+                return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                    std::string(operation) + " length exceeds configured read segment limit of " +
+                                            std::to_string(max_read_segment_bytes) + " bytes");
+            }
+            return grpc::Status::OK;
+        }
+
+        static int64_t effective_search_limit(int64_t requested_limit, int64_t max_search_matches,
+                                              bool &resource_limit_applies) {
+            resource_limit_applies = false;
+            if (max_search_matches > 0 && (requested_limit <= 0 || requested_limit > max_search_matches)) {
+                resource_limit_applies = true;
+                return max_search_matches;
+            }
+            return requested_limit;
+        }
+
         EditorServiceImpl::EditorServiceImpl(HeartbeatConfig heartbeat_config, ResourceLimits resource_limits,
                                              std::function<void()> shutdown_callback,
                                              std::vector<std::string> transform_plugin_directories,
@@ -1575,9 +1606,9 @@ namespace omega_edit {
         grpc::Status EditorServiceImpl::GetContentType(grpc::ServerContext * /*context*/,
                                                        const ::omega_edit::v1::GetContentTypeRequest *request,
                                                        ::omega_edit::v1::GetContentTypeResponse *response) {
-            if (request->offset() < 0) {
-                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
-            }
+            auto request_status = validate_materialized_segment_request(
+                    "content type", request->offset(), request->length(), resource_limits_.max_read_segment_bytes);
+            if (!request_status.ok()) { return request_status; }
 
             auto locked_session = session_manager_.lock_session(request->session_id());
             if (!locked_session) {
@@ -1618,9 +1649,9 @@ namespace omega_edit {
         grpc::Status EditorServiceImpl::GetLanguage(grpc::ServerContext * /*context*/,
                                                     const ::omega_edit::v1::GetLanguageRequest *request,
                                                     ::omega_edit::v1::GetLanguageResponse *response) {
-            if (request->offset() < 0) {
-                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
-            }
+            auto request_status = validate_materialized_segment_request(
+                    "language", request->offset(), request->length(), resource_limits_.max_read_segment_bytes);
+            if (!request_status.ok()) { return request_status; }
 
             auto locked_session = session_manager_.lock_session(request->session_id());
             if (!locked_session) {
@@ -1997,9 +2028,9 @@ namespace omega_edit {
         grpc::Status EditorServiceImpl::GetSegment(grpc::ServerContext * /*context*/,
                                                    const ::omega_edit::v1::GetSegmentRequest *request,
                                                    ::omega_edit::v1::GetSegmentResponse *response) {
-            if (request->offset() < 0) {
-                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "offset must be non-negative");
-            }
+            auto request_status = validate_materialized_segment_request("segment", request->offset(), request->length(),
+                                                                        resource_limits_.max_read_segment_bytes);
+            if (!request_status.ok()) { return request_status; }
 
             auto locked_session = session_manager_.lock_session(request->session_id());
             if (!locked_session) {
@@ -2042,6 +2073,17 @@ namespace omega_edit {
             int64_t offset = request->has_offset() ? request->offset() : 0;
             int64_t length = request->has_length() ? request->length() : 0;
             int64_t limit = request->has_limit() ? request->limit() : 0;// 0 = no limit
+            if (offset < 0 || length < 0 || limit < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "search offset, length, and limit must be non-negative");
+            }
+            if (length > 0 && offset > (std::numeric_limits<int64_t>::max)() - length) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "search range is invalid");
+            }
+
+            bool resource_limit_applies = false;
+            const auto bounded_limit =
+                    effective_search_limit(limit, resource_limits_.max_search_matches, resource_limit_applies);
             std::vector<int64_t> match_offsets;
 
             {
@@ -2058,9 +2100,15 @@ namespace omega_edit {
 
                 if (ctx) {
                     int64_t num_matches = 0;
-                    while ((limit <= 0 || num_matches < limit) && omega_search_next_match(ctx, 1) > 0) {
+                    while ((bounded_limit <= 0 || num_matches < bounded_limit) && omega_search_next_match(ctx, 1) > 0) {
                         match_offsets.push_back(omega_search_context_get_match_offset(ctx));
                         ++num_matches;
+                    }
+                    if (resource_limit_applies && num_matches >= bounded_limit && omega_search_next_match(ctx, 1) > 0) {
+                        omega_search_destroy_context(ctx);
+                        return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                            "search matches exceed configured search match limit of " +
+                                                    std::to_string(resource_limits_.max_search_matches));
                     }
                     omega_search_destroy_context(ctx);
                 }

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -411,6 +411,9 @@ static void print_usage(const char *progname) {
               << "      --max-change-bytes <bytes>   Limit insert/overwrite payload size (0 = unbounded)\n"
               << "      --max-viewports-per-session <count>\n"
               << "                                   Limit concurrently open viewports per session (0 = unbounded)\n"
+              << "      --max-read-segment-bytes <bytes>\n"
+              << "                                   Limit materialized read/classification segments (0 = unbounded)\n"
+              << "      --max-search-matches <count> Limit unary search matches returned by one RPC (0 = unbounded)\n"
               << "\nTransform plugin options:\n"
               << "      --transform-plugin-dir <dir>\n"
               << "                                   Register transform plugins from a directory (repeatable)\n"
@@ -445,6 +448,8 @@ int main(int argc, char **argv) {
     size_t viewport_event_queue_capacity = resource_limits.viewport_event_queue_capacity;
     int64_t max_change_bytes = resource_limits.max_change_bytes;
     size_t max_viewports_per_session = resource_limits.max_viewports_per_session;
+    int64_t max_read_segment_bytes = resource_limits.max_read_segment_bytes;
+    int64_t max_search_matches = resource_limits.max_search_matches;
     std::vector<std::string> transform_plugin_directories;
     std::string transform_plugin_host_path;
     bool allow_experimental_transform_plugins = false;
@@ -501,6 +506,16 @@ int main(int argc, char **argv) {
     if (const char *env = std::getenv("OMEGA_EDIT_MAX_VIEWPORTS_PER_SESSION")) {
         if (!parse_size_t(env, "OMEGA_EDIT_MAX_VIEWPORTS_PER_SESSION", 0, std::numeric_limits<size_t>::max(),
                           max_viewports_per_session))
+            return 1;
+    }
+    if (const char *env = std::getenv("OMEGA_EDIT_MAX_READ_SEGMENT_BYTES")) {
+        if (!parse_int64(env, "OMEGA_EDIT_MAX_READ_SEGMENT_BYTES", 0, std::numeric_limits<int64_t>::max(),
+                         max_read_segment_bytes))
+            return 1;
+    }
+    if (const char *env = std::getenv("OMEGA_EDIT_MAX_SEARCH_MATCHES")) {
+        if (!parse_int64(env, "OMEGA_EDIT_MAX_SEARCH_MATCHES", 0, std::numeric_limits<int64_t>::max(),
+                         max_search_matches))
             return 1;
     }
     if (const char *env = std::getenv("OMEGA_EDIT_TRANSFORM_PLUGIN_DIRS")) {
@@ -613,6 +628,16 @@ int main(int argc, char **argv) {
                 if (!parse_size_t(value, "--max-viewports-per-session", 0, std::numeric_limits<size_t>::max(),
                                   max_viewports_per_session))
                     return 1;
+            } else if (key == "--max-read-segment-bytes") {
+                if (!require_option_value(key, value)) { return 1; }
+                if (!parse_int64(value, "--max-read-segment-bytes", 0, std::numeric_limits<int64_t>::max(),
+                                 max_read_segment_bytes))
+                    return 1;
+            } else if (key == "--max-search-matches") {
+                if (!require_option_value(key, value)) { return 1; }
+                if (!parse_int64(value, "--max-search-matches", 0, std::numeric_limits<int64_t>::max(),
+                                 max_search_matches))
+                    return 1;
             } else if (key == "--transform-plugin-dir") {
                 if (!require_option_value(key, value)) { return 1; }
                 transform_plugin_directories.push_back(value);
@@ -653,6 +678,8 @@ int main(int argc, char **argv) {
     resource_limits.viewport_event_queue_capacity = viewport_event_queue_capacity;
     resource_limits.max_change_bytes = max_change_bytes;
     resource_limits.max_viewports_per_session = max_viewports_per_session;
+    resource_limits.max_read_segment_bytes = max_read_segment_bytes;
+    resource_limits.max_search_matches = max_search_matches;
 
     // Create service with shutdown callback that requests shutdown via the monitor thread
     auto shutdown_callback = []() {

--- a/server/cpp/src/session_manager.h
+++ b/server/cpp/src/session_manager.h
@@ -38,10 +38,12 @@ namespace omega_edit {
 
         /// Configurable service limits to bound server-side resource usage.
         struct ResourceLimits {
-            size_t session_event_queue_capacity{1024}; ///< 0 = unbounded
-            size_t viewport_event_queue_capacity{256}; ///< 0 = unbounded
-            int64_t max_change_bytes{64 * 1024 * 1024};///< 0 = unbounded
-            size_t max_viewports_per_session{256};     ///< 0 = unbounded
+            size_t session_event_queue_capacity{1024};                    ///< 0 = unbounded
+            size_t viewport_event_queue_capacity{256};                    ///< 0 = unbounded
+            int64_t max_change_bytes{64 * 1024 * 1024};                   ///< 0 = unbounded
+            size_t max_viewports_per_session{256};                        ///< 0 = unbounded
+            int64_t max_read_segment_bytes{OMEGA_VIEWPORT_CAPACITY_LIMIT};///< 0 = unbounded
+            int64_t max_search_matches{1000000};                          ///< 0 = unbounded
         };
 
         struct TransformProgressData {


### PR DESCRIPTION
## What changed

- Added configurable `max_read_segment_bytes` and `max_search_matches` server resource limits, with `0` preserving trusted unbounded operation.
- Enforced the read/classification limit before allocation in `GetSegment`, `GetContentType`, and `GetLanguage`.
- Enforced the search match limit for unary `SearchSession` responses with a clear `RESOURCE_EXHAUSTED` failure when more matches exist.
- Threaded the new limits through native CLI/env options and the Node server launcher API.
- Added resource-limit coverage for segment reads, content/language classification, and high-frequency search.
- Updated `SHORTCOMINGS.md` to remove the fixed P1 items and record them as resolved.

## Why

OmegaEdit needs to scale without hard caps that betray the massive-file mission. These changes bound default server memory/response exposure while keeping explicit `0 = unbounded` operator escape hatches for trusted deployments.

## Validation

- `cmake --build --preset ninja-debug-minimal`
- `ctest --build-config Debug --test-dir _build/core -E "^File Copy$" --output-on-failure` passed 126/126
- `tsc -p packages/server/tsconfig.json --noEmit`
- `tsc -p packages/client/tsconfig.esm.json --noEmit`
- `tsc -p packages/client/tsconfig.cjs.json --noEmit`
- `tsc -p packages/client/tsconfig.tests.esm.json --noEmit`
- Repo-configured Biome check on touched TS files using a temp Linux Biome install

## Local caveats

- Full core CTest has one repeatable unrelated WSL filesystem mode-bit failure: `File Copy` (`33152 != 33279`).
- C++ gRPC server integration tests could not run locally because `server/cpp/build` is a stale Windows CMake cache, fresh Linux configure lacks Protobuf/gRPC CMake packages, and the packaged server binary in this checkout is Windows-only.
