### PR TITLE
harden transform codec plugins

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -11,7 +11,9 @@ around the initial Find toggle state, auto bytes-per-row overfitting, and the
 duplicate Ctrl-Z undo toast are also treated as fixed by the current extension
 branch/PR and are not listed as open. The redo preservation bug across
 transform undo boundaries found by the brutal-testing harness is also fixed by
-the current core test branch/PR and is no longer listed as open.
+the current core test branch/PR and is no longer listed as open. The zlib
+decompression cap and C++ codec cancellation/base58 guardrail items are also
+fixed and no longer listed as open.
 
 Recent core/server/plugin review findings have been folded into the priority
 list below rather than kept as a second appended review. A fresh core/server
@@ -36,14 +38,13 @@ Risk guide:
 
 1. **Critical deployment boundary**: add optional TLS/mTLS and an authorization
    hook before making any "hardened for production" attestation.
-2. **Massive-file pressure caps**: bound or stream `replace_matches`.
-3. **Plugin input hardening**: cap zlib decompression output and add cooperative
-   cancellation to the C++ codec plugins.
-4. **Undo performance batch**: implement the remaining low-risk undo pieces
+2. **Massive-file pressure caps**: bound or stream `replace_matches`, and apply
+   a configurable segment-size cap to read/classification RPCs.
+3. **Undo performance batch**: implement the remaining low-risk undo pieces
    (transaction extents, redo batching, snapshot telemetry).
-5. **Streaming import**: pair existing streaming export with a streaming/chunked
+4. **Streaming import**: pair existing streaming export with a streaming/chunked
    import path.
-6. **Checkpoint caps/dedupe**: add server/API guardrails for unbounded checkpoint
+5. **Checkpoint caps/dedupe**: add server/API guardrails for unbounded checkpoint
    creation.
 
 The first batch now favors deployment hardening, resource caps, and remaining
@@ -209,27 +210,6 @@ Suggested fix:
 - Decide whether public TS APIs become BigInt-first, accept `number | bigint`,
   or expose parallel BigInt methods.
 - Keep safe-number wrappers for legacy callers during the transition.
-
-### 9. Zlib decompression has no output-size or ratio cap
-
-**Impact:** High (decompression-bomb memory exhaustion)
-**Risk:** Low to Medium
-**Area:** Transform plugins (zlib)
-
-`zlib_decompress` grows the output buffer by doubling with only a `SIZE_MAX/2`
-ceiling, so a few kilobytes of compressible input can inflate to gigabytes of
-resident memory. The loop does poll cancellation, but there is no maximum output
-size or compression-ratio guard.
-
-Relevant code:
-- `plugins/src/zlib.c:142`
-- `plugins/src/zlib.c:178`
-
-Suggested fix:
-- Add a configurable maximum decompressed-output size (and/or ratio) and fail
-  with a clear error when exceeded.
-- Keep the existing per-iteration cancellation polling.
-- Add a decompression-bomb test that asserts the cap is enforced.
 
 ### 10. Plugin workers still run with server user privileges
 
@@ -502,28 +482,6 @@ Suggested fix:
 - Route all mark-dirty-and-notify call sites through one helper.
 - Update tests that currently force dirty state by negating capacity.
 
-### 21. C++ codec plugins lack cancellation, and base58 is quadratic
-
-**Impact:** Medium to High (CPU hang on large selections)
-**Risk:** Low
-**Area:** Transform plugins (text/decimal codecs)
-
-The C++ REPLACE codecs pull the whole selection into memory via `selected_bytes`
-and then run their encode/decode loops with no cancellation polling, unlike the C
-plugins which poll roughly every 4096 bytes. base58 encode/decode are also
-`O(n^2)` over the selection, so a large selection becomes an uninterruptible
-multi-second-to-minutes CPU hang.
-
-Relevant code:
-- `plugins/src/plugin_options.hpp:185`
-- `plugins/src/text_codecs.cpp:195`
-- `plugins/src/text_codecs.cpp:224`
-
-Suggested fix:
-- Poll `omega_transform_plugin_sdk_is_cancelled` inside the C++ codec loops.
-- Cap base58 selection size or document it as a short-field codec.
-- Add cancellation and large-input tests for the C++ codecs.
-
 ### 22. OpenSSL cipher plugin does not zeroize key material
 
 **Impact:** Medium
@@ -763,8 +721,6 @@ claiming production hardening:
   original snapshot after the user truncates or rewrites the source file.
 - Plugin fuzzing: fuzz the format inspectors and text/decimal codecs, especially
   base58, for hangs, unbounded output, and decode round-trips.
-- Decompression caps: assert zlib decompression enforces its output-size/ratio
-  ceiling and stays cancellable.
 - Plugin cancellation: assert every bundled plugin honors cooperative
   cancellation partway through a large selection.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -13,11 +13,14 @@ an `operator` field plus a single repeated byte or repeating mask sequence, for
 example `{"operator":"xor","byte":"0x42"}` or
 `{"operator":"and","mask":["0x0F","0xF0"]}`. The zlib exemplar exposes an
 `action` field for compression or decompression; compression accepts `level`
-values from `-1` through `9`.
+values from `-1` through `9`, and decompression accepts `maxOutputBytes` with a
+64 MiB default cap.
 The richer data-format exemplars cover digest/hash inspection, AES cipher
 transforms, CRC/checksum inspection, binary-to-text codecs, character set
 transcoding, decimal field encodings, byte-order swaps, record/text escaping
-helpers, and lightweight format inspectors for TLV-style data. The OpenSSL
+helpers, and lightweight format inspectors for TLV-style data. The base58 text
+codec is intentionally capped at 64 KiB selections because its exemplar
+implementation is quadratic. The OpenSSL
 exemplars use OpenSSL 3's EVP API to calculate MD5, SHA-1, SHA-2, SHA-3, and
 BLAKE2 inspect-only text results and to encrypt/decrypt selected bytes with
 AES-CBC or AES-CTR. MD5 and SHA-1 are included for legacy formats,

--- a/plugins/src/decimal_codecs.cpp
+++ b/plugins/src/decimal_codecs.cpp
@@ -26,15 +26,24 @@ namespace {
             "\"packed-decimal\",\"comp-3\",\"zoned-decimal\",\"overpunch\"]},\"direction\":{\"type\":\"string\","
             "\"title\":\"Direction\",\"default\":\"encode\",\"enum\":[\"encode\",\"decode\"]}},"
             "\"additionalProperties\":false}";
+    constexpr size_t DECIMAL_CODEC_CANCEL_POLL_INTERVAL = 4096;
+
+    bool cancel_requested(const omega_transform_plugin_request_t *request_ptr, size_t &work_count) {
+        if ((work_count++ & (DECIMAL_CODEC_CANCEL_POLL_INTERVAL - 1U)) != 0U) { return false; }
+        return omega_transform_plugin_sdk_is_cancelled(request_ptr) != 0;
+    }
 
     bool is_ascii_space(omega_byte_t byte) { return std::isspace(static_cast<unsigned char>(byte)) != 0; }
 
     bool is_ascii_digit(omega_byte_t byte) { return std::isdigit(static_cast<unsigned char>(byte)) != 0; }
 
-    bool digits_from_ascii(const std::vector<omega_byte_t> &input, std::string &digits, bool &negative) {
+    bool digits_from_ascii(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                           std::string &digits, bool &negative) {
         digits.clear();
         negative = false;
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (byte == '+' || is_ascii_space(byte)) { continue; }
             if (byte == '-') {
                 negative = true;
@@ -56,21 +65,27 @@ namespace {
         return true;
     }
 
-    bool encode_bcd(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool encode_bcd(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                    std::vector<omega_byte_t> &out) {
         std::string digits;
         bool negative = false;
-        if (!digits_from_ascii(input, digits, negative) || negative) { return false; }
+        if (!digits_from_ascii(request_ptr, input, digits, negative) || negative) { return false; }
         if ((digits.size() % 2) != 0) { digits.insert(digits.begin(), '0'); }
         out.clear();
+        size_t work_count = 0;
         for (size_t i = 0; i < digits.size(); i += 2) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             out.push_back(static_cast<omega_byte_t>(((digits[i] - '0') << 4U) | (digits[i + 1] - '0')));
         }
         return true;
     }
 
-    bool decode_bcd(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool decode_bcd(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                    std::vector<omega_byte_t> &out) {
         std::string digits;
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             char high = 0;
             char low = 0;
             if (!decode_nibble((byte >> 4U) & 0x0FU, high) || !decode_nibble(byte & 0x0FU, low)) { return false; }
@@ -81,14 +96,17 @@ namespace {
         return true;
     }
 
-    bool encode_packed(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool encode_packed(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                       std::vector<omega_byte_t> &out) {
         std::string digits;
         bool negative = false;
-        if (!digits_from_ascii(input, digits, negative)) { return false; }
+        if (!digits_from_ascii(request_ptr, input, digits, negative)) { return false; }
         digits.push_back(negative ? 'D' : 'C');
         if ((digits.size() % 2) != 0) { digits.insert(digits.begin(), '0'); }
         out.clear();
+        size_t work_count = 0;
         for (size_t i = 0; i < digits.size(); i += 2) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             const unsigned int high = digits[i] >= 'A' ? 0x0DU : static_cast<unsigned int>(digits[i] - '0');
             const unsigned int low = digits[i + 1] >= 'A' ? (digits[i + 1] == 'D' ? 0x0DU : 0x0CU)
                                                           : static_cast<unsigned int>(digits[i + 1] - '0');
@@ -97,11 +115,14 @@ namespace {
         return true;
     }
 
-    bool decode_packed(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool decode_packed(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                       std::vector<omega_byte_t> &out) {
         if (input.empty()) { return false; }
         std::string digits;
         bool negative = false;
+        size_t work_count = 0;
         for (size_t i = 0; i < input.size(); ++i) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             const unsigned int high = (input[i] >> 4U) & 0x0FU;
             const unsigned int low = input[i] & 0x0FU;
             char digit = 0;
@@ -123,12 +144,15 @@ namespace {
         return true;
     }
 
-    bool encode_zoned(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out, bool overpunch) {
+    bool encode_zoned(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                      std::vector<omega_byte_t> &out, bool overpunch) {
         std::string digits;
         bool negative = false;
-        if (!digits_from_ascii(input, digits, negative)) { return false; }
+        if (!digits_from_ascii(request_ptr, input, digits, negative)) { return false; }
         out.clear();
+        size_t work_count = 0;
         for (size_t i = 0; i < digits.size(); ++i) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             const unsigned int digit = static_cast<unsigned int>(digits[i] - '0');
             if (overpunch && i + 1 == digits.size()) {
                 out.push_back(static_cast<omega_byte_t>((negative ? 0xD0U : 0xC0U) | digit));
@@ -139,11 +163,14 @@ namespace {
         return true;
     }
 
-    bool decode_zoned(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out, bool overpunch) {
+    bool decode_zoned(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                      std::vector<omega_byte_t> &out, bool overpunch) {
         if (input.empty()) { return false; }
         std::string digits;
         bool negative = false;
+        size_t work_count = 0;
         for (size_t i = 0; i < input.size(); ++i) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             const unsigned int zone = (input[i] >> 4U) & 0x0FU;
             const unsigned int digit = input[i] & 0x0FU;
             if (digit > 9U) { return false; }
@@ -198,13 +225,17 @@ omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr
     std::vector<omega_byte_t> output;
     bool ok = false;
     if (codec == "bcd") {
-        ok = direction == "encode" ? encode_bcd(input, output) : decode_bcd(input, output);
+        ok = direction == "encode" ? encode_bcd(request_ptr, input, output) : decode_bcd(request_ptr, input, output);
     } else if (codec == "packed-decimal") {
-        ok = direction == "encode" ? encode_packed(input, output) : decode_packed(input, output);
+        ok = direction == "encode" ? encode_packed(request_ptr, input, output)
+                                   : decode_packed(request_ptr, input, output);
     } else if (codec == "zoned-decimal") {
-        ok = direction == "encode" ? encode_zoned(input, output, false) : decode_zoned(input, output, false);
+        ok = direction == "encode" ? encode_zoned(request_ptr, input, output, false)
+                                   : decode_zoned(request_ptr, input, output, false);
     } else if (codec == "overpunch") {
-        ok = direction == "encode" ? encode_zoned(input, output, true) : decode_zoned(input, output, true);
+        ok = direction == "encode" ? encode_zoned(request_ptr, input, output, true)
+                                   : decode_zoned(request_ptr, input, output, true);
     }
-    return ok ? omega_edit::plugin::set_replacement(request_ptr, response_ptr, output) : -1;
+    if (!ok || omega_transform_plugin_sdk_is_cancelled(request_ptr)) { return -1; }
+    return omega_edit::plugin::set_replacement(request_ptr, response_ptr, output);
 }

--- a/plugins/src/text_codecs.cpp
+++ b/plugins/src/text_codecs.cpp
@@ -29,6 +29,13 @@ namespace {
             "\"base64url\",\"base32\",\"base32-crockford\",\"ascii85\",\"base85\",\"z85\",\"base58\",\"percent\","
             "\"url\",\"quoted-printable\",\"uuencode\",\"yenc\"]},\"direction\":{\"type\":\"string\",\"title\":"
             "\"Direction\",\"default\":\"encode\",\"enum\":[\"encode\",\"decode\"]}},\"additionalProperties\":false}";
+    constexpr size_t TEXT_CODEC_CANCEL_POLL_INTERVAL = 4096;
+    constexpr size_t TEXT_CODEC_BASE58_MAX_INPUT_BYTES = 64 * 1024;
+
+    bool cancel_requested(const omega_transform_plugin_request_t *request_ptr, size_t &work_count) {
+        if ((work_count++ & (TEXT_CODEC_CANCEL_POLL_INTERVAL - 1U)) != 0U) { return false; }
+        return omega_transform_plugin_sdk_is_cancelled(request_ptr) != 0;
+    }
 
     int hex_value(omega_byte_t byte) {
         if (byte >= '0' && byte <= '9') { return byte - '0'; }
@@ -45,21 +52,27 @@ namespace {
         return static_cast<omega_byte_t>(std::toupper(static_cast<unsigned char>(byte)));
     }
 
-    std::vector<omega_byte_t> hex_encode(const std::vector<omega_byte_t> &input) {
+    bool hex_encode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                    std::vector<omega_byte_t> &out) {
         static constexpr char alphabet[] = "0123456789abcdef";
-        std::vector<omega_byte_t> out;
+        out.clear();
         out.reserve(input.size() * 2);
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             out.push_back(static_cast<omega_byte_t>(alphabet[(byte >> 4U) & 0x0FU]));
             out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
         }
-        return out;
+        return true;
     }
 
-    bool hex_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool hex_decode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                    std::vector<omega_byte_t> &out) {
         out.clear();
         int high = -1;
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (is_ascii_space(byte)) { continue; }
             const int value = hex_value(byte);
             if (value < 0) { return false; }
@@ -73,11 +86,14 @@ namespace {
         return high < 0;
     }
 
-    std::vector<omega_byte_t> base64url_encode(const std::vector<omega_byte_t> &input) {
+    bool base64url_encode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                          std::vector<omega_byte_t> &out) {
         static constexpr char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-        std::vector<omega_byte_t> out;
+        out.clear();
         out.reserve(((input.size() + 2) / 3) * 4);
+        size_t work_count = 0;
         for (size_t i = 0; i < input.size();) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             const unsigned int a = input[i++];
             const bool has_b = i < input.size();
             const unsigned int b = has_b ? input[i++] : 0;
@@ -89,7 +105,7 @@ namespace {
             if (has_b) { out.push_back(static_cast<omega_byte_t>(alphabet[(triple >> 6U) & 0x3FU])); }
             if (has_c) { out.push_back(static_cast<omega_byte_t>(alphabet[triple & 0x3FU])); }
         }
-        return out;
+        return true;
     }
 
     int base64url_value(omega_byte_t byte) {
@@ -102,11 +118,14 @@ namespace {
         return -1;
     }
 
-    bool base64url_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool base64url_decode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                          std::vector<omega_byte_t> &out) {
         std::vector<int> values;
         size_t padding_count = 0;
         bool saw_padding = false;
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (is_ascii_space(byte)) { continue; }
             const int value = base64url_value(byte);
             if (value == -1) { return false; }
@@ -129,6 +148,7 @@ namespace {
         while ((values.size() % 4) != 0) { values.push_back(0); }
         out.clear();
         for (size_t i = 0; i < values.size(); i += 4) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             const unsigned int triple =
                     (static_cast<unsigned int>(values[i]) << 18U) | (static_cast<unsigned int>(values[i + 1]) << 12U) |
                     (static_cast<unsigned int>(values[i + 2]) << 6U) | static_cast<unsigned int>(values[i + 3]);
@@ -140,12 +160,15 @@ namespace {
         return true;
     }
 
-    std::vector<omega_byte_t> base32_encode(const std::vector<omega_byte_t> &input, bool crockford) {
+    bool base32_encode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                       bool crockford, std::vector<omega_byte_t> &out) {
         const char *alphabet = crockford ? "0123456789ABCDEFGHJKMNPQRSTVWXYZ" : "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-        std::vector<omega_byte_t> out;
+        out.clear();
         uint32_t buffer = 0;
         int bits = 0;
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             buffer = (buffer << 8U) | byte;
             bits += 8;
             while (bits >= 5) {
@@ -157,7 +180,7 @@ namespace {
         if (!crockford) {
             while ((out.size() % 8) != 0) { out.push_back('='); }
         }
-        return out;
+        return true;
     }
 
     int base32_value(omega_byte_t byte, bool crockford) {
@@ -174,11 +197,14 @@ namespace {
         return -1;
     }
 
-    bool base32_decode(const std::vector<omega_byte_t> &input, bool crockford, std::vector<omega_byte_t> &out) {
+    bool base32_decode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                       bool crockford, std::vector<omega_byte_t> &out) {
         out.clear();
         uint32_t buffer = 0;
         int bits = 0;
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (is_ascii_space(byte) || byte == '=') { continue; }
             const int value = base32_value(byte, crockford);
             if (value < 0) { return false; }
@@ -192,12 +218,17 @@ namespace {
         return true;
     }
 
-    std::vector<omega_byte_t> base58_encode(const std::vector<omega_byte_t> &input) {
+    bool base58_encode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                       std::vector<omega_byte_t> &out) {
+        if (input.size() > TEXT_CODEC_BASE58_MAX_INPUT_BYTES) { return false; }
         static constexpr char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
         std::vector<omega_byte_t> digits(1, 0);
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             int carry = byte;
             for (auto &digit : digits) {
+                if (cancel_requested(request_ptr, work_count)) { return false; }
                 carry += digit << 8U;
                 digit = static_cast<omega_byte_t>(carry % 58);
                 carry /= 58;
@@ -207,8 +238,9 @@ namespace {
                 carry /= 58;
             }
         }
-        std::vector<omega_byte_t> out;
+        out.clear();
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (byte == 0) {
                 out.push_back('1');
             } else {
@@ -216,20 +248,26 @@ namespace {
             }
         }
         for (auto iter = digits.rbegin(); iter != digits.rend(); ++iter) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             out.push_back(static_cast<omega_byte_t>(alphabet[*iter]));
         }
-        return out;
+        return true;
     }
 
-    bool base58_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool base58_decode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                       std::vector<omega_byte_t> &out) {
+        if (input.size() > TEXT_CODEC_BASE58_MAX_INPUT_BYTES) { return false; }
         static constexpr char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
         std::vector<omega_byte_t> bytes(1, 0);
+        size_t work_count = 0;
         for (const auto ch : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (is_ascii_space(ch)) { continue; }
             const char *found = std::find(std::begin(alphabet), std::end(alphabet) - 1, ch);
             if (found == std::end(alphabet) - 1) { return false; }
             int carry = static_cast<int>(found - alphabet);
             for (auto &byte : bytes) {
+                if (cancel_requested(request_ptr, work_count)) { return false; }
                 carry += byte * 58;
                 byte = static_cast<omega_byte_t>(carry & 0xFF);
                 carry >>= 8U;
@@ -241,20 +279,27 @@ namespace {
         }
         out.clear();
         for (const auto ch : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (ch == '1') {
                 out.push_back(0);
             } else if (!is_ascii_space(ch)) {
                 break;
             }
         }
-        for (auto iter = bytes.rbegin(); iter != bytes.rend(); ++iter) { out.push_back(*iter); }
+        for (auto iter = bytes.rbegin(); iter != bytes.rend(); ++iter) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
+            out.push_back(*iter);
+        }
         return true;
     }
 
-    std::vector<omega_byte_t> percent_encode(const std::vector<omega_byte_t> &input) {
+    bool percent_encode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                        std::vector<omega_byte_t> &out) {
         static constexpr char alphabet[] = "0123456789ABCDEF";
-        std::vector<omega_byte_t> out;
+        out.clear();
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (is_ascii_alnum(byte) || byte == '-' || byte == '_' || byte == '.' || byte == '~') {
                 out.push_back(byte);
             } else {
@@ -263,12 +308,15 @@ namespace {
                 out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
             }
         }
-        return out;
+        return true;
     }
 
-    bool percent_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool percent_decode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                        std::vector<omega_byte_t> &out) {
         out.clear();
+        size_t work_count = 0;
         for (size_t i = 0; i < input.size(); ++i) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (input[i] != '%') {
                 out.push_back(input[i]);
                 continue;
@@ -282,10 +330,13 @@ namespace {
         return true;
     }
 
-    std::vector<omega_byte_t> quoted_printable_encode(const std::vector<omega_byte_t> &input) {
+    bool quoted_printable_encode(const omega_transform_plugin_request_t *request_ptr,
+                                 const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
         static constexpr char alphabet[] = "0123456789ABCDEF";
-        std::vector<omega_byte_t> out;
+        out.clear();
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if ((byte >= 33 && byte <= 60) || (byte >= 62 && byte <= 126) || byte == '\t' || byte == ' ') {
                 out.push_back(byte);
             } else {
@@ -294,12 +345,15 @@ namespace {
                 out.push_back(static_cast<omega_byte_t>(alphabet[byte & 0x0FU]));
             }
         }
-        return out;
+        return true;
     }
 
-    bool quoted_printable_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool quoted_printable_decode(const omega_transform_plugin_request_t *request_ptr,
+                                 const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
         out.clear();
+        size_t work_count = 0;
         for (size_t i = 0; i < input.size(); ++i) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (input[i] != '=') {
                 out.push_back(input[i]);
                 continue;
@@ -328,12 +382,16 @@ namespace {
         return -1;
     }
 
-    std::vector<omega_byte_t> uuencode(const std::vector<omega_byte_t> &input) {
-        std::vector<omega_byte_t> out;
+    bool uuencode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                  std::vector<omega_byte_t> &out) {
+        out.clear();
+        size_t work_count = 0;
         for (size_t line = 0; line < input.size(); line += 45) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             const size_t count = std::min<size_t>(45, input.size() - line);
             out.push_back(uu_char(static_cast<unsigned int>(count)));
             for (size_t i = 0; i < count; i += 3) {
+                if (cancel_requested(request_ptr, work_count)) { return false; }
                 const unsigned int a = input[line + i];
                 const unsigned int b = i + 1 < count ? input[line + i + 1] : 0;
                 const unsigned int c = i + 2 < count ? input[line + i + 2] : 0;
@@ -346,13 +404,16 @@ namespace {
         }
         out.push_back('`');
         out.push_back('\n');
-        return out;
+        return true;
     }
 
-    bool uudecode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool uudecode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                  std::vector<omega_byte_t> &out) {
         out.clear();
         size_t cursor = 0;
+        size_t work_count = 0;
         while (cursor < input.size()) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             while (cursor < input.size() && (input[cursor] == '\r' || input[cursor] == '\n')) { ++cursor; }
             if (cursor >= input.size()) { break; }
             const int count = uu_value(input[cursor++]);
@@ -360,6 +421,7 @@ namespace {
             if (count == 0) { return true; }
             int produced = 0;
             while (produced < count) {
+                if (cancel_requested(request_ptr, work_count)) { return false; }
                 if (cursor + 4 > input.size()) { return false; }
                 const int a = uu_value(input[cursor++]);
                 const int b = uu_value(input[cursor++]);
@@ -384,9 +446,12 @@ namespace {
         return true;
     }
 
-    std::vector<omega_byte_t> yenc_encode(const std::vector<omega_byte_t> &input) {
-        std::vector<omega_byte_t> out;
+    bool yenc_encode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                     std::vector<omega_byte_t> &out) {
+        out.clear();
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             omega_byte_t encoded = static_cast<omega_byte_t>(byte + 42U);
             if (encoded == 0 || encoded == '\n' || encoded == '\r' || encoded == '=') {
                 out.push_back('=');
@@ -394,12 +459,15 @@ namespace {
             }
             out.push_back(encoded);
         }
-        return out;
+        return true;
     }
 
-    bool yenc_decode(const std::vector<omega_byte_t> &input, std::vector<omega_byte_t> &out) {
+    bool yenc_decode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                     std::vector<omega_byte_t> &out) {
         out.clear();
+        size_t work_count = 0;
         for (size_t i = 0; i < input.size(); ++i) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             omega_byte_t byte = input[i];
             if (byte == '=') {
                 if (++i >= input.size()) { return false; }
@@ -410,11 +478,14 @@ namespace {
         return true;
     }
 
-    std::vector<omega_byte_t> ascii85_encode(const std::vector<omega_byte_t> &input, bool z85) {
+    bool ascii85_encode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                        bool z85, std::vector<omega_byte_t> &out) {
         static constexpr char z85_alphabet[] =
                 "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
-        std::vector<omega_byte_t> out;
+        out.clear();
+        size_t work_count = 0;
         for (size_t i = 0; i < input.size(); i += 4) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             const size_t count = std::min<size_t>(4, input.size() - i);
             uint32_t value = 0;
             for (size_t j = 0; j < 4; ++j) { value = (value << 8U) | (j < count ? input[i + j] : 0); }
@@ -432,7 +503,7 @@ namespace {
             out.insert(out.end(), encoded.begin(),
                        encoded.begin() + static_cast<std::array<omega_byte_t, 5>::difference_type>(emit));
         }
-        return out;
+        return true;
     }
 
     int ascii85_value(omega_byte_t byte, bool z85) {
@@ -445,11 +516,14 @@ namespace {
         return byte >= '!' && byte <= 'u' ? byte - '!' : -1;
     }
 
-    bool ascii85_decode(const std::vector<omega_byte_t> &input, bool z85, std::vector<omega_byte_t> &out) {
+    bool ascii85_decode(const omega_transform_plugin_request_t *request_ptr, const std::vector<omega_byte_t> &input,
+                        bool z85, std::vector<omega_byte_t> &out) {
         out.clear();
         std::array<int, 5> group{};
         int group_size = 0;
+        size_t work_count = 0;
         for (const auto byte : input) {
+            if (cancel_requested(request_ptr, work_count)) { return false; }
             if (is_ascii_space(byte)) { continue; }
             if (!z85 && byte == 'z') {
                 if (group_size != 0) { return false; }
@@ -492,7 +566,8 @@ extern "C" OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(ome
                       OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
     info_ptr->help =
             "Choose a text codec and encode or decode direction. Codecs include hex/base16, base64url, base32, "
-            "base32-crockford, ascii85/base85, z85, base58, percent/url, quoted-printable, uuencode, and yenc.";
+            "base32-crockford, ascii85/base85, z85, base58, percent/url, quoted-printable, uuencode, and yenc. "
+            "Base58 is limited to selections up to 64 KiB.";
     info_ptr->example = "{\"codec\":\"base32\",\"direction\":\"encode\"}";
     info_ptr->default_args = "{\"codec\":\"hex\",\"direction\":\"encode\"}";
     info_ptr->args_schema = TEXT_CODEC_ARGS_SCHEMA;
@@ -518,63 +593,64 @@ omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr
     bool ok = true;
     if (codec == "hex") {
         if (direction == "encode") {
-            output = hex_encode(input);
+            ok = hex_encode(request_ptr, input, output);
         } else {
-            ok = hex_decode(input, output);
+            ok = hex_decode(request_ptr, input, output);
         }
     } else if (codec == "base64url") {
         if (direction == "encode") {
-            output = base64url_encode(input);
+            ok = base64url_encode(request_ptr, input, output);
         } else {
-            ok = base64url_decode(input, output);
+            ok = base64url_decode(request_ptr, input, output);
         }
     } else if (codec == "base32" || codec == "base32-crockford") {
         const bool crockford = codec == "base32-crockford";
         if (direction == "encode") {
-            output = base32_encode(input, crockford);
+            ok = base32_encode(request_ptr, input, crockford, output);
         } else {
-            ok = base32_decode(input, crockford, output);
+            ok = base32_decode(request_ptr, input, crockford, output);
         }
     } else if (codec == "base58") {
         if (direction == "encode") {
-            output = base58_encode(input);
+            ok = base58_encode(request_ptr, input, output);
         } else {
-            ok = base58_decode(input, output);
+            ok = base58_decode(request_ptr, input, output);
         }
     } else if (codec == "percent") {
         if (direction == "encode") {
-            output = percent_encode(input);
+            ok = percent_encode(request_ptr, input, output);
         } else {
-            ok = percent_decode(input, output);
+            ok = percent_decode(request_ptr, input, output);
         }
     } else if (codec == "quoted-printable") {
         if (direction == "encode") {
-            output = quoted_printable_encode(input);
+            ok = quoted_printable_encode(request_ptr, input, output);
         } else {
-            ok = quoted_printable_decode(input, output);
+            ok = quoted_printable_decode(request_ptr, input, output);
         }
     } else if (codec == "uuencode") {
         if (direction == "encode") {
-            output = uuencode(input);
+            ok = uuencode(request_ptr, input, output);
         } else {
-            ok = uudecode(input, output);
+            ok = uudecode(request_ptr, input, output);
         }
     } else if (codec == "yenc") {
         if (direction == "encode") {
-            output = yenc_encode(input);
+            ok = yenc_encode(request_ptr, input, output);
         } else {
-            ok = yenc_decode(input, output);
+            ok = yenc_decode(request_ptr, input, output);
         }
     } else if (codec == "ascii85" || codec == "z85") {
         const bool z85 = codec == "z85";
         if (z85 && (input.size() % (direction == "encode" ? 4 : 5)) != 0) { return -1; }
         if (direction == "encode") {
-            output = ascii85_encode(input, z85);
+            ok = ascii85_encode(request_ptr, input, z85, output);
         } else {
-            ok = ascii85_decode(input, z85, output);
+            ok = ascii85_decode(request_ptr, input, z85, output);
         }
     } else {
         return -1;
     }
-    return ok ? omega_edit::plugin::set_replacement(request_ptr, response_ptr, output) : -1;
+    if (!ok || omega_transform_plugin_sdk_is_cancelled(request_ptr)) { return -1; }
+    return omega_edit::plugin::set_replacement(request_ptr, response_ptr, output);
 }

--- a/plugins/src/zlib.c
+++ b/plugins/src/zlib.c
@@ -13,7 +13,9 @@
  **********************************************************************************************************************/
 
 #include <ctype.h>
+#include <errno.h>
 #include <limits.h>
+#include <omega_edit/config.h>
 #include <omega_edit/transform_plugin_sdk.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -25,6 +27,7 @@ typedef enum omega_zlib_action_t { OMEGA_ZLIB_COMPRESS, OMEGA_ZLIB_DECOMPRESS } 
 typedef struct omega_zlib_options_t {
     omega_zlib_action_t action;
     int level;
+    int64_t max_output_bytes;
 } omega_zlib_options_t;
 
 static const char ZLIB_ARGS_SCHEMA[] =
@@ -32,8 +35,12 @@ static const char ZLIB_ARGS_SCHEMA[] =
         "\"description\":\"Compress or decompress zlib data.\",\"default\":\"compress\","
         "\"enum\":[\"compress\",\"decompress\"]},\"level\":{\"type\":\"integer\",\"title\":\"Compression level\","
         "\"description\":\"Used when compressing: -1 uses the zlib default; 0 stores without compression; "
-        "9 is smallest.\",\"default\":-1,\"minimum\":-1,\"maximum\":9}},"
+        "9 is smallest.\",\"default\":-1,\"minimum\":-1,\"maximum\":9},\"maxOutputBytes\":{\"type\":\"integer\","
+        "\"title\":\"Maximum decompressed bytes\",\"description\":\"Used when decompressing. Expansion above this "
+        "limit fails before allocating more output memory.\",\"default\":67108864,\"minimum\":1}},"
         "\"additionalProperties\":false}";
+
+static const int64_t ZLIB_DEFAULT_MAX_OUTPUT_BYTES = OMEGA_MEMORY_BUFFER_LIMIT;
 
 static int input_length_to_ulong(int64_t input_length, uLong *input_length_out) {
     if (!input_length_out || input_length < 0 || (uint64_t) input_length > ULONG_MAX) { return -1; }
@@ -89,10 +96,23 @@ static int zlib_parse_integer(const char **cursor, int *value_out) {
     return 0;
 }
 
+static int zlib_parse_positive_int64(const char **cursor, int64_t *value_out) {
+    if (!cursor || !*cursor || !value_out) { return -1; }
+    zlib_skip_ws(cursor);
+    errno = 0;
+    char *end_ptr = NULL;
+    const long long parsed = strtoll(*cursor, &end_ptr, 10);
+    if (end_ptr == *cursor || errno == ERANGE || parsed < 1 || (uint64_t) parsed > INT64_MAX) { return -1; }
+    *cursor = end_ptr;
+    *value_out = (int64_t) parsed;
+    return 0;
+}
+
 static int zlib_parse_options(const char *options_json, omega_zlib_options_t *options_out) {
     if (!options_out) { return -1; }
     options_out->action = OMEGA_ZLIB_COMPRESS;
     options_out->level = Z_DEFAULT_COMPRESSION;
+    options_out->max_output_bytes = ZLIB_DEFAULT_MAX_OUTPUT_BYTES;
     if (!options_json || !*options_json) { return 0; }
 
     const char *cursor = options_json;
@@ -122,6 +142,8 @@ static int zlib_parse_options(const char *options_json, omega_zlib_options_t *op
             }
         } else if (strcmp(key, "level") == 0) {
             if (zlib_parse_integer(&cursor, &options_out->level) != 0) { return -1; }
+        } else if (strcmp(key, "maxOutputBytes") == 0) {
+            if (zlib_parse_positive_int64(&cursor, &options_out->max_output_bytes) != 0) { return -1; }
         } else {
             return -1;
         }
@@ -139,15 +161,17 @@ static int zlib_parse_options(const char *options_json, omega_zlib_options_t *op
     return -1;
 }
 
-static int grow_buffer(omega_byte_t **buffer_ptr, size_t *capacity_ptr) {
-    if (!buffer_ptr || !capacity_ptr || *capacity_ptr > (SIZE_MAX / 2)) { return -1; }
+static int grow_buffer(omega_byte_t **buffer_ptr, size_t *capacity_ptr, size_t max_capacity) {
+    if (!buffer_ptr || !capacity_ptr || max_capacity == 0 || *capacity_ptr >= max_capacity) { return -1; }
 
     const size_t next_capacity = *capacity_ptr == 0 ? 1024 : *capacity_ptr * 2;
-    omega_byte_t *next_buffer = (omega_byte_t *) realloc(*buffer_ptr, next_capacity);
+    if (next_capacity < *capacity_ptr) { return -1; }
+    const size_t bounded_capacity = next_capacity > max_capacity ? max_capacity : next_capacity;
+    omega_byte_t *next_buffer = (omega_byte_t *) realloc(*buffer_ptr, bounded_capacity);
     if (!next_buffer) { return -1; }
 
     *buffer_ptr = next_buffer;
-    *capacity_ptr = next_capacity;
+    *capacity_ptr = bounded_capacity;
     return 0;
 }
 
@@ -176,8 +200,10 @@ static int zlib_compress(const omega_transform_plugin_request_t *request_ptr,
 }
 
 static int zlib_decompress(const omega_transform_plugin_request_t *request_ptr,
-                           omega_transform_plugin_response_t *response_ptr) {
+                           omega_transform_plugin_response_t *response_ptr, int64_t max_output_bytes) {
     if ((uint64_t) request_ptr->input_length > UINT_MAX) { return -1; }
+    if (max_output_bytes < 1 || (uint64_t) max_output_bytes > SIZE_MAX) { return -1; }
+    const size_t max_output_size = (size_t) max_output_bytes;
 
     z_stream stream;
     memset(&stream, 0, sizeof(stream));
@@ -192,7 +218,7 @@ static int zlib_decompress(const omega_transform_plugin_request_t *request_ptr,
 
     while (1) {
         if (omega_transform_plugin_sdk_is_cancelled(request_ptr)) { break; }
-        if (stream.total_out >= capacity && grow_buffer(&output, &capacity) != 0) { break; }
+        if (stream.total_out >= capacity && grow_buffer(&output, &capacity, max_output_size) != 0) { break; }
 
         const uLong previous_total_in = stream.total_in;
         const uLong previous_total_out = stream.total_out;
@@ -225,7 +251,8 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK |
                       OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
     info_ptr->help = "Choose compress or decompress. Compression level uses -1 for the zlib default, "
-                     "0 for no compression, 1 for fastest compression, or 9 for best compression.";
+                     "0 for no compression, 1 for fastest compression, or 9 for best compression. "
+                     "Decompression stops at maxOutputBytes, defaulting to 64 MiB.";
     info_ptr->example = "{\"action\":\"compress\",\"level\":9}";
     info_ptr->default_args = "{\"action\":\"compress\",\"level\":-1}";
     info_ptr->args_schema = ZLIB_ARGS_SCHEMA;
@@ -244,5 +271,5 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_trans
     omega_zlib_options_t options;
     if (zlib_parse_options(request_ptr->options_json, &options) != 0) { return -1; }
     return options.action == OMEGA_ZLIB_COMPRESS ? zlib_compress(request_ptr, response_ptr, options.level)
-                                                 : zlib_decompress(request_ptr, response_ptr);
+                                                 : zlib_decompress(request_ptr, response_ptr, options.max_output_bytes);
 }

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -216,7 +216,11 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                                   zlib_info->args_schema));
     REQUIRE(0 ==
             omega_transform_plugin_options_match_args_schema("{\"action\":\"decompress\"}", zlib_info->args_schema));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"action\":\"decompress\",\"maxOutputBytes\":1024}",
+                                                                  zlib_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"action\":\"compress\",\"level\":10}",
+                                                                   zlib_info->args_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"action\":\"decompress\",\"maxOutputBytes\":0}",
                                                                    zlib_info->args_schema));
     const auto cipher_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.openssl_ciphers");
     REQUIRE("OpenSSL Ciphers" == std::string(cipher_info->name));
@@ -759,6 +763,41 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(text_codec_session_ptr);
 
+    const auto oversized_base58_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(oversized_base58_session_ptr);
+    std::vector<omega_byte_t> oversized_base58_input((64 * 1024) + 1, 'x');
+    REQUIRE(0 < omega_edit_insert_bytes(oversized_base58_session_ptr, 0, oversized_base58_input.data(),
+                                        static_cast<int64_t>(oversized_base58_input.size())));
+    const auto oversized_base58_change_count = omega_session_get_num_changes(oversized_base58_session_ptr);
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(
+                          registry_ptr, "omega.example.text_codecs", oversized_base58_session_ptr, 0, 0,
+                          "{\"codec\":\"base58\",\"direction\":\"encode\"}", &response));
+    REQUIRE(oversized_base58_change_count == omega_session_get_num_changes(oversized_base58_session_ptr));
+    REQUIRE(static_cast<int64_t>(oversized_base58_input.size()) ==
+            omega_session_get_computed_file_size(oversized_base58_session_ptr));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(oversized_base58_session_ptr);
+
+    const auto cancellable_text_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(cancellable_text_session_ptr);
+    std::vector<omega_byte_t> cancellable_text_input(8192, 0xFF);
+    REQUIRE(0 < omega_edit_insert_bytes(cancellable_text_session_ptr, 0, cancellable_text_input.data(),
+                                        static_cast<int64_t>(cancellable_text_input.size())));
+    const auto cancellable_text_change_count = omega_session_get_num_changes(cancellable_text_session_ptr);
+    cancellation_state_t base58_cancel_state{0, 1};
+    int64_t base58_cancelled_serial = -1;
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session_with_progress_cancel_and_serial(
+                          registry_ptr, "omega.example.text_codecs", cancellable_text_session_ptr, 0, 0,
+                          "{\"codec\":\"base58\",\"direction\":\"encode\"}", nullptr, nullptr, cancel_after_callback,
+                          &base58_cancel_state, &response, &base58_cancelled_serial));
+    REQUIRE(base58_cancel_state.calls > base58_cancel_state.cancel_after);
+    REQUIRE(0 == base58_cancelled_serial);
+    REQUIRE(cancellable_text_change_count == omega_session_get_num_changes(cancellable_text_session_ptr));
+    REQUIRE(static_cast<int64_t>(cancellable_text_input.size()) ==
+            omega_session_get_computed_file_size(cancellable_text_session_ptr));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(cancellable_text_session_ptr);
+
     const auto charset_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(charset_session_ptr);
     REQUIRE(0 < omega_edit_insert_string(charset_session_ptr, 0, "ABC"));
@@ -823,6 +862,27 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                              omega_session_get_computed_file_size(decimal_session_ptr)));
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(decimal_session_ptr);
+
+    const auto cancellable_decimal_session_ptr =
+            omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(cancellable_decimal_session_ptr);
+    const std::string cancellable_decimal_input(8192, '7');
+    REQUIRE(0 < omega_edit_insert_string(cancellable_decimal_session_ptr, 0, cancellable_decimal_input.c_str()));
+    const auto cancellable_decimal_change_count = omega_session_get_num_changes(cancellable_decimal_session_ptr);
+    cancellation_state_t decimal_cancel_state{0, 1};
+    int64_t decimal_cancelled_serial = -1;
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session_with_progress_cancel_and_serial(
+                          registry_ptr, "omega.example.decimal_codecs", cancellable_decimal_session_ptr, 0, 0,
+                          "{\"codec\":\"packed-decimal\",\"direction\":\"encode\"}", nullptr, nullptr,
+                          cancel_after_callback, &decimal_cancel_state, &response, &decimal_cancelled_serial));
+    REQUIRE(decimal_cancel_state.calls > decimal_cancel_state.cancel_after);
+    REQUIRE(0 == decimal_cancelled_serial);
+    REQUIRE(cancellable_decimal_change_count == omega_session_get_num_changes(cancellable_decimal_session_ptr));
+    REQUIRE(cancellable_decimal_input ==
+            omega_session_get_segment_string(cancellable_decimal_session_ptr, 0,
+                                             omega_session_get_computed_file_size(cancellable_decimal_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(cancellable_decimal_session_ptr);
 
     const auto format_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(format_session_ptr);
@@ -892,6 +952,41 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                         omega_session_get_computed_file_size(codec_session_ptr)));
     REQUIRE(5 == response.replacement_length);
     omega_transform_plugin_response_clear(&response);
+
+    const auto zlib_bomb_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(zlib_bomb_session_ptr);
+    const std::string repeated_zlib_input(4096, 'A');
+    REQUIRE(0 < omega_edit_insert_bytes(zlib_bomb_session_ptr, 0,
+                                        reinterpret_cast<const omega_byte_t *>(repeated_zlib_input.data()),
+                                        static_cast<int64_t>(repeated_zlib_input.size())));
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib",
+                                                                  zlib_bomb_session_ptr, 0, 0,
+                                                                  "{\"action\":\"compress\",\"level\":9}", &response));
+    const auto compressed_zlib_bomb = omega_session_get_segment_string(
+            zlib_bomb_session_ptr, 0, omega_session_get_computed_file_size(zlib_bomb_session_ptr));
+    REQUIRE(compressed_zlib_bomb.size() < repeated_zlib_input.size());
+    omega_transform_plugin_response_clear(&response);
+
+    const auto zlib_cap_change_count = omega_session_get_num_changes(zlib_bomb_session_ptr);
+    REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(
+                          registry_ptr, "omega.example.zlib", zlib_bomb_session_ptr, 0, 0,
+                          "{\"action\":\"decompress\",\"maxOutputBytes\":1024}", &response));
+    REQUIRE(zlib_cap_change_count == omega_session_get_num_changes(zlib_bomb_session_ptr));
+    REQUIRE(compressed_zlib_bomb ==
+            omega_session_get_segment_string(zlib_bomb_session_ptr, 0,
+                                             omega_session_get_computed_file_size(zlib_bomb_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+
+    const std::string zlib_cap_options =
+            "{\"action\":\"decompress\",\"maxOutputBytes\":" + std::to_string(repeated_zlib_input.size()) + "}";
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib",
+                                                                  zlib_bomb_session_ptr, 0, 0, zlib_cap_options.c_str(),
+                                                                  &response));
+    REQUIRE(repeated_zlib_input ==
+            omega_session_get_segment_string(zlib_bomb_session_ptr, 0,
+                                             omega_session_get_computed_file_size(zlib_bomb_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(zlib_bomb_session_ptr);
 
     REQUIRE(0 <
             omega_edit_insert_string(codec_session_ptr, omega_session_get_computed_file_size(codec_session_ptr), "!"));

--- a/wiki/Transform-Plugins.md
+++ b/wiki/Transform-Plugins.md
@@ -344,8 +344,8 @@ The repository ships small examples in `plugins/src/`:
 | `omega.example.format_inspectors` | `format_inspectors.cpp` | Inspect | Protobuf varint, ASN.1 BER/DER TLV, and configurable TLV summaries. |
 | `omega.example.openssl_digests` | `openssl_digests.c` | Inspect | MD5, SHA-1, SHA-2, SHA-3, and BLAKE2 digest calculation using OpenSSL 3 without changing session content. |
 | `omega.example.record_text_helpers` | `record_text_helpers.cpp` | Replace | Newline normalization, fixed-width lines, delimiter escaping, CSV quoting, XML entities, and JSON string escaping. |
-| `omega.example.text_codecs` | `text_codecs.cpp` | Replace | Hex/base16, Base64URL, Base32, Base32-Crockford, Ascii85/Base85, Z85, Base58, percent/URL, quoted-printable, uuencode, and yEnc encode/decode helpers. |
-| `omega.example.zlib` | `zlib.c` | Replace | Zlib compression/decompression with an `action` option. Compression accepts `level` values from `-1` through `9`. |
+| `omega.example.text_codecs` | `text_codecs.cpp` | Replace | Hex/base16, Base64URL, Base32, Base32-Crockford, Ascii85/Base85, Z85, Base58, percent/URL, quoted-printable, uuencode, and yEnc encode/decode helpers. Base58 is capped at 64 KiB selections. |
+| `omega.example.zlib` | `zlib.c` | Replace | Zlib compression/decompression with an `action` option. Compression accepts `level` values from `-1` through `9`; decompression accepts `maxOutputBytes` with a 64 MiB default cap. |
 | `omega.example.repeat` | `repeat.c` | Replace | Expansion by replacing a range with two copies of itself. |
 
 These examples are intentionally small so they can serve as test fixtures and copyable


### PR DESCRIPTION
## Summary

This PR closes the plugin input-hardening shortcomings for zlib decompression and the C++ text/decimal codec plugins.

- Adds a configurable `maxOutputBytes` guard to zlib decompression, defaulting to 64 MiB.
- Adds cooperative cancellation polling to text and decimal codec loops.
- Caps the quadratic base58 text codec at 64 KiB selections and documents that limit.
- Adds regression coverage for zlib decompression caps, base58 oversized input, and text/decimal codec cancellation.
- Updates plugin docs and removes the fixed items from `SHORTCOMINGS.md`.

## Validation

- `cmake --preset ninja-debug-minimal`
- `cmake --build _build --target omega_transform_plugin_tests -j 2`
- `ctest --test-dir _build/plugins --output-on-failure` passed.
- `ctest --test-dir _build/core --output-on-failure -j 2` passed 126/127 tests; the remaining `File Copy` test fails consistently on this `/mnt/d` checkout because copied mode bits differ (`0x8180` vs `0x81ff`) and the test reports a missing file-time comparison target. This appears unrelated to the plugin changes and reproduced when run alone.