### PR TITLE
Improve test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ coverage:
 	cmake -G $(GENERATOR) -S . -B _build-coverage -DBUILD_SHARED_LIBS=NO -DBUILD_DOCS=NO -DBUILD_EXAMPLES=NO -DBUILD_COVERAGE=YES -DCMAKE_BUILD_TYPE=Debug
 	cmake --build _build-coverage --config Debug
 	ctest -C Debug --test-dir _build-coverage/core --output-on-failure
-	ctest -C Debug --test-dir _build-coverage/plugins --output-on-failure
+	test ! -d _build-coverage/plugins || ctest -C Debug --test-dir _build-coverage/plugins --output-on-failure
 	@echo "Coverage data generated in _build-coverage/"
 	@echo "Run 'lcov --capture --directory _build-coverage --output-file coverage.info' to generate a report"
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ coverage:
 	cmake -G $(GENERATOR) -S . -B _build-coverage -DBUILD_SHARED_LIBS=NO -DBUILD_DOCS=NO -DBUILD_EXAMPLES=NO -DBUILD_COVERAGE=YES -DCMAKE_BUILD_TYPE=Debug
 	cmake --build _build-coverage --config Debug
 	ctest -C Debug --test-dir _build-coverage/core --output-on-failure
+	ctest -C Debug --test-dir _build-coverage/plugins --output-on-failure
 	@echo "Coverage data generated in _build-coverage/"
 	@echo "Run 'lcov --capture --directory _build-coverage --output-file coverage.info' to generate a report"
 

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -194,6 +194,13 @@ TEST_CASE("Byte APIs treat zero-length inputs as empty and keep string helpers c
     REQUIRE(1 == omega_search_context_get_match_offset(cstring_search));
     omega_search_destroy_context(cstring_search);
 
+    REQUIRE(-1 == omega_edit_overwrite_cstring(session_ptr, 0, nullptr));
+    REQUIRE(-1 == omega_edit_replace_cstring(session_ptr, 0, 1, nullptr));
+    REQUIRE(0 < omega_edit_overwrite_cstring(session_ptr, 0, "ABCDE"));
+    REQUIRE("ABCDE" == omega_session_get_segment_string(session_ptr, 0, 5));
+    REQUIRE(0 < omega_edit_replace_cstring(session_ptr, 1, 3, "oo"));
+    REQUIRE("AooE" == omega_session_get_segment_string(session_ptr, 0, 4));
+
     REQUIRE(nullptr == omega_search_create_context_bytes(session_ptr, bytes, 0, 0, 0, 0, 0));
 
     omega_edit_destroy_session(session_ptr);

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -531,6 +531,22 @@ TEST_CASE("Named options and explicit C-string helpers", "[SessionApiTests]") {
     REQUIRE("beta" == std::string(reinterpret_cast<const char *>(buffer), sizeof(buffer)));
     omega_util_remove_file(output_path.c_str());
 
+    const omega_byte_t byte_pattern[] = {'o', 'm', 'e', 'g', 'a'};
+    const omega_byte_t byte_replacement[] = {'A', 'L', 'P', 'H', 'A'};
+    replacement_count = 0;
+    omega_edit_replace_matches_options_t byte_replace_options{};
+    byte_replace_options.offset = 0;
+    byte_replace_options.length = 0;
+    byte_replace_options.limit = 1;
+    byte_replace_options.front_to_back = OMEGA_EDIT_TRUE;
+    byte_replace_options.replacement_count_out = &replacement_count;
+    REQUIRE(0 == omega_edit_replace_matches_bytes_with_options(
+                         session_ptr, byte_pattern, static_cast<int64_t>(sizeof(byte_pattern)), byte_replacement,
+                         static_cast<int64_t>(sizeof(byte_replacement)), &byte_replace_options));
+    REQUIRE(1 == replacement_count);
+    REQUIRE("ALPHA beta omega" ==
+            omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
     omega_edit_destroy_session(session_ptr);
 }
 

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -148,6 +148,64 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"bytes\":[\"AA\",\"0F\"]}", array_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"bytes\":[\"AA\"]}", array_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"bytes\":[\"aa\",\"0F\"]}", array_schema));
+    const char *strict_without_properties_schema = R"json({
+        "type":"object",
+        "additionalProperties":false
+    })json";
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(R"json({"extra":1})json",
+                                                                   strict_without_properties_schema));
+    const char *escaped_string_schema = R"json({
+        "type":"object",
+        "properties":{"text":{"type":"string","enum":["\b\f\n\r\t"]}},
+        "additionalProperties":false
+    })json";
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(R"json({"text":"\b\f\n\r\t"})json",
+                                                                  escaped_string_schema));
+    const char *numeric_integer_schema = R"json({
+        "type":"object",
+        "properties":{"value":{"type":"integer","minimum":-100,"maximum":100}},
+        "additionalProperties":false
+    })json";
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(R"json({"value":1e+2})json", numeric_integer_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(R"json({"value":1e+})json", numeric_integer_schema));
+    const char *deep_enum_schema = R"json({
+        "type":"object",
+        "properties":{"value":{"enum":[null,true,[1,true,null],{"nested":["\u20AC",2]}]}},
+        "additionalProperties":false
+    })json";
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(R"json({"value":null})json", deep_enum_schema));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(R"json({"value":true})json", deep_enum_schema));
+    REQUIRE(0 ==
+            omega_transform_plugin_options_match_args_schema(R"json({"value":[1,true,null]})json", deep_enum_schema));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(R"json({"value":{"nested":["\u20AC",2]}})json",
+                                                                  deep_enum_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(R"json({"value":[1,true]})json", deep_enum_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(R"json({"value":{"other":["\u20AC",2]}})json",
+                                                                   deep_enum_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(R"json({"value":[1,]})json", deep_enum_schema));
+    REQUIRE(-1 ==
+            omega_transform_plugin_options_match_args_schema(R"json({"value":"unterminated})json", deep_enum_schema));
+    const char *escaped_dot_pattern_schema = R"json({
+        "type":"object",
+        "properties":{"name":{"type":"string","pattern":"^a\\.$"}},
+        "additionalProperties":false
+    })json";
+    REQUIRE(0 ==
+            omega_transform_plugin_options_match_args_schema(R"json({"name":"a."})json", escaped_dot_pattern_schema));
+    const char *escaped_digit_pattern_schema = R"json({
+        "type":"object",
+        "properties":{"name":{"type":"string","pattern":"^(a)\\1$"}},
+        "additionalProperties":false
+    })json";
+    REQUIRE(-1 ==
+            omega_transform_plugin_options_match_args_schema(R"json({"name":"aa"})json", escaped_digit_pattern_schema));
+    const char *bad_range_quantifier_schema = R"json({
+        "type":"object",
+        "properties":{"name":{"type":"string","pattern":"^a{z}$"}},
+        "additionalProperties":false
+    })json";
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(R"json({"name":"a{z}"})json",
+                                                                   bad_range_quantifier_schema));
     const char *unsupported_number_schema =
             "{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"number\"}},\"additionalProperties\":false}";
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"value\":1.5}", unsupported_number_schema));

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -156,11 +156,11 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                                    strict_without_properties_schema));
     const char *escaped_string_schema = R"json({
         "type":"object",
-        "properties":{"text":{"type":"string","enum":["\b\f\n\r\t"]}},
+        "properties":{"text":{"type":"string","enum":["\u0008\u000C\u000A\u000D\u0009"]}},
         "additionalProperties":false
     })json";
-    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(R"json({"text":"\b\f\n\r\t"})json",
-                                                                  escaped_string_schema));
+    REQUIRE(0 == omega_transform_plugin_options_match_args_schema(
+                         R"json({"text":"\u0008\u000C\u000A\u000D\u0009"})json", escaped_string_schema));
     const char *numeric_integer_schema = R"json({
         "type":"object",
         "properties":{"value":{"type":"integer","minimum":-100,"maximum":100}},


### PR DESCRIPTION
## Summary

- Include the transform plugin integration suite in `make coverage` so plugin-backed core paths contribute to coverage.
- Add targeted schema/parser edge cases for transform plugin option validation, including escaped strings, numeric exponent parsing, deep enum equality, malformed JSON, Unicode, and risky regex patterns.
- Cover public C-string edit helpers and the byte-oriented replace-matches options wrapper.

## Impact

This raises meaningful core library line coverage above the 80% target while exercising behavior that can fail in subtle ways around JSON parsing, regex safety, and public API wrappers.

## Validation

- `cmake --build _build-coverage --config Debug`
- `ctest -C Debug --test-dir _build-coverage/core -R "Byte APIs treat zero-length inputs|Named options and explicit C-string helpers" --output-on-failure`
- `ctest -C Debug --test-dir _build-coverage/plugins -R omega_transform_plugin_tests --output-on-failure`
- `ctest -C Debug --test-dir _build-coverage/core -E '^File Copy$' --output-on-failure`
- `ctest -C Debug --test-dir _build-coverage/plugins --output-on-failure`

Final local core library line coverage from `gcov`: `3793/4642 = 81.71%`.

Note: the full core CTest suite has a pre-existing `File Copy` permission-mode assertion failure on this WSL mount, so the broad local run excluded only that test.