### PR TITLE
Complete search/replace scale design

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -592,27 +592,38 @@ Suggested fix:
 - Consider isolating or resource-limiting content detection for untrusted input.
 - Document the third-party parser exposure in the deployment trust boundary.
 
-### 31. Search navigation does not decorate viewport-neighbor matches
+### 31. Text pane and Data Inspector only expose ASCII-oriented byte display
 
-**Impact:** Low to Medium
+**Impact:** Low
 **Risk:** Low
-**Area:** Client/server search UX, viewport match decoration
+**Area:** VS Code hex editor text pane, Data Inspector, text search
 
-Interactive search can walk to the next or previous match without knowing the
-global match count, but the navigation result does not yet include the other
-matches visible in the active viewport. That means a UI can focus the requested
-match but cannot cheaply decorate the surrounding viewport matches as part of
-the same navigation flow.
+The TEXT pane currently treats bytes as ASCII-ish printable characters with a
+placeholder for non-printable values. Other hex editors let users switch that
+view among common single-byte character sets such as ASCII, Windows ANSI
+code pages, DOS/OEM code pages, EBCDIC, and Macintosh/MacRoman. The Data
+Inspector should expose the same byte-to-character interpretations so a selected
+byte or range can be inspected without mentally translating high-bit bytes.
+Text search should use the selected text encoding when converting the query to
+bytes, while hex search should remain byte-literal and unaffected.
+
+Important product detail: "ANSI" and "DOS" are families, not one universal
+mapping. The UI should pick explicit defaults such as Windows-1252 and CP437,
+while leaving room for additional code pages later.
 
 Suggested fix:
-- Keep next/previous navigation anchor-based (`limit = 1`) in the requested
-  direction.
-- After locating the focused match, issue a bounded search over the active
-  viewport range with `limit + 1` so the UI can highlight visible sibling
-  matches and show overflow hints without claiming a global total.
-- Cover forward, reverse, and viewport-edge cases in client tests.
-
----
+- Add a text encoding selector for the TEXT pane, initially covering ASCII,
+  Windows-1252, CP437, EBCDIC, and MacRoman.
+- Add matching Data Inspector fields for the selected byte/range so high-bit
+  bytes can be interpreted in the same supported character sets.
+- Route text search query encoding through the selected character set, keep
+  match offsets byte-native, and make charset changes invalidate/re-run any
+  active text search window.
+- Keep the core byte model unchanged; this should be display/inspection-layer
+  decoding unless a later API need emerges.
+- Cover printable ASCII identity, high-byte divergence across encodings,
+  EBCDIC alphabet bytes, non-printable placeholder behavior, and text-search
+  byte encoding for each supported character set in tests.
 
 ## Testing Gaps For Attestation
 
@@ -621,8 +632,6 @@ claiming production hardening:
 
 - Save durability: add fault-injection coverage around interrupted saves beyond
   the current atomic/durable publishing coverage.
-- Remaining overflow paths: helper and edit-range tests exist, but add more
-  near-`INT64_MAX` coverage through public APIs and server RPC boundaries.
 - Change-detail payload bounds: request details for a change larger than the
   inline payload limit and assert bounded memory/response behavior.
 - Same-session availability under long scans: run a slow operation (large
@@ -723,5 +732,11 @@ These areas were in the old document but are no longer open backlog items:
   server gRPC/session-destroy cancellation paths, and bundled plugin polling
   loops, with TypeScript client, AI/MCP, and VS Code webview cancellation wired
   through to the same RPC cancellation path.
+- Large-search navigation now keeps anchor-based next/previous lookup bounded,
+  then decorates the active viewport with a separately bounded neighbor match
+  window that handles reverse navigation, overlaps, viewport boundaries, and
+  external range-map/debugger highlight overlays independently.
+- Near-`INT64_MAX` overflow coverage now exercises public C APIs and raw server
+  RPC boundaries for search, replace, segment, and viewport ranges.
 - Event mask signed `ALL_EVENTS` ambiguity.
 - Output collision suffix range and deprecated protobuf generator dependencies.

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -597,6 +597,46 @@ TEST_CASE("Overflow Sized Edit Ranges Are Rejected Without Mutating Session", "[
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Public Search Replace And Viewport APIs Reject Int64 Overflow Ranges", "[EdgeCase][Overflow]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abcabc"));
+
+    const auto max = (std::numeric_limits<int64_t>::max)();
+    const omega_byte_t pattern[] = {'a', 'b'};
+    const omega_byte_t replacement[] = {'x'};
+    int64_t replacement_count = -1;
+    int64_t delete_count = -1;
+    int64_t insert_count = -1;
+    int64_t overwrite_count = -1;
+
+    REQUIRE(nullptr == omega_search_create_context_bytes(session_ptr, pattern, 2, max, 1, 0, 0));
+    REQUIRE(-1 == omega_edit_replace_matches_bytes(session_ptr, pattern, 2, replacement, 1, 0, 0, max, 1, 1, 1, 0,
+                                                   &replacement_count, &delete_count, &insert_count, &overwrite_count));
+    REQUIRE(0 == replacement_count);
+    REQUIRE(0 == delete_count);
+    REQUIRE(0 == insert_count);
+    REQUIRE(0 == overwrite_count);
+
+    replacement_count = -1;
+    REQUIRE(-1 == omega_edit_replace_all_bytes(session_ptr, pattern, 2, replacement, 1, 0, max, 1, &replacement_count));
+    REQUIRE(0 == replacement_count);
+
+    replacement_count = -1;
+    REQUIRE(-1 == omega_edit_replace_all_bytes_directional(session_ptr, pattern, 2, replacement, 1, 0, 1, max, 1,
+                                                           &replacement_count));
+    REQUIRE(0 == replacement_count);
+
+    auto *viewport = omega_edit_create_viewport(session_ptr, max, 1, 0, nullptr, nullptr, NO_EVENTS);
+    REQUIRE(nullptr == viewport);
+
+    REQUIRE(6 == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(1 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Computed File Size Returns -1 On Segment Overflow", "[EdgeCase][Overflow]") {
     const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
     REQUIRE(session_ptr);

--- a/packages/client/src/editor_search.ts
+++ b/packages/client/src/editor_search.ts
@@ -47,11 +47,30 @@ export interface EditorFindAdjacentRequest extends EditorSearchRequest {
   direction: 'forward' | 'backward'
   anchorOffset: number
   fileSize: number
+  viewportOffset?: number
+  viewportLength?: number
+  viewportLimit?: number
+}
+
+export interface EditorViewportMatchWindow {
+  offset: number
+  length: number
+  matches: number[]
+  hasMore: boolean
 }
 
 export interface EditorFindAdjacentResult {
   offset: number
   patternLength: number
+  viewport?: EditorViewportMatchWindow
+}
+
+export interface EditorViewportMatchesRequest extends EditorSearchRequest {
+  fileSize: number
+  viewportOffset: number
+  viewportLength: number
+  viewportLimit?: number
+  focusedOffset?: number
 }
 
 export interface EditorReplaceAllRequest extends EditorSearchRequest {
@@ -116,6 +135,26 @@ function filterNonOverlapping(
     }
   }
   return result
+}
+
+function isUsableNonNegativeInteger(
+  value: number | undefined
+): value is number {
+  return value !== undefined && Number.isSafeInteger(value) && value >= 0
+}
+
+function matchOverlapsRange(
+  matchOffset: number,
+  patternLength: number,
+  rangeOffset: number,
+  rangeLength: number
+): boolean {
+  return (
+    patternLength > 0 &&
+    rangeLength > 0 &&
+    matchOffset < rangeOffset + rangeLength &&
+    matchOffset + patternLength > rangeOffset
+  )
 }
 
 export class EditorSearchController {
@@ -220,65 +259,195 @@ export class EditorSearchController {
       Number.isSafeInteger(request.anchorOffset) && request.anchorOffset >= 0
         ? Math.min(request.anchorOffset, Math.max(0, request.fileSize - 1))
         : -1
+    const buildResult = async (
+      offset: number
+    ): Promise<EditorFindAdjacentResult> => {
+      const viewport =
+        offset >= 0
+          ? await this.collectViewportMatches(
+              pattern,
+              request.caseInsensitive ?? false,
+              request.fileSize,
+              request.viewportOffset,
+              request.viewportLength,
+              request.viewportLimit,
+              offset
+            )
+          : undefined
+      return {
+        offset,
+        patternLength: pattern.length,
+        ...(viewport ? { viewport } : {}),
+      }
+    }
 
     if (request.direction === 'forward') {
-      if (clampedAnchor >= 0 && clampedAnchor + 1 < request.fileSize) {
+      const nextOffset = clampedAnchor >= 0 ? clampedAnchor + 1 : 0
+      if (nextOffset < request.fileSize) {
         const matches = await this.searchSession(
           this.sessionId,
           pattern,
           request.caseInsensitive ?? false,
           false,
-          clampedAnchor + 1,
+          nextOffset,
           0,
           1
         )
         if (matches.length > 0) {
-          return { offset: matches[0], patternLength: pattern.length }
+          return await buildResult(matches[0])
         }
       }
 
+      const wrapLength =
+        clampedAnchor >= 0
+          ? Math.min(request.fileSize, clampedAnchor + pattern.length - 1)
+          : 0
       const wrappedMatches = await this.searchSession(
         this.sessionId,
         pattern,
         request.caseInsensitive ?? false,
         false,
         0,
-        clampedAnchor > 0 ? clampedAnchor : 0,
+        wrapLength,
         1
       )
-      return {
-        offset: wrappedMatches[0] ?? -1,
-        patternLength: pattern.length,
-      }
+      return await buildResult(wrappedMatches[0] ?? -1)
     }
 
-    if (clampedAnchor > 0) {
+    const reverseLength =
+      clampedAnchor >= 0
+        ? Math.min(request.fileSize, clampedAnchor + pattern.length - 1)
+        : request.fileSize
+    if (reverseLength > 0) {
       const matches = await this.searchSession(
         this.sessionId,
         pattern,
         request.caseInsensitive ?? false,
         true,
         0,
-        clampedAnchor,
+        reverseLength,
         1
       )
       if (matches.length > 0) {
-        return { offset: matches[0], patternLength: pattern.length }
+        return await buildResult(matches[0])
       }
     }
 
+    const wrapOffset = clampedAnchor >= 0 ? clampedAnchor + 1 : 0
     const wrappedMatches = await this.searchSession(
       this.sessionId,
       pattern,
       request.caseInsensitive ?? false,
       true,
-      clampedAnchor >= 0 ? clampedAnchor + 1 : 0,
+      wrapOffset,
       0,
       1
     )
+    return await buildResult(wrappedMatches[0] ?? -1)
+  }
+
+  public async findViewportMatches(
+    request: EditorViewportMatchesRequest
+  ): Promise<EditorViewportMatchWindow | undefined> {
+    const normalizedQuery = request.query.trim()
+    const pattern = toPatternBytes(normalizedQuery, request.isHex)
+    if (!normalizedQuery || pattern.length === 0 || request.fileSize <= 0) {
+      return undefined
+    }
+
+    return await this.collectViewportMatches(
+      pattern,
+      request.caseInsensitive ?? false,
+      request.fileSize,
+      request.viewportOffset,
+      request.viewportLength,
+      request.viewportLimit,
+      request.focusedOffset ?? -1
+    )
+  }
+
+  private async collectViewportMatches(
+    pattern: Uint8Array,
+    caseInsensitive: boolean,
+    fileSize: number,
+    viewportOffset: number | undefined,
+    viewportLength: number | undefined,
+    viewportLimit: number | undefined,
+    focusedOffset: number
+  ): Promise<EditorViewportMatchWindow | undefined> {
+    if (
+      pattern.length === 0 ||
+      fileSize <= 0 ||
+      !isUsableNonNegativeInteger(viewportOffset) ||
+      !isUsableNonNegativeInteger(viewportLength) ||
+      viewportLength === 0 ||
+      viewportOffset >= fileSize
+    ) {
+      return undefined
+    }
+
+    const visibleOffset = Math.min(viewportOffset, fileSize)
+    const visibleLength = Math.min(viewportLength, fileSize - visibleOffset)
+    if (visibleLength <= 0) {
+      return undefined
+    }
+
+    const boundaryPadding = Math.max(0, pattern.length - 1)
+    const viewportSizedLimit = visibleLength + boundaryPadding + 1
+    const limit =
+      isUsableNonNegativeInteger(viewportLimit) && viewportLimit > 0
+        ? viewportLimit
+        : viewportSizedLimit
+    const boundedLimit = Math.max(1, limit)
+    const searchOffset = Math.max(0, visibleOffset - boundaryPadding)
+    const searchEnd = Math.min(
+      fileSize,
+      visibleOffset + visibleLength + boundaryPadding
+    )
+    const rawMatches = await this.searchSession(
+      this.sessionId,
+      pattern,
+      caseInsensitive,
+      false,
+      searchOffset,
+      searchEnd - searchOffset,
+      boundedLimit + 1
+    )
+    const visibleMatches = rawMatches
+      .filter((matchOffset) =>
+        matchOverlapsRange(
+          matchOffset,
+          pattern.length,
+          visibleOffset,
+          visibleLength
+        )
+      )
+      .sort((a, b) => a - b)
+
+    let matches = visibleMatches.slice(0, boundedLimit + 1)
+    let hasMore = visibleMatches.length > boundedLimit
+
+    if (
+      focusedOffset >= 0 &&
+      matchOverlapsRange(
+        focusedOffset,
+        pattern.length,
+        visibleOffset,
+        visibleLength
+      ) &&
+      !matches.includes(focusedOffset)
+    ) {
+      hasMore = true
+      matches = Array.from(
+        new Set([...matches.slice(0, boundedLimit), focusedOffset])
+      ).sort((a, b) => a - b)
+    }
+
     return {
-      offset: wrappedMatches[0] ?? -1,
-      patternLength: pattern.length,
+      offset: visibleOffset,
+      length: visibleLength,
+      matches,
+      hasMore,
     }
   }
 

--- a/packages/client/tests/specs/editorPatterns.spec.ts
+++ b/packages/client/tests/specs/editorPatterns.spec.ts
@@ -336,4 +336,57 @@ describe('Editor Patterns', () => {
       isReverse: false,
     })
   })
+
+  it('should collect viewport neighbors with a boundary-padded bounded search', async () => {
+    const searchCalls: Array<{
+      offset: number
+      length: number
+      limit: number
+      isReverse: boolean
+    }> = []
+
+    const controller = new EditorSearchController('session-id', {
+      windowLimit: 1,
+      async searchSession(
+        _sessionId: string,
+        _pattern: string | Uint8Array,
+        _caseInsensitive: boolean = false,
+        isReverse: boolean = false,
+        offset: number = 0,
+        length: number = 0,
+        limit: number = 0
+      ) {
+        searchCalls.push({ offset, length, limit, isReverse })
+        return searchCalls.length === 1 ? [12] : [9, 10, 12, 18, 19, 22]
+      },
+      async replaceSession() {
+        return 0
+      },
+      async replaceSessionCheckpointed() {
+        return 0
+      },
+    })
+
+    const result = await controller.findAdjacent({
+      query: 'abc',
+      isHex: false,
+      direction: 'forward',
+      anchorOffset: 0,
+      fileSize: 50,
+      viewportOffset: 10,
+      viewportLength: 8,
+    })
+
+    expect(result.offset).to.equal(12)
+    expect(result.viewport).to.deep.equal({
+      offset: 10,
+      length: 8,
+      matches: [9, 10, 12],
+      hasMore: false,
+    })
+    expect(searchCalls).to.deep.equal([
+      { offset: 1, length: 0, limit: 1, isReverse: false },
+      { offset: 8, length: 12, limit: 12, isReverse: false },
+    ])
+  })
 })

--- a/packages/client/tests/specs/search.spec.ts
+++ b/packages/client/tests/specs/search.spec.ts
@@ -56,8 +56,8 @@ describe('Searching', () => {
     pattern: Uint8Array
     replacement: Uint8Array
     isCaseInsensitive?: boolean
-    offset?: number
-    length?: number
+    offset?: number | string | bigint
+    length?: number | string | bigint
   }) {
     const client = await getClient()
     return await new Promise<{
@@ -69,7 +69,7 @@ describe('Searching', () => {
       offset: number
       length: number
     }>((resolve, reject) => {
-      client.replaceSessionCheckpointed(request, (err, response) => {
+      client.replaceSessionCheckpointed(request as any, (err, response) => {
         if (err) {
           return reject(err)
         }
@@ -79,6 +79,49 @@ describe('Searching', () => {
         return resolve(response)
       })
     })
+  }
+
+  async function expectRawRpcInvalidArgument(
+    methodName:
+      | 'createViewport'
+      | 'getSegment'
+      | 'replaceSession'
+      | 'replaceSessionCheckpointed'
+      | 'searchSession',
+    request: Record<string, unknown>,
+    expectedDetail: string
+  ) {
+    const client = (await getClient()) as unknown as Record<
+      string,
+      (
+        request: Record<string, unknown>,
+        callback: (
+          err: (Error & { code?: number }) | null,
+          response?: unknown
+        ) => void
+      ) => void
+    >
+
+    const err = await new Promise<Error & { code?: number }>(
+      (resolve, reject) => {
+        client[methodName]!(request, (rpcErr, response) => {
+          if (rpcErr) {
+            return resolve(rpcErr)
+          }
+          return reject(
+            new Error(
+              `${methodName} unexpectedly succeeded with ${JSON.stringify(
+                response
+              )}`
+            )
+          )
+        })
+      }
+    )
+
+    expect(err.message).to.include('INVALID_ARGUMENT')
+    expect(err.message).to.include(expectedDetail)
+    expect(err.code).to.equal(GrpcStatus.INVALID_ARGUMENT)
   }
 
   beforeEach(async () => {
@@ -256,6 +299,69 @@ describe('Searching', () => {
         ((err as Error & { cause?: { code?: number } }).cause ?? {}).code
       ).to.equal(GrpcStatus.INVALID_ARGUMENT)
     }
+  })
+
+  it('Should reject raw RPC ranges that overflow int64 boundaries', async () => {
+    await overwrite(session_id, 0, Buffer.from('abcabc'))
+    const maxInt64 = '9223372036854775807'
+
+    await expectRawRpcInvalidArgument(
+      'getSegment',
+      {
+        sessionId: session_id,
+        offset: maxInt64,
+        length: '1',
+      },
+      'segment range is invalid'
+    )
+    await expectRawRpcInvalidArgument(
+      'searchSession',
+      {
+        sessionId: session_id,
+        pattern: Buffer.from('a'),
+        offset: maxInt64,
+        length: '1',
+      },
+      'search range is invalid'
+    )
+    await expectRawRpcInvalidArgument(
+      'replaceSession',
+      {
+        sessionId: session_id,
+        pattern: Buffer.from('ab'),
+        replacement: Buffer.from('x'),
+        offset: maxInt64,
+        length: '1',
+        limit: 1,
+      },
+      'replace range is invalid'
+    )
+    await expectRawRpcInvalidArgument(
+      'replaceSessionCheckpointed',
+      {
+        sessionId: session_id,
+        pattern: Buffer.from('ab'),
+        replacement: Buffer.from('x'),
+        offset: maxInt64,
+        length: '1',
+      },
+      'checkpointed replace range is invalid'
+    )
+    await expectRawRpcInvalidArgument(
+      'createViewport',
+      {
+        sessionId: session_id,
+        offset: maxInt64,
+        capacity: 1,
+        isFloating: false,
+      },
+      'viewport range is invalid'
+    )
+
+    expect(await getChangeCount(session_id)).to.equal(1)
+    expect(
+      await getSegment(session_id, 0, await getComputedFileSize(session_id))
+    ).deep.equals(Buffer.from('abcabc'))
   })
 
   it('Should be able to optimize replacement operations', () => {
@@ -1102,6 +1208,133 @@ describe('Searching', () => {
     expect(
       await getSegment(session_id, 0, await getComputedFileSize(session_id))
     ).deep.equals(Buffer.from(original, 'utf8'))
+  })
+
+  it('Should decorate viewport neighbor matches that cross viewport boundaries', async () => {
+    await overwrite(session_id, 0, Buffer.from('xxabcxxabcxx'))
+    const fileSize = await getComputedFileSize(session_id)
+    const controller = new EditorSearchController(session_id, {
+      windowLimit: 1,
+    })
+
+    const result = await controller.findAdjacent({
+      query: 'abc',
+      isHex: false,
+      caseInsensitive: false,
+      direction: 'forward',
+      anchorOffset: 0,
+      fileSize,
+      viewportOffset: 3,
+      viewportLength: 5,
+    })
+
+    expect(result.offset).to.equal(2)
+    expect(result.patternLength).to.equal(3)
+    expect(result.viewport).to.deep.equal({
+      offset: 3,
+      length: 5,
+      matches: [2, 7],
+      hasMore: false,
+    })
+  })
+
+  it('Should walk overlapping large-search matches forward and backward', async () => {
+    await overwrite(session_id, 0, Buffer.from('aaaaaa'))
+    const fileSize = await getComputedFileSize(session_id)
+    const controller = new EditorSearchController(session_id, {
+      windowLimit: 100,
+    })
+
+    const forward = await controller.findAdjacent({
+      query: 'aa',
+      isHex: false,
+      caseInsensitive: false,
+      direction: 'forward',
+      anchorOffset: 0,
+      fileSize,
+      viewportOffset: 1,
+      viewportLength: 4,
+    })
+    expect(forward.offset).to.equal(1)
+    expect(forward.viewport).to.deep.equal({
+      offset: 1,
+      length: 4,
+      matches: [0, 1, 2, 3, 4],
+      hasMore: false,
+    })
+
+    const backward = await controller.findAdjacent({
+      query: 'aa',
+      isHex: false,
+      caseInsensitive: false,
+      direction: 'backward',
+      anchorOffset: 2,
+      fileSize,
+      viewportOffset: 1,
+      viewportLength: 4,
+    })
+    expect(backward.offset).to.equal(1)
+
+    const wrapped = await controller.findAdjacent({
+      query: 'aa',
+      isHex: false,
+      caseInsensitive: false,
+      direction: 'forward',
+      anchorOffset: 4,
+      fileSize,
+      viewportOffset: 0,
+      viewportLength: 6,
+    })
+    expect(wrapped.offset).to.equal(0)
+  })
+
+  it('Should default viewport match caps above the visible byte count', async () => {
+    await overwrite(session_id, 0, Buffer.from('aaaaaaaaaa'))
+    const fileSize = await getComputedFileSize(session_id)
+    const controller = new EditorSearchController(session_id, {
+      windowLimit: 1,
+    })
+
+    const viewport = await controller.findViewportMatches({
+      query: 'a',
+      isHex: false,
+      caseInsensitive: false,
+      fileSize,
+      viewportOffset: 0,
+      viewportLength: 10,
+    })
+
+    expect(viewport).to.deep.equal({
+      offset: 0,
+      length: 10,
+      matches: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      hasMore: false,
+    })
+  })
+
+  it('Should surface explicit viewport overflow while retaining the focused match', async () => {
+    await overwrite(session_id, 0, Buffer.from('aaaaaaaaaa'))
+    const fileSize = await getComputedFileSize(session_id)
+    const controller = new EditorSearchController(session_id, {
+      windowLimit: 100,
+    })
+
+    const result = await controller.findAdjacent({
+      query: 'a',
+      isHex: false,
+      caseInsensitive: false,
+      direction: 'forward',
+      anchorOffset: 7,
+      fileSize,
+      viewportOffset: 0,
+      viewportLength: 10,
+      viewportLimit: 3,
+    })
+
+    expect(result.offset).to.equal(8)
+    expect(result.viewport?.hasMore).to.equal(true)
+    expect(result.viewport?.matches).to.have.length(4)
+    expect(result.viewport?.matches).to.include(8)
   })
 
   it('Should record the normalized query in checkpoint transactions for large replace-all', async () => {

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -2291,6 +2291,9 @@ namespace omega_edit {
                 return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                                     "replace offset, length, and limit must be non-negative");
             }
+            if (length > 0 && offset > (std::numeric_limits<int64_t>::max)() - length) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "replace range is invalid");
+            }
 
             const auto payload_status = validate_replace_payload_sizes(request->pattern(), request->replacement(),
                                                                        resource_limits_.max_change_bytes, "replace");
@@ -2423,6 +2426,9 @@ namespace omega_edit {
             if (offset < 0 || length < 0) {
                 return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                                     "checkpointed replace offset and length must be non-negative");
+            }
+            if (length > 0 && offset > (std::numeric_limits<int64_t>::max)() - length) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "checkpointed replace range is invalid");
             }
 
             const auto payload_status =

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -6612,14 +6612,39 @@ export class HexEditorProvider
             anchorOffset: msg.offset,
             fileSize: session.fileSize,
           })
+          if (navigation.offset >= 0) {
+            await this.scrollTo(session, navigation.offset)
+          }
+          const viewportOffset = session.offset
+          const viewportLength = Math.min(
+            session.webviewState.visibleByteCount,
+            Math.max(0, session.fileSize - viewportOffset)
+          )
+          const viewport =
+            navigation.offset >= 0 && viewportLength > 0
+              ? await session.search.findViewportMatches({
+                  query: msg.query,
+                  isHex: msg.isHex,
+                  caseInsensitive: msg.caseInsensitive ?? false,
+                  fileSize: session.fileSize,
+                  viewportOffset,
+                  viewportLength,
+                  focusedOffset: navigation.offset,
+                })
+              : undefined
           this.postWebviewMessage(session, {
             type: 'searchNavigationResult',
             offset: navigation.offset,
             patternLength: navigation.patternLength,
+            ...(viewport
+              ? {
+                  viewportOffset: viewport.offset,
+                  viewportLength: viewport.length,
+                  viewportMatches: viewport.matches,
+                  viewportHasMoreMatches: viewport.hasMore,
+                }
+              : {}),
           })
-          if (navigation.offset >= 0) {
-            await this.scrollTo(session, navigation.offset)
-          }
           break
         }
       }

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -364,6 +364,10 @@ export type HostToWebviewMessage =
       type: 'searchNavigationResult'
       offset: number
       patternLength: number
+      viewportOffset?: number
+      viewportLength?: number
+      viewportMatches?: number[]
+      viewportHasMoreMatches?: boolean
     }
   | {
       type: 'searchNavigationCommand'

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -730,6 +730,9 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerJs, /normalizeExternalHighlights/)
   assert.match(providerJs, /type:\s*['"]externalHighlights['"]/)
   assert.match(providerJs, /type:\s*['"]rangeMapTree['"]/)
+  assert.match(providerJs, /findViewportMatches/)
+  assert.match(providerJs, /viewportMatches:\s*viewport\.matches/)
+  assert.match(providerJs, /viewportHasMoreMatches:\s*viewport\.hasMore/)
   assert.match(providerJs, /setSessionRangeMap/)
   assert.match(providerJs, /case\s+['"]loadRangeMap['"]/)
   assert.match(providerJs, /case\s+['"]unloadRangeMap['"]/)
@@ -763,6 +766,8 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(protocolSource, /externalHighlights/)
   assert.match(protocolSource, /WebviewRangeMapNode/)
   assert.match(protocolSource, /rangeMapTree/)
+  assert.match(protocolSource, /viewportMatches\?: number\[\]/)
+  assert.match(protocolSource, /viewportHasMoreMatches\?: boolean/)
   assert.match(protocolSource, /type: 'loadRangeMap'/)
   assert.match(protocolSource, /type: 'unloadRangeMap'/)
   assert.match(protocolSource, /type: 'bytesPerRow'/)
@@ -1087,6 +1092,8 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(svelteAppSource, /clearSearchResults\(\)/)
   assert.match(svelteAppSource, /type: 'findAdjacentMatch'/)
   assert.match(svelteAppSource, /type: 'goToMatch'/)
+  assert.match(svelteAppSource, /viewportMatches \?\? \[\]/)
+  assert.match(svelteAppSource, /message\.viewportOffset === visibleOffset/)
   assert.match(svelteAppSource, /case 'searchNavigationCommand'/)
   assert.match(svelteAppSource, /case 'replaceComplete'/)
   assert.match(svelteAppSource, /normalizeReplacementHex/)
@@ -1179,6 +1186,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(svelteAppSource, /viewportProfile=\{latestViewportProfile\}/)
   assert.match(svelteAppSource, /\{serverHealth\}/)
   assert.match(svelteAppSource, /visibleByteCount=\{visibleByteCount\(\)\}/)
+  assert.match(svelteAppSource, /searchLength=\{searchPatternLength\}/)
   assert.match(editorWorkspaceSource, /PreviewGrid/)
   assert.match(editorWorkspaceSource, /FileScrollbar/)
   assert.match(editorWorkspaceSource, /editor-grid-shell/)
@@ -1208,6 +1216,8 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(editorWorkspaceSource, /onReorderAnalysisSection/)
   assert.match(editorWorkspaceSource, /externalHighlights/)
   assert.match(editorWorkspaceSource, /rangeMapTree/)
+  assert.match(editorWorkspaceSource, /\{searchMatches\}/)
+  assert.match(editorWorkspaceSource, /\{searchLength\}/)
   assert.match(editorWorkspaceSource, /onSelectRangeMapNode/)
   assert.doesNotMatch(editorWorkspaceSource, /onSelectExternalHighlight/)
   assert.match(editorWorkspaceSource, /onLoadRangeMap/)
@@ -1277,6 +1287,16 @@ test('compiled extension entrypoints exist after build', () => {
     /class:hover=\{rowIndex === hoveredRowIndex\}/
   )
   assert.match(previewGridSource, /class:columnHover/)
+  assert.match(previewGridSource, /const searchHitByOffset = \$derived\.by/)
+  assert.match(previewGridSource, /searchHitByOffset\.has\(byteOffset\)/)
+  assert.match(
+    previewGridSource,
+    /class:searchHit=\{isSearchHit\(byteOffset\)\}/
+  )
+  assert.match(
+    previewGridSource,
+    /class:searchHit=\{isSearchHit\(byteOffset\)\}[\s\S]*class:externalHighlight=\{!!externalHighlight\}/
+  )
   assert.match(previewGridSource, /class:activePane/)
   assert.match(previewGridSource, /class:printable=\{isPrintable\(byte\)\}/)
   assert.match(previewGridSource, /class:control=\{isControlByte\(byte\)\}/)

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -2282,6 +2282,11 @@
     searchMode = 'large'
     searchCurrentOffset = message.offset
     searchPatternLength = message.patternLength || searchPatternLength
+    searchMatches =
+      message.viewportOffset === undefined || message.viewportOffset === visibleOffset
+        ? (message.viewportMatches ?? [])
+        : []
+    searchMatchIndex = searchMatches.indexOf(message.offset)
     selectSearchMatch(message.offset)
   }
 
@@ -2748,6 +2753,8 @@
     {selectionEnd}
     searchStart={searchHighlightStart}
     searchEnd={searchHighlightEnd}
+    {searchMatches}
+    searchLength={searchPatternLength}
     inspectorStart={inspectorHighlightStart}
     inspectorEnd={inspectorHighlightEnd}
     {externalHighlights}

--- a/vscode-extension/webview-ui/src/components/EditorWorkspace.svelte
+++ b/vscode-extension/webview-ui/src/components/EditorWorkspace.svelte
@@ -47,6 +47,8 @@
     selectionEnd?: number
     searchStart?: number
     searchEnd?: number
+    searchMatches?: number[]
+    searchLength?: number
     inspectorStart?: number
     inspectorEnd?: number
     externalHighlights?: WebviewExternalHighlight[]
@@ -119,6 +121,8 @@
     selectionEnd = -1,
     searchStart = -1,
     searchEnd = -1,
+    searchMatches = [],
+    searchLength = 0,
     inspectorStart = -1,
     inspectorEnd = -1,
     externalHighlights = [],
@@ -383,6 +387,8 @@
           {activePane}
           searchStart={searchStart}
           searchEnd={searchEnd}
+          {searchMatches}
+          {searchLength}
           inspectorStart={inspectorStart}
           inspectorEnd={inspectorEnd}
           {externalHighlights}

--- a/vscode-extension/webview-ui/src/components/PreviewGrid.svelte
+++ b/vscode-extension/webview-ui/src/components/PreviewGrid.svelte
@@ -17,6 +17,8 @@
     selectionEnd?: number
     searchStart?: number
     searchEnd?: number
+    searchMatches?: number[]
+    searchLength?: number
     inspectorStart?: number
     inspectorEnd?: number
     externalHighlights?: WebviewExternalHighlight[]
@@ -49,6 +51,8 @@
     selectionEnd = -1,
     searchStart = -1,
     searchEnd = -1,
+    searchMatches = [],
+    searchLength = 0,
     inspectorStart = -1,
     inspectorEnd = -1,
     externalHighlights = [],
@@ -104,6 +108,34 @@
       for (let byteOffset = start; byteOffset < end; byteOffset += 1) {
         if (!lookup.has(byteOffset)) {
           lookup.set(byteOffset, highlight)
+          if (lookup.size >= visibleByteCount) {
+            return lookup
+          }
+        }
+      }
+    }
+
+    return lookup
+  })
+  const searchHitByOffset = $derived.by(() => {
+    const lookup = new Set<number>()
+    const visibleStart = offset
+    const visibleEnd = offset + data.length
+    const visibleByteCount = Math.max(0, visibleEnd - visibleStart)
+    const length = Math.max(0, searchLength)
+    if (visibleByteCount === 0 || length <= 0) {
+      return lookup
+    }
+
+    for (const matchOffset of searchMatches) {
+      if (!Number.isSafeInteger(matchOffset) || matchOffset < 0) {
+        continue
+      }
+      const start = Math.max(visibleStart, matchOffset)
+      const end = Math.min(visibleEnd, matchOffset + length)
+      for (let byteOffset = start; byteOffset < end; byteOffset += 1) {
+        if (!lookup.has(byteOffset)) {
+          lookup.add(byteOffset)
           if (lookup.size >= visibleByteCount) {
             return lookup
           }
@@ -220,7 +252,7 @@
   }
 
   function isSearchHit(byteOffset: number): boolean {
-    return (
+    return searchHitByOffset.has(byteOffset) || (
       searchStart >= 0 &&
       searchEnd >= searchStart &&
       byteOffset >= searchStart &&


### PR DESCRIPTION
## Summary

This completes the search/replace scale design batch by keeping interactive next/previous search bounded while separately decorating the active viewport with visible neighbor matches. It also closes the near-`INT64_MAX` testing gap through public C APIs and raw server RPC boundaries.

The VS Code hex editor now receives viewport match windows for large search navigation and renders those search hits independently of range-map/debugger highlights. The server also rejects overflowing replace ranges explicitly before they fall through to less-specific range handling.

## User Impact

Users can walk large search results forward or backward without needing a global count, while the active viewport can still show neighboring matches. Search match rendering remains orthogonal to external highlights. Overflowing search/replace/segment/viewport RPC ranges now fail deterministically with `INVALID_ARGUMENT` and leave session content unchanged.

## Backlog

`SHORTCOMINGS.md` now records the follow-on text encoding work for the TEXT pane, Data Inspector, and text-search query encoding across ASCII, Windows-1252, CP437, EBCDIC, and MacRoman-style display modes.

## Validation

- `cmake --build --preset ninja-debug-minimal`
- `cmd.exe /C "call C:\\PROGRA~1\\MICROS~1\\2022\\COMMUN~1\\Common7\\Tools\\VsDevCmd.bat -arch=x64 >nul && cd /d D:\\GitHub\\omega-edit\\server\\cpp && cmake --build build --config Debug"`
- `cmd.exe /C "set YARN_IGNORE_ENGINES=1&& yarn workspace @omega-edit/client build"`
- focused client search/editor-pattern specs: 29 passed
- full client suite: 181 passed, 1 skipped
- new public C API overflow CTest: passed
- themed native CTest subset for search/replace/viewport/overflow: 31 passed
- VS Code extension compile, Svelte check, webview build, and unit tests: 9 passed
- `cmd.exe /C "set YARN_IGNORE_ENGINES=1&& yarn lint"`
- `git diff --check`

Note: a full WSL core CTest run was 129/130 because the existing `File Copy` POSIX mode-preservation assertion does not hold on the Windows-mounted `/mnt/d` workspace. The Windows-native `filesystem_tests` binary passed.
