### PR TITLE
Clean up code quality shortcomings

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -17,7 +17,14 @@ fixed and no longer listed as open. The profile/character-count scan buffer
 issue, search read-failure reporting issue, and unbounded `replace_matches`
 materialization issue are also fixed and no longer listed as open. The utility
 string-helper issue and the fixed failure-signaling edges for unknown CLI
-options and missing session files are likewise no longer listed as open.
+options and missing session files are likewise no longer listed as open. The
+code-quality cleanup for computed-content inspection lock scope,
+descriptor-preserving temp-file writes, explicit C-string/named-options APIs, OpenSSL
+cipher key scrubbing, shared C plugin option parsing, targeted duplication
+extractions, and the replace/save failure-signaling edges is also complete and
+no longer listed as open. Mutation-capable transform RPCs still intentionally
+serialize the session while a plugin runs because they can modify the current
+core model.
 
 Recent core/server/plugin review findings have been folded into the priority
 list below rather than kept as a second appended review. A fresh core/server
@@ -288,102 +295,6 @@ Suggested fix:
 - Add an integration test that submits a change just under and just over the
   effective limit and asserts the intended error text.
 
-### 14. Whole-content operations hold the per-session core lock for their full duration
-
-**Impact:** Medium (per-session availability on massive files)
-**Risk:** Medium
-**Area:** C++ server fingerprint/inspection/transform paths
-
-`GetSessionFingerprint` and `InspectSessionContent` over *computed* content, and
-`ApplyTransformPlugin` generally, hold the session's `core_mutex` while
-streaming the entire session content through the digest/inspect/transform
-plugin. On a massive file that is minutes of wall-clock time during which every
-other RPC on that session (viewport reads, heartbeat-adjacent calls, saves)
-blocks — and, combined with item 3, can escalate to a server-wide stall. The
-file-snapshot paths already avoid this by reading the snapshot outside the
-lock.
-
-Relevant code:
-- `server/cpp/src/editor_service.cpp:1765`
-- `server/cpp/src/editor_service.cpp:1911`
-- `server/cpp/src/editor_service.cpp:2341`
-
-Suggested fix:
-- For computed-content digests/inspections, materialize a temporary snapshot
-  (or reuse the checkpoint machinery) under the lock, then stream from the
-  snapshot outside the lock, as the original/checkpoint paths do.
-- Document that transforms intentionally serialize the session, and rely on the
-  existing transform/mutation guards for mutual exclusion rather than the core
-  lock alone where possible.
-- Add a test that runs a digest over a large session and asserts a concurrent
-  viewport read completes promptly.
-
-### 16. Temp files are created, closed, then reopened by path
-
-**Impact:** Medium (local symlink-swap hardening)
-**Risk:** Low
-**Area:** Core checkpoint/payload/save temp-file handling
-
-The common pattern is `omega_util_mkstemp` (0600, `O_EXCL`) followed by
-`close(fd)` and a later `FOPEN(path, "wb")` — in checkpoint creation, payload
-capture, save's temp file, and `reserve_output_path_`. Between the close and
-the reopen, a local attacker with write access to the directory (for example a
-shared `/tmp` checkpoint directory) can swap the file for a symlink and the
-subsequent open-for-write follows it. The exclusive create wins the name, but
-the identity guarantee is dropped when the fd is closed.
-
-Relevant code:
-- `core/src/lib/edit.cpp:987`
-- `core/src/lib/edit.cpp:1011`
-- `core/src/lib/edit.cpp:2259`
-- `core/src/lib/edit.cpp:291`
-
-Suggested fix:
-- Keep the descriptor from `mkstemp` and wrap it with `fdopen` instead of
-  closing and reopening by name.
-- Where reopening is unavoidable, verify identity (`O_NOFOLLOW`, or
-  fstat/st_ino comparison) before writing.
-- Document that checkpoint directories should not be world-writable shared
-  directories.
-
-### 18. C-string and byte edit APIs encode different zero-length semantics
-
-**Impact:** Medium
-**Risk:** Low to Medium
-**Area:** Core C API
-
-The C-string helpers infer length with `strlen` when the length argument is zero,
-while `_bytes` variants treat length zero as an explicit no-op. The headers warn
-about this now, but the API shape is still easy to misuse with embedded NULs or
-when callers expect zero to mean the same thing everywhere.
-
-Relevant code:
-- `core/src/include/omega_edit/edit.h`
-
-Suggested fix:
-- Add safer, clearly named APIs for inferred-length text edits.
-- Keep byte APIs explicit-only.
-- Add examples that steer binary callers to `_bytes` variants.
-
-### 19. Long positional argument lists remain hard to use safely
-
-**Impact:** Medium
-**Risk:** Low to Medium
-**Area:** Core C API ergonomics
-
-Search/replace and viewport APIs still use long positional lists and `int`
-booleans for options such as floating, ordering, and overwrite mode. Argument
-swaps are easy to miss at call sites.
-
-Relevant code:
-- `core/src/include/omega_edit/edit.h`
-- `core/src/include/omega_edit/viewport.h`
-
-Suggested fix:
-- Add options-struct APIs for new callers.
-- Preserve existing positional APIs for ABI compatibility.
-- Use enum/boolean-like typed fields in the options structs.
-
 ### 20. Viewport dirty state uses a negative-capacity sentinel
 
 **Impact:** Medium
@@ -411,29 +322,6 @@ Suggested fix:
 - Keep capacity non-negative internally.
 - Route all mark-dirty-and-notify call sites through one helper.
 - Update tests that currently force dirty state by negating capacity.
-
-### 22. OpenSSL cipher plugin does not zeroize key material
-
-**Impact:** Medium
-**Risk:** Low
-**Area:** Transform plugins (crypto hygiene)
-
-`cipher_parse_options` holds the raw key/IV in a stack `omega_cipher_options_t`
-(and the hex key in a stack buffer during parsing) and never scrubs them with
-`OPENSSL_cleanse` before returning, so key bytes linger in freed stack memory.
-Transform output is also persisted to checkpoint files in the clear, which is
-inherent to how transforms materialize but worth stating for a crypto-grade
-attestation.
-
-Relevant code:
-- `plugins/src/openssl_ciphers.c:166`
-- `plugins/src/openssl_ciphers.c:355`
-
-Suggested fix:
-- `OPENSSL_cleanse` the key/IV buffers (and the parsing scratch buffer) before
-  returning from apply.
-- Document that transform output, including ciphertext, is written to checkpoint
-  files unencrypted.
 
 ---
 
@@ -487,91 +375,6 @@ Suggested fix:
 - Batch redo by transaction.
 - Reuse notification batching and viewport-update coalescing where possible.
 
-### 26. C transform plugins each reimplement the same JSON parser
-
-**Impact:** Low
-**Risk:** Low
-**Area:** Transform plugins (C option parsing)
-
-base64, zlib, cipher, digest, and the bitmask header each carry their own
-`*_skip_ws` / `*_parse_json_string` / `*_parse_options` scaffolding. The C++
-plugins already share `plugin_options.hpp`; the C plugins have no equivalent, so
-the same parser is duplicated and independently maintained.
-
-Relevant code:
-- `plugins/src/base64.c:34`
-- `plugins/src/zlib.c:48`
-- `plugins/src/openssl_ciphers.c:84`
-- `plugins/src/openssl_digests.c:61`
-- `plugins/src/bitmask_options.h:53`
-
-Suggested fix:
-- Extract a shared C options header mirroring `plugin_options.hpp`.
-- Consolidate to a single audited JSON-options parser to shrink the attack
-  surface.
-- Keep per-plugin schema validation.
-
-### 27. Core/server duplication that should be consolidated
-
-**Impact:** Low (maintainability, divergence risk)
-**Risk:** Low
-**Area:** Core edit internals, C++ server RPC scaffolding
-
-Several near-identical code blocks are maintained in parallel and have already
-started to drift:
-
-- `create_checkpoint_file_` and `create_payload_file_` differ only in the
-  filename template (`core/src/lib/edit.cpp:972`, `core/src/lib/edit.cpp:996`).
-- `update_model_helper_` and `insert_payload_segment_` duplicate the
-  segment-split/walk scaffolding (~40 lines) around different insert bodies
-  (`core/src/lib/edit.cpp:640`, `core/src/lib/edit.cpp:738`).
-- `rebuild_model_to_change_count_` repeats the "reinitialize from backing file"
-  block in two branches (`core/src/lib/edit.cpp:859`).
-- `omega_session_get_num_change_transactions` and
-  `omega_session_get_num_undone_change_transactions` are copy-pasted loops over
-  different vectors (`core/src/lib/session.cpp:270`,
-  `core/src/lib/session.cpp:295`).
-- `GetSessionFingerprint` and `InspectSessionContent` each duplicate the entire
-  snapshot-vs-computed branch pair, including two ten-argument
-  `inspect_with_streaming_plugin` calls that differ only in messages
-  (`server/cpp/src/editor_service.cpp:1702`,
-  `server/cpp/src/editor_service.cpp:1856`); `GetContentType` and `GetLanguage`
-  are likewise structural twins (`server/cpp/src/editor_service.cpp:1546`,
-  `server/cpp/src/editor_service.cpp:1589`).
-- Nearly every RPC repeats the same guard/lock/NOT_FOUND prologue by hand.
-
-Suggested fix:
-- Extract a single temp-file-in-checkpoint-dir helper parameterized by prefix.
-- Factor the model segment split/walk into one helper used by both insert
-  paths.
-- Introduce a small `resolve_content_source(...)` helper (and an error-message
-  struct for `inspect_with_streaming_plugin`) so fingerprint/inspect share one
-  body.
-- Add a `with_locked_session(request_id, handler)` helper for the RPC prologue.
-
-### 29. Failure-signaling edges can mislead callers or operators
-
-**Impact:** Low to Medium
-**Risk:** Low
-**Area:** Core edit results, save durability signaling
-
-A collection of small signaling gaps, individually rare but relevant to a
-reliability attestation:
-
-- `replace_bytes_impl_` returns `0` (the "nothing changed" value) when the
-  insert fails *and* the compensating undo of the already-applied delete also
-  fails, so in that allocation-failure corner the session content changed while
-  the caller is told it did not (`core/src/lib/edit.cpp:396`).
-- `omega_edit_save_segment` returns `-12` when `sync_parent_directory_` fails
-  *after* the atomic rename has already published the file, so a completed save
-  is reported as a failure with no way to distinguish post-commit durability
-  warnings from real failures (`core/src/lib/edit.cpp:2376`).
-
-Suggested fix:
-- Return a distinct negative error when the replace rollback itself fails, and
-  a distinct post-commit code (or success-with-warning) for the directory-sync
-  case.
-
 ### 30. Content detection feeds untrusted bytes to third-party parsers
 
 **Impact:** Low to Medium
@@ -588,9 +391,17 @@ Relevant code:
 - `server/cpp/src/cld3_language_detector.cpp:132`
 
 Suggested fix:
-- Track and update libmagic/CLD3 versions as part of the release process.
-- Consider isolating or resource-limiting content detection for untrusted input.
-- Document the third-party parser exposure in the deployment trust boundary.
+- Move content-type and language guessing behind detector/inspect plugins that
+  run through the existing transform-plugin worker boundary instead of calling
+  libmagic/CLD3 in the server process.
+- Keep `GetContentType` and `GetLanguage` as compatibility RPCs that dispatch
+  to configured detector plugins, or introduce plugin-backed replacement RPCs
+  and deprecate the in-process implementations.
+- Treat libmagic/CLD3-backed detectors as optional operator-selected plugins,
+  with the same production/experimental support levels, cancellation, resource
+  limits, and worker sandboxing policy as transform plugins.
+- Track and update bundled detector plugin dependencies as part of the release
+  process, and document the plugin trust boundary for deployments.
 
 ### 31. Text pane and Data Inspector only expose ASCII-oriented byte display
 
@@ -658,9 +469,6 @@ claiming production hardening:
   `omega_search_next_match` is not an uninitialized-read issue; the struct uses
   non-static data member initializers, so default initialization covers the
   fields read by `populate_data_segment_`.
-- The C transform plugins' hand-rolled JSON string parsers use fixed stack
-  buffers with strict `length + 1 >= out_size` guards; no buffer overflow was
-  found across the base64/zlib/cipher/digest/bitmask parsers.
 - The xxhash streaming ring-buffer arithmetic in `common_checksums.cpp` is
   bounds-safe, and the streaming checksums honor cancellation via
   `for_each_chunk`.

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -75,6 +75,18 @@ omega_session_t *omega_edit_create_session_from_bytes(const omega_byte_t *data_p
 void omega_edit_destroy_session(omega_session_t *session_ptr);
 
 /**
+ * Options for creating a viewport with named fields.
+ */
+typedef struct {
+    int64_t offset;
+    int64_t capacity;
+    omega_edit_bool_t is_floating;
+    omega_viewport_event_cbk_t cbk;
+    void *user_data_ptr;
+    int32_t event_interest;
+} omega_edit_viewport_options_t;
+
+/**
  * Create a new viewport, returns a pointer to the new viewport
  * @param session_ptr session to create the new viewport in
  * @param offset offset for the new viewport
@@ -89,6 +101,15 @@ void omega_edit_destroy_session(omega_session_t *session_ptr);
 omega_viewport_t *omega_edit_create_viewport(omega_session_t *session_ptr, int64_t offset, int64_t capacity,
                                              int is_floating, omega_viewport_event_cbk_t cbk, void *user_data_ptr,
                                              int32_t event_interest);
+
+/**
+ * Create a new viewport using a named options structure.
+ * @param session_ptr session to create the new viewport in
+ * @param options viewport creation options
+ * @return pointer to the new viewport, or NULL on failure
+ */
+omega_viewport_t *omega_edit_create_viewport_with_options(omega_session_t *session_ptr,
+                                                          const omega_edit_viewport_options_t *options);
 
 /**
  * Destroy a given viewport
@@ -170,6 +191,20 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
  * @return 0 on success, non-zero otherwise
  */
 int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path);
+
+/**
+ * Write a session byte range to an already-open file without publishing a save event.
+ *
+ * The caller owns `file_ptr` and is responsible for closing it. The file is flushed before this function returns.
+ * The session model is not modified.
+ *
+ * @param session_ptr session to copy from
+ * @param file_ptr already-open output file
+ * @param offset starting byte offset in the session
+ * @param length number of bytes to copy, or zero to copy from offset to the end of the session
+ * @return zero on success and non-zero otherwise
+ */
+int omega_edit_save_segment_to_file(const omega_session_t *session_ptr, FILE *file_ptr, int64_t offset, int64_t length);
 
 /**
  * Copy a bounded session byte range into a newly allocated memory buffer.
@@ -284,6 +319,13 @@ int64_t omega_edit_insert_bytes(omega_session_t *session_ptr, int64_t offset, co
 int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length);
 
 /**
+ * Insert a null-terminated C string at the given offset.
+ *
+ * This is the explicit inferred-length text variant. Binary callers should use omega_edit_insert_bytes.
+ */
+int64_t omega_edit_insert_cstring(omega_session_t *session_ptr, int64_t offset, const char *cstr);
+
+/**
  * Overwrite bytes at the given offset with the given new bytes
  * @param session_ptr session to make the change in
  * @param offset location offset to make the change
@@ -309,6 +351,13 @@ int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset,
  * use omega_edit_overwrite_bytes and pass an explicit byte length.
  */
 int64_t omega_edit_overwrite(omega_session_t *session_ptr, int64_t offset, const char *cstr, int64_t length);
+
+/**
+ * Overwrite bytes at the given offset with a null-terminated C string.
+ *
+ * This is the explicit inferred-length text variant. Binary callers should use omega_edit_overwrite_bytes.
+ */
+int64_t omega_edit_overwrite_cstring(omega_session_t *session_ptr, int64_t offset, const char *cstr);
 
 /**
  * Replace a span of bytes at the given offset with a new byte sequence.
@@ -380,6 +429,31 @@ int64_t omega_edit_replace(omega_session_t *session_ptr, int64_t offset, int64_t
                            int64_t insert_length);
 
 /**
+ * Replace a span of bytes at the given offset with a null-terminated C string.
+ *
+ * This is the explicit inferred-length text variant. Binary callers should use omega_edit_replace_bytes.
+ */
+int64_t omega_edit_replace_cstring(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
+                                   const char *cstr);
+
+/**
+ * Options for replacing matches with named fields.
+ */
+typedef struct {
+    omega_edit_bool_t case_insensitive;
+    omega_edit_bool_t is_reverse;
+    int64_t offset;
+    int64_t length;
+    int64_t limit;
+    omega_edit_bool_t front_to_back;
+    omega_edit_bool_t overwrite_only;
+    int64_t *replacement_count_out;
+    int64_t *delete_count_out;
+    int64_t *insert_count_out;
+    int64_t *overwrite_count_out;
+} omega_edit_replace_matches_options_t;
+
+/**
  * Replace matching byte patterns inside a session range using in-place transactional edits.
  *
  * Matches are located against the original session content and replaced in one logical transaction. Matching is
@@ -420,6 +494,21 @@ int omega_edit_replace_matches_bytes(omega_session_t *session_ptr, const omega_b
                                      int64_t *insert_count_out, int64_t *overwrite_count_out);
 
 /**
+ * Replace matching byte patterns using named options.
+ * @param session_ptr session to edit
+ * @param pattern pattern bytes to search for
+ * @param pattern_length explicit number of bytes in pattern
+ * @param replacement replacement bytes, or null if `replacement_length` is zero
+ * @param replacement_length explicit number of bytes in replacement
+ * @param options named replace options
+ * @return zero on success and non-zero otherwise
+ */
+int omega_edit_replace_matches_bytes_with_options(omega_session_t *session_ptr, const omega_byte_t *pattern,
+                                                  int64_t pattern_length, const omega_byte_t *replacement,
+                                                  int64_t replacement_length,
+                                                  const omega_edit_replace_matches_options_t *options);
+
+/**
  * Replace matching C-string patterns inside a session range using in-place transactional edits.
  * @param session_ptr session to edit
  * @param pattern pattern C string to search for
@@ -446,6 +535,24 @@ int omega_edit_replace_matches(omega_session_t *session_ptr, const char *pattern
                                int is_reverse, int64_t offset, int64_t length, int64_t limit, int front_to_back,
                                int overwrite_only, int64_t *replacement_count_out, int64_t *delete_count_out,
                                int64_t *insert_count_out, int64_t *overwrite_count_out);
+
+/**
+ * Replace matching C-string patterns using named options.
+ */
+int omega_edit_replace_matches_with_options(omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,
+                                            const char *replacement, int64_t replacement_length,
+                                            const omega_edit_replace_matches_options_t *options);
+
+/**
+ * Options for streamed replace-all operations.
+ */
+typedef struct {
+    omega_edit_bool_t case_insensitive;
+    omega_edit_bool_t is_reverse;
+    int64_t offset;
+    int64_t length;
+    int64_t *replacement_count_out;
+} omega_edit_replace_all_options_t;
 
 /**
  * Replace all non-overlapping matches of a byte pattern within a session range using a streamed checkpoint rewrite.
@@ -504,6 +611,14 @@ int omega_edit_replace_all_bytes_directional(omega_session_t *session_ptr, const
                                              int64_t offset, int64_t length, int64_t *replacement_count_out);
 
 /**
+ * Replace all non-overlapping matches of a byte pattern using named options.
+ */
+int omega_edit_replace_all_bytes_with_options(omega_session_t *session_ptr, const omega_byte_t *pattern,
+                                              int64_t pattern_length, const omega_byte_t *replacement,
+                                              int64_t replacement_length,
+                                              const omega_edit_replace_all_options_t *options);
+
+/**
  * Replace all non-overlapping matches of a C-string pattern within a session range using a streamed checkpoint rewrite.
  * @param session_ptr session to edit
  * @param pattern pattern C string to search for
@@ -521,6 +636,22 @@ int omega_edit_replace_all_bytes_directional(omega_session_t *session_ptr, const
 int omega_edit_replace_all(omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,
                            const char *replacement, int64_t replacement_length, int case_insensitive, int64_t offset,
                            int64_t length, int64_t *replacement_count_out);
+
+/**
+ * Replace all non-overlapping C-string matches using named options.
+ */
+int omega_edit_replace_all_with_options(omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,
+                                        const char *replacement, int64_t replacement_length,
+                                        const omega_edit_replace_all_options_t *options);
+
+/**
+ * Replace all non-overlapping matches of a null-terminated C-string pattern with a null-terminated C string.
+ *
+ * This is the explicit inferred-length text variant. Binary callers should use omega_edit_replace_all_bytes.
+ */
+int omega_edit_replace_all_cstring(omega_session_t *session_ptr, const char *pattern, const char *replacement,
+                                   int case_insensitive, int64_t offset, int64_t length,
+                                   int64_t *replacement_count_out);
 
 /**
  * Apply an array of edit script operations sequentially to the given session.

--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -207,6 +207,32 @@ int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_
 int omega_edit_save_segment_to_file(const omega_session_t *session_ptr, FILE *file_ptr, int64_t offset, int64_t length);
 
 /**
+ * Options for writing a session byte range to an already-open file.
+ */
+typedef struct {
+    /** Flush stdio buffers only; skip the OS-level disk sync for short-lived temporary snapshots. */
+    omega_edit_bool_t skip_disk_sync;
+} omega_edit_save_segment_to_file_options_t;
+
+/**
+ * Write a session byte range to an already-open file without publishing a save event.
+ *
+ * The caller owns `file_ptr` and is responsible for closing it. The file's stdio buffers are flushed before this
+ * function returns. Unless options_ptr is non-null and skip_disk_sync is true, the file is also synced to disk.
+ * The session model is not modified.
+ *
+ * @param session_ptr session to copy from
+ * @param file_ptr already-open output file
+ * @param offset starting byte offset in the session
+ * @param length number of bytes to copy, or zero to copy from offset to the end of the session
+ * @param options_ptr optional write behavior controls
+ * @return zero on success and non-zero otherwise
+ */
+int omega_edit_save_segment_to_file_with_options(const omega_session_t *session_ptr, FILE *file_ptr, int64_t offset,
+                                                 int64_t length,
+                                                 const omega_edit_save_segment_to_file_options_t *options_ptr);
+
+/**
  * Copy a bounded session byte range into a newly allocated memory buffer.
  * @param session_ptr session to copy from
  * @param data_ptr_out receives a malloc-allocated buffer containing the copied bytes (caller must free).  The buffer is

--- a/core/src/include/omega_edit/fwd_defs.h
+++ b/core/src/include/omega_edit/fwd_defs.h
@@ -88,8 +88,17 @@ typedef enum {
     IO_FLG_FORCE_OVERWRITE = 1 << 1//< Force overwrite of original file, even if modified outside the session
 } omega_io_flags_t;
 
+/** Boolean-like option value used by options-struct APIs */
+typedef enum { OMEGA_EDIT_FALSE = 0, OMEGA_EDIT_TRUE = 1 } omega_edit_bool_t;
+
 /** Error code to indicate that the original session file has been modified since the session was created */
 #define ORIGINAL_MODIFIED (-100)
+
+/** Replace failed after the delete step and the attempted rollback also failed; session content may have changed */
+#define OMEGA_EDIT_REPLACE_ROLLBACK_FAILED (-101)
+
+/** Save data was published, but syncing the parent directory failed; contents may still be durable on the filesystem */
+#define OMEGA_EDIT_SAVE_DIRECTORY_SYNC_FAILED (-102)
 
 /** Mask types */
 typedef enum { MASK_AND, MASK_OR, MASK_XOR } omega_mask_kind_t;

--- a/core/src/include/omega_edit/viewport.h
+++ b/core/src/include/omega_edit/viewport.h
@@ -131,6 +131,23 @@ int32_t omega_viewport_set_event_interest(omega_viewport_t *viewport_ptr, int32_
 int omega_viewport_modify(omega_viewport_t *viewport_ptr, int64_t offset, int64_t capacity, int is_floating);
 
 /**
+ * Options for modifying viewport settings with named fields.
+ */
+typedef struct {
+    int64_t offset;
+    int64_t capacity;
+    omega_edit_bool_t is_floating;
+} omega_viewport_modify_options_t;
+
+/**
+ * Change viewport settings using named options.
+ * @param viewport_ptr viewport to change settings on
+ * @param options viewport modification options
+ * @return 0 on success, non-zero otherwise
+ */
+int omega_viewport_modify_with_options(omega_viewport_t *viewport_ptr, const omega_viewport_modify_options_t *options);
+
+/**
  * Determine if the given viewport is in the given segment
  * @param viewport_ptr viewport to determine if it's in the given segment
  * @param offset beginning offset of the segment

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -99,8 +99,8 @@ namespace {
                                                                 OMEGA_REPLACE_MATCH_SCRIPT_OPS_PER_MATCH))));
 
     auto initialize_model_segments_(omega_model_segments_t &model_segments, int64_t length) -> bool;
-    auto create_checkpoint_file_(omega_session_t *session_ptr, char *checkpoint_filename,
-                                 size_t checkpoint_filename_size) -> int;
+    auto create_checkpoint_file_for_write_(omega_session_t *session_ptr, char *checkpoint_filename,
+                                           size_t checkpoint_filename_size) -> FILE *;
     auto promote_checkpoint_file_(omega_session_t *session_ptr, const char *checkpoint_filename, int64_t file_size,
                                   bool notify_transform,
                                   const const_omega_change_ptr_t &transform_change_ptr) -> int64_t;
@@ -307,9 +307,14 @@ namespace {
         auto open_reserved_path = [mode](const char *candidate) -> FILE * {
             const auto fd = OPEN(candidate, O_CREAT | O_EXCL | O_WRONLY | O_BINARY, mode);
             if (fd < 0) { return nullptr; }
-            CLOSE(fd);
-            const auto file_ptr = FOPEN(candidate, "wb");
+            FILE *file_ptr = nullptr;
+#ifdef OMEGA_BUILD_WINDOWS
+            file_ptr = _fdopen(fd, "wb");
+#else
+            file_ptr = fdopen(fd, "wb");
+#endif
             if (!file_ptr) {
+                CLOSE(fd);
                 omega_util_remove_file(candidate);
                 return nullptr;
             }
@@ -433,6 +438,7 @@ namespace {
         int64_t last_serial = 0;
         bool changed = false;
         bool success = false;
+        int64_t failure_result = 0;
 
         do {
             const auto delete_serial = omega_edit_delete(session_ptr, offset, delete_length);
@@ -442,7 +448,10 @@ namespace {
 
             const auto insert_serial = omega_edit_insert_bytes(session_ptr, offset, bytes, insert_length);
             if (insert_serial <= 0) {
-                if (0 >= omega_edit_undo_last_change(session_ptr)) { break; }
+                if (0 >= omega_edit_undo_last_change(session_ptr)) {
+                    failure_result = OMEGA_EDIT_REPLACE_ROLLBACK_FAILED;
+                    break;
+                }
                 changed = false;
                 break;
             }
@@ -452,7 +461,7 @@ namespace {
         } while (false);
 
         restore_viewport_callbacks_(session_ptr, callbacks_were_paused, changed);
-        return success ? last_serial : 0;
+        return success ? last_serial : failure_result;
     }
 
     auto apply_script_op_(omega_session_t *session_ptr, const omega_edit_script_op_t &op) -> int64_t {
@@ -687,13 +696,9 @@ namespace {
         } catch (const std::bad_alloc &) { return -1; }
 
         char checkpoint_filename[FILENAME_MAX + 1];
-        if (0 != create_checkpoint_file_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename))) { return -1; }
-
-        auto *checkpoint_fptr = FOPEN(checkpoint_filename, "wb");
-        if (checkpoint_fptr == nullptr) {
-            omega_util_remove_file(checkpoint_filename);
-            return -1;
-        }
+        auto *checkpoint_fptr =
+                create_checkpoint_file_for_write_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename));
+        if (checkpoint_fptr == nullptr) { return -1; }
 
         auto rc = 0;
         scoped_search_context_t search_context(omega_search_create_context_bytes(
@@ -1201,52 +1206,59 @@ namespace {
         }
     }
 
-    auto create_checkpoint_file_(omega_session_t *session_ptr, char *checkpoint_filename,
-                                 size_t checkpoint_filename_size) -> int {
-        if (!session_ptr || !checkpoint_filename || checkpoint_filename_size == 0) { return -1; }
-        const auto *const checkpoint_directory = omega_session_get_checkpoint_directory(session_ptr);
-        if (omega_util_directory_exists(checkpoint_directory) == 0) {
-            LOG_ERROR("checkpoint directory '" << checkpoint_directory << "' does not exist");
-            return -1;
-        }
-        const auto snprintf_result =
-                snprintf(checkpoint_filename, checkpoint_filename_size, "%s%c.OmegaEdit-chk.%zu.XXXXXX",
-                         checkpoint_directory, omega_util_directory_separator(), session_ptr->models_.size());
-        if (snprintf_result < 0 || static_cast<size_t>(snprintf_result) >= checkpoint_filename_size) {
-            LOG_ERROR("failed to create checkpoint filename template");
-            return -1;
-        }
-        const auto checkpoint_fd = omega_util_mkstemp(checkpoint_filename, 0600);// S_IRUSR | S_IWUSR
-        if (checkpoint_fd < 0) {
-            LOG_ERROR("omega_util_mkstemp failed for checkpoint file '" << checkpoint_filename << "'");
-            return -1;
-        }
-        close(checkpoint_fd);
-        return 0;
+    auto open_owned_fd_as_file_(int fd, const char *mode) -> FILE * {
+        if (fd < 0 || !mode) { return nullptr; }
+        FILE *file_ptr = nullptr;
+#ifdef OMEGA_BUILD_WINDOWS
+        file_ptr = _fdopen(fd, mode);
+#else
+        file_ptr = fdopen(fd, mode);
+#endif
+        if (!file_ptr) { CLOSE(fd); }
+        return file_ptr;
     }
 
-    auto create_payload_file_(omega_session_t *session_ptr, char *payload_filename,
-                              size_t payload_filename_size) -> int {
-        if (!session_ptr || !payload_filename || payload_filename_size == 0) { return -1; }
+    auto create_temp_file_in_checkpoint_dir_(omega_session_t *session_ptr, const char *prefix, char *filename,
+                                             size_t filename_size) -> int {
+        if (!session_ptr || !prefix || !filename || filename_size == 0) { return -1; }
         const auto *const checkpoint_directory = omega_session_get_checkpoint_directory(session_ptr);
         if (omega_util_directory_exists(checkpoint_directory) == 0) {
             LOG_ERROR("checkpoint directory '" << checkpoint_directory << "' does not exist");
             return -1;
         }
         const auto snprintf_result =
-                snprintf(payload_filename, payload_filename_size, "%s%c.OmegaEdit-payload.%zu.XXXXXX",
-                         checkpoint_directory, omega_util_directory_separator(), session_ptr->models_.size());
-        if (snprintf_result < 0 || static_cast<size_t>(snprintf_result) >= payload_filename_size) {
-            LOG_ERROR("failed to create payload filename template");
+                snprintf(filename, filename_size, "%s%c.OmegaEdit-%s.%zu.XXXXXX", checkpoint_directory,
+                         omega_util_directory_separator(), prefix, session_ptr->models_.size());
+        if (snprintf_result < 0 || static_cast<size_t>(snprintf_result) >= filename_size) {
+            LOG_ERROR("failed to create temporary filename template");
             return -1;
         }
-        const auto payload_fd = omega_util_mkstemp(payload_filename, 0600);// S_IRUSR | S_IWUSR
-        if (payload_fd < 0) {
-            LOG_ERROR("omega_util_mkstemp failed for payload file '" << payload_filename << "'");
+        const auto fd = omega_util_mkstemp(filename, 0600);// S_IRUSR | S_IWUSR
+        if (fd < 0) {
+            LOG_ERROR("omega_util_mkstemp failed for temporary file '" << filename << "'");
             return -1;
         }
-        close(payload_fd);
-        return 0;
+        return fd;
+    }
+
+    auto create_checkpoint_file_for_write_(omega_session_t *session_ptr, char *checkpoint_filename,
+                                           size_t checkpoint_filename_size) -> FILE * {
+        const auto fd =
+                create_temp_file_in_checkpoint_dir_(session_ptr, "chk", checkpoint_filename, checkpoint_filename_size);
+        if (fd < 0) { return nullptr; }
+        auto *file_ptr = open_owned_fd_as_file_(fd, "wb");
+        if (!file_ptr) { omega_util_remove_file(checkpoint_filename); }
+        return file_ptr;
+    }
+
+    auto create_payload_file_for_write_(omega_session_t *session_ptr, char *payload_filename,
+                                        size_t payload_filename_size) -> FILE * {
+        const auto fd =
+                create_temp_file_in_checkpoint_dir_(session_ptr, "payload", payload_filename, payload_filename_size);
+        if (fd < 0) { return nullptr; }
+        auto *file_ptr = open_owned_fd_as_file_(fd, "wb");
+        if (!file_ptr) { omega_util_remove_file(payload_filename); }
+        return file_ptr;
     }
 
     auto promote_checkpoint_file_(omega_session_t *session_ptr, const char *checkpoint_filename, int64_t file_size,
@@ -1399,14 +1411,9 @@ namespace {
         return processed;
     }
 
-    auto save_session_range_to_payload_file_(omega_session_t *session_ptr, const char *payload_file_path,
-                                             int64_t offset, int64_t length) -> int {
-        if (!session_ptr || !payload_file_path || offset < 0 || length < 0) { return -1; }
-        auto *payload_file_ptr = FOPEN(payload_file_path, "wb");
-        if (!payload_file_ptr) {
-            LOG_ERRNO();
-            return -1;
-        }
+    auto save_session_range_to_payload_file_(omega_session_t *session_ptr, FILE *payload_file_ptr,
+                                             const char *payload_file_path, int64_t offset, int64_t length) -> int {
+        if (!session_ptr || !payload_file_ptr || !payload_file_path || offset < 0 || length < 0) { return -1; }
 
         std::unique_ptr<omega_byte_t[]> io_buf;
         try {
@@ -1449,8 +1456,10 @@ namespace {
         }
 
         char payload_filename[FILENAME_MAX + 1];
-        if (0 != create_payload_file_(session_ptr, payload_filename, sizeof(payload_filename))) { return false; }
-        if (0 != save_session_range_to_payload_file_(session_ptr, payload_filename, offset, length)) {
+        auto *payload_file_ptr =
+                create_payload_file_for_write_(session_ptr, payload_filename, sizeof(payload_filename));
+        if (!payload_file_ptr) { return false; }
+        if (0 != save_session_range_to_payload_file_(session_ptr, payload_file_ptr, payload_filename, offset, length)) {
             omega_util_remove_file(payload_filename);
             return false;
         }
@@ -1505,13 +1514,9 @@ namespace {
         } catch (const std::bad_alloc &) { return -1; }
 
         char checkpoint_filename[FILENAME_MAX + 1];
-        if (0 != create_checkpoint_file_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename))) { return -1; }
-
-        auto *checkpoint_fptr = FOPEN(checkpoint_filename, "wb");
-        if (checkpoint_fptr == nullptr) {
-            omega_util_remove_file(checkpoint_filename);
-            return -1;
-        }
+        auto *checkpoint_fptr =
+                create_checkpoint_file_for_write_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename));
+        if (checkpoint_fptr == nullptr) { return -1; }
 
         session_stream_cursor_t cursor;
         auto rc = 0;
@@ -1603,10 +1608,9 @@ namespace {
         return byte_count - remaining;
     }
 
-    int save_segment_transformed_(omega_session_t *session_ptr, const char *file_path,
-                                  omega_util_byte_transform_t transform, void *user_data_ptr, int64_t transform_offset,
-                                  int64_t transform_length) {
-        if (!session_ptr || !file_path || !transform) { return -1; }
+    int save_segment_transformed_(omega_session_t *session_ptr, FILE *temp_fptr, omega_util_byte_transform_t transform,
+                                  void *user_data_ptr, int64_t transform_offset, int64_t transform_length) {
+        if (!session_ptr || !temp_fptr || !transform) { return -1; }
         if (transform_offset < 0) { return -1; }
         const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
         if (computed_file_size < 0) { return -1; }
@@ -1622,11 +1626,6 @@ namespace {
             io_buf = std::make_unique<omega_byte_t[]>(OMEGA_IO_BUFFER_SIZE);
         } catch (const std::bad_alloc &) { return -1; }
 
-        const auto temp_fptr = FOPEN(file_path, "wb");
-        if (!temp_fptr) {
-            LOG_ERRNO();
-            return -1;
-        }
         int64_t write_offset = 0;
         int64_t file_write_pos = 0;
         for (const auto &segment : session_ptr->models_.back()->model_segments) {
@@ -1643,7 +1642,6 @@ namespace {
                                 session_ptr->models_.back()->file_ptr, segment->change_offset, segment->computed_length,
                                 temp_fptr, file_write_pos, transform, user_data_ptr, transform_file_begin,
                                 transform_file_end, io_buf.get()) != segment->computed_length) {
-                        FCLOSE(temp_fptr);
                         LOG_ERROR("write_segment_to_file_transformed_ failed");
                         return -1;
                     }
@@ -1652,10 +1650,7 @@ namespace {
                 case model_segment_kind_t::SEGMENT_INSERT: {
                     const auto len = segment->computed_length;
                     int64_t segment_file_end = 0;
-                    if (!safe_add_int64_(file_write_pos, len, segment_file_end)) {
-                        FCLOSE(temp_fptr);
-                        return -1;
-                    }
+                    if (!safe_add_int64_(file_write_pos, len, segment_file_end)) { return -1; }
                     int64_t seg_remaining = len;
                     int64_t seg_offset = 0;
                     while (seg_remaining > 0) {
@@ -1664,19 +1659,12 @@ namespace {
                         if (!safe_add_int64_(segment->change_offset, seg_offset, payload_offset) ||
                             omega_change_copy_payload_bytes_(segment->change_ptr.get(), segment->payload_role,
                                                              payload_offset, io_buf.get(), chunk) != 0) {
-                            FCLOSE(temp_fptr);
                             return -1;
                         }
                         int64_t buf_begin = 0;
-                        if (!safe_add_int64_(file_write_pos, seg_offset, buf_begin)) {
-                            FCLOSE(temp_fptr);
-                            return -1;
-                        }
+                        if (!safe_add_int64_(file_write_pos, seg_offset, buf_begin)) { return -1; }
                         int64_t buf_end = 0;
-                        if (!safe_add_int64_(buf_begin, chunk, buf_end)) {
-                            FCLOSE(temp_fptr);
-                            return -1;
-                        }
+                        if (!safe_add_int64_(buf_begin, chunk, buf_end)) { return -1; }
                         if (buf_begin < transform_file_end && buf_end > transform_file_begin) {
                             const auto t_start = std::max(transform_file_begin - buf_begin, int64_t(0));
                             const auto t_end = std::min(transform_file_end - buf_begin, chunk);
@@ -1684,15 +1672,11 @@ namespace {
                                                             user_data_ptr);
                         }
                         if (static_cast<int64_t>(fwrite(io_buf.get(), 1, chunk, temp_fptr)) != chunk) {
-                            FCLOSE(temp_fptr);
                             LOG_ERROR("fwrite failed");
                             return -1;
                         }
                         seg_remaining -= chunk;
-                        if (!safe_add_int64_(seg_offset, chunk, seg_offset)) {
-                            FCLOSE(temp_fptr);
-                            return -1;
-                        }
+                        if (!safe_add_int64_(seg_offset, chunk, seg_offset)) { return -1; }
                     }
                     break;
                 }
@@ -1701,11 +1685,9 @@ namespace {
             }
             if (!safe_add_int64_(file_write_pos, segment->computed_length, file_write_pos) ||
                 !safe_add_int64_(write_offset, segment->computed_length, write_offset)) {
-                FCLOSE(temp_fptr);
                 return -1;
             }
         }
-        FCLOSE(temp_fptr);
         if (file_write_pos != computed_file_size) {
             LOG_ERROR("failed to write all bytes, expected: " << computed_file_size << ", got: " << file_write_pos);
             return -1;
@@ -1726,10 +1708,15 @@ namespace {
         if (effective_length < 0) { return -1; }
 
         char checkpoint_filename[FILENAME_MAX + 1];
-        if (0 != create_checkpoint_file_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename))) { return -1; }
+        auto *checkpoint_fptr =
+                create_checkpoint_file_for_write_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename));
+        if (!checkpoint_fptr) { return -1; }
 
-        if (0 != save_segment_transformed_(session_ptr, checkpoint_filename, byte_transform, user_data_ptr, offset,
-                                           effective_length)) {
+        const auto transform_write_ok = 0 == save_segment_transformed_(session_ptr, checkpoint_fptr, byte_transform,
+                                                                       user_data_ptr, offset, effective_length);
+        const auto transform_flush_ok = transform_write_ok && flush_file_to_disk_(checkpoint_fptr);
+        const auto transform_close_ok = FCLOSE(checkpoint_fptr) == 0;
+        if (!transform_write_ok || !transform_flush_ok || !transform_close_ok) {
             LOG_ERROR("save_segment_transformed_ failed");
             omega_util_remove_file(checkpoint_filename);
             return -1;
@@ -1921,9 +1908,8 @@ omega_session_t *omega_edit_create_session_from_bytes(const omega_byte_t *data_p
                   << static_cast<char *>(checkpoint_filename) << "'");
         return nullptr;
     }
-    close(checkpoint_fd);
 
-    auto *file_ptr = FOPEN(checkpoint_filename, "wb");
+    auto *file_ptr = open_owned_fd_as_file_(checkpoint_fd, "wb");
     if (file_ptr == nullptr) {
         omega_util_remove_file(checkpoint_filename);
         return nullptr;
@@ -1998,6 +1984,14 @@ omega_viewport_t *omega_edit_create_viewport(omega_session_t *session_ptr, int64
     return nullptr;
 }
 
+omega_viewport_t *omega_edit_create_viewport_with_options(omega_session_t *session_ptr,
+                                                          const omega_edit_viewport_options_t *options) {
+    if (!options) { return nullptr; }
+    return omega_edit_create_viewport(session_ptr, options->offset, options->capacity,
+                                      options->is_floating != OMEGA_EDIT_FALSE ? 1 : 0, options->cbk,
+                                      options->user_data_ptr, options->event_interest);
+}
+
 void omega_edit_destroy_viewport(omega_viewport_t *viewport_ptr) {
     if (!viewport_ptr) { return; }
     for (auto iter = viewport_ptr->session_ptr->viewports_.rbegin();
@@ -2057,6 +2051,12 @@ int64_t omega_edit_insert(omega_session_t *session_ptr, int64_t offset, const ch
     return omega_edit_insert_bytes(session_ptr, offset, (const omega_byte_t *) cstr, cstr_length);
 }
 
+int64_t omega_edit_insert_cstring(omega_session_t *session_ptr, int64_t offset, const char *cstr) {
+    if (!cstr) { return -1; }
+    return omega_edit_insert_bytes(session_ptr, offset, reinterpret_cast<const omega_byte_t *>(cstr),
+                                   static_cast<int64_t>(strlen(cstr)));
+}
+
 int64_t omega_edit_overwrite_bytes(omega_session_t *session_ptr, int64_t offset, const omega_byte_t *bytes,
                                    int64_t length) {
     if (!session_ptr) { return -1; }
@@ -2090,6 +2090,12 @@ int64_t omega_edit_overwrite(omega_session_t *session_ptr, int64_t offset, const
     return omega_edit_overwrite_bytes(session_ptr, offset, (const omega_byte_t *) cstr, cstr_length);
 }
 
+int64_t omega_edit_overwrite_cstring(omega_session_t *session_ptr, int64_t offset, const char *cstr) {
+    if (!cstr) { return -1; }
+    return omega_edit_overwrite_bytes(session_ptr, offset, reinterpret_cast<const omega_byte_t *>(cstr),
+                                      static_cast<int64_t>(strlen(cstr)));
+}
+
 int64_t omega_edit_replace_bytes(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
                                  const omega_byte_t *bytes, int64_t insert_length) {
     return replace_bytes_impl_(session_ptr, offset, delete_length, bytes, insert_length);
@@ -2115,6 +2121,13 @@ int64_t omega_edit_replace(omega_session_t *session_ptr, int64_t offset, int64_t
     }
     const auto cstr_length = (insert_length == 0) ? static_cast<int64_t>(strlen(cstr)) : insert_length;
     return omega_edit_replace_bytes(session_ptr, offset, delete_length, (const omega_byte_t *) cstr, cstr_length);
+}
+
+int64_t omega_edit_replace_cstring(omega_session_t *session_ptr, int64_t offset, int64_t delete_length,
+                                   const char *cstr) {
+    if (!cstr) { return -1; }
+    return omega_edit_replace_bytes(session_ptr, offset, delete_length, reinterpret_cast<const omega_byte_t *>(cstr),
+                                    static_cast<int64_t>(strlen(cstr)));
 }
 
 int omega_edit_replace_matches_bytes(omega_session_t *session_ptr, const omega_byte_t *pattern, int64_t pattern_length,
@@ -2265,6 +2278,31 @@ int omega_edit_replace_matches(omega_session_t *session_ptr, const char *pattern
             insert_count_out, overwrite_count_out);
 }
 
+int omega_edit_replace_matches_bytes_with_options(omega_session_t *session_ptr, const omega_byte_t *pattern,
+                                                  int64_t pattern_length, const omega_byte_t *replacement,
+                                                  int64_t replacement_length,
+                                                  const omega_edit_replace_matches_options_t *options) {
+    if (!options) { return -1; }
+    return omega_edit_replace_matches_bytes(
+            session_ptr, pattern, pattern_length, replacement, replacement_length,
+            options->case_insensitive != OMEGA_EDIT_FALSE ? 1 : 0, options->is_reverse != OMEGA_EDIT_FALSE ? 1 : 0,
+            options->offset, options->length, options->limit, options->front_to_back != OMEGA_EDIT_FALSE ? 1 : 0,
+            options->overwrite_only != OMEGA_EDIT_FALSE ? 1 : 0, options->replacement_count_out,
+            options->delete_count_out, options->insert_count_out, options->overwrite_count_out);
+}
+
+int omega_edit_replace_matches_with_options(omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,
+                                            const char *replacement, int64_t replacement_length,
+                                            const omega_edit_replace_matches_options_t *options) {
+    if (!options) { return -1; }
+    return omega_edit_replace_matches(
+            session_ptr, pattern, pattern_length, replacement, replacement_length,
+            options->case_insensitive != OMEGA_EDIT_FALSE ? 1 : 0, options->is_reverse != OMEGA_EDIT_FALSE ? 1 : 0,
+            options->offset, options->length, options->limit, options->front_to_back != OMEGA_EDIT_FALSE ? 1 : 0,
+            options->overwrite_only != OMEGA_EDIT_FALSE ? 1 : 0, options->replacement_count_out,
+            options->delete_count_out, options->insert_count_out, options->overwrite_count_out);
+}
+
 int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_t *pattern, int64_t pattern_length,
                                  const omega_byte_t *replacement, int64_t replacement_length, int case_insensitive,
                                  int64_t offset, int64_t length, int64_t *replacement_count_out) {
@@ -2306,15 +2344,10 @@ int omega_edit_replace_all_bytes(omega_session_t *session_ptr, const omega_byte_
     }
 
     char checkpoint_filename[FILENAME_MAX + 1];
-    if (0 != create_checkpoint_file_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename))) {
-        omega_search_destroy_context(search_context);
-        return -1;
-    }
-
-    auto *checkpoint_fptr = FOPEN(checkpoint_filename, "wb");
+    auto *checkpoint_fptr =
+            create_checkpoint_file_for_write_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename));
     if (checkpoint_fptr == nullptr) {
         omega_search_destroy_context(search_context);
-        omega_util_remove_file(checkpoint_filename);
         return -1;
     }
 
@@ -2414,6 +2447,17 @@ int omega_edit_replace_all_bytes_directional(omega_session_t *session_ptr, const
                                                   case_insensitive, offset, length, replacement_count_out);
 }
 
+int omega_edit_replace_all_bytes_with_options(omega_session_t *session_ptr, const omega_byte_t *pattern,
+                                              int64_t pattern_length, const omega_byte_t *replacement,
+                                              int64_t replacement_length,
+                                              const omega_edit_replace_all_options_t *options) {
+    if (!options) { return -1; }
+    return omega_edit_replace_all_bytes_directional(
+            session_ptr, pattern, pattern_length, replacement, replacement_length,
+            options->case_insensitive != OMEGA_EDIT_FALSE ? 1 : 0, options->is_reverse != OMEGA_EDIT_FALSE ? 1 : 0,
+            options->offset, options->length, options->replacement_count_out);
+}
+
 int omega_edit_replace_all(omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,
                            const char *replacement, int64_t replacement_length, int case_insensitive, int64_t offset,
                            int64_t length, int64_t *replacement_count_out) {
@@ -2431,6 +2475,32 @@ int omega_edit_replace_all(omega_session_t *session_ptr, const char *pattern, in
                                         resolved_pattern_length, reinterpret_cast<const omega_byte_t *>(replacement),
                                         resolved_replacement_length, case_insensitive, offset, length,
                                         replacement_count_out);
+}
+
+int omega_edit_replace_all_with_options(omega_session_t *session_ptr, const char *pattern, int64_t pattern_length,
+                                        const char *replacement, int64_t replacement_length,
+                                        const omega_edit_replace_all_options_t *options) {
+    if (!options || !pattern) { return -1; }
+    const auto resolved_pattern_length = pattern_length ? pattern_length : static_cast<int64_t>(strlen(pattern));
+    if (!replacement) {
+        if (replacement_length > 0) { return -1; }
+        return omega_edit_replace_all_bytes_with_options(session_ptr, reinterpret_cast<const omega_byte_t *>(pattern),
+                                                         resolved_pattern_length, nullptr, 0, options);
+    }
+    const auto resolved_replacement_length =
+            replacement_length ? replacement_length : static_cast<int64_t>(strlen(replacement));
+    return omega_edit_replace_all_bytes_with_options(
+            session_ptr, reinterpret_cast<const omega_byte_t *>(pattern), resolved_pattern_length,
+            reinterpret_cast<const omega_byte_t *>(replacement), resolved_replacement_length, options);
+}
+
+int omega_edit_replace_all_cstring(omega_session_t *session_ptr, const char *pattern, const char *replacement,
+                                   int case_insensitive, int64_t offset, int64_t length,
+                                   int64_t *replacement_count_out) {
+    if (!pattern || !replacement) { return -1; }
+    return omega_edit_replace_all(session_ptr, pattern, static_cast<int64_t>(strlen(pattern)), replacement,
+                                  static_cast<int64_t>(strlen(replacement)), case_insensitive, offset, length,
+                                  replacement_count_out);
 }
 
 int omega_edit_apply_script(omega_session_t *session_ptr, const omega_edit_script_op_t *ops, size_t op_count) {
@@ -2557,8 +2627,7 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
             LOG_ERRNO();
             return -4;
         }
-        CLOSE(temp_fd);
-        temp_fptr = FOPEN(temp_filename, "wb");
+        temp_fptr = open_owned_fd_as_file_(temp_fd, "wb");
         if (!temp_fptr) {
             LOG_ERRNO();
             omega_util_remove_file(temp_filename);
@@ -2674,16 +2743,19 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
             omega_util_remove_file(temp_filename);
             return -12;
         }
+        cleanup_output = false;
+        output_path = file_path;
         if (!sync_parent_directory_(file_path)) {
             LOG_ERRNO();
-            return -12;
+            return OMEGA_EDIT_SAVE_DIRECTORY_SYNC_FAILED;
         }
-    } else if (!sync_parent_directory_(output_path)) {
-        LOG_ERRNO();
-        return -12;
+    } else {
+        cleanup_output = false;
+        if (!sync_parent_directory_(output_path)) {
+            LOG_ERRNO();
+            return OMEGA_EDIT_SAVE_DIRECTORY_SYNC_FAILED;
+        }
     }
-    cleanup_output = false;
-    output_path = overwrite ? file_path : output_path;
     if (overwrite_original) {
         if (0 != refresh_original_file_modification_time_(session_ptr, file_path)) {
             LOG_ERROR("failed to refresh original file modification time: " << file_path);
@@ -2700,6 +2772,30 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
 
 int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path) {
     return omega_edit_save_segment(session_ptr, file_path, io_flags, saved_file_path, 0, 0);
+}
+
+int omega_edit_save_segment_to_file(const omega_session_t *session_ptr, FILE *file_ptr, int64_t offset,
+                                    int64_t length) {
+    if (!session_ptr || !file_ptr || offset < 0 || length < 0) { return -1; }
+    const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
+    if (computed_file_size < 0 || offset > computed_file_size) { return -1; }
+    const auto adjusted_length =
+            length <= 0 ? computed_file_size - offset : std::min(length, computed_file_size - offset);
+    if (adjusted_length < 0) { return -1; }
+
+    std::unique_ptr<omega_byte_t[]> io_buf;
+    try {
+        io_buf = std::make_unique<omega_byte_t[]>(OMEGA_IO_BUFFER_SIZE);
+    } catch (const std::bad_alloc &) { return -1; }
+
+    session_stream_cursor_t cursor;
+    int64_t end_offset = 0;
+    if (!safe_add_int64_(offset, adjusted_length, end_offset) ||
+        !initialize_session_stream_cursor_(session_ptr, offset, cursor) ||
+        stream_session_range_(cursor, end_offset, file_ptr, io_buf.get()) != adjusted_length) {
+        return -1;
+    }
+    return flush_file_to_disk_(file_ptr) ? 0 : -1;
 }
 
 int omega_edit_save_segment_to_bytes(const omega_session_t *session_ptr, omega_byte_t **data_ptr_out,
@@ -2918,8 +3014,12 @@ int64_t omega_edit_redo_last_undo(omega_session_t *session_ptr) {
 int omega_edit_create_checkpoint(omega_session_t *session_ptr) {
     if (!session_ptr) { return -1; }
     char checkpoint_filename[FILENAME_MAX + 1];
-    if (0 != create_checkpoint_file_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename))) { return -1; }
-    if (0 != omega_edit_save(session_ptr, checkpoint_filename, IO_FLG_OVERWRITE, nullptr)) {
+    auto *checkpoint_file_ptr =
+            create_checkpoint_file_for_write_(session_ptr, checkpoint_filename, sizeof(checkpoint_filename));
+    if (!checkpoint_file_ptr) { return -1; }
+    const auto save_ok = 0 == omega_edit_save_segment_to_file(session_ptr, checkpoint_file_ptr, 0, 0);
+    const auto close_ok = FCLOSE(checkpoint_file_ptr) == 0;
+    if (!save_ok || !close_ok) {
         LOG_ERROR("failed to save checkpoint to '" << checkpoint_filename << "'");
         omega_util_remove_file(checkpoint_filename);
         return -1;

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -110,9 +110,10 @@ namespace {
                                omega_byte_t *io_buf) -> int64_t;
     auto write_bytes_to_file_(FILE *file_ptr, const omega_byte_t *bytes, int64_t length) -> int64_t;
 
-    auto flush_file_to_disk_(FILE *file_ptr) -> bool {
+    auto flush_file_(FILE *file_ptr, bool sync_to_disk) -> bool {
         if (!file_ptr) { return false; }
         if (fflush(file_ptr) != 0) { return false; }
+        if (!sync_to_disk) { return true; }
 #ifdef OMEGA_BUILD_WINDOWS
         const auto fd = _fileno(file_ptr);
         if (fd < 0) { return false; }
@@ -124,6 +125,8 @@ namespace {
         return fd >= 0 && fsync(fd) == 0;
 #endif
     }
+
+    auto flush_file_to_disk_(FILE *file_ptr) -> bool { return flush_file_(file_ptr, true); }
 
     auto sync_parent_directory_(const char *path) -> bool {
         if (!path || !*path) { return false; }
@@ -2774,8 +2777,9 @@ int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_
     return omega_edit_save_segment(session_ptr, file_path, io_flags, saved_file_path, 0, 0);
 }
 
-int omega_edit_save_segment_to_file(const omega_session_t *session_ptr, FILE *file_ptr, int64_t offset,
-                                    int64_t length) {
+int omega_edit_save_segment_to_file_with_options(const omega_session_t *session_ptr, FILE *file_ptr, int64_t offset,
+                                                 int64_t length,
+                                                 const omega_edit_save_segment_to_file_options_t *options_ptr) {
     if (!session_ptr || !file_ptr || offset < 0 || length < 0) { return -1; }
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
     if (computed_file_size < 0 || offset > computed_file_size) { return -1; }
@@ -2795,7 +2799,13 @@ int omega_edit_save_segment_to_file(const omega_session_t *session_ptr, FILE *fi
         stream_session_range_(cursor, end_offset, file_ptr, io_buf.get()) != adjusted_length) {
         return -1;
     }
-    return flush_file_to_disk_(file_ptr) ? 0 : -1;
+    const auto sync_to_disk = !options_ptr || options_ptr->skip_disk_sync != OMEGA_EDIT_TRUE;
+    return flush_file_(file_ptr, sync_to_disk) ? 0 : -1;
+}
+
+int omega_edit_save_segment_to_file(const omega_session_t *session_ptr, FILE *file_ptr, int64_t offset,
+                                    int64_t length) {
+    return omega_edit_save_segment_to_file_with_options(session_ptr, file_ptr, offset, length, nullptr);
 }
 
 int omega_edit_save_segment_to_bytes(const omega_session_t *session_ptr, omega_byte_t **data_ptr_out,

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -38,7 +38,22 @@ using omega_edit::internal::safe_add_int64_;
 
 namespace {
     constexpr int64_t OMEGA_SESSION_SCAN_BUFFER_SIZE = 65536;
-}
+
+    int64_t count_change_transactions_(const omega_changes_t &changes) {
+        int64_t result = 0;
+        bool transaction_bit = false;
+        for (const auto &change : changes) {
+            if (result == 0) {
+                transaction_bit = omega_change_get_transaction_bit_(change.get());
+                ++result;
+            } else if (transaction_bit != omega_change_get_transaction_bit_(change.get())) {
+                transaction_bit = !transaction_bit;
+                ++result;
+            }
+        }
+        return result;
+    }
+}// namespace
 
 int omega_session_byte_frequency_profile_size() { return OMEGA_EDIT_BYTE_FREQUENCY_PROFILE_SIZE; }
 
@@ -274,50 +289,14 @@ int omega_session_get_transaction_state(const omega_session_t *session_ptr) {
 int64_t omega_session_get_num_change_transactions(const omega_session_t *session_ptr) {
     if (!session_ptr) { return 0; }
     int64_t result = 0;
-    // Count the number of transactions in each model
-    for (const auto &model : session_ptr->models_) {
-        int64_t transactions_in_model = 0;
-        bool transaction_bit = false;
-        // Count the number of transactions in this model
-        for (const auto &change : model->changes) {
-            // If the transaction bit is different from the current transaction bit, then we have a new transaction
-            if (transactions_in_model) {
-                if (transaction_bit != omega_change_get_transaction_bit_(change.get())) {
-                    transaction_bit = !transaction_bit;
-                    ++transactions_in_model;
-                }
-            } else {
-                transaction_bit = omega_change_get_transaction_bit_(change.get());
-                ++transactions_in_model;
-            }
-        }
-        result += transactions_in_model;
-    }
+    for (const auto &model : session_ptr->models_) { result += count_change_transactions_(model->changes); }
     return result;
 }
 
 int64_t omega_session_get_num_undone_change_transactions(const omega_session_t *session_ptr) {
     if (!session_ptr) { return 0; }
     int64_t result = 0;
-    // Count the number of transactions in each model
-    for (const auto &model : session_ptr->models_) {
-        int64_t transactions_in_model = 0;
-        bool transaction_bit = false;
-        // Count the number of transactions in this model
-        for (const auto &change : model->changes_undone) {
-            // If the transaction bit is different from the current transaction bit, then we have a new transaction
-            if (transactions_in_model) {
-                if (transaction_bit != omega_change_get_transaction_bit_(change.get())) {
-                    transaction_bit = !transaction_bit;
-                    ++transactions_in_model;
-                }
-            } else {
-                transaction_bit = omega_change_get_transaction_bit_(change.get());
-                ++transactions_in_model;
-            }
-        }
-        result += transactions_in_model;
-    }
+    for (const auto &model : session_ptr->models_) { result += count_change_transactions_(model->changes_undone); }
     return result;
 }
 

--- a/core/src/lib/viewport.cpp
+++ b/core/src/lib/viewport.cpp
@@ -127,6 +127,12 @@ int omega_viewport_modify(omega_viewport_t *viewport_ptr, int64_t offset, int64_
     return -1;
 }
 
+int omega_viewport_modify_with_options(omega_viewport_t *viewport_ptr, const omega_viewport_modify_options_t *options) {
+    if (!options) { return -1; }
+    return omega_viewport_modify(viewport_ptr, options->offset, options->capacity,
+                                 options->is_floating != OMEGA_EDIT_FALSE ? 1 : 0);
+}
+
 const omega_byte_t *omega_viewport_get_data(const omega_viewport_t *viewport_ptr) {
     if (!viewport_ptr) { return nullptr; }
     const auto mut_viewport_ptr = const_cast<omega_viewport_t *>(viewport_ptr);

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -519,17 +519,17 @@ TEST_CASE("Named options and explicit C-string helpers", "[SessionApiTests]") {
     REQUIRE("omega beta omega" == std::string(reinterpret_cast<const char *>(bytes), static_cast<size_t>(length)));
     free(bytes);
 
-    const char *const output_path = MAKE_PATH("session_api_options_segment.dat");
-    omega_util_remove_file(output_path);
-    auto *file_ptr = FOPEN(output_path, "wb");
+    const auto output_path = std::string(MAKE_PATH("session_api_options_segment.dat"));
+    omega_util_remove_file(output_path.c_str());
+    auto *file_ptr = FOPEN(output_path.c_str(), "wb");
     REQUIRE(file_ptr);
     REQUIRE(0 == omega_edit_save_segment_to_file(session_ptr, file_ptr, 6, 4));
     REQUIRE(0 == FCLOSE(file_ptr));
 
     omega_byte_t buffer[4]{};
-    REQUIRE(4 == omega_util_read_file_segment(output_path, 0, buffer, sizeof(buffer)));
+    REQUIRE(4 == omega_util_read_file_segment(output_path.c_str(), 0, buffer, sizeof(buffer)));
     REQUIRE("beta" == std::string(reinterpret_cast<const char *>(buffer), sizeof(buffer)));
-    omega_util_remove_file(output_path);
+    omega_util_remove_file(output_path.c_str());
 
     omega_edit_destroy_session(session_ptr);
 }

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -22,6 +22,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_contains.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <cstdio>
 #include <vector>
 
 using Catch::Matchers::Contains;
@@ -469,6 +470,67 @@ TEST_CASE("Session Save", "[SessionSaveTests]") {
                                  saved_filename));
     REQUIRE(omega_util_paths_equivalent(MAKE_PATH("session_save.empty.dat"), saved_filename));
     REQUIRE(0 == omega_util_compare_files(MAKE_PATH("empty_file.dat"), MAKE_PATH("session_save.empty.dat")));
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Named options and explicit C-string helpers", "[SessionApiTests]") {
+    auto *session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(0 < omega_edit_insert_cstring(session_ptr, 0, "alpha beta alpha"));
+
+    int64_t replacement_count = 0;
+    omega_edit_replace_matches_options_t replace_options{};
+    replace_options.offset = 0;
+    replace_options.length = 0;
+    replace_options.limit = 1;
+    replace_options.front_to_back = OMEGA_EDIT_TRUE;
+    replace_options.replacement_count_out = &replacement_count;
+    REQUIRE(0 == omega_edit_replace_matches_with_options(session_ptr, "alpha", 0, "omega", 0, &replace_options));
+    REQUIRE(1 == replacement_count);
+
+    replacement_count = 0;
+    omega_edit_replace_all_options_t replace_all_options{};
+    replace_all_options.offset = 0;
+    replace_all_options.length = 0;
+    replace_all_options.replacement_count_out = &replacement_count;
+    REQUIRE(0 == omega_edit_replace_all_with_options(session_ptr, "alpha", 0, "omega", 0, &replace_all_options));
+    REQUIRE(1 == replacement_count);
+
+    omega_edit_viewport_options_t viewport_options{};
+    viewport_options.offset = 0;
+    viewport_options.capacity = 5;
+    auto *viewport_ptr = omega_edit_create_viewport_with_options(session_ptr, &viewport_options);
+    REQUIRE(viewport_ptr);
+
+    omega_viewport_modify_options_t modify_options{};
+    modify_options.offset = 6;
+    modify_options.capacity = 4;
+    modify_options.is_floating = OMEGA_EDIT_TRUE;
+    REQUIRE(0 == omega_viewport_modify_with_options(viewport_ptr, &modify_options));
+    REQUIRE(6 == omega_viewport_get_offset(viewport_ptr));
+    REQUIRE(4 == omega_viewport_get_capacity(viewport_ptr));
+    REQUIRE(1 == omega_viewport_is_floating(viewport_ptr));
+
+    omega_byte_t *bytes = nullptr;
+    int64_t length = 0;
+    REQUIRE(0 == omega_edit_save_to_bytes(session_ptr, &bytes, &length));
+    REQUIRE(16 == length);
+    REQUIRE("omega beta omega" == std::string(reinterpret_cast<const char *>(bytes), static_cast<size_t>(length)));
+    free(bytes);
+
+    const char *const output_path = MAKE_PATH("session_api_options_segment.dat");
+    omega_util_remove_file(output_path);
+    auto *file_ptr = FOPEN(output_path, "wb");
+    REQUIRE(file_ptr);
+    REQUIRE(0 == omega_edit_save_segment_to_file(session_ptr, file_ptr, 6, 4));
+    REQUIRE(0 == FCLOSE(file_ptr));
+
+    omega_byte_t buffer[4]{};
+    REQUIRE(4 == omega_util_read_file_segment(output_path, 0, buffer, sizeof(buffer)));
+    REQUIRE("beta" == std::string(reinterpret_cast<const char *>(buffer), sizeof(buffer)));
+    omega_util_remove_file(output_path);
+
     omega_edit_destroy_session(session_ptr);
 }
 

--- a/plugins/src/base64.c
+++ b/plugins/src/base64.c
@@ -12,7 +12,8 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#include <ctype.h>
+#include "c_plugin_options.h"
+
 #include <omega_edit/transform_plugin_sdk.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -26,31 +27,6 @@ static const char BASE64_ARGS_SCHEMA[] =
         "{\"type\":\"object\",\"properties\":{\"direction\":{\"type\":\"string\",\"title\":\"Direction\","
         "\"description\":\"Encode bytes as Base64 text or decode Base64 text to bytes.\",\"default\":\"encode\","
         "\"enum\":[\"encode\",\"decode\"]}},\"additionalProperties\":false}";
-
-static void base64_skip_ws(const char **cursor) {
-    while (cursor && *cursor && isspace((unsigned char) **cursor)) { ++(*cursor); }
-}
-
-static int base64_parse_json_string(const char **cursor, char *out, size_t out_size) {
-    if (!cursor || !*cursor || **cursor != '"' || out_size == 0) { return -1; }
-    ++(*cursor);
-    size_t length = 0;
-    while (**cursor && **cursor != '"') {
-        char ch = **cursor;
-        if (ch == '\\') {
-            ++(*cursor);
-            if (!**cursor) { return -1; }
-            ch = **cursor;
-        }
-        if (length + 1 >= out_size) { return -1; }
-        out[length++] = ch;
-        ++(*cursor);
-    }
-    if (**cursor != '"') { return -1; }
-    ++(*cursor);
-    out[length] = '\0';
-    return 0;
-}
 
 static int base64_parse_direction_text(const char *value, omega_base64_direction_t *direction_out) {
     if (!value || !direction_out) { return -1; }
@@ -71,33 +47,33 @@ static int base64_parse_options(const char *options_json, omega_base64_direction
     if (!options_json || !*options_json) { return 0; }
 
     const char *cursor = options_json;
-    base64_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != '{') { return -1; }
     ++cursor;
-    base64_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor == '}') {
         ++cursor;
-        base64_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
         return *cursor == '\0' ? 0 : -1;
     }
 
     char key[32];
-    if (base64_parse_json_string(&cursor, key, sizeof(key)) != 0 || strcmp(key, "direction") != 0) { return -1; }
-    base64_skip_ws(&cursor);
+    if (omega_plugin_json_parse_string(&cursor, key, sizeof(key)) != 0 || strcmp(key, "direction") != 0) { return -1; }
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != ':') { return -1; }
     ++cursor;
-    base64_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
 
     char direction[16];
-    if (base64_parse_json_string(&cursor, direction, sizeof(direction)) != 0 ||
+    if (omega_plugin_json_parse_string(&cursor, direction, sizeof(direction)) != 0 ||
         base64_parse_direction_text(direction, direction_out) != 0) {
         return -1;
     }
 
-    base64_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != '}') { return -1; }
     ++cursor;
-    base64_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     return *cursor == '\0' ? 0 : -1;
 }
 

--- a/plugins/src/bitmask_options.h
+++ b/plugins/src/bitmask_options.h
@@ -15,6 +15,8 @@
 #ifndef OMEGA_EDIT_BITMASK_OPTIONS_H
 #define OMEGA_EDIT_BITMASK_OPTIONS_H
 
+#include "c_plugin_options.h"
+
 #include <ctype.h>
 #include <omega_edit/transform_plugin_sdk.h>
 #include <stddef.h>
@@ -46,32 +48,6 @@ static const char OMEGA_BITMASK_OPTIONS_ARGS_SCHEMA[] =
         "\"items\":{\"type\":\"string\",\"pattern\":\"^0x[0-9A-Fa-f]{1,2}$\"}}},"
         "\"additionalProperties\":false}";
 
-static void omega_bitmask_skip_ws(const char **cursor) {
-    while (**cursor && isspace((unsigned char) **cursor)) { ++(*cursor); }
-}
-
-static int omega_bitmask_parse_json_string(const char **cursor, char *out, size_t out_size) {
-    if (**cursor != '"' || out_size == 0) { return -1; }
-    ++(*cursor);
-
-    size_t length = 0;
-    while (**cursor && **cursor != '"') {
-        char ch = **cursor;
-        if (ch == '\\') {
-            ++(*cursor);
-            if (!**cursor) { return -1; }
-            ch = **cursor;
-        }
-        if (length + 1 >= out_size) { return -1; }
-        out[length++] = ch;
-        ++(*cursor);
-    }
-    if (**cursor != '"') { return -1; }
-    ++(*cursor);
-    out[length] = '\0';
-    return 0;
-}
-
 static int omega_bitmask_parse_byte_text(const char *value, omega_byte_t *byte_out) {
     if (!value || !*value || !byte_out) { return -1; }
 
@@ -96,10 +72,10 @@ static int omega_bitmask_parse_byte_number(const char **cursor, omega_byte_t *by
 }
 
 static int omega_bitmask_parse_byte_value(const char **cursor, omega_byte_t *byte_out) {
-    omega_bitmask_skip_ws(cursor);
+    omega_plugin_json_skip_ws(cursor);
     if (**cursor == '"') {
         char value[16];
-        if (omega_bitmask_parse_json_string(cursor, value, sizeof(value)) != 0) { return -1; }
+        if (omega_plugin_json_parse_string(cursor, value, sizeof(value)) != 0) { return -1; }
         return omega_bitmask_parse_byte_text(value, byte_out);
     }
     return omega_bitmask_parse_byte_number(cursor, byte_out);
@@ -123,75 +99,23 @@ static int omega_bitmask_parse_operation_text(const char *value, omega_bitmask_o
 }
 
 static int omega_bitmask_parse_operation_value(const char **cursor, omega_bitmask_operation_t *operation_out) {
-    omega_bitmask_skip_ws(cursor);
+    omega_plugin_json_skip_ws(cursor);
     char value[16];
-    if (omega_bitmask_parse_json_string(cursor, value, sizeof(value)) != 0) { return -1; }
+    if (omega_plugin_json_parse_string(cursor, value, sizeof(value)) != 0) { return -1; }
     return omega_bitmask_parse_operation_text(value, operation_out);
-}
-
-static int omega_bitmask_skip_json_string(const char **cursor) {
-    if (**cursor != '"') { return -1; }
-    ++(*cursor);
-    while (**cursor && **cursor != '"') {
-        if (**cursor == '\\') {
-            ++(*cursor);
-            if (!**cursor) { return -1; }
-        }
-        ++(*cursor);
-    }
-    if (**cursor != '"') { return -1; }
-    ++(*cursor);
-    return 0;
-}
-
-static int omega_bitmask_skip_json_value(const char **cursor) {
-    omega_bitmask_skip_ws(cursor);
-    if (**cursor == '"') { return omega_bitmask_skip_json_string(cursor); }
-
-    if (**cursor == '{' || **cursor == '[') {
-        char nesting[OMEGA_BITMASK_MAX_BYTES];
-        size_t depth = 0;
-
-        nesting[depth++] = **cursor;
-        ++(*cursor);
-        while (**cursor && depth > 0) {
-            if (**cursor == '"') {
-                if (omega_bitmask_skip_json_string(cursor) != 0) { return -1; }
-                continue;
-            }
-            if (**cursor == '{' || **cursor == '[') {
-                if (depth >= OMEGA_BITMASK_MAX_BYTES) { return -1; }
-                nesting[depth++] = **cursor;
-                ++(*cursor);
-                continue;
-            }
-            if (**cursor == '}' || **cursor == ']') {
-                const char expected = nesting[depth - 1] == '{' ? '}' : ']';
-                if (**cursor != expected) { return -1; }
-                --depth;
-                ++(*cursor);
-                continue;
-            }
-            ++(*cursor);
-        }
-        return depth == 0 ? 0 : -1;
-    }
-
-    while (**cursor && **cursor != ',' && **cursor != '}' && **cursor != ']') { ++(*cursor); }
-    return 0;
 }
 
 static int omega_bitmask_parse_mask_value(const char **cursor, omega_bitmask_options_t *mask_out) {
     if (!cursor || !*cursor || !mask_out) { return -1; }
 
-    omega_bitmask_skip_ws(cursor);
+    omega_plugin_json_skip_ws(cursor);
     if (**cursor != '[') {
         mask_out->length = 1;
         return omega_bitmask_parse_byte_value(cursor, &mask_out->bytes[0]);
     }
 
     ++(*cursor);
-    omega_bitmask_skip_ws(cursor);
+    omega_plugin_json_skip_ws(cursor);
     if (**cursor == ']') { return -1; }
 
     size_t length = 0;
@@ -202,7 +126,7 @@ static int omega_bitmask_parse_mask_value(const char **cursor, omega_bitmask_opt
         }
         ++length;
 
-        omega_bitmask_skip_ws(cursor);
+        omega_plugin_json_skip_ws(cursor);
         if (**cursor == ']') {
             ++(*cursor);
             mask_out->length = length;
@@ -210,7 +134,7 @@ static int omega_bitmask_parse_mask_value(const char **cursor, omega_bitmask_opt
         }
         if (**cursor != ',') { return -1; }
         ++(*cursor);
-        omega_bitmask_skip_ws(cursor);
+        omega_plugin_json_skip_ws(cursor);
     }
 
     return -1;
@@ -225,42 +149,42 @@ static int omega_bitmask_parse_options(const char *options_json, omega_byte_t de
     if (!options_json || !*options_json) { return 0; }
 
     const char *cursor = options_json;
-    omega_bitmask_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != '{') { return -1; }
     ++cursor;
 
-    omega_bitmask_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor == '}') {
         ++cursor;
-        omega_bitmask_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
         return *cursor == '\0' ? 0 : -1;
     }
 
     while (*cursor) {
         char key[32];
-        if (omega_bitmask_parse_json_string(&cursor, key, sizeof(key)) != 0) { return -1; }
-        omega_bitmask_skip_ws(&cursor);
+        if (omega_plugin_json_parse_string(&cursor, key, sizeof(key)) != 0) { return -1; }
+        omega_plugin_json_skip_ws(&cursor);
         if (*cursor != ':') { return -1; }
         ++cursor;
-        omega_bitmask_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
 
         if (strcmp(key, "operator") == 0) {
             if (omega_bitmask_parse_operation_value(&cursor, &mask_out->operation) != 0) { return -1; }
         } else if (strcmp(key, "byte") == 0 || strcmp(key, "mask") == 0) {
             if (omega_bitmask_parse_mask_value(&cursor, mask_out) != 0) { return -1; }
         } else {
-            if (omega_bitmask_skip_json_value(&cursor) != 0) { return -1; }
+            if (omega_plugin_json_skip_value(&cursor, OMEGA_BITMASK_MAX_BYTES) != 0) { return -1; }
         }
 
-        omega_bitmask_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
         if (*cursor == '}') {
             ++cursor;
-            omega_bitmask_skip_ws(&cursor);
+            omega_plugin_json_skip_ws(&cursor);
             return *cursor == '\0' ? 0 : -1;
         }
         if (*cursor != ',') { return -1; }
         ++cursor;
-        omega_bitmask_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
     }
 
     return -1;

--- a/plugins/src/c_plugin_options.h
+++ b/plugins/src/c_plugin_options.h
@@ -1,0 +1,116 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2026 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS, WITHOUT    *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language         *
+ * governing permissions and limitations under the License.                                                           *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#ifndef OMEGA_EDIT_C_PLUGIN_OPTIONS_H
+#define OMEGA_EDIT_C_PLUGIN_OPTIONS_H
+
+#include <ctype.h>
+#include <stddef.h>
+#include <string.h>
+
+static inline void omega_plugin_json_skip_ws(const char **cursor) {
+    while (cursor && *cursor && isspace((unsigned char) **cursor)) { ++(*cursor); }
+}
+
+static inline int omega_plugin_json_parse_string(const char **cursor, char *out, size_t out_size) {
+    if (!cursor || !*cursor || **cursor != '"' || out_size == 0) { return -1; }
+    ++(*cursor);
+    size_t length = 0;
+    while (**cursor && **cursor != '"') {
+        char ch = **cursor;
+        if (ch == '\\') {
+            ++(*cursor);
+            if (!**cursor) { return -1; }
+            ch = **cursor;
+        }
+        if (length + 1 >= out_size) { return -1; }
+        out[length++] = ch;
+        ++(*cursor);
+    }
+    if (**cursor != '"') { return -1; }
+    ++(*cursor);
+    out[length] = '\0';
+    return 0;
+}
+
+static inline int omega_plugin_json_parse_bool(const char **cursor, int *value_out) {
+    if (!cursor || !*cursor || !value_out) { return -1; }
+    if (strncmp(*cursor, "true", 4) == 0) {
+        *cursor += 4;
+        *value_out = 1;
+        return 0;
+    }
+    if (strncmp(*cursor, "false", 5) == 0) {
+        *cursor += 5;
+        *value_out = 0;
+        return 0;
+    }
+    return -1;
+}
+
+static inline int omega_plugin_json_skip_string(const char **cursor) {
+    if (!cursor || !*cursor || **cursor != '"') { return -1; }
+    ++(*cursor);
+    while (**cursor && **cursor != '"') {
+        if (**cursor == '\\') {
+            ++(*cursor);
+            if (!**cursor) { return -1; }
+        }
+        ++(*cursor);
+    }
+    if (**cursor != '"') { return -1; }
+    ++(*cursor);
+    return 0;
+}
+
+static inline int omega_plugin_json_skip_value(const char **cursor, size_t max_depth) {
+    if (!cursor || !*cursor || max_depth == 0) { return -1; }
+    omega_plugin_json_skip_ws(cursor);
+    if (**cursor == '"') { return omega_plugin_json_skip_string(cursor); }
+
+    if (**cursor == '{' || **cursor == '[') {
+        char nesting[256];
+        size_t depth = 0;
+        if (max_depth > sizeof(nesting)) { max_depth = sizeof(nesting); }
+
+        nesting[depth++] = **cursor;
+        ++(*cursor);
+        while (**cursor && depth > 0) {
+            if (**cursor == '"') {
+                if (omega_plugin_json_skip_string(cursor) != 0) { return -1; }
+                continue;
+            }
+            if (**cursor == '{' || **cursor == '[') {
+                if (depth >= max_depth) { return -1; }
+                nesting[depth++] = **cursor;
+                ++(*cursor);
+                continue;
+            }
+            if (**cursor == '}' || **cursor == ']') {
+                const char expected = nesting[depth - 1] == '{' ? '}' : ']';
+                if (**cursor != expected) { return -1; }
+                --depth;
+                ++(*cursor);
+                continue;
+            }
+            ++(*cursor);
+        }
+        return depth == 0 ? 0 : -1;
+    }
+
+    while (**cursor && **cursor != ',' && **cursor != '}' && **cursor != ']') { ++(*cursor); }
+    return 0;
+}
+
+#endif// OMEGA_EDIT_C_PLUGIN_OPTIONS_H

--- a/plugins/src/openssl_ciphers.c
+++ b/plugins/src/openssl_ciphers.c
@@ -12,9 +12,11 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#include <ctype.h>
+#include "c_plugin_options.h"
+
 #include <limits.h>
 #include <omega_edit/transform_plugin_sdk.h>
+#include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -77,46 +79,6 @@ static const char CIPHER_ARGS_SCHEMA[] =
         "\"description\":\"Use PKCS#7 padding for CBC encryption/decryption. Ignored by CTR.\",\"default\":true}},"
         "\"additionalProperties\":false}";
 
-static void cipher_skip_ws(const char **cursor) {
-    while (cursor && *cursor && isspace((unsigned char) **cursor)) { ++(*cursor); }
-}
-
-static int cipher_parse_json_string(const char **cursor, char *out, size_t out_size) {
-    if (!cursor || !*cursor || **cursor != '"' || out_size == 0) { return -1; }
-    ++(*cursor);
-    size_t length = 0;
-    while (**cursor && **cursor != '"') {
-        char ch = **cursor;
-        if (ch == '\\') {
-            ++(*cursor);
-            if (!**cursor) { return -1; }
-            ch = **cursor;
-        }
-        if (length + 1 >= out_size) { return -1; }
-        out[length++] = ch;
-        ++(*cursor);
-    }
-    if (**cursor != '"') { return -1; }
-    ++(*cursor);
-    out[length] = '\0';
-    return 0;
-}
-
-static int cipher_parse_boolean(const char **cursor, int *value_out) {
-    if (!cursor || !*cursor || !value_out) { return -1; }
-    if (strncmp(*cursor, "true", 4) == 0) {
-        *cursor += 4;
-        *value_out = 1;
-        return 0;
-    }
-    if (strncmp(*cursor, "false", 5) == 0) {
-        *cursor += 5;
-        *value_out = 0;
-        return 0;
-    }
-    return -1;
-}
-
 static int cipher_hex_value(char ch) {
     if (ch >= '0' && ch <= '9') { return ch - '0'; }
     if (ch >= 'a' && ch <= 'f') { return 10 + ch - 'a'; }
@@ -175,64 +137,66 @@ static int cipher_parse_options(const char *options_json, omega_cipher_options_t
     int saw_iv = 0;
 
     const char *cursor = options_json;
-    cipher_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != '{') { return -1; }
     ++cursor;
-    cipher_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
 
     while (*cursor && *cursor != '}') {
         char key[32];
-        if (cipher_parse_json_string(&cursor, key, sizeof(key)) != 0) { return -1; }
-        cipher_skip_ws(&cursor);
+        if (omega_plugin_json_parse_string(&cursor, key, sizeof(key)) != 0) { return -1; }
+        omega_plugin_json_skip_ws(&cursor);
         if (*cursor != ':') { return -1; }
         ++cursor;
-        cipher_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
 
         if (strcmp(key, "action") == 0) {
             char action[16];
-            if (cipher_parse_json_string(&cursor, action, sizeof(action)) != 0 ||
+            if (omega_plugin_json_parse_string(&cursor, action, sizeof(action)) != 0 ||
                 cipher_parse_action_text(action, &options_out->action) != 0) {
                 return -1;
             }
             saw_action = 1;
         } else if (strcmp(key, "algorithm") == 0) {
             char algorithm[32];
-            if (cipher_parse_json_string(&cursor, algorithm, sizeof(algorithm)) != 0) { return -1; }
+            if (omega_plugin_json_parse_string(&cursor, algorithm, sizeof(algorithm)) != 0) { return -1; }
             options_out->algorithm = cipher_find_algorithm(algorithm);
             if (!options_out->algorithm) { return -1; }
             saw_algorithm = 1;
         } else if (strcmp(key, "keyHex") == 0) {
-            char key_hex[96];
-            if (cipher_parse_json_string(&cursor, key_hex, sizeof(key_hex)) != 0 ||
-                cipher_parse_hex_bytes(key_hex, options_out->key, sizeof(options_out->key), &options_out->key_length) !=
-                        0) {
-                return -1;
-            }
+            char key_hex[96] = {0};
+            const int key_result = omega_plugin_json_parse_string(&cursor, key_hex, sizeof(key_hex)) == 0
+                                           ? cipher_parse_hex_bytes(key_hex, options_out->key, sizeof(options_out->key),
+                                                                    &options_out->key_length)
+                                           : -1;
+            OPENSSL_cleanse(key_hex, sizeof(key_hex));
+            if (key_result != 0) { return -1; }
             saw_key = 1;
         } else if (strcmp(key, "ivHex") == 0) {
-            char iv_hex[64];
-            if (cipher_parse_json_string(&cursor, iv_hex, sizeof(iv_hex)) != 0 ||
-                cipher_parse_hex_bytes(iv_hex, options_out->iv, sizeof(options_out->iv), &options_out->iv_length) !=
-                        0) {
-                return -1;
-            }
+            char iv_hex[64] = {0};
+            const int iv_result = omega_plugin_json_parse_string(&cursor, iv_hex, sizeof(iv_hex)) == 0
+                                          ? cipher_parse_hex_bytes(iv_hex, options_out->iv, sizeof(options_out->iv),
+                                                                   &options_out->iv_length)
+                                          : -1;
+            OPENSSL_cleanse(iv_hex, sizeof(iv_hex));
+            if (iv_result != 0) { return -1; }
             saw_iv = 1;
         } else if (strcmp(key, "padding") == 0) {
-            if (cipher_parse_boolean(&cursor, &options_out->padding) != 0) { return -1; }
+            if (omega_plugin_json_parse_bool(&cursor, &options_out->padding) != 0) { return -1; }
         } else {
             return -1;
         }
 
-        cipher_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
         if (*cursor == '}') { break; }
         if (*cursor != ',') { return -1; }
         ++cursor;
-        cipher_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
     }
 
     if (*cursor != '}') { return -1; }
     ++cursor;
-    cipher_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != '\0' || !saw_action || !saw_algorithm || !saw_key || !saw_iv) { return -1; }
     if (options_out->key_length != options_out->algorithm->key_length ||
         options_out->iv_length != options_out->algorithm->iv_length) {
@@ -356,6 +320,12 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
 OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_apply(const omega_transform_plugin_request_t *request_ptr,
                                                                omega_transform_plugin_response_t *response_ptr) {
     omega_cipher_options_t options;
-    if (cipher_parse_options(request_ptr ? request_ptr->options_json : NULL, &options) != 0) { return -1; }
-    return cipher_transform(request_ptr, response_ptr, &options);
+    const int parse_result = cipher_parse_options(request_ptr ? request_ptr->options_json : NULL, &options);
+    if (parse_result != 0) {
+        OPENSSL_cleanse(&options, sizeof(options));
+        return -1;
+    }
+    const int transform_result = cipher_transform(request_ptr, response_ptr, &options);
+    OPENSSL_cleanse(&options, sizeof(options));
+    return transform_result;
 }

--- a/plugins/src/openssl_digests.c
+++ b/plugins/src/openssl_digests.c
@@ -12,7 +12,8 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#include <ctype.h>
+#include "c_plugin_options.h"
+
 #include <omega_edit/transform_plugin_sdk.h>
 #include <openssl/evp.h>
 #include <stdint.h>
@@ -54,31 +55,6 @@ static const char DIGEST_ARGS_SCHEMA[] =
         "{\"label\":\"BLAKE2\",\"values\":[\"blake2b-512\",\"blake2s-256\"]}]}},"
         "\"additionalProperties\":false}";
 
-static void digest_skip_ws(const char **cursor) {
-    while (cursor && *cursor && isspace((unsigned char) **cursor)) { ++(*cursor); }
-}
-
-static int digest_parse_json_string(const char **cursor, char *out, size_t out_size) {
-    if (!cursor || !*cursor || **cursor != '"' || out_size == 0) { return -1; }
-    ++(*cursor);
-    size_t length = 0;
-    while (**cursor && **cursor != '"') {
-        char ch = **cursor;
-        if (ch == '\\') {
-            ++(*cursor);
-            if (!**cursor) { return -1; }
-            ch = **cursor;
-        }
-        if (length + 1 >= out_size) { return -1; }
-        out[length++] = ch;
-        ++(*cursor);
-    }
-    if (**cursor != '"') { return -1; }
-    ++(*cursor);
-    out[length] = '\0';
-    return 0;
-}
-
 static const omega_digest_algorithm_t *digest_find_algorithm(const char *algorithm) {
     if (!algorithm) { return NULL; }
     const size_t count = sizeof(OMEGA_DIGEST_ALGORITHMS) / sizeof(OMEGA_DIGEST_ALGORITHMS[0]);
@@ -95,32 +71,32 @@ static int digest_parse_options(const char *options_json, const omega_digest_alg
     if (!options_json || !*options_json) { return 0; }
 
     const char *cursor = options_json;
-    digest_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != '{') { return -1; }
     ++cursor;
-    digest_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor == '}') {
         ++cursor;
-        digest_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
         return *cursor == '\0' ? 0 : -1;
     }
 
     char key[32];
-    if (digest_parse_json_string(&cursor, key, sizeof(key)) != 0 || strcmp(key, "algorithm") != 0) { return -1; }
-    digest_skip_ws(&cursor);
+    if (omega_plugin_json_parse_string(&cursor, key, sizeof(key)) != 0 || strcmp(key, "algorithm") != 0) { return -1; }
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != ':') { return -1; }
     ++cursor;
-    digest_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
 
     char algorithm[32];
-    if (digest_parse_json_string(&cursor, algorithm, sizeof(algorithm)) != 0) { return -1; }
+    if (omega_plugin_json_parse_string(&cursor, algorithm, sizeof(algorithm)) != 0) { return -1; }
     *algorithm_out = digest_find_algorithm(algorithm);
     if (!*algorithm_out) { return -1; }
 
-    digest_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != '}') { return -1; }
     ++cursor;
-    digest_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     return *cursor == '\0' ? 0 : -1;
 }
 

--- a/plugins/src/zlib.c
+++ b/plugins/src/zlib.c
@@ -12,7 +12,8 @@
  *                                                                                                                    *
  **********************************************************************************************************************/
 
-#include <ctype.h>
+#include "c_plugin_options.h"
+
 #include <errno.h>
 #include <limits.h>
 #include <omega_edit/config.h>
@@ -48,31 +49,6 @@ static int input_length_to_ulong(int64_t input_length, uLong *input_length_out) 
     return 0;
 }
 
-static void zlib_skip_ws(const char **cursor) {
-    while (cursor && *cursor && isspace((unsigned char) **cursor)) { ++(*cursor); }
-}
-
-static int zlib_parse_json_string(const char **cursor, char *out, size_t out_size) {
-    if (!cursor || !*cursor || **cursor != '"' || out_size == 0) { return -1; }
-    ++(*cursor);
-    size_t length = 0;
-    while (**cursor && **cursor != '"') {
-        char ch = **cursor;
-        if (ch == '\\') {
-            ++(*cursor);
-            if (!**cursor) { return -1; }
-            ch = **cursor;
-        }
-        if (length + 1 >= out_size) { return -1; }
-        out[length++] = ch;
-        ++(*cursor);
-    }
-    if (**cursor != '"') { return -1; }
-    ++(*cursor);
-    out[length] = '\0';
-    return 0;
-}
-
 static int zlib_parse_action_text(const char *value, omega_zlib_action_t *action_out) {
     if (!value || !action_out) { return -1; }
     if (strcmp(value, "compress") == 0) {
@@ -87,7 +63,7 @@ static int zlib_parse_action_text(const char *value, omega_zlib_action_t *action
 }
 
 static int zlib_parse_integer(const char **cursor, int *value_out) {
-    zlib_skip_ws(cursor);
+    omega_plugin_json_skip_ws(cursor);
     char *end_ptr = NULL;
     const long parsed = strtol(*cursor, &end_ptr, 10);
     if (end_ptr == *cursor || parsed < Z_DEFAULT_COMPRESSION || parsed > Z_BEST_COMPRESSION) { return -1; }
@@ -98,7 +74,7 @@ static int zlib_parse_integer(const char **cursor, int *value_out) {
 
 static int zlib_parse_positive_int64(const char **cursor, int64_t *value_out) {
     if (!cursor || !*cursor || !value_out) { return -1; }
-    zlib_skip_ws(cursor);
+    omega_plugin_json_skip_ws(cursor);
     errno = 0;
     char *end_ptr = NULL;
     const long long parsed = strtoll(*cursor, &end_ptr, 10);
@@ -116,27 +92,27 @@ static int zlib_parse_options(const char *options_json, omega_zlib_options_t *op
     if (!options_json || !*options_json) { return 0; }
 
     const char *cursor = options_json;
-    zlib_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor != '{') { return -1; }
     ++cursor;
-    zlib_skip_ws(&cursor);
+    omega_plugin_json_skip_ws(&cursor);
     if (*cursor == '}') {
         ++cursor;
-        zlib_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
         return *cursor == '\0' ? 0 : -1;
     }
 
     while (*cursor) {
         char key[32];
-        if (zlib_parse_json_string(&cursor, key, sizeof(key)) != 0) { return -1; }
-        zlib_skip_ws(&cursor);
+        if (omega_plugin_json_parse_string(&cursor, key, sizeof(key)) != 0) { return -1; }
+        omega_plugin_json_skip_ws(&cursor);
         if (*cursor != ':') { return -1; }
         ++cursor;
-        zlib_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
 
         if (strcmp(key, "action") == 0) {
             char action[16];
-            if (zlib_parse_json_string(&cursor, action, sizeof(action)) != 0 ||
+            if (omega_plugin_json_parse_string(&cursor, action, sizeof(action)) != 0 ||
                 zlib_parse_action_text(action, &options_out->action) != 0) {
                 return -1;
             }
@@ -148,15 +124,15 @@ static int zlib_parse_options(const char *options_json, omega_zlib_options_t *op
             return -1;
         }
 
-        zlib_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
         if (*cursor == '}') {
             ++cursor;
-            zlib_skip_ws(&cursor);
+            omega_plugin_json_skip_ws(&cursor);
             return *cursor == '\0' ? 0 : -1;
         }
         if (*cursor != ',') { return -1; }
         ++cursor;
-        zlib_skip_ws(&cursor);
+        omega_plugin_json_skip_ws(&cursor);
     }
     return -1;
 }

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -258,8 +258,11 @@ namespace omega_edit {
                 return grpc::Status(grpc::StatusCode::INTERNAL, "failed to open computed content snapshot file");
             }
 
-            const auto save_ok = 0 == omega_edit_save_segment_to_file(session, file, source.effective_offset,
-                                                                      source.effective_length);
+            omega_edit_save_segment_to_file_options_t save_options{};
+            save_options.skip_disk_sync = OMEGA_EDIT_TRUE;
+            const auto save_ok =
+                    0 == omega_edit_save_segment_to_file_with_options(session, file, source.effective_offset,
+                                                                      source.effective_length, &save_options);
             const auto close_ok = std::fclose(file) == 0;
             if (!save_ok || !close_ok) {
                 omega_util_remove_file(snapshot_path);

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -37,6 +37,7 @@
 #include <vector>
 
 #ifdef _WIN32
+#include <io.h>
 #include <psapi.h>
 #include <windows.h>
 #elif defined(__APPLE__)
@@ -174,61 +175,137 @@ namespace omega_edit {
             }
         }
 
-        static int read_session_content_segment(const omega_session_t *session, session_content_source content,
-                                                omega_segment_t *segment, int64_t offset) {
-            switch (content) {
-                case ::omega_edit::v1::SESSION_CONTENT_SOURCE_ORIGINAL:
-                    return omega_session_get_original_segment(session, segment, offset);
-                case ::omega_edit::v1::SESSION_CONTENT_SOURCE_COMPUTED:
-                    return omega_session_get_segment(session, segment, offset);
-                default:
-                    return -1;
-            }
-        }
-
-        struct session_content_reader {
-            const omega_session_t *session{};
-            session_content_source content{};
-            int64_t offset{};
-            int64_t length{};
-        };
-
         struct session_content_file_reader {
             std::string file_path;
             int64_t offset{};
             int64_t length{};
         };
 
-        static int64_t read_session_content_chunk(int64_t relative_offset, omega_byte_t *buffer, int64_t length,
-                                                  void *user_data_ptr) {
-            auto *reader = static_cast<session_content_reader *>(user_data_ptr);
-            if (!reader || !reader->session || !buffer || relative_offset < 0 || length < 0 ||
-                relative_offset > reader->length) {
-                return -1;
+        static grpc::Status validate_session_content_range(int64_t content_byte_length, int64_t request_offset,
+                                                           int64_t request_length, int64_t &effective_offset,
+                                                           int64_t &effective_length);
+
+        struct session_content_file_source {
+            std::string checkpoint_directory;
+            std::string file_path;
+            int64_t content_byte_length{-1};
+            int64_t effective_offset{};
+            int64_t effective_length{};
+            int64_t reader_file_offset{};
+            bool owns_file{};
+
+            session_content_file_source() = default;
+            session_content_file_source(const session_content_file_source &) = delete;
+            auto operator=(const session_content_file_source &) -> session_content_file_source & = delete;
+            session_content_file_source(session_content_file_source &&other) noexcept
+                : checkpoint_directory(std::move(other.checkpoint_directory)), file_path(std::move(other.file_path)),
+                  content_byte_length(other.content_byte_length), effective_offset(other.effective_offset),
+                  effective_length(other.effective_length), reader_file_offset(other.reader_file_offset),
+                  owns_file(other.owns_file) {
+                other.owns_file = false;
+            }
+            auto operator=(session_content_file_source &&other) noexcept -> session_content_file_source & {
+                if (this != &other) {
+                    if (owns_file && !file_path.empty()) { omega_util_remove_file(file_path.c_str()); }
+                    checkpoint_directory = std::move(other.checkpoint_directory);
+                    file_path = std::move(other.file_path);
+                    content_byte_length = other.content_byte_length;
+                    effective_offset = other.effective_offset;
+                    effective_length = other.effective_length;
+                    reader_file_offset = other.reader_file_offset;
+                    owns_file = other.owns_file;
+                    other.owns_file = false;
+                }
+                return *this;
+            }
+            ~session_content_file_source() {
+                if (owns_file && !file_path.empty()) { omega_util_remove_file(file_path.c_str()); }
+            }
+        };
+
+        static FILE *open_owned_fd_as_file(int fd, const char *mode) {
+            if (fd < 0 || !mode) { return nullptr; }
+            FILE *file = nullptr;
+#ifdef _WIN32
+            file = _fdopen(fd, mode);
+            if (!file) { _close(fd); }
+#else
+            file = fdopen(fd, mode);
+            if (!file) { close(fd); }
+#endif
+            return file;
+        }
+
+        static grpc::Status create_computed_content_snapshot(omega_session_t *session,
+                                                             session_content_file_source &source) {
+            char snapshot_path[FILENAME_MAX + 1] = {};
+            const auto count =
+                    source.checkpoint_directory.empty()
+                            ? snprintf(snapshot_path, sizeof(snapshot_path), ".OmegaEdit-inspect.XXXXXX")
+                            : snprintf(snapshot_path, sizeof(snapshot_path), "%s%c.OmegaEdit-inspect.XXXXXX",
+                                       source.checkpoint_directory.c_str(), omega_util_directory_separator());
+            if (count < 0 || static_cast<size_t>(count) >= sizeof(snapshot_path)) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "failed to create computed content snapshot name");
             }
 
-            const auto remaining = reader->length - relative_offset;
-            const auto read_length = std::min(std::min(length, remaining), SESSION_CONTENT_INSPECTION_CHUNK_SIZE);
-            if (read_length == 0) { return 0; }
-
-            auto *segment = omega_segment_create(read_length);
-            if (!segment) { return -1; }
-            const auto rc = read_session_content_segment(reader->session, reader->content, segment,
-                                                         reader->offset + relative_offset);
-            if (rc != 0) {
-                omega_segment_destroy(segment);
-                return -1;
+            const auto fd = omega_util_mkstemp(snapshot_path, 0600);
+            if (fd < 0) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "failed to create computed content snapshot file");
+            }
+            auto *file = open_owned_fd_as_file(fd, "wb");
+            if (!file) {
+                omega_util_remove_file(snapshot_path);
+                return grpc::Status(grpc::StatusCode::INTERNAL, "failed to open computed content snapshot file");
             }
 
-            const auto segment_length = std::min(read_length, omega_segment_get_length(segment));
-            auto *data = omega_segment_get_data(segment);
-            if (segment_length <= 0 || !data) {
-                omega_segment_destroy(segment);
-                return -1;
+            const auto save_ok = 0 == omega_edit_save_segment_to_file(session, file, source.effective_offset,
+                                                                      source.effective_length);
+            const auto close_ok = std::fclose(file) == 0;
+            if (!save_ok || !close_ok) {
+                omega_util_remove_file(snapshot_path);
+                return grpc::Status(grpc::StatusCode::INTERNAL, "failed to write computed content snapshot");
             }
-            std::memcpy(buffer, data, static_cast<size_t>(segment_length));
-            omega_segment_destroy(segment);
-            return segment_length;
+
+            source.file_path = snapshot_path;
+            source.reader_file_offset = 0;
+            source.owns_file = true;
+            return grpc::Status::OK;
+        }
+
+        static grpc::Status prepare_session_content_file_source(SessionManager &session_manager,
+                                                                const std::string &session_id,
+                                                                session_content_source content,
+                                                                int64_t requested_offset, int64_t requested_length,
+                                                                session_content_file_source &source,
+                                                                const char *operation_name) {
+            auto locked_session = session_manager.lock_session(session_id);
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + session_id);
+            }
+
+            auto *session = locked_session.session();
+            source.content_byte_length = get_session_content_byte_length(session, content);
+            const auto range_status =
+                    validate_session_content_range(source.content_byte_length, requested_offset, requested_length,
+                                                   source.effective_offset, source.effective_length);
+            if (!range_status.ok()) { return range_status; }
+
+            const auto *checkpoint_directory_ptr = omega_session_get_checkpoint_directory(session);
+            source.checkpoint_directory = checkpoint_directory_ptr ? checkpoint_directory_ptr : "";
+
+            if (session_content_source_uses_file_snapshot(content)) {
+                const auto *snapshot_path_ptr = get_session_content_snapshot_file_path(session, content);
+                if (!snapshot_path_ptr || !*snapshot_path_ptr) {
+                    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                        std::string(operation_name) + " content source is not file-backed");
+                }
+                source.file_path = snapshot_path_ptr;
+                source.reader_file_offset = source.effective_offset;
+                source.owns_file = false;
+                return grpc::Status::OK;
+            }
+
+            return create_computed_content_snapshot(session, source);
         }
 
         static int64_t read_session_content_file_chunk(int64_t relative_offset, omega_byte_t *buffer, int64_t length,
@@ -1891,79 +1968,27 @@ namespace omega_edit {
             const auto options_json = make_digest_options_json(algorithm);
 
             const auto inspection_content = fingerprint_content_to_session_content(content);
-            int64_t byte_length = -1;
             transform_plugin_response_guard plugin_response;
+            session_content_file_source source;
+            auto source_status = prepare_session_content_file_source(
+                    session_manager_, request->session_id(), inspection_content, 0, 0, source, "session fingerprint");
+            if (!source_status.ok()) { return source_status; }
 
-            if (session_content_source_uses_file_snapshot(inspection_content)) {
-                std::string checkpoint_directory;
-                std::string snapshot_file_path;
-                {
-                    auto locked_session = session_manager_.lock_session(request->session_id());
-                    if (!locked_session) {
-                        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-                    }
-                    auto *session = locked_session.session();
-                    byte_length = get_session_content_byte_length(session, inspection_content);
-                    if (byte_length < 0) {
-                        return grpc::Status(grpc::StatusCode::INTERNAL,
-                                            "session content length unavailable for fingerprint");
-                    }
-                    const auto *checkpoint_directory_ptr = omega_session_get_checkpoint_directory(session);
-                    checkpoint_directory = checkpoint_directory_ptr ? checkpoint_directory_ptr : "";
-                    const auto *snapshot_path_ptr = get_session_content_snapshot_file_path(session, inspection_content);
-                    if (!snapshot_path_ptr || !*snapshot_path_ptr) {
-                        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                            "session fingerprint content source is not file-backed");
-                    }
-                    snapshot_file_path = snapshot_path_ptr;
-                }
-
-                session_content_file_reader reader{snapshot_file_path, 0, byte_length};
-                const auto inspect_status = inspect_with_streaming_plugin(
-                        context, transform_plugin_registry_, transform_plugin_registry_mutex_,
-                        SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, options_json.c_str(), checkpoint_directory.c_str(), 0,
-                        byte_length, read_session_content_file_chunk, &reader, grpc::StatusCode::FAILED_PRECONDITION,
-                        "session fingerprint digest plugin is not registered: " +
-                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                        "session fingerprint digest plugin must be a streaming inspect plugin",
-                        "unsupported fingerprint digest algorithm: " + algorithm,
-                        "session fingerprint digest plugin cancelled: " +
-                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                        grpc::StatusCode::ABORTED,
-                        "session fingerprint digest plugin failed: " +
-                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                        &plugin_response.response);
-                if (!inspect_status.ok()) { return inspect_status; }
-            } else {
-                auto locked_session = session_manager_.lock_session(request->session_id());
-                if (!locked_session) {
-                    return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-                }
-                auto *session = locked_session.session();
-                byte_length = get_session_content_byte_length(session, inspection_content);
-                if (byte_length < 0) {
-                    return grpc::Status(grpc::StatusCode::INTERNAL,
-                                        "session content length unavailable for fingerprint");
-                }
-
-                session_content_reader reader{session, inspection_content, 0, byte_length};
-                const auto inspect_status = inspect_with_streaming_plugin(
-                        context, transform_plugin_registry_, transform_plugin_registry_mutex_,
-                        SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, options_json.c_str(),
-                        omega_session_get_checkpoint_directory(session), 0, byte_length, read_session_content_chunk,
-                        &reader, grpc::StatusCode::FAILED_PRECONDITION,
-                        "session fingerprint digest plugin is not registered: " +
-                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                        "session fingerprint digest plugin must be a streaming inspect plugin",
-                        "unsupported fingerprint digest algorithm: " + algorithm,
-                        "session fingerprint digest plugin cancelled: " +
-                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                        grpc::StatusCode::ABORTED,
-                        "session fingerprint digest plugin failed: " +
-                                std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                        &plugin_response.response);
-                if (!inspect_status.ok()) { return inspect_status; }
-            }
+            session_content_file_reader reader{source.file_path, source.reader_file_offset, source.effective_length};
+            const auto inspect_status = inspect_with_streaming_plugin(
+                    context, transform_plugin_registry_, transform_plugin_registry_mutex_,
+                    SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, options_json.c_str(), source.checkpoint_directory.c_str(), 0,
+                    source.effective_length, read_session_content_file_chunk, &reader,
+                    grpc::StatusCode::FAILED_PRECONDITION,
+                    "session fingerprint digest plugin is not registered: " +
+                            std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                    "session fingerprint digest plugin must be a streaming inspect plugin",
+                    "unsupported fingerprint digest algorithm: " + algorithm,
+                    "session fingerprint digest plugin cancelled: " + std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                    grpc::StatusCode::ABORTED,
+                    "session fingerprint digest plugin failed: " + std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                    &plugin_response.response);
+            if (!inspect_status.ok()) { return inspect_status; }
 
             if (plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
                 return grpc::Status(grpc::StatusCode::INTERNAL,
@@ -1979,7 +2004,7 @@ namespace omega_edit {
             response->set_session_id(request->session_id());
             response->set_content(content);
             auto *fingerprint = response->mutable_fingerprint();
-            fingerprint->set_byte_length(byte_length);
+            fingerprint->set_byte_length(source.content_byte_length);
             auto *digest_response = fingerprint->mutable_digest();
             digest_response->set_algorithm(algorithm);
             digest_response->set_value(digest_value);
@@ -2040,70 +2065,25 @@ namespace omega_edit {
 
             const int64_t requested_offset = request->has_offset() ? request->offset() : 0;
             const int64_t requested_length = request->has_length() ? request->length() : 0;
-            int64_t content_byte_length = -1;
-            int64_t effective_offset = 0;
-            int64_t effective_length = 0;
-            std::string checkpoint_directory;
             transform_plugin_response_guard plugin_response;
             const char *options_json = request->has_options_json() ? request->options_json().c_str() : nullptr;
+            session_content_file_source source;
+            auto source_status = prepare_session_content_file_source(session_manager_, request->session_id(), content,
+                                                                     requested_offset, requested_length, source,
+                                                                     "session content inspection");
+            if (!source_status.ok()) { return source_status; }
 
-            if (session_content_source_uses_file_snapshot(content)) {
-                std::string snapshot_file_path;
-                {
-                    auto locked_session = session_manager_.lock_session(request->session_id());
-                    if (!locked_session) {
-                        return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-                    }
-                    auto *session = locked_session.session();
-                    content_byte_length = get_session_content_byte_length(session, content);
-                    const auto range_status =
-                            validate_session_content_range(content_byte_length, requested_offset, requested_length,
-                                                           effective_offset, effective_length);
-                    if (!range_status.ok()) { return range_status; }
-                    const auto *checkpoint_directory_ptr = omega_session_get_checkpoint_directory(session);
-                    checkpoint_directory = checkpoint_directory_ptr ? checkpoint_directory_ptr : "";
-                    const auto *snapshot_path_ptr = get_session_content_snapshot_file_path(session, content);
-                    if (!snapshot_path_ptr || !*snapshot_path_ptr) {
-                        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                                            "session content source is not file-backed");
-                    }
-                    snapshot_file_path = snapshot_path_ptr;
-                }
-
-                session_content_file_reader reader{snapshot_file_path, effective_offset, effective_length};
-                const auto inspect_status = inspect_with_streaming_plugin(
-                        context, transform_plugin_registry_, transform_plugin_registry_mutex_, request->plugin_id(),
-                        options_json, checkpoint_directory.c_str(), effective_offset, effective_length,
-                        read_session_content_file_chunk, &reader, grpc::StatusCode::NOT_FOUND,
-                        "transform plugin not found: " + request->plugin_id(),
-                        "session content inspection requires a streaming inspect plugin",
-                        "transform options do not match schema: " + request->plugin_id(),
-                        "session content inspection cancelled: " + request->plugin_id(), grpc::StatusCode::ABORTED,
-                        "session content inspection failed: " + request->plugin_id(), &plugin_response.response);
-                if (!inspect_status.ok()) { return inspect_status; }
-            } else {
-                auto locked_session = session_manager_.lock_session(request->session_id());
-                if (!locked_session) {
-                    return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
-                }
-                auto *session = locked_session.session();
-                content_byte_length = get_session_content_byte_length(session, content);
-                const auto range_status = validate_session_content_range(
-                        content_byte_length, requested_offset, requested_length, effective_offset, effective_length);
-                if (!range_status.ok()) { return range_status; }
-
-                session_content_reader reader{session, content, effective_offset, effective_length};
-                const auto inspect_status = inspect_with_streaming_plugin(
-                        context, transform_plugin_registry_, transform_plugin_registry_mutex_, request->plugin_id(),
-                        options_json, omega_session_get_checkpoint_directory(session), effective_offset,
-                        effective_length, read_session_content_chunk, &reader, grpc::StatusCode::NOT_FOUND,
-                        "transform plugin not found: " + request->plugin_id(),
-                        "session content inspection requires a streaming inspect plugin",
-                        "transform options do not match schema: " + request->plugin_id(),
-                        "session content inspection cancelled: " + request->plugin_id(), grpc::StatusCode::ABORTED,
-                        "session content inspection failed: " + request->plugin_id(), &plugin_response.response);
-                if (!inspect_status.ok()) { return inspect_status; }
-            }
+            session_content_file_reader reader{source.file_path, source.reader_file_offset, source.effective_length};
+            const auto inspect_status = inspect_with_streaming_plugin(
+                    context, transform_plugin_registry_, transform_plugin_registry_mutex_, request->plugin_id(),
+                    options_json, source.checkpoint_directory.c_str(), source.effective_offset, source.effective_length,
+                    read_session_content_file_chunk, &reader, grpc::StatusCode::NOT_FOUND,
+                    "transform plugin not found: " + request->plugin_id(),
+                    "session content inspection requires a streaming inspect plugin",
+                    "transform options do not match schema: " + request->plugin_id(),
+                    "session content inspection cancelled: " + request->plugin_id(), grpc::StatusCode::ABORTED,
+                    "session content inspection failed: " + request->plugin_id(), &plugin_response.response);
+            if (!inspect_status.ok()) { return inspect_status; }
 
             if (!inspect_plugin_response_is_valid(plugin_response.response)) {
                 return grpc::Status(grpc::StatusCode::INTERNAL,
@@ -2113,9 +2093,9 @@ namespace omega_edit {
             response->set_session_id(request->session_id());
             response->set_content(content);
             response->set_plugin_id(request->plugin_id());
-            response->set_offset(effective_offset);
-            response->set_length(effective_length);
-            response->set_content_byte_length(content_byte_length);
+            response->set_offset(source.effective_offset);
+            response->set_length(source.effective_length);
+            response->set_content_byte_length(source.content_byte_length);
             if (plugin_response.response.result_label) {
                 response->set_result_label(plugin_response.response.result_label);
             }
@@ -2606,6 +2586,9 @@ namespace omega_edit {
                 return status_for_session_operation_start(transform_guard.result(), "transform", request->session_id());
             }
 
+            // Replace-capable plugins mutate the non-thread-safe core session, so transforms intentionally serialize
+            // the session while the plugin runs. Read-only whole-content inspections snapshot above and stream outside
+            // this lock instead.
             auto locked_session = session_manager_.lock_session(request->session_id());
             if (!locked_session) {
                 return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());


### PR DESCRIPTION
## Summary
- Fixes SHORTCOMINGS.md items 14, 16, 18, 19, 22, 26, 27, and 29, then refreshes the remaining list.
- Adds explicit C-string helpers, named options structs, safer temp-file handling, clearer replace/save status codes, and a segment-to-file save API.
- Consolidates C plugin option parsing and reduces server transform lock hold time by snapshotting computed content before running inspect/fingerprint plugins.
- Updates item 30 to propose plugin-backed Content Type and Language guessing, per follow-up direction.

## Verification
- `cmake --build --preset ninja-debug-minimal`
- `_build/core/src/tests/session_tests "[SessionApiTests]"`
- `ctest --test-dir _build/core --output-on-failure -R "session|Session|transform|Transform"`
- `ctest --test-dir _build/plugins --output-on-failure -R "omega_transform_plugin_tests"`
- `git diff --check`

## Notes
- `git diff --check` reported only the existing CRLF conversion warning for `core/src/include/omega_edit/viewport.h`.
- I could not verify the C++ gRPC server build locally: `conan-debug` points at a Windows-style binary directory, and the existing `server/cpp/build` CMake cache references Windows paths/tools.