### PR TITLE
docs(vscode): document data editor keyboard shortcuts

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -156,17 +156,30 @@ This mode decision is made only when the user runs an explicit search. If a repl
 
 ## Keyboard Shortcuts
 
-| Key                      | Action                                                     |
-| ------------------------ | ---------------------------------------------------------- |
-| `Ctrl+Z`                 | Native VS Code undo                                       |
-| `Ctrl+Y`                 | Native VS Code redo                                       |
-| `Ctrl+S`                 | Native VS Code save                                       |
-| `Ctrl+Shift+S`           | Native VS Code save as                                    |
-| `Ctrl+F`                 | Focus search                                               |
-| Arrow keys               | Move selection, or scroll by line when nothing is selected |
-| `Page Up` / `Page Down`  | Scroll by 32 rows                                          |
-| `Ctrl+Home` / `Ctrl+End` | Jump to start / end                                        |
-| Mouse wheel              | Scroll by 4 rows                                           |
+| Key | Action |
+| --- | --- |
+| `Ctrl/Cmd+Z` | Native VS Code undo |
+| `Ctrl+Y` / `Cmd+Shift+Z` | Native VS Code redo |
+| `Ctrl/Cmd+S` | Native VS Code save |
+| `Ctrl/Cmd+Shift+S` | Native VS Code save as |
+| `Ctrl/Cmd+C`, `Ctrl/Cmd+X`, `Ctrl/Cmd+V` | Copy, cut, and paste selected bytes |
+| `Tab` | Switch between the hex and text panes |
+| Arrow keys | Move the selection by one byte or one row |
+| `Shift` + Arrow keys | Extend the selection while moving |
+| `Page Up` / `Page Down` | Move by one visible page and scroll |
+| `Home` / `End` | Jump to start / end |
+| `Insert` | Toggle insert/overwrite editing mode |
+| `Backspace` / `Delete` | Delete the selection or adjacent byte |
+| `Ctrl/Cmd+F` | Open search and focus the search field |
+| `Ctrl/Cmd+H` | Open search and replace and focus the replacement field |
+| `F3` / `Shift+F3` | Move to the next / previous search match |
+| `Ctrl/Cmd+G` / `Ctrl/Cmd+L` | Focus the offset jump field |
+| Mouse wheel | Scroll by 4 rows |
+
+The toolbar and command palette also expose the search actions. The `F3`
+shortcuts apply while focus is outside an editable input.
+See the [keyboard shortcuts wiki page](https://github.com/ctc-oss/omega-edit/wiki/VS-Code-Data-Editor-Keyboard-Shortcuts)
+for details.
 
 ## Testing
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -149,6 +149,9 @@ A complete, runnable reference extension lives at [`vscode-extension/`](https://
 
 The current reference implementation also uses the higher-level `@omega-edit/client` editor helpers for session lifecycle, live session state, undo/save-state bookkeeping, and bounded-vs-large search behavior instead of hand-rolling that glue in the provider.
 
+See [VS Code Data Editor Keyboard Shortcuts](VS-Code-Data-Editor-Keyboard-Shortcuts)
+for editing, navigation, clipboard, and search controls.
+
 ```bash
 cd vscode-extension
 npm install

--- a/wiki/VS-Code-Data-Editor-Keyboard-Shortcuts.md
+++ b/wiki/VS-Code-Data-Editor-Keyboard-Shortcuts.md
@@ -1,0 +1,52 @@
+# VS Code Data Editor Keyboard Shortcuts
+
+The Ωedit™ reference VS Code extension supports keyboard editing and navigation in
+its hex and text panes. Click a byte in either pane before using the grid-specific
+shortcuts below.
+
+## Editing and Navigation
+
+| Key | Action |
+| --- | --- |
+| `Tab` | Switch between the hex and text panes. |
+| Arrow keys | Move the active byte selection by one byte or one row. |
+| `Shift` + Arrow keys | Extend the selection while moving. |
+| `Home` / `End` | Jump to the beginning / end of the file. |
+| `Page Up` / `Page Down` | Move by one visible page and scroll the viewport. |
+| `Insert` | Toggle insert/overwrite editing mode. |
+| `Backspace` | Delete the selection, or the byte before the active offset. |
+| `Delete` | Delete the selection, or the byte at the active offset. |
+| Hexadecimal character | Edit the active byte when the hex pane is active. |
+| Text character | Edit the active byte using the selected text encoding when the text pane is active. |
+
+Typing and deletion are disabled while the editor is read-only or a transform is
+in progress.
+
+## Standard VS Code Shortcuts
+
+The custom editor participates in VS Code's native document commands:
+
+| Windows / Linux | macOS | Action |
+| --- | --- | --- |
+| `Ctrl+Z` | `Cmd+Z` | Undo |
+| `Ctrl+Y` | `Cmd+Shift+Z` | Redo |
+| `Ctrl+S` | `Cmd+S` | Save |
+| `Ctrl+Shift+S` | `Cmd+Shift+S` | Save as |
+| `Ctrl+C` | `Cmd+C` | Copy the selected bytes |
+| `Ctrl+X` | `Cmd+X` | Cut the selected bytes |
+| `Ctrl+V` | `Cmd+V` | Paste bytes at the active offset |
+
+## Search and Mouse Navigation
+
+- `Ctrl/Cmd+F` opens search and focuses the search field.
+- `Ctrl/Cmd+H` opens search and replace and focuses the replacement field.
+- `F3` and `Shift+F3` move to the next and previous search match while focus is
+  outside an editable input.
+- `Ctrl/Cmd+G` and `Ctrl/Cmd+L` focus the offset jump field.
+- The toolbar and command palette also expose the search actions.
+- The mouse wheel scrolls the data viewport by four rows per step.
+
+The current handlers are implemented in
+[`PreviewGrid.svelte`](https://github.com/ctc-oss/omega-edit/blob/main/vscode-extension/webview-ui/src/components/PreviewGrid.svelte)
+and
+[`App.svelte`](https://github.com/ctc-oss/omega-edit/blob/main/vscode-extension/webview-ui/src/App.svelte).


### PR DESCRIPTION
## Summary

- Add a dedicated wiki reference for Data Editor editing, navigation, clipboard, search, pane, and offset shortcuts.
- Link the reference from the wiki home and VS Code extension README.
- Match the documented search and pane shortcuts to the current Svelte handlers.

Closes #1529

## Verification

- [x] Documentation reviewed against current keyboard handlers
- [ ] `yarn lint`
- [ ] VS Code extension lint, compile, and unit tests