### PR TITLE
Bound replace matches and stream large replace-all

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -13,7 +13,11 @@ branch/PR and are not listed as open. The redo preservation bug across
 transform undo boundaries found by the brutal-testing harness is also fixed by
 the current core test branch/PR and is no longer listed as open. The zlib
 decompression cap and C++ codec cancellation/base58 guardrail items are also
-fixed and no longer listed as open.
+fixed and no longer listed as open. The profile/character-count scan buffer
+issue, search read-failure reporting issue, and unbounded `replace_matches`
+materialization issue are also fixed and no longer listed as open. The utility
+string-helper issue and the fixed failure-signaling edges for unknown CLI
+options and missing session files are likewise no longer listed as open.
 
 Recent core/server/plugin review findings have been folded into the priority
 list below rather than kept as a second appended review. A fresh core/server
@@ -38,8 +42,8 @@ Risk guide:
 
 1. **Critical deployment boundary**: add optional TLS/mTLS and an authorization
    hook before making any "hardened for production" attestation.
-2. **Massive-file pressure caps**: bound or stream `replace_matches`, and apply
-   a configurable segment-size cap to read/classification RPCs.
+2. **Massive-file pressure caps**: apply a configurable segment-size cap to
+   read/classification RPCs.
 3. **Undo performance batch**: implement the remaining low-risk undo pieces
    (transaction extents, redo batching, snapshot telemetry).
 4. **Streaming import**: pair existing streaming export with a streaming/chunked
@@ -141,31 +145,6 @@ Suggested fix:
 - Consider structural sharing or copy-on-write segment nodes so snapshots are
   cheap references instead of deep clones.
 - Surface basic metrics for snapshot count/bytes in tests or debug logs.
-
-### 5. `replace_matches` buffers every match in memory
-
-**Impact:** High for very large files and common patterns
-**Risk:** Medium
-**Area:** Core replace/search, C++ server replace RPC
-
-`omega_edit_replace_matches_bytes` accumulates all accepted match offsets in a
-vector, builds a full operation script, then applies one change record per
-operation. The default limit can be unlimited, so replacing a common pattern in a
-large file can consume memory proportional to match count. The streaming,
-checkpointed `omega_edit_replace_all_bytes` path avoids this shape.
-
-Relevant code:
-- `core/src/lib/edit.cpp:1886`
-- `core/src/lib/edit.cpp:1916`
-- `core/src/lib/edit.cpp:1941`
-- `core/src/lib/edit.cpp:1959`
-
-Suggested fix:
-- Add an internal match-count or operation-count ceiling for the current script
-  path.
-- Prefer a streaming/checkpointed implementation when the caller requests
-  unbounded replacement.
-- Add scale tests that assert bounded memory or a clear graceful failure.
 
 ### 7. Change-log import is still full-document JSON parsing
 
@@ -339,29 +318,6 @@ Suggested fix:
 - Add a test that runs a digest over a large session and asserts a concurrent
   viewport read completes promptly.
 
-### 15. Profile and character-count scans read in `BUFSIZ` chunks
-
-**Impact:** Medium (massive-file scan throughput, especially on Windows)
-**Risk:** Low
-**Area:** Core session statistics
-
-`omega_session_byte_frequency_profile` and `omega_session_character_counts`
-iterate the session in `BUFSIZ`-sized segments. `BUFSIZ` is 512 bytes on MSVC
-(8 KiB on glibc), so profiling a 10 GiB session on Windows performs ~20 million
-`populate_data_segment_` calls, each doing an `upper_bound` over the segment
-list plus a seek/read. The rest of the codebase uses a 64 KiB
-`OMEGA_IO_BUFFER_SIZE` for streaming.
-
-Relevant code:
-- `core/src/lib/session.cpp:385`
-- `core/src/lib/session.cpp:422`
-
-Suggested fix:
-- Use `OMEGA_IO_BUFFER_SIZE` (or a dedicated scan buffer constant) instead of
-  `BUFSIZ` for both scans.
-- Null-check the `omega_segment_create` result explicitly.
-- Add a benchmark or perf regression note for full-file profiling.
-
 ### 16. Temp files are created, closed, then reopened by path
 
 **Impact:** Medium (local symlink-swap hardening)
@@ -389,32 +345,6 @@ Suggested fix:
   fstat/st_ino comparison) before writing.
 - Document that checkpoint directories should not be world-writable shared
   directories.
-
-### 17. Search treats read failures as "no match"
-
-**Impact:** Medium (silently wrong results on I/O errors)
-**Risk:** Low
-**Area:** Core search, C++ server search RPC
-
-`omega_search_next_match` ignores the return value of
-`populate_data_segment_`; on a read failure the segment length is zero, the
-window loop ends, and the context reports "no more matches". A transient I/O
-error therefore looks identical to a legitimate miss. On the server side,
-`SearchSession` also returns `OK` with an empty match list when context
-creation fails (invalid offset/length/pattern), so callers cannot distinguish
-"no matches" from "search never ran".
-
-Relevant code:
-- `core/src/lib/search.cpp:221`
-- `server/cpp/src/editor_service.cpp:2025`
-
-Suggested fix:
-- Propagate populate failures out of `omega_search_next_match` (distinct error
-  return) and surface them as RPC errors.
-- Return `INVALID_ARGUMENT` from `SearchSession` when the search context cannot
-  be created.
-- Add a test with an out-of-range offset asserting an error rather than an
-  empty result.
 
 ### 18. C-string and byte edit APIs encode different zero-length semantics
 
@@ -619,31 +549,11 @@ Suggested fix:
   body.
 - Add a `with_locked_session(request_id, handler)` helper for the RPC prologue.
 
-### 28. Utility string helpers have minor robustness gaps
-
-**Impact:** Low
-**Risk:** Low
-**Area:** Core C utility helpers
-
-`omega_util_strndup` does not null-check `s` before `memcpy`, so a null source
-with a non-zero length would crash; current callers pass valid pointers.
-`omega_util_strncmp` compares with signed `char` subtraction, so its ordering
-result differs from `strcmp` for bytes `>= 0x80` (equality is unaffected).
-
-Relevant code:
-- `core/src/lib/utility.c:214`
-- `core/src/lib/utility.c:232`
-
-Suggested fix:
-- Guard `omega_util_strndup` against a null source.
-- Compare bytes as `unsigned char` in `omega_util_strncmp` if strcmp-compatible
-  ordering is expected.
-
 ### 29. Failure-signaling edges can mislead callers or operators
 
 **Impact:** Low to Medium
 **Risk:** Low
-**Area:** Core edit results, server startup/CLI
+**Area:** Core edit results, save durability signaling
 
 A collection of small signaling gaps, individually rare but relevant to a
 reliability attestation:
@@ -656,20 +566,11 @@ reliability attestation:
   *after* the atomic rename has already published the file, so a completed save
   is reported as a failure with no way to distinguish post-commit durability
   warnings from real failures (`core/src/lib/edit.cpp:2376`).
-- `main.cpp` silently ignores unknown CLI options, so a typo in a resource-cap
-  or security-relevant flag leaves defaults in effect without any warning
-  (`server/cpp/src/main.cpp:509`).
-- `CreateSession` maps "file does not exist" to `INTERNAL` rather than
-  `NOT_FOUND`/`INVALID_ARGUMENT` (`server/cpp/src/main.cpp` comment says this
-  matches previous behavior) (`server/cpp/src/editor_service.cpp:917`).
 
 Suggested fix:
 - Return a distinct negative error when the replace rollback itself fails, and
   a distinct post-commit code (or success-with-warning) for the directory-sync
   case.
-- Reject unknown CLI options (or at least log a warning listing them).
-- Use `NOT_FOUND` for missing session files, keeping the old message text if
-  compatibility matters.
 
 ### 30. Content detection feeds untrusted bytes to third-party parsers
 
@@ -691,6 +592,26 @@ Suggested fix:
 - Consider isolating or resource-limiting content detection for untrusted input.
 - Document the third-party parser exposure in the deployment trust boundary.
 
+### 31. Search navigation does not decorate viewport-neighbor matches
+
+**Impact:** Low to Medium
+**Risk:** Low
+**Area:** Client/server search UX, viewport match decoration
+
+Interactive search can walk to the next or previous match without knowing the
+global match count, but the navigation result does not yet include the other
+matches visible in the active viewport. That means a UI can focus the requested
+match but cannot cheaply decorate the surrounding viewport matches as part of
+the same navigation flow.
+
+Suggested fix:
+- Keep next/previous navigation anchor-based (`limit = 1`) in the requested
+  direction.
+- After locating the focused match, issue a bounded search over the active
+  viewport range with `limit + 1` so the UI can highlight visible sibling
+  matches and show overflow hints without claiming a global total.
+- Cover forward, reverse, and viewport-edge cases in client tests.
+
 ---
 
 ## Testing Gaps For Attestation
@@ -702,8 +623,6 @@ claiming production hardening:
   the current atomic/durable publishing coverage.
 - Remaining overflow paths: helper and edit-range tests exist, but add more
   near-`INT64_MAX` coverage through public APIs and server RPC boundaries.
-- `replace_matches` scale: assert bounded memory use or clear failure on huge
-  match counts.
 - Change-detail payload bounds: request details for a change larger than the
   inline payload limit and assert bounded memory/response behavior.
 - Same-session availability under long scans: run a slow operation (large
@@ -712,8 +631,6 @@ claiming production hardening:
   more aggressively.
 - gRPC message-size boundaries: submit changes just under/over the effective
   transport and `max_change_bytes` limits and assert the intended error paths.
-- Search error paths: assert I/O failures and invalid ranges surface as errors,
-  not empty match lists.
 - Transform/mutation concurrency: add real-thread coverage for
   `try_begin_transform` returning `MUTATION_IN_PROGRESS` and for transform vs.
   mutation mutual exclusion.

--- a/core/src/examples/replace.cpp
+++ b/core/src/examples/replace.cpp
@@ -42,7 +42,7 @@ int main(int arc, char **argv) {
     auto match_context_ptr = omega_scoped_ptr<omega_search_context_t>(
             omega_search_create_context_string(session_ptr.get(), argv[3]), omega_search_destroy_context);
     const auto pattern_length = omega_search_context_get_pattern_length(match_context_ptr.get());
-    if (0 != omega_search_next_match(match_context_ptr.get(), 1)) {
+    if (omega_search_next_match(match_context_ptr.get(), 1) > 0) {
         const auto replacement_length = static_cast<int64_t>(replacement.length());
         do {
             const auto pattern_offset = omega_search_context_get_match_offset(match_context_ptr.get());
@@ -67,8 +67,8 @@ int main(int arc, char **argv) {
                 }
             }
             ++replacements;
-        } while (0 != omega_search_next_match(match_context_ptr.get(),
-                                              replacement_length));//advance find by the replacement length
+        } while (omega_search_next_match(match_context_ptr.get(), replacement_length) >
+                 0);//advance find by the replacement length
     }
     if (0 != omega_edit_save(session_ptr.get(), argv[2], omega_io_flags_t::IO_FLG_NONE, nullptr)) {
         cerr << "Error saving session to " << argv[2] << endl;

--- a/core/src/examples/search.cpp
+++ b/core/src/examples/search.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
         int num_matches = 0;
         auto search_context = omega_search_create_context(session_ptr, pattern, 0, start_offset, length,
                                                           case_insensitive, reverse_search);
-        while (omega_search_next_match(search_context, 1)) {
+        while (omega_search_next_match(search_context, 1) > 0) {
             const auto match_offset = omega_search_context_get_match_offset(search_context);
             const auto match_length = omega_search_context_get_pattern_length(search_context);
             cout << "offset: " << match_offset << ", length: " << match_length

--- a/core/src/include/omega_edit/config.h
+++ b/core/src/include/omega_edit/config.h
@@ -63,6 +63,11 @@
 #define OMEGA_MEMORY_BUFFER_LIMIT (64LL * 1024LL * 1024LL)
 #endif//OMEGA_MEMORY_BUFFER_LIMIT
 
+#ifndef OMEGA_REPLACE_MATCHES_LIMIT
+/** Maximum selected matches that transactional replace-matches may materialize into one in-memory script. */
+#define OMEGA_REPLACE_MATCHES_LIMIT 1000000LL
+#endif//OMEGA_REPLACE_MATCHES_LIMIT
+
 #ifndef OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT
 /** Maximum primitive payload byte range stored inline before using file-backed storage. */
 #define OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT OMEGA_MEMORY_BUFFER_LIMIT

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -402,7 +402,9 @@ int64_t omega_edit_replace(omega_session_t *session_ptr, int64_t offset, int64_t
  * @param is_reverse zero to search forward and non-zero to search backward before applying replacements
  * @param offset starting byte offset of the replace range
  * @param length number of bytes in the replace range, or zero to search from `offset` to end of session
- * @param limit maximum number of matches to replace, or zero for no limit
+ * @param limit maximum number of matches to replace, or zero for no caller-specified limit. The transactional
+ * replace path still refuses to materialize more than OMEGA_REPLACE_MATCHES_LIMIT selected matches, further bounded by
+ * OMEGA_MEMORY_BUFFER_LIMIT; use omega_edit_replace_all_bytes for streamed large replace-all work.
  * @param front_to_back non-zero to apply replacements from low offsets to high offsets, zero for high-to-low
  * @param overwrite_only non-zero to overwrite replacement bytes in place instead of replacing the full matched span
  * @param replacement_count_out optional out-parameter that receives the number of matches selected for replacement
@@ -428,7 +430,9 @@ int omega_edit_replace_matches_bytes(omega_session_t *session_ptr, const omega_b
  * @param is_reverse zero to search forward and non-zero to search backward before applying replacements
  * @param offset starting byte offset of the replace range
  * @param length number of bytes in the replace range, or zero to search from `offset` to end of session
- * @param limit maximum number of matches to replace, or zero for no limit
+ * @param limit maximum number of matches to replace, or zero for no caller-specified limit. The transactional
+ * replace path still refuses to materialize more than OMEGA_REPLACE_MATCHES_LIMIT selected matches, further bounded by
+ * OMEGA_MEMORY_BUFFER_LIMIT; use omega_edit_replace_all for streamed large replace-all work.
  * @param front_to_back non-zero to apply replacements from low offsets to high offsets, zero for high-to-low
  * @param overwrite_only non-zero to overwrite replacement bytes in place instead of replacing the full matched span
  * @param replacement_count_out optional out-parameter that receives the number of matches selected for replacement
@@ -473,6 +477,31 @@ int omega_edit_replace_matches(omega_session_t *session_ptr, const char *pattern
 int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_t *pattern, int64_t pattern_length,
                                  const omega_byte_t *replacement, int64_t replacement_length, int case_insensitive,
                                  int64_t offset, int64_t length, int64_t *replacement_count_out);
+
+/**
+ * Replace all non-overlapping matches of a byte pattern using a streamed checkpoint rewrite and explicit search
+ * direction.
+ *
+ * Forward replacement selects matches greedily from low offsets to high offsets. Reverse replacement selects matches
+ * greedily from high offsets to low offsets, preserving reverse-search overlap semantics without materializing every
+ * match offset.
+ *
+ * @param session_ptr session to edit
+ * @param pattern pattern bytes to search for
+ * @param pattern_length explicit number of bytes in pattern
+ * @param replacement replacement bytes, or null if `replacement_length` is zero
+ * @param replacement_length explicit number of bytes in replacement
+ * @param case_insensitive zero for case-sensitive matching and non-zero for case-insensitive matching
+ * @param is_reverse zero to select matches forward and non-zero to select matches backward
+ * @param offset starting byte offset of the replace range
+ * @param length number of bytes in the replace range, or zero to search from `offset` to end of session
+ * @param replacement_count_out optional out-parameter that receives the number of replacements performed
+ * @return zero on success and non-zero otherwise
+ */
+int omega_edit_replace_all_bytes_directional(omega_session_t *session_ptr, const omega_byte_t *pattern,
+                                             int64_t pattern_length, const omega_byte_t *replacement,
+                                             int64_t replacement_length, int case_insensitive, int is_reverse,
+                                             int64_t offset, int64_t length, int64_t *replacement_count_out);
 
 /**
  * Replace all non-overlapping matches of a C-string pattern within a session range using a streamed checkpoint rewrite.

--- a/core/src/include/omega_edit/search.h
+++ b/core/src/include/omega_edit/search.h
@@ -116,7 +116,7 @@ int64_t omega_search_context_get_pattern_length(const omega_search_context_t *se
  * Given a search context, find the next match
  * @param search_context_ptr search context to find the next match in
  * @param advance_context advance the internal search context offset by this many bytes
- * @return non-zero if a match is found, zero otherwise
+ * @return positive if a match is found, zero if no match remains, negative on search failure
  */
 int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t advance_context);
 

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -91,8 +91,24 @@ using omega_edit::internal::valid_nonnegative_range_;
 namespace {
     constexpr int64_t OMEGA_IO_BUFFER_SIZE = 65536;
     constexpr int OMEGA_OUTPUT_PATH_SUFFIX_ATTEMPTS = 1000000;
+    constexpr int64_t OMEGA_REPLACE_MATCH_SCRIPT_OPS_PER_MATCH = 1;
+    constexpr int64_t OMEGA_REPLACE_MATCH_SCRIPT_MATCH_LIMIT =
+            (std::min)(static_cast<int64_t>(OMEGA_REPLACE_MATCHES_LIMIT),
+                       static_cast<int64_t>(OMEGA_MEMORY_BUFFER_LIMIT /
+                                            (sizeof(int64_t) + (sizeof(omega_edit_script_op_t) *
+                                                                OMEGA_REPLACE_MATCH_SCRIPT_OPS_PER_MATCH))));
 
     auto initialize_model_segments_(omega_model_segments_t &model_segments, int64_t length) -> bool;
+    auto create_checkpoint_file_(omega_session_t *session_ptr, char *checkpoint_filename,
+                                 size_t checkpoint_filename_size) -> int;
+    auto promote_checkpoint_file_(omega_session_t *session_ptr, const char *checkpoint_filename, int64_t file_size,
+                                  bool notify_transform,
+                                  const const_omega_change_ptr_t &transform_change_ptr) -> int64_t;
+    auto initialize_session_stream_cursor_(const omega_session_t *session_ptr, int64_t offset,
+                                           session_stream_cursor_t &cursor) -> bool;
+    auto stream_session_range_(session_stream_cursor_t &cursor, int64_t end_offset, FILE *to_file_ptr,
+                               omega_byte_t *io_buf) -> int64_t;
+    auto write_bytes_to_file_(FILE *file_ptr, const omega_byte_t *bytes, int64_t length) -> int64_t;
 
     auto flush_file_to_disk_(FILE *file_ptr) -> bool {
         if (!file_ptr) { return false; }
@@ -531,6 +547,216 @@ namespace {
         ops.push_back(op);
         ++stats.deletes;
         ++stats.inserts;
+    }
+
+    auto match_overlaps_prior_(bool is_reverse, bool has_prior, int64_t match_offset, int64_t pattern_length,
+                               int64_t last_accepted_offset, bool &ok) -> bool {
+        ok = true;
+        if (!has_prior) { return false; }
+        int64_t match_end = 0;
+        int64_t last_accepted_end = 0;
+        if (!safe_add_int64_(match_offset, pattern_length, match_end) ||
+            !safe_add_int64_(last_accepted_offset, pattern_length, last_accepted_end)) {
+            ok = false;
+            return false;
+        }
+        return is_reverse ? (match_end > last_accepted_offset) : (match_offset < last_accepted_end);
+    }
+
+    auto compute_single_replace_match_stats_(const omega_byte_t *pattern, int64_t pattern_length,
+                                             const omega_byte_t *replacement,
+                                             int64_t replacement_length) -> replace_match_stats_t {
+        replace_match_stats_t stats;
+        std::vector<omega_edit_script_op_t> sample_ops;
+        sample_ops.reserve(1);
+        append_optimized_replace_ops_(sample_ops, stats, 0, pattern, pattern_length, replacement, replacement_length,
+                                      false);
+        return stats;
+    }
+
+    auto scale_replace_stats_(const replace_match_stats_t &stats, int64_t replacement_count,
+                              replace_match_stats_t &scaled_stats) -> bool {
+        if (replacement_count < 0) { return false; }
+        scaled_stats = {};
+        scaled_stats.replacements = replacement_count;
+        scaled_stats.deletes = stats.deletes > 0 ? replacement_count : 0;
+        scaled_stats.inserts = stats.inserts > 0 ? replacement_count : 0;
+        scaled_stats.overwrites = stats.overwrites > 0 ? replacement_count : 0;
+        return true;
+    }
+
+    auto safe_multiply_nonnegative_int64_(int64_t lhs, int64_t rhs, int64_t &result) -> bool {
+        if (lhs < 0) { return false; }
+        if (lhs == 0 || rhs == 0) {
+            result = 0;
+            return true;
+        }
+        if (rhs > 0) {
+            if (lhs > (std::numeric_limits<int64_t>::max)() / rhs) { return false; }
+        } else {
+            if (rhs == (std::numeric_limits<int64_t>::min)()) { return false; }
+            const auto abs_rhs = -rhs;
+            if (lhs > (std::numeric_limits<int64_t>::max)() / abs_rhs) { return false; }
+        }
+        result = lhs * rhs;
+        return true;
+    }
+
+    auto count_non_overlapping_matches_(omega_session_t *session_ptr, const omega_byte_t *pattern,
+                                        int64_t pattern_length, int64_t offset, int64_t length, int case_insensitive,
+                                        int is_reverse, int64_t &match_count) -> int {
+        match_count = 0;
+        scoped_search_context_t search_context(omega_search_create_context_bytes(
+                session_ptr, pattern, pattern_length, offset, length, case_insensitive, is_reverse));
+        if (!search_context.get()) { return -1; }
+
+        int64_t last_accepted_offset = -1;
+        auto has_accepted_match = false;
+        auto search_result = 0;
+        while ((search_result = omega_search_next_match(search_context.get(), 1)) > 0) {
+            const auto match_offset = omega_search_context_get_match_offset(search_context.get());
+            auto overlap_check_ok = true;
+            const auto overlaps_prior = match_overlaps_prior_(is_reverse != 0, has_accepted_match, match_offset,
+                                                              pattern_length, last_accepted_offset, overlap_check_ok);
+            if (!overlap_check_ok) { return -1; }
+            if (overlaps_prior) { continue; }
+            if (!safe_add_int64_(match_count, 1, match_count)) { return -1; }
+            last_accepted_offset = match_offset;
+            has_accepted_match = true;
+        }
+        return search_result < 0 ? -1 : 0;
+    }
+
+    auto write_session_range_to_file_at_(const omega_session_t *session_ptr, int64_t start_offset, int64_t end_offset,
+                                         FILE *to_file_ptr, omega_byte_t *io_buf, int64_t output_offset) -> bool {
+        if (!session_ptr || !to_file_ptr || !io_buf || start_offset < 0 || end_offset < start_offset ||
+            output_offset < 0) {
+            return false;
+        }
+        if (start_offset == end_offset) { return true; }
+        if (0 != FSEEK(to_file_ptr, output_offset, SEEK_SET)) { return false; }
+        session_stream_cursor_t cursor;
+        if (!initialize_session_stream_cursor_(session_ptr, start_offset, cursor)) { return false; }
+        return stream_session_range_(cursor, end_offset, to_file_ptr, io_buf) == (end_offset - start_offset);
+    }
+
+    auto write_bytes_to_file_at_(FILE *to_file_ptr, int64_t output_offset, const omega_byte_t *bytes,
+                                 int64_t length) -> bool {
+        if (!to_file_ptr || output_offset < 0 || length < 0 || (!bytes && length > 0)) { return false; }
+        if (length == 0) { return true; }
+        if (0 != FSEEK(to_file_ptr, output_offset, SEEK_SET)) { return false; }
+        return write_bytes_to_file_(to_file_ptr, bytes, length) == length;
+    }
+
+    auto replace_all_bytes_reverse_checkpointed_(omega_session_t *session_ptr, const omega_byte_t *pattern,
+                                                 int64_t pattern_length, const omega_byte_t *replacement,
+                                                 int64_t replacement_length, int case_insensitive, int64_t offset,
+                                                 int64_t length, int64_t *replacement_count_out) -> int {
+        if (replacement_count_out != nullptr) { *replacement_count_out = 0; }
+        if (!session_ptr || !pattern || pattern_length <= 0 || offset < 0 || length < 0 || replacement_length < 0) {
+            return -1;
+        }
+        if (!replacement && replacement_length > 0) { return -1; }
+        if (omega_session_changes_paused(session_ptr) != 0) { return -1; }
+
+        const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+        if (computed_file_size < 0 || offset > computed_file_size) { return -1; }
+        const auto adjusted_length =
+                length <= 0 ? computed_file_size - offset : std::min(length, computed_file_size - offset);
+        if (adjusted_length < 0) { return -1; }
+        if (pattern_length > adjusted_length) { return 0; }
+
+        int64_t replacement_count = 0;
+        if (0 != count_non_overlapping_matches_(session_ptr, pattern, pattern_length, offset, adjusted_length,
+                                                case_insensitive, 1, replacement_count)) {
+            return -1;
+        }
+        if (replacement_count == 0) { return 0; }
+
+        const auto replacement_delta = replacement_length - pattern_length;
+        int64_t total_delta = 0;
+        int64_t checkpoint_file_size = 0;
+        if (!safe_multiply_nonnegative_int64_(replacement_count, replacement_delta, total_delta) ||
+            !safe_add_int64_(computed_file_size, total_delta, checkpoint_file_size) || checkpoint_file_size < 0) {
+            return -1;
+        }
+
+        std::unique_ptr<omega_byte_t[]> io_buf;
+        try {
+            io_buf = std::make_unique<omega_byte_t[]>(OMEGA_IO_BUFFER_SIZE);
+        } catch (const std::bad_alloc &) { return -1; }
+
+        char checkpoint_filename[FILENAME_MAX + 1];
+        if (0 != create_checkpoint_file_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename))) { return -1; }
+
+        auto *checkpoint_fptr = FOPEN(checkpoint_filename, "wb");
+        if (checkpoint_fptr == nullptr) {
+            omega_util_remove_file(checkpoint_filename);
+            return -1;
+        }
+
+        auto rc = 0;
+        scoped_search_context_t search_context(omega_search_create_context_bytes(
+                session_ptr, pattern, pattern_length, offset, adjusted_length, case_insensitive, 1));
+        if (!search_context.get()) { rc = -1; }
+
+        int64_t input_cursor_end = computed_file_size;
+        int64_t output_cursor_end = checkpoint_file_size;
+        int64_t last_accepted_offset = -1;
+        auto has_accepted_match = false;
+        auto search_result = 0;
+        while (rc == 0 && (search_result = omega_search_next_match(search_context.get(), 1)) > 0) {
+            const auto match_offset = omega_search_context_get_match_offset(search_context.get());
+            auto overlap_check_ok = true;
+            const auto overlaps_prior = match_overlaps_prior_(true, has_accepted_match, match_offset, pattern_length,
+                                                              last_accepted_offset, overlap_check_ok);
+            if (!overlap_check_ok) {
+                rc = -1;
+                break;
+            }
+            if (overlaps_prior) { continue; }
+
+            int64_t match_end = 0;
+            if (!safe_add_int64_(match_offset, pattern_length, match_end) || match_end > input_cursor_end) {
+                rc = -1;
+                break;
+            }
+
+            const auto bytes_after_match = input_cursor_end - match_end;
+            if (!safe_add_int64_(output_cursor_end, -bytes_after_match, output_cursor_end) ||
+                !write_session_range_to_file_at_(session_ptr, match_end, input_cursor_end, checkpoint_fptr,
+                                                 io_buf.get(), output_cursor_end) ||
+                !safe_add_int64_(output_cursor_end, -replacement_length, output_cursor_end) ||
+                !write_bytes_to_file_at_(checkpoint_fptr, output_cursor_end, replacement, replacement_length)) {
+                rc = -1;
+                break;
+            }
+
+            input_cursor_end = match_offset;
+            last_accepted_offset = match_offset;
+            has_accepted_match = true;
+        }
+        if (search_result < 0) { rc = -1; }
+
+        if (rc == 0) {
+            if (!safe_add_int64_(output_cursor_end, -input_cursor_end, output_cursor_end) || output_cursor_end != 0 ||
+                !write_session_range_to_file_at_(session_ptr, 0, input_cursor_end, checkpoint_fptr, io_buf.get(), 0)) {
+                rc = -1;
+            }
+        }
+
+        search_context.reset();
+        FCLOSE(checkpoint_fptr);
+
+        if (rc != 0 || omega_util_file_size(checkpoint_filename) != checkpoint_file_size) {
+            omega_util_remove_file(checkpoint_filename);
+            return -1;
+        }
+        if (0 != promote_checkpoint_file_(session_ptr, checkpoint_filename, checkpoint_file_size, true, nullptr)) {
+            return -1;
+        }
+        if (replacement_count_out != nullptr) { *replacement_count_out = replacement_count; }
+        return 0;
     }
 
     inline void update_viewport_offset_adjustment_(omega_viewport_t *viewport_ptr, const omega_change_t *change_ptr) {
@@ -1871,7 +2097,7 @@ int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, i
 
 int omega_edit_replace_bytes_checkpointed(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
                                           const omega_byte_t *bytes, int64_t insert_length) {
-    return replace_bytes_checkpointed_(session_ptr, offset, delete_length, bytes, insert_length);
+    return replace_bytes_checkpointed_(session_ptr, offset, delete_length, bytes, insert_length) < 0 ? -1 : 0;
 }
 
 int64_t omega_edit_replace_bytes_as_transform(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
@@ -1921,22 +2147,64 @@ int omega_edit_replace_matches_bytes(omega_session_t *session_ptr, const omega_b
     if (!search_context.get()) { return -1; }
 
     try {
+        if (OMEGA_REPLACE_MATCH_SCRIPT_MATCH_LIMIT <= 0) { return -1; }
+
+        const auto collect_limit = (limit > 0) ? (std::min)(limit, OMEGA_REPLACE_MATCH_SCRIPT_MATCH_LIMIT)
+                                               : OMEGA_REPLACE_MATCH_SCRIPT_MATCH_LIMIT;
         std::vector<int64_t> match_offsets;
         int64_t last_accepted_offset = -1;
-        while ((limit <= 0 || static_cast<int64_t>(match_offsets.size()) < limit) &&
-               omega_search_next_match(search_context.get(), 1) > 0) {
+        auto search_result = 0;
+        while (static_cast<int64_t>(match_offsets.size()) < collect_limit &&
+               (search_result = omega_search_next_match(search_context.get(), 1)) > 0) {
             const auto match_offset = omega_search_context_get_match_offset(search_context.get());
-            int64_t match_end = 0;
-            int64_t last_accepted_end = 0;
-            if (!safe_add_int64_(match_offset, pattern_length, match_end) ||
-                (!match_offsets.empty() && !safe_add_int64_(last_accepted_offset, pattern_length, last_accepted_end))) {
-                return -1;
-            }
-            const bool overlaps_prior = !match_offsets.empty() && (is_reverse ? (match_end > last_accepted_offset)
-                                                                              : (match_offset < last_accepted_end));
+            auto overlap_check_ok = true;
+            const auto overlaps_prior = match_overlaps_prior_(is_reverse != 0, !match_offsets.empty(), match_offset,
+                                                              pattern_length, last_accepted_offset, overlap_check_ok);
+            if (!overlap_check_ok) { return -1; }
             if (overlaps_prior) { continue; }
             match_offsets.push_back(match_offset);
             last_accepted_offset = match_offset;
+        }
+        if (search_result < 0) { return -1; }
+        if ((limit <= 0 || static_cast<int64_t>(match_offsets.size()) < limit) &&
+            static_cast<int64_t>(match_offsets.size()) >= OMEGA_REPLACE_MATCH_SCRIPT_MATCH_LIMIT) {
+            while ((search_result = omega_search_next_match(search_context.get(), 1)) > 0) {
+                const auto match_offset = omega_search_context_get_match_offset(search_context.get());
+                auto overlap_check_ok = true;
+                const auto overlaps_prior =
+                        match_overlaps_prior_(is_reverse != 0, !match_offsets.empty(), match_offset, pattern_length,
+                                              last_accepted_offset, overlap_check_ok);
+                if (!overlap_check_ok) { return -1; }
+                if (!overlaps_prior) {
+                    const auto can_stream_replace_all = limit <= 0 && overwrite_only == 0;
+                    if (!can_stream_replace_all) { return -1; }
+
+                    search_context.reset();
+                    int64_t streamed_replacement_count = 0;
+                    const auto rc =
+                            is_reverse != 0
+                                    ? replace_all_bytes_reverse_checkpointed_(
+                                              session_ptr, pattern, pattern_length, replacement, replacement_length,
+                                              case_insensitive, offset, length, &streamed_replacement_count)
+                                    : omega_edit_replace_all_bytes(session_ptr, pattern, pattern_length, replacement,
+                                                                   replacement_length, case_insensitive, offset, length,
+                                                                   &streamed_replacement_count);
+                    if (rc != 0) { return -1; }
+
+                    const auto single_match_stats = compute_single_replace_match_stats_(
+                            pattern, pattern_length, replacement, replacement_length);
+                    replace_match_stats_t streamed_stats;
+                    if (!scale_replace_stats_(single_match_stats, streamed_replacement_count, streamed_stats)) {
+                        return -1;
+                    }
+                    if (replacement_count_out != nullptr) { *replacement_count_out = streamed_stats.replacements; }
+                    if (delete_count_out != nullptr) { *delete_count_out = streamed_stats.deletes; }
+                    if (insert_count_out != nullptr) { *insert_count_out = streamed_stats.inserts; }
+                    if (overwrite_count_out != nullptr) { *overwrite_count_out = streamed_stats.overwrites; }
+                    return 0;
+                }
+            }
+            if (search_result < 0) { return -1; }
         }
         search_context.reset();
 
@@ -2019,7 +2287,12 @@ int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_
                                                                    adjusted_length, case_insensitive, 0);
     if (!search_context) { return -1; }
 
-    if (omega_search_next_match(search_context, pattern_length) == 0) {
+    auto search_result = omega_search_next_match(search_context, pattern_length);
+    if (search_result < 0) {
+        omega_search_destroy_context(search_context);
+        return -1;
+    }
+    if (search_result == 0) {
         omega_search_destroy_context(search_context);
         return 0;
     }
@@ -2092,8 +2365,10 @@ int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_
                 break;
             }
             ++replacement_count;
-        } while (omega_search_next_match(search_context, pattern_length) > 0);
+            search_result = omega_search_next_match(search_context, pattern_length);
+        } while (search_result > 0);
 
+        if (search_result < 0) { rc = -1; }
         if (rc != 0) { break; }
 
         const auto remaining_replace_range = replace_end - cursor.offset;
@@ -2125,6 +2400,18 @@ int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_
     if (0 != promote_checkpoint_file_(session_ptr, checkpoint_filename, checkpoint_file_size, true)) { return -1; }
     if (replacement_count_out != nullptr) { *replacement_count_out = replacement_count; }
     return 0;
+}
+
+int omega_edit_replace_all_bytes_directional(omega_session_t *session_ptr, const omega_byte_t *pattern,
+                                             int64_t pattern_length, const omega_byte_t *replacement,
+                                             int64_t replacement_length, int case_insensitive, int is_reverse,
+                                             int64_t offset, int64_t length, int64_t *replacement_count_out) {
+    return is_reverse != 0
+                   ? replace_all_bytes_reverse_checkpointed_(session_ptr, pattern, pattern_length, replacement,
+                                                             replacement_length, case_insensitive, offset, length,
+                                                             replacement_count_out)
+                   : omega_edit_replace_all_bytes(session_ptr, pattern, pattern_length, replacement, replacement_length,
+                                                  case_insensitive, offset, length, replacement_count_out);
 }
 
 int omega_edit_replace_all(omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,

--- a/core/src/lib/search.cpp
+++ b/core/src/lib/search.cpp
@@ -137,7 +137,7 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
     // Calculate the last offset in the session. If we have no match, then this will be the match offset.
     int64_t last_offset = 0;
     if (!safe_add_int64_(search_context_ptr->session_offset, search_context_ptr->session_length, last_offset)) {
-        return 0;
+        return -1;
     }
 
     // Check if we are going to begin the search at the session offset.
@@ -182,7 +182,7 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
                 omega_data_create_(&scratch_buffer, data_segment.capacity);
                 omega_data_destroy_(&search_context_ptr->scratch_buffer, search_context_ptr->scratch_capacity);
                 search_context_ptr->scratch_buffer = std::move(scratch_buffer);
-            } catch (const std::bad_alloc &) { return 0; }
+            } catch (const std::bad_alloc &) { return -1; }
             search_context_ptr->scratch_capacity = data_segment.capacity;
         }
         omega_data_borrow_(
@@ -195,7 +195,7 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
         if (is_reverse) {
             int64_t session_end = 0;
             if (!safe_add_int64_(search_context_ptr->session_offset, search_context_ptr->session_length, session_end)) {
-                return 0;
+                return -1;
             }
             if (is_begin) {
                 data_segment.offset = session_end - data_segment.capacity;
@@ -204,13 +204,13 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
                 if (!safe_add_int64_(data_segment.capacity, advance_context, rewind) ||
                     !safe_add_int64_(search_context_ptr->match_offset, -rewind, data_segment.offset) ||
                     !safe_add_int64_(data_segment.offset, 1, data_segment.offset)) {
-                    return 0;
+                    return -1;
                 }
             }
         } else {
             int64_t next_offset = 0;
             if (!is_begin && !safe_add_int64_(search_context_ptr->match_offset, advance_context, next_offset)) {
-                return 0;
+                return -1;
             }
             data_segment.offset = is_begin ? search_context_ptr->session_offset : next_offset;
         }
@@ -218,7 +218,7 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
         // Loop until a match is found, or we have searched the entire segment.
         do {
             // Populate the data segment to be searched.
-            populate_data_segment_(search_context_ptr->session_ptr, &data_segment);
+            if (populate_data_segment_(search_context_ptr->session_ptr, &data_segment) != 0) { return -1; }
 
             // Get a pointer to the segment data.
             auto *segment_data_ptr = omega_segment_get_data(&data_segment);
@@ -234,7 +234,9 @@ int omega_search_next_match(omega_search_context_t *search_context_ptr, int64_t 
                                          pattern, search_context_ptr->pattern_length)) {
                 // If a match is found, update the match offset in the search context.
                 const auto found_offset = static_cast<int64_t>(found - segment_data_ptr);
-                if (!safe_add_int64_(data_segment.offset, found_offset, search_context_ptr->match_offset)) { return 0; }
+                if (!safe_add_int64_(data_segment.offset, found_offset, search_context_ptr->match_offset)) {
+                    return -1;
+                }
                 return 1;
             }
 

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -36,6 +36,10 @@ using omega_edit::internal::omega_session_end_event_batch_;
 using omega_edit::internal::populate_data_segment_;
 using omega_edit::internal::safe_add_int64_;
 
+namespace {
+    constexpr int64_t OMEGA_SESSION_SCAN_BUFFER_SIZE = 65536;
+}
+
 int omega_session_byte_frequency_profile_size() { return OMEGA_EDIT_BYTE_FREQUENCY_PROFILE_SIZE; }
 
 int omega_session_byte_frequency_profile_dos_eol_index() { return OMEGA_EDIT_PROFILE_DOS_EOL; }
@@ -382,7 +386,8 @@ int omega_session_byte_frequency_profile(const omega_session_t *session_ptr,
     }
     memset(profile_ptr, 0, sizeof(omega_byte_frequency_profile_t));
     if (0 < length) {
-        const auto segment_ptr = omega_segment_create((std::min)(length, static_cast<int64_t>(BUFSIZ)));
+        const auto segment_ptr = omega_segment_create((std::min)(length, OMEGA_SESSION_SCAN_BUFFER_SIZE));
+        if (!segment_ptr) { return -1; }
         omega_byte_t last_profiled_byte = 0;
         int64_t dos_eol_count = 0;
         while (length) {
@@ -419,23 +424,26 @@ int omega_session_character_counts(const omega_session_t *session_ptr, omega_cha
         return -1;
     }
     omega_character_counts_set_BOM(omega_character_counts_reset(counts_ptr), bom);
-    const auto segment_ptr = omega_segment_create((std::min)(length, static_cast<int64_t>(BUFSIZ)));
-    while (length) {
-        const auto rc = omega_session_get_segment(session_ptr, segment_ptr, offset);
-        if (rc != 0) {
-            omega_segment_destroy(segment_ptr);
-            return rc;
+    if (0 < length) {
+        const auto segment_ptr = omega_segment_create((std::min)(length, OMEGA_SESSION_SCAN_BUFFER_SIZE));
+        if (!segment_ptr) { return -1; }
+        while (length) {
+            const auto rc = omega_session_get_segment(session_ptr, segment_ptr, offset);
+            if (rc != 0) {
+                omega_segment_destroy(segment_ptr);
+                return rc;
+            }
+            const auto segment_data = omega_segment_get_data(segment_ptr);
+            const auto count_length = (std::min)(length, omega_segment_get_length(segment_ptr));
+            omega_util_count_characters(segment_data, count_length, counts_ptr);
+            if (!safe_add_int64_(offset, count_length, offset)) {
+                omega_segment_destroy(segment_ptr);
+                return -1;
+            }
+            length -= count_length;
         }
-        const auto segment_data = omega_segment_get_data(segment_ptr);
-        const auto count_length = (std::min)(length, omega_segment_get_length(segment_ptr));
-        omega_util_count_characters(segment_data, count_length, counts_ptr);
-        if (!safe_add_int64_(offset, count_length, offset)) {
-            omega_segment_destroy(segment_ptr);
-            return -1;
-        }
-        length -= count_length;
+        omega_segment_destroy(segment_ptr);
     }
-    omega_segment_destroy(segment_ptr);
     return 0;
 }
 

--- a/core/src/lib/utility.c
+++ b/core/src/lib/utility.c
@@ -215,7 +215,7 @@ int omega_util_strncmp(const char *s1, const char *s2, uint64_t sz) {
     if (!s1 || !s2) { return s1 == s2 ? 0 : (s1 ? 1 : -1); }
     int rc = 0;
     for (uint64_t i = 0; i < sz; ++i) {
-        if (0 != (rc = s1[i] - s2[i])) break;
+        if (0 != (rc = (unsigned char) s1[i] - (unsigned char) s2[i])) break;
     }
     return rc;
 }
@@ -230,9 +230,10 @@ int omega_util_strnicmp(const char *s1, const char *s2, uint64_t sz) {
 }
 
 char *omega_util_strndup(const char *s, size_t len) {
+    if (!s && len > 0) { return NULL; }
     char *result = (char *) malloc(len + 1);
     if (result != NULL) {
-        memcpy(result, s, len);
+        if (len > 0) { memcpy(result, s, len); }
         result[len] = '\0';
     }
     return result;

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -789,6 +789,23 @@ TEST_CASE("Overflow Sized Read Ranges Are Rejected", "[EdgeCase][Overflow]") {
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Search Reports Backing Read Failures", "[EdgeCase][Search]") {
+    const auto session_ptr = omega_edit_create_session(MAKE_PATH("test1.dat"), nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(omega_session_get_computed_file_size(session_ptr) > 0);
+
+    auto *search_context = omega_search_create_context_string(session_ptr, "a", 1, 0, false, false);
+    REQUIRE(search_context);
+
+    auto &first_segment = session_ptr->models_.back()->model_segments.front();
+    first_segment->change_offset = omega_session_get_original_file_size(session_ptr) + 1024;
+
+    REQUIRE(-1 == omega_search_next_match(search_context, 1));
+
+    omega_search_destroy_context(search_context);
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Save To Bytes Rejects Ranges Above Memory Buffer Limit", "[EdgeCase][LargeFile]") {
     const auto path = (DATA_DIR / "oversized_to_bytes.dat").string();
     {
@@ -938,6 +955,37 @@ TEST_CASE("Checkpoint Replace All Supports Range And Case Insensitivity", "[Edge
     REQUIRE(0 == omega_check_model(session_ptr));
 
     omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Directional Checkpoint Replace All Preserves Reverse Overlap Selection",
+          "[EdgeCase][CheckpointReplaceAll]") {
+    const auto forward_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(forward_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(forward_session_ptr, 0, "aaaaaaa"));
+
+    int64_t replacement_count = -1;
+    REQUIRE(0 == omega_edit_replace_all_bytes_directional(
+                         forward_session_ptr, reinterpret_cast<const omega_byte_t *>("aa"), 2,
+                         reinterpret_cast<const omega_byte_t *>("b"), 1, 0, 0, 0, 0, &replacement_count));
+    REQUIRE(3 == replacement_count);
+    REQUIRE(omega_session_get_segment_string(forward_session_ptr, 0,
+                                             omega_session_get_computed_file_size(forward_session_ptr)) == "bbba");
+    REQUIRE(0 == omega_check_model(forward_session_ptr));
+    omega_edit_destroy_session(forward_session_ptr);
+
+    const auto reverse_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(reverse_session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(reverse_session_ptr, 0, "aaaaaaa"));
+
+    replacement_count = -1;
+    REQUIRE(0 == omega_edit_replace_all_bytes_directional(
+                         reverse_session_ptr, reinterpret_cast<const omega_byte_t *>("aa"), 2,
+                         reinterpret_cast<const omega_byte_t *>("b"), 1, 0, 1, 0, 0, &replacement_count));
+    REQUIRE(3 == replacement_count);
+    REQUIRE(omega_session_get_segment_string(reverse_session_ptr, 0,
+                                             omega_session_get_computed_file_size(reverse_session_ptr)) == "abbb");
+    REQUIRE(0 == omega_check_model(reverse_session_ptr));
+    omega_edit_destroy_session(reverse_session_ptr);
 }
 
 TEST_CASE("Checkpoint Replace All Leaves Session Unchanged Without Matches", "[EdgeCase][CheckpointReplaceAll]") {

--- a/core/src/tests/omegaEdit_tests.cpp
+++ b/core/src/tests/omegaEdit_tests.cpp
@@ -943,6 +943,10 @@ TEST_CASE("Compare", "[CompareTests]") {
 
     const char high_byte_lhs[] = {static_cast<char>(0xFF), '\0'};
     const char high_byte_rhs[] = {static_cast<char>(0xFF), '\0'};
+    const char high_byte[] = {static_cast<char>(0x80), '\0'};
+    const char low_byte[] = {static_cast<char>(0x7F), '\0'};
+    REQUIRE(omega_util_strncmp(high_byte, low_byte, 1) > 0);
+    REQUIRE(omega_util_strncmp(low_byte, high_byte, 1) < 0);
     REQUIRE(0 == omega_util_strnicmp(high_byte_lhs, high_byte_rhs, 1));
 }
 
@@ -980,7 +984,7 @@ TEST_CASE("Search-Forward", "[SearchTests]") {
     auto match_context = omega_search_create_context_string(session_ptr, needle);
     REQUIRE(match_context);
     REQUIRE(1 == omega_session_get_num_search_contexts(session_ptr));
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(0 == needles_found);
     omega_search_destroy_context(match_context);
     REQUIRE(0 == omega_session_get_num_search_contexts(session_ptr));
@@ -993,7 +997,7 @@ TEST_CASE("Search-Forward", "[SearchTests]") {
     REQUIRE(omega_session_get_computed_file_size(session_ptr) ==
             omega_search_context_get_session_length(match_context));
     REQUIRE(1 == omega_session_get_num_search_contexts(session_ptr));
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(5 == needles_found);
     omega_search_destroy_context(match_context);
     REQUIRE(0 == omega_session_get_num_search_contexts(session_ptr));
@@ -1030,35 +1034,35 @@ TEST_CASE("Search-Forward", "[SearchTests]") {
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, needle);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(2 == needles_found);
     omega_search_destroy_context(match_context);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, needle, 0, 0, true);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(6 == needles_found);
     omega_search_destroy_context(match_context);
 
     // test single-byte needles since these use a different search algorithm
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "e", 0, 0, false);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(19 == needles_found);
     omega_search_destroy_context(match_context);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "E", 0, 0, false);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(3 == needles_found);
     omega_search_destroy_context(match_context);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "E", 0, 0, true);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(22 == needles_found);
     omega_search_destroy_context(match_context);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "F", 0, 0, false);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(0 == needles_found);
     omega_search_destroy_context(match_context);
 
@@ -1072,7 +1076,7 @@ TEST_CASE("Search-Forward", "[SearchTests]") {
     REQUIRE(0 > omega_segment_get_offset(segment_peek));
     REQUIRE(0 == omega_segment_get_offset_adjustment(segment_peek));
     auto pattern_length = omega_search_context_get_pattern_length(match_context);
-    if (omega_search_next_match(match_context, 1)) {
+    if (omega_search_next_match(match_context, 1) > 0) {
         const auto advance_context = static_cast<int64_t>(replace.length());
         do {
             const auto pattern_offset = omega_search_context_get_match_offset(match_context);
@@ -1096,7 +1100,7 @@ TEST_CASE("Search-Forward", "[SearchTests]") {
                                                      omega_segment_get_capacity(segment_peek)) ==
                     (const char *) omega_segment_get_data(segment_peek));
             ++needles_found;
-        } while (omega_search_next_match(match_context, advance_context));
+        } while (omega_search_next_match(match_context, advance_context) > 0);
     }
     omega_segment_destroy(segment_peek);
     REQUIRE(6 == needles_found);
@@ -1107,7 +1111,7 @@ TEST_CASE("Search-Forward", "[SearchTests]") {
     needles_found = 0;
     pattern_length = omega_search_context_get_pattern_length(match_context);
     REQUIRE(pattern_length == 1);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(12 == needles_found);
     omega_search_destroy_context(match_context);
     REQUIRE(0 == omega_edit_save(session_ptr, MAKE_PATH("search-test.actual.1.dat"), omega_io_flags_t::IO_FLG_OVERWRITE,
@@ -1123,38 +1127,38 @@ TEST_CASE("Search-Forward", "[SearchTests]") {
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "a", 0, 0, false);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(4 == needles_found);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "a", 0,
                                                        omega_session_get_computed_file_size(session_ptr) - 2, false);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(3 == needles_found);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "a", 1, 0, false);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(4 == needles_found);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "a", 5, 0, false);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(3 == needles_found);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "a", 0, 5, false);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(1 == needles_found);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "a", 4, 3, false);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(1 == needles_found);
     needles_found = 0;
     match_context = omega_search_create_context_string(session_ptr, "a", 1, 3, false);
     REQUIRE(match_context);
-    while (omega_search_next_match(match_context, 1)) { ++needles_found; }
+    while (omega_search_next_match(match_context, 1) > 0) { ++needles_found; }
     REQUIRE(0 == needles_found);
     omega_edit_destroy_session(session_ptr);
 }
@@ -1168,7 +1172,7 @@ TEST_CASE("Search-Reverse", "[SearchTests]") {
     auto search_context_ptr = omega_search_create_context_string(session_ptr, "Pursuit", 0, 0, true, true);
     REQUIRE(search_context_ptr);
     auto matches = std::vector<int64_t>();
-    while (omega_search_next_match(search_context_ptr, 1)) {
+    while (omega_search_next_match(search_context_ptr, 1) > 0) {
         matches.push_back(omega_search_context_get_match_offset(search_context_ptr));
     }
     REQUIRE(3 == matches.size());
@@ -1179,7 +1183,7 @@ TEST_CASE("Search-Reverse", "[SearchTests]") {
     omega_search_destroy_context(search_context_ptr);
     search_context_ptr = omega_search_create_context_string(session_ptr, "P", 0, 0, true, true);
     REQUIRE(search_context_ptr);
-    while (omega_search_next_match(search_context_ptr, 1)) {
+    while (omega_search_next_match(search_context_ptr, 1) > 0) {
         matches.push_back(omega_search_context_get_match_offset(search_context_ptr));
     }
     REQUIRE(7 == matches.size());
@@ -1194,7 +1198,7 @@ TEST_CASE("Search-Reverse", "[SearchTests]") {
     omega_search_destroy_context(search_context_ptr);
     search_context_ptr = omega_search_create_context_string(session_ptr, "The", 0, 0, false, true);
     REQUIRE(search_context_ptr);
-    while (omega_search_next_match(search_context_ptr, 1)) {
+    while (omega_search_next_match(search_context_ptr, 1) > 0) {
         matches.push_back(omega_search_context_get_match_offset(search_context_ptr));
     }
     REQUIRE(2 == matches.size());
@@ -1206,7 +1210,7 @@ TEST_CASE("Search-Reverse", "[SearchTests]") {
     omega_edit_insert_string(session_ptr, 0, "Needle");
     search_context_ptr = omega_search_create_context_string(session_ptr, "Needle", 0, 0, false, true);
     REQUIRE(search_context_ptr);
-    while (omega_search_next_match(search_context_ptr, 1)) {
+    while (omega_search_next_match(search_context_ptr, 1) > 0) {
         matches.push_back(omega_search_context_get_match_offset(search_context_ptr));
     }
     REQUIRE(1 == matches.size());

--- a/core/src/tests/utility_tests.cpp
+++ b/core/src/tests/utility_tests.cpp
@@ -155,4 +155,10 @@ TEST_CASE("Null Pointer Safety - Utility", "[NullSafety]") {
     REQUIRE(0 == omega_util_strnicmp(nullptr, nullptr, 5));
     REQUIRE(-1 == omega_util_strnicmp(nullptr, "hello", 5));
     REQUIRE(1 == omega_util_strnicmp("hello", nullptr, 5));
+
+    auto *empty = omega_util_strndup(nullptr, 0);
+    REQUIRE(empty != nullptr);
+    REQUIRE('\0' == empty[0]);
+    free(empty);
+    REQUIRE(nullptr == omega_util_strndup(nullptr, 1));
 }

--- a/packages/client/tests/specs/search.spec.ts
+++ b/packages/client/tests/specs/search.spec.ts
@@ -40,6 +40,7 @@ import {
   searchSession,
   undo,
 } from '@omega-edit/client'
+import { status as GrpcStatus } from '@grpc/grpc-js'
 import {
   createTestSession,
   destroyTestSession,
@@ -238,6 +239,23 @@ describe('Searching', () => {
       undefined
     )
     expect(needles).to.be.empty
+  })
+
+  it('Should reject invalid search contexts instead of returning no matches', async () => {
+    await overwrite(session_id, 0, Buffer.from('abc'))
+
+    try {
+      await searchSession(session_id, 'a', false, false, 4, 1)
+      expect.fail('searchSession should reject an out-of-range search window')
+    } catch (err) {
+      expect((err as Error).message).to.include('INVALID_ARGUMENT')
+      expect((err as Error).message).to.include(
+        'search context could not be created'
+      )
+      expect(
+        ((err as Error & { cause?: { code?: number } }).cause ?? {}).code
+      ).to.equal(GrpcStatus.INVALID_ARGUMENT)
+    }
   })
 
   it('Should be able to optimize replacement operations', () => {

--- a/packages/client/tests/specs/server.spec.ts
+++ b/packages/client/tests/specs/server.spec.ts
@@ -552,6 +552,21 @@ describe('Server Resource Limits', () => {
     viewportEventQueueCapacity: 1,
   }
 
+  const seedAaa = async () => {
+    await insert(session_id, 0, Buffer.from('a'))
+    await insert(session_id, 1, Buffer.from('a'))
+    await insert(session_id, 2, Buffer.from('a'))
+  }
+
+  const expectSessionText = async (expected: string) => {
+    expect(await getComputedFileSize(session_id)).to.equal(expected.length)
+    for (let offset = 0; offset < expected.length; offset++) {
+      expect(await getSegment(session_id, offset, 1)).deep.equals(
+        Buffer.from(expected[offset])
+      )
+    }
+  }
+
   beforeEach(async () => {
     if (isUds) {
       const udsJavaHome = process.env.OMEGA_EDIT_TEST_JAVA_HOME
@@ -815,6 +830,70 @@ describe('Server Resource Limits', () => {
       await searchSession(session_id, 'a', false, false, 0, 0, 0)
       expect.fail(
         'searchSession should reject responses larger than maxSearchMatches'
+      )
+    } catch (err) {
+      expectResourceExhausted(err, 'configured search match limit of 2')
+    }
+  })
+
+  it(`on port ${serverTestPort} should stream unbounded replace-all above the configured match limit`, async () => {
+    await seedAaa()
+
+    expect(
+      await replaceSession(
+        session_id,
+        'a',
+        'b',
+        false,
+        false,
+        0,
+        0,
+        0,
+        true,
+        false
+      )
+    ).to.equal(3)
+    await expectSessionText('bbb')
+  })
+
+  it(`on port ${serverTestPort} should stream unbounded reverse replace-all above the configured match limit`, async () => {
+    await seedAaa()
+
+    expect(
+      await replaceSession(
+        session_id,
+        'a',
+        'b',
+        false,
+        true,
+        0,
+        0,
+        0,
+        true,
+        false
+      )
+    ).to.equal(3)
+    await expectSessionText('bbb')
+  })
+
+  it(`on port ${serverTestPort} should reject explicit transactional replace limits above the configured match limit`, async () => {
+    await seedAaa()
+
+    try {
+      await replaceSession(
+        session_id,
+        'a',
+        'b',
+        false,
+        false,
+        0,
+        0,
+        3,
+        true,
+        false
+      )
+      expect.fail(
+        'replaceSession should reject explicit transactional limits above maxSearchMatches'
       )
     } catch (err) {
       expectResourceExhausted(err, 'configured search match limit of 2')

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -1500,8 +1500,9 @@ describe('Sessions', () => {
     try {
       await createSession('-invalid-')
       expect.fail('Should have thrown')
-    } catch (e) {
-      // expected
+    } catch (err) {
+      expect((err as Error).message).to.include('NOT_FOUND')
+      expect((err as Error).message).to.include('file does not exist')
     }
   })
 })

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -766,6 +766,119 @@ namespace omega_edit {
             return requested_limit;
         }
 
+        static int64_t transactional_replace_match_limit(const ResourceLimits &resource_limits) {
+            auto limit = static_cast<int64_t>(OMEGA_REPLACE_MATCHES_LIMIT);
+            if (resource_limits.max_search_matches > 0) {
+                limit = (std::min)(limit, resource_limits.max_search_matches);
+            }
+            return limit;
+        }
+
+        static bool match_overlaps_prior(bool is_reverse, bool has_prior, int64_t match_offset, int64_t pattern_length,
+                                         int64_t last_accepted_offset, bool &ok) {
+            ok = true;
+            if (!has_prior) { return false; }
+            if (match_offset > (std::numeric_limits<int64_t>::max)() - pattern_length ||
+                last_accepted_offset > (std::numeric_limits<int64_t>::max)() - pattern_length) {
+                ok = false;
+                return false;
+            }
+            const auto match_end = match_offset + pattern_length;
+            const auto last_accepted_end = last_accepted_offset + pattern_length;
+            return is_reverse ? (match_end > last_accepted_offset) : (match_offset < last_accepted_end);
+        }
+
+        static grpc::Status count_replace_matches_until_limit(omega_session_t *session, const std::string &pattern,
+                                                              bool case_insensitive, bool is_reverse, int64_t offset,
+                                                              int64_t length, int64_t session_size,
+                                                              int64_t max_selected_matches,
+                                                              int64_t &selected_match_count,
+                                                              bool &selected_match_limit_exceeded) {
+            selected_match_count = 0;
+            selected_match_limit_exceeded = false;
+            if (!session || pattern.empty() || max_selected_matches < 0) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "replace preflight arguments are invalid");
+            }
+
+            const auto effective_length =
+                    length > 0 ? (std::min)(length, session_size - offset) : session_size - offset;
+            if (static_cast<int64_t>(pattern.size()) > effective_length) { return grpc::Status::OK; }
+
+            auto *ctx =
+                    omega_search_create_context_bytes(session, reinterpret_cast<const omega_byte_t *>(pattern.data()),
+                                                      static_cast<int64_t>(pattern.size()), offset, effective_length,
+                                                      case_insensitive ? 1 : 0, is_reverse ? 1 : 0);
+            if (!ctx) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "replace search context could not be created");
+            }
+
+            int64_t last_accepted_offset = -1;
+            auto has_accepted_match = false;
+            auto search_result = 0;
+            while ((search_result = omega_search_next_match(ctx, 1)) > 0) {
+                const auto match_offset = omega_search_context_get_match_offset(ctx);
+                auto overlap_check_ok = true;
+                const auto overlaps_prior = match_overlaps_prior(is_reverse, has_accepted_match, match_offset,
+                                                                 static_cast<int64_t>(pattern.size()),
+                                                                 last_accepted_offset, overlap_check_ok);
+                if (!overlap_check_ok) {
+                    omega_search_destroy_context(ctx);
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "replace match range is invalid");
+                }
+                if (overlaps_prior) { continue; }
+                if (selected_match_count >= max_selected_matches) {
+                    selected_match_limit_exceeded = true;
+                    omega_search_destroy_context(ctx);
+                    return grpc::Status::OK;
+                }
+                ++selected_match_count;
+                last_accepted_offset = match_offset;
+                has_accepted_match = true;
+            }
+
+            omega_search_destroy_context(ctx);
+            if (search_result < 0) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "replace search failed while reading session content");
+            }
+            return grpc::Status::OK;
+        }
+
+        static void compute_replace_lowered_counts(const std::string &pattern, const std::string &replacement,
+                                                   int64_t replacement_count, int64_t &delete_count,
+                                                   int64_t &insert_count, int64_t &overwrite_count) {
+            delete_count = 0;
+            insert_count = 0;
+            overwrite_count = 0;
+            if (replacement_count <= 0) { return; }
+
+            size_t prefix_length = 0;
+            while (prefix_length < pattern.size() && prefix_length < replacement.size() &&
+                   pattern[prefix_length] == replacement[prefix_length]) {
+                ++prefix_length;
+            }
+
+            size_t suffix_length = 0;
+            while (suffix_length < pattern.size() - prefix_length &&
+                   suffix_length < replacement.size() - prefix_length &&
+                   pattern[pattern.size() - 1 - suffix_length] == replacement[replacement.size() - 1 - suffix_length]) {
+                ++suffix_length;
+            }
+
+            const auto remove_length = pattern.size() - prefix_length - suffix_length;
+            const auto insert_length = replacement.size() - prefix_length - suffix_length;
+            if (remove_length == 0 && insert_length == 0) { return; }
+            if (remove_length == 0) {
+                insert_count = replacement_count;
+            } else if (insert_length == 0) {
+                delete_count = replacement_count;
+            } else if (remove_length == insert_length) {
+                overwrite_count = replacement_count;
+            } else {
+                delete_count = replacement_count;
+                insert_count = replacement_count;
+            }
+        }
+
         EditorServiceImpl::EditorServiceImpl(HeartbeatConfig heartbeat_config, ResourceLimits resource_limits,
                                              std::function<void()> shutdown_callback,
                                              std::vector<std::string> transform_plugin_directories,
@@ -970,11 +1083,11 @@ namespace omega_edit {
                                     "create session accepts either file_path or initial_data, not both");
             }
 
-            // Validate file path exists if provided (match previous server behavior)
+            // Validate file path exists if provided.
             if (!file_path.empty()) {
                 std::error_code ec;
                 if (!std::filesystem::exists(file_path, ec) || ec) {
-                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                    return grpc::Status(grpc::StatusCode::NOT_FOUND,
                                         std::string("Failed to create session: file does not exist: ") + file_path);
                 }
             }
@@ -2093,22 +2206,52 @@ namespace omega_edit {
                 }
                 auto *session = locked_session.session();
 
-                auto *ctx = omega_search_create_context_bytes(
-                        session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
-                        static_cast<int64_t>(request->pattern().size()), offset, length, case_insensitive ? 1 : 0,
-                        is_reverse ? 1 : 0);
+                const auto session_size = omega_session_get_computed_file_size(session);
+                if (session_size < 0) {
+                    return grpc::Status(grpc::StatusCode::INTERNAL,
+                                        "failed to compute session size for session: " + request->session_id());
+                }
+                if (offset > session_size) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "search context could not be created");
+                }
+                const auto effective_length = length > 0 ? length : session_size - offset;
+                if (length > 0 && effective_length > session_size - offset) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "search range is invalid");
+                }
+                if (static_cast<int64_t>(request->pattern().size()) <= effective_length) {
+                    auto *ctx = omega_search_create_context_bytes(
+                            session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+                            static_cast<int64_t>(request->pattern().size()), offset, length, case_insensitive ? 1 : 0,
+                            is_reverse ? 1 : 0);
 
-                if (ctx) {
+                    if (!ctx) {
+                        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "search context could not be created");
+                    }
+
                     int64_t num_matches = 0;
-                    while ((bounded_limit <= 0 || num_matches < bounded_limit) && omega_search_next_match(ctx, 1) > 0) {
+                    auto search_result = 0;
+                    while ((bounded_limit <= 0 || num_matches < bounded_limit) &&
+                           (search_result = omega_search_next_match(ctx, 1)) > 0) {
                         match_offsets.push_back(omega_search_context_get_match_offset(ctx));
                         ++num_matches;
                     }
-                    if (resource_limit_applies && num_matches >= bounded_limit && omega_search_next_match(ctx, 1) > 0) {
+                    if (search_result < 0) {
                         omega_search_destroy_context(ctx);
-                        return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
-                                            "search matches exceed configured search match limit of " +
-                                                    std::to_string(resource_limits_.max_search_matches));
+                        return grpc::Status(grpc::StatusCode::INTERNAL, "search failed while reading session content");
+                    }
+                    if (resource_limit_applies && num_matches >= bounded_limit) {
+                        search_result = omega_search_next_match(ctx, 1);
+                        if (search_result < 0) {
+                            omega_search_destroy_context(ctx);
+                            return grpc::Status(grpc::StatusCode::INTERNAL,
+                                                "search failed while reading session content");
+                        }
+                        if (search_result > 0) {
+                            omega_search_destroy_context(ctx);
+                            return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                                "search matches exceed configured search match limit of " +
+                                                        std::to_string(resource_limits_.max_search_matches));
+                        }
                     }
                     omega_search_destroy_context(ctx);
                 }
@@ -2199,16 +2342,58 @@ namespace omega_edit {
                                                 request->session_id());
                 }
 
-                const auto rc = omega_edit_replace_matches_bytes(
-                        session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
-                        static_cast<int64_t>(request->pattern().size()),
-                        reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
-                        static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0,
-                        is_reverse ? 1 : 0, offset, length, limit, front_to_back ? 1 : 0, overwrite_only ? 1 : 0,
-                        &replacement_count, &delete_count, &insert_count, &overwrite_count);
-                if (rc != 0) {
-                    return grpc::Status(grpc::StatusCode::INTERNAL,
-                                        "replace failed for session: " + request->session_id());
+                auto bounded_replace_limit = limit;
+                const auto replace_match_limit = transactional_replace_match_limit(resource_limits_);
+                if (replace_match_limit <= 0) {
+                    return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                        "transactional replace match limit is disabled; use checkpointed replace");
+                }
+                auto replace_completed = false;
+                if (limit <= 0 || limit > replace_match_limit) {
+                    auto selected_match_count = int64_t{0};
+                    auto selected_match_limit_exceeded = false;
+                    const auto preflight_status = count_replace_matches_until_limit(
+                            session, request->pattern(), case_insensitive, is_reverse, offset, length, session_size,
+                            replace_match_limit, selected_match_count, selected_match_limit_exceeded);
+                    if (!preflight_status.ok()) { return preflight_status; }
+                    if (selected_match_limit_exceeded) {
+                        const auto can_stream_replace_all = limit <= 0 && !overwrite_only;
+                        if (!can_stream_replace_all) {
+                            return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
+                                                "replace matches exceed configured search match limit of " +
+                                                        std::to_string(replace_match_limit) +
+                                                        "; use checkpointed replace for large replace-all operations");
+                        }
+                        const auto rc = omega_edit_replace_all_bytes_directional(
+                                session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+                                static_cast<int64_t>(request->pattern().size()),
+                                reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
+                                static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0,
+                                is_reverse ? 1 : 0, offset, length, &replacement_count);
+                        if (rc != 0) {
+                            return grpc::Status(grpc::StatusCode::INTERNAL,
+                                                "checkpointed replace fallback failed for session: " +
+                                                        request->session_id());
+                        }
+                        compute_replace_lowered_counts(request->pattern(), request->replacement(), replacement_count,
+                                                       delete_count, insert_count, overwrite_count);
+                        replace_completed = true;
+                    }
+                    bounded_replace_limit = selected_match_count;
+                }
+
+                if (!replace_completed) {
+                    const auto rc = omega_edit_replace_matches_bytes(
+                            session, reinterpret_cast<const omega_byte_t *>(request->pattern().data()),
+                            static_cast<int64_t>(request->pattern().size()),
+                            reinterpret_cast<const omega_byte_t *>(request->replacement().data()),
+                            static_cast<int64_t>(request->replacement().size()), case_insensitive ? 1 : 0,
+                            is_reverse ? 1 : 0, offset, length, bounded_replace_limit, front_to_back ? 1 : 0,
+                            overwrite_only ? 1 : 0, &replacement_count, &delete_count, &insert_count, &overwrite_count);
+                    if (rc != 0) {
+                        return grpc::Status(grpc::StatusCode::INTERNAL,
+                                            "replace failed for session: " + request->session_id());
+                    }
                 }
             }
 

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -644,8 +644,10 @@ int main(int argc, char **argv) {
             } else if (key == "--transform-plugin-host") {
                 if (!require_option_value(key, value)) { return 1; }
                 transform_plugin_host_path = value;
+            } else {
+                std::cerr << "Unknown option: " << key << std::endl;
+                return 1;
             }
-            // Silently ignore unknown options.
         }
     }
 


### PR DESCRIPTION
## Summary

- Bound transactional `replace_matches` materialization with `OMEGA_REPLACE_MATCHES_LIMIT` and memory-buffer-aware limits.
- Add streamed checkpoint fallback for unbounded replace-all when match caps are exceeded, including directional reverse streaming that preserves reverse-search overlap semantics.
- Tighten search/session/utility/server signaling edges and update `SHORTCOMINGS.md`, including a follow-up for viewport-neighbor match decoration.

## Why

Large search and replace workflows should not require materializing an unknown number of matches in memory. Interactive flows can walk matches with bounded searches, while unbounded replace-all should stream once caps are crossed.

## Impact

Callers now get bounded transactional replacement for explicit/interactive operations and checkpointed streaming for large unbounded replace-all. Server resource-limit behavior rejects explicit over-cap transactional replacement with `RESOURCE_EXHAUSTED` while allowing safe streamed all-replace.

## Validation

- `cmake --build --preset ninja-debug-minimal --target edge_case_tests omegaEdit_tests utility_tests`
- `_build/core/src/tests/edge_case_tests`
- `_build/core/src/tests/omegaEdit_tests`
- `_build/core/src/tests/utility_tests`
- `biome check --write packages/client/tests/specs/server.spec.ts packages/client/tests/specs/search.spec.ts packages/client/tests/specs/session.spec.ts`
- `YARN_IGNORE_ENGINES=1 yarn workspace @omega-edit/client build`
- Windows shared core rebuild/install and C++ gRPC server relink
- Windows live `server.spec.ts` with 32 passing tests
- Windows live `search.spec.ts` and `session.spec.ts` with 46 passing tests
- `git diff --check`
