### PR TITLE
fix: codecov coverage inputs

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -53,6 +53,7 @@ comment:
 ignore:
   - core/src/examples
   - core/src/tests
+  - plugins/tests
   - packages/client/dist
   - packages/client/scripts
   - packages/client/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -457,7 +457,7 @@ jobs:
           lcov --capture --directory build-coverage --output-file coverage-native.info \
             --rc branch_coverage=1 --ignore-errors mismatch,gcov,source
           lcov --remove coverage-native.info \
-            '*/src/tests/*' '*/src/examples/*' '*/_deps/*' '/usr/*' '*/catch2/*' \
+            '*/src/tests/*' '*/src/examples/*' '*/plugins/tests/*' '*/_deps/*' '/usr/*' '*/catch2/*' \
             --output-file coverage-native.info --rc branch_coverage=1 --ignore-errors unused
           lcov --list coverage-native.info
 
@@ -578,7 +578,7 @@ jobs:
           use_oidc: true
           fail_ci_if_error: true
 
-  coverage-client-uds:
+  test-client-uds:
     strategy:
       matrix:
         include:
@@ -587,33 +587,22 @@ jobs:
           - os: macos-15
             label: macos
       fail-fast: false
-    name: Client UDS Coverage ${{ matrix.os }}
+    name: Client UDS Tests ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Build middleware for UDS coverage
+      - name: Build middleware for UDS tests
         uses: ./.github/workflows/build-middleware
         with:
           runner-os: ${{ runner.os }}
           os-name: ${{ matrix.os }}
           skip-tests: 'true'
 
-      - name: Run client UDS coverage
-        run: yarn workspace @omega-edit/client test:coverage:uds
+      - name: Run client UDS tests
+        run: yarn workspace @omega-edit/client test:uds
         env:
           CPP_SERVER_BINARY: ''
-
-      - name: Upload TypeScript UDS coverage to Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          files: packages/client/coverage/lcov.info
-          disable_search: true
-          flags: client-uds-${{ matrix.label }}
-          name: omega-edit-client-uds-${{ matrix.label }}
-          use_oidc: true
-          fail_ci_if_error: true


### PR DESCRIPTION
## Summary

Fix the coverage inputs that feed the README Codecov badge after the coverage test expansion landed.

- Exclude `plugins/tests` from native lcov and Codecov ignore rules so test sources do not count as production coverage.
- Keep UDS transport checks running, but run them as UDS tests instead of duplicate coverage uploads.
- Remove the unused OIDC permission from the UDS job now that it no longer uploads to Codecov.

## Root Cause

The README badge is dynamic, and `main` still showed `72%` because Codecov was aggregating noisy coverage inputs. Native lcov still included plugin test sources, and the UDS jobs uploaded duplicate TypeScript coverage reports under extra flags.

I also checked the client source-coverage path: pointing Vitest directly at `src` produces real data, but current client source coverage is only about 57%, so that is separate coverage debt rather than something to sneak into this badge fix.

## Validation

- `git diff --check`
- Parsed `.github/workflows/tests.yml` and `.github/codecov.yml` with PyYAML
- Validated `.github/codecov.yml` with `https://api.codecov.io/validate`
- `npm exec --yes --package=node@24 -- node "/mnt/c/Program Files (x86)/Yarn/lib/cli.js" workspace @omega-edit/client lint`

CI is rerunning on the squashed commit.