### PR TITLE
fix: Auto Save rollback conflicts

### DIFF
--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -164,6 +164,32 @@ int omega_edit_serial_result_is_success(int64_t result);
 int omega_edit_status_result_is_success(int result);
 
 /**
+ * Callback used to verify an overwrite target immediately before core publishes a saved file.
+ *
+ * The callback is invoked only when the target is the session's original file and core detects that it changed since
+ * the last synchronization. Return zero to allow the overwrite or non-zero to preserve the target and report
+ * ORIGINAL_MODIFIED. Core does not lock the target across this callback and the following atomic replacement, so the
+ * callback detects conflicts but cannot provide transactional compare-and-swap semantics against concurrent writers.
+ */
+typedef int (*omega_edit_overwrite_guard_cbk_t)(const char *file_path, void *user_data_ptr);
+
+/** Optional behavior for publishing a session save. */
+typedef struct {
+    omega_edit_overwrite_guard_cbk_t overwrite_guard;
+    void *overwrite_guard_user_data;
+} omega_edit_save_options_t;
+
+/**
+ * Save a segment with an optional native overwrite guard.
+ *
+ * This is equivalent to omega_edit_save_segment when options_ptr is null. A configured overwrite guard is evaluated
+ * at the final publish boundary only when core's normal original-file modification check detects a conflict.
+ */
+int omega_edit_save_segment_with_options(omega_session_t *session_ptr, const char *file_path, int io_flags,
+                                         char *saved_file_path, int64_t offset, int64_t length,
+                                         const omega_edit_save_options_t *options_ptr);
+
+/**
  * Save a segment of the the given session (the edited file) to the given file path.  If the save file already exists,
  * it can be overwritten if overwrite is non zero.  If the file exists and overwrite is zero, a new unique file name
  * will be used as determined by omega_util_available_filename.  If the file being edited is overwritten, the affected
@@ -192,6 +218,10 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
  * @return 0 on success, non-zero otherwise
  */
 int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path);
+
+/** Save a complete session with an optional native overwrite guard. */
+int omega_edit_save_with_options(omega_session_t *session_ptr, const char *file_path, int io_flags,
+                                 char *saved_file_path, const omega_edit_save_options_t *options_ptr);
 
 /**
  * Write a session byte range to an already-open file without publishing a save event.

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -2585,8 +2585,9 @@ int omega_edit_apply_transform(omega_session_t *session_ptr, omega_util_byte_tra
                    : -1;
 }
 
-int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path,
-                            int64_t offset, int64_t length) {
+int omega_edit_save_segment_with_options(omega_session_t *session_ptr, const char *file_path, int io_flags,
+                                         char *saved_file_path, int64_t offset, int64_t length,
+                                         const omega_edit_save_options_t *options_ptr) {
     if (!session_ptr || !file_path || !*file_path || offset < 0) { return -1; }
     const auto computed_file_size = omega_session_get_computed_file_size(session_ptr);
     if (computed_file_size < 0) { return -1; }
@@ -2613,7 +2614,8 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
             (overwrite && (session_file_path != nullptr) && (omega_util_file_exists(file_path) != 0) &&
              (omega_util_paths_equivalent(file_path, session_file_path) != 0));
 
-    if (overwrite_original && (force_overwrite == 0) &&
+    const auto has_overwrite_guard = options_ptr != nullptr && options_ptr->overwrite_guard != nullptr;
+    if (overwrite_original && (force_overwrite == 0) && !has_overwrite_guard &&
         original_file_modified_since_last_sync_(session_ptr, session_file_path)) {
         LOG_ERROR("original file '" << session_file_path
                                     << "' has been modified since the session was created, save failed (use "
@@ -2761,6 +2763,13 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
         return -9;
     }
     if (overwrite) {
+        if (overwrite_original && (force_overwrite == 0) &&
+            original_file_modified_since_last_sync_(session_ptr, session_file_path) &&
+            (!has_overwrite_guard ||
+             options_ptr->overwrite_guard(file_path, options_ptr->overwrite_guard_user_data) != 0)) {
+            omega_util_remove_file(temp_filename);
+            return ORIGINAL_MODIFIED;
+        }
         if (!atomic_replace_file_(temp_filename, file_path)) {
             LOG_ERRNO();
             omega_util_remove_file(temp_filename);
@@ -2793,8 +2802,19 @@ int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path,
     return 0;
 }
 
+int omega_edit_save_segment(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path,
+                            int64_t offset, int64_t length) {
+    return omega_edit_save_segment_with_options(session_ptr, file_path, io_flags, saved_file_path, offset, length,
+                                                nullptr);
+}
+
 int omega_edit_save(omega_session_t *session_ptr, const char *file_path, int io_flags, char *saved_file_path) {
-    return omega_edit_save_segment(session_ptr, file_path, io_flags, saved_file_path, 0, 0);
+    return omega_edit_save_with_options(session_ptr, file_path, io_flags, saved_file_path, nullptr);
+}
+
+int omega_edit_save_with_options(omega_session_t *session_ptr, const char *file_path, int io_flags,
+                                 char *saved_file_path, const omega_edit_save_options_t *options_ptr) {
+    return omega_edit_save_segment_with_options(session_ptr, file_path, io_flags, saved_file_path, 0, 0, options_ptr);
 }
 
 int omega_edit_save_segment_to_file_with_options(const omega_session_t *session_ptr, FILE *file_ptr, int64_t offset,

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -75,6 +75,19 @@ void write_test_file(const char *path, const char *bytes) {
     output.close();
     REQUIRE(output.good());
 }
+
+void write_test_file_after_modification_time(const char *path, const char *bytes, int64_t previous_modification_time) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    int64_t modification_time = previous_modification_time;
+    do {
+        write_test_file(path, bytes);
+        REQUIRE(0 == omega_util_get_modification_time(path, &modification_time));
+        if (modification_time > previous_modification_time) { return; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    } while (std::chrono::steady_clock::now() < deadline);
+    REQUIRE(modification_time > previous_modification_time);
+}
+
 void session_save_test_session_cbk(const omega_session_t *session_ptr, omega_session_event_t session_event,
                                    const void *) {
     auto count_ptr = reinterpret_cast<int *>(omega_session_get_user_data_ptr(session_ptr));
@@ -554,8 +567,9 @@ TEST_CASE("Guarded session save fails closed at the publish boundary", "[Session
     REQUIRE(session);
     REQUIRE(0 < omega_edit_overwrite_string(session, 0, "OMEGA"));
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    write_test_file(path.c_str(), "external");
+    int64_t original_modification_time = 0;
+    REQUIRE(0 == omega_util_get_modification_time(path.c_str(), &original_modification_time));
+    write_test_file_after_modification_time(path.c_str(), "external", original_modification_time);
     write_test_file(external_path.c_str(), "external");
 
     overwrite_guard_test_state guard_state{};
@@ -603,6 +617,11 @@ TEST_CASE("Guarded session save fails closed at the publish boundary", "[Session
 
     // Once the successful save refreshes core's synchronized file version, the guard is not called on the fast path.
     REQUIRE(0 == omega_edit_save_with_options(session, path.c_str(), IO_FLG_OVERWRITE, saved_filename, &options));
+    REQUIRE(4 == guard_state.calls);
+
+    // A non-null options struct without a callback is equivalent to the legacy save API.
+    omega_edit_save_options_t empty_options{};
+    REQUIRE(0 == omega_edit_save_with_options(session, path.c_str(), IO_FLG_OVERWRITE, saved_filename, &empty_options));
     REQUIRE(4 == guard_state.calls);
 
     // Explicit force-overwrite remains an intentional bypass and never consults the guard.

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -22,10 +22,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_contains.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <cstdio>
-#ifdef OMEGA_BUILD_WINDOWS
 #include <chrono>
+#include <cstdio>
+#include <fstream>
 #include <thread>
+#ifdef OMEGA_BUILD_WINDOWS
 #include <windows.h>
 #endif
 #include <vector>
@@ -42,6 +43,37 @@ typedef struct mask_info_struct {
 static inline omega_byte_t byte_mask_transform(omega_byte_t byte, void *user_data_ptr) {
     const auto mask_info_ptr = reinterpret_cast<mask_info_t *>(user_data_ptr);
     return omega_util_mask_byte(byte, mask_info_ptr->mask, mask_info_ptr->mask_kind);
+}
+
+struct overwrite_guard_test_state {
+    int calls{};
+    int result{};
+    const char *replacement_bytes{};
+};
+
+int overwrite_guard_test_cbk(const char *, void *user_data_ptr) {
+    auto *state = static_cast<overwrite_guard_test_state *>(user_data_ptr);
+    if (!state) { return -1; }
+    ++state->calls;
+    return state->result;
+}
+
+int mutating_overwrite_guard_test_cbk(const char *path, void *user_data_ptr) {
+    auto *state = static_cast<overwrite_guard_test_state *>(user_data_ptr);
+    if (!state || !path || !state->replacement_bytes) { return -1; }
+    ++state->calls;
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output << state->replacement_bytes;
+    output.close();
+    return output.good() ? state->result : -1;
+}
+
+void write_test_file(const char *path, const char *bytes) {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    REQUIRE(output.good());
+    output << bytes;
+    output.close();
+    REQUIRE(output.good());
 }
 void session_save_test_session_cbk(const omega_session_t *session_ptr, omega_session_event_t session_event,
                                    const void *) {
@@ -507,6 +539,83 @@ TEST_CASE("Session Save", "[SessionSaveTests]") {
     REQUIRE(omega_util_paths_equivalent(MAKE_PATH("session_save.empty.dat"), saved_filename));
     REQUIRE(0 == omega_util_compare_files(MAKE_PATH("empty_file.dat"), MAKE_PATH("session_save.empty.dat")));
     omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Guarded session save fails closed at the publish boundary", "[SessionSaveTests]") {
+    const auto path = std::string(MAKE_PATH("session_save.guard.dat"));
+    const auto external_path = std::string(MAKE_PATH("session_save.guard.external.dat"));
+    const auto saved_path = std::string(MAKE_PATH("session_save.guard.saved.dat"));
+    omega_util_remove_file(path.c_str());
+    omega_util_remove_file(external_path.c_str());
+    omega_util_remove_file(saved_path.c_str());
+    write_test_file(path.c_str(), "original");
+
+    auto *session = omega_edit_create_session(path.c_str(), nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session);
+    REQUIRE(0 < omega_edit_overwrite_string(session, 0, "OMEGA"));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    write_test_file(path.c_str(), "external");
+    write_test_file(external_path.c_str(), "external");
+
+    overwrite_guard_test_state guard_state{};
+    guard_state.result = 1;
+    omega_edit_save_options_t options{};
+    options.overwrite_guard = overwrite_guard_test_cbk;
+    options.overwrite_guard_user_data = &guard_state;
+    char saved_filename[FILENAME_MAX] = {};
+
+    REQUIRE(ORIGINAL_MODIFIED ==
+            omega_edit_save_with_options(session, path.c_str(), IO_FLG_OVERWRITE, saved_filename, &options));
+    REQUIRE(1 == guard_state.calls);
+    REQUIRE(saved_filename[0] == '\0');
+    REQUIRE(0 == omega_util_compare_files(path.c_str(), external_path.c_str()));
+
+    // A verifier failure is also a denial; staged session bytes must never escape.
+    guard_state.result = -1;
+    write_test_file(path.c_str(), "external-error");
+    write_test_file(external_path.c_str(), "external-error");
+    REQUIRE(ORIGINAL_MODIFIED ==
+            omega_edit_save_with_options(session, path.c_str(), IO_FLG_OVERWRITE, saved_filename, &options));
+    REQUIRE(2 == guard_state.calls);
+    REQUIRE(saved_filename[0] == '\0');
+    REQUIRE(0 == omega_util_compare_files(path.c_str(), external_path.c_str()));
+
+    // Simulate a concurrent writer detected by the verifier itself. Its bytes win when verification denies publish.
+    guard_state.result = 1;
+    guard_state.replacement_bytes = "raced-write";
+    options.overwrite_guard = mutating_overwrite_guard_test_cbk;
+    REQUIRE(ORIGINAL_MODIFIED ==
+            omega_edit_save_with_options(session, path.c_str(), IO_FLG_OVERWRITE, saved_filename, &options));
+    REQUIRE(3 == guard_state.calls);
+    write_test_file(external_path.c_str(), "raced-write");
+    REQUIRE(0 == omega_util_compare_files(path.c_str(), external_path.c_str()));
+
+    options.overwrite_guard = overwrite_guard_test_cbk;
+    guard_state.replacement_bytes = nullptr;
+    guard_state.result = 0;
+    REQUIRE(0 == omega_edit_save_with_options(session, path.c_str(), IO_FLG_OVERWRITE, saved_filename, &options));
+    REQUIRE(4 == guard_state.calls);
+    REQUIRE(omega_util_paths_equivalent(path.c_str(), saved_filename));
+
+    REQUIRE(0 == omega_edit_save(session, saved_path.c_str(), IO_FLG_OVERWRITE, nullptr));
+    REQUIRE(0 == omega_util_compare_files(path.c_str(), saved_path.c_str()));
+
+    // Once the successful save refreshes core's synchronized file version, the guard is not called on the fast path.
+    REQUIRE(0 == omega_edit_save_with_options(session, path.c_str(), IO_FLG_OVERWRITE, saved_filename, &options));
+    REQUIRE(4 == guard_state.calls);
+
+    // Explicit force-overwrite remains an intentional bypass and never consults the guard.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    write_test_file(path.c_str(), "external-again");
+    guard_state.result = 1;
+    REQUIRE(0 == omega_edit_save_with_options(session, path.c_str(), IO_FLG_FORCE_OVERWRITE, saved_filename, &options));
+    REQUIRE(4 == guard_state.calls);
+
+    omega_edit_destroy_session(session);
+    omega_util_remove_file(path.c_str());
+    omega_util_remove_file(external_path.c_str());
+    omega_util_remove_file(saved_path.c_str());
 }
 
 TEST_CASE("Named options and explicit C-string helpers", "[SessionApiTests]") {

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -245,6 +245,14 @@ export interface SaveSessionRequest {
    * @generated from protobuf field: optional int64 length = 5
    */
   length?: number // Length of the byte range to save (default: entire file).
+  /**
+   * Fingerprint of the last content OmegaEdit successfully wrote to the original file. When core detects an
+   * original-file modification conflict, the native server may permit the overwrite only if the target still
+   * matches this fingerprint at core's final publish boundary.
+   *
+   * @generated from protobuf field: optional omega_edit.v1.SessionContentFingerprint expected_original_fingerprint = 6
+   */
+  expectedOriginalFingerprint?: SessionContentFingerprint
 }
 /**
  * Response after a save operation.
@@ -3802,6 +3810,12 @@ class SaveSessionRequest$Type extends MessageType<SaveSessionRequest> {
         T: 3 /*ScalarType.INT64*/,
         L: 2 /*LongType.NUMBER*/,
       },
+      {
+        no: 6,
+        name: 'expected_original_fingerprint',
+        kind: 'message',
+        T: () => SessionContentFingerprint,
+      },
     ])
   }
   create(value?: PartialMessage<SaveSessionRequest>): SaveSessionRequest {
@@ -3838,6 +3852,15 @@ class SaveSessionRequest$Type extends MessageType<SaveSessionRequest> {
           break
         case /* optional int64 length */ 5:
           message.length = reader.int64().toNumber()
+          break
+        case /* optional omega_edit.v1.SessionContentFingerprint expected_original_fingerprint */ 6:
+          message.expectedOriginalFingerprint =
+            SessionContentFingerprint.internalBinaryRead(
+              reader,
+              reader.uint32(),
+              options,
+              message.expectedOriginalFingerprint
+            )
           break
         default:
           let u = options.readUnknownField
@@ -3878,6 +3901,13 @@ class SaveSessionRequest$Type extends MessageType<SaveSessionRequest> {
     /* optional int64 length = 5; */
     if (message.length !== undefined)
       writer.tag(5, WireType.Varint).int64(message.length)
+    /* optional omega_edit.v1.SessionContentFingerprint expected_original_fingerprint = 6; */
+    if (message.expectedOriginalFingerprint)
+      SessionContentFingerprint.internalBinaryWrite(
+        message.expectedOriginalFingerprint,
+        writer.tag(6, WireType.LengthDelimited).fork(),
+        options
+      ).join()
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -48,6 +48,7 @@ import {
   type RestoreToChangeCountResponse,
   type SaveSessionRequest,
   type SaveSessionResponse,
+  type SessionContentFingerprint,
   type SearchSessionRequest,
   type SearchSessionResponse,
   type SingleCount,
@@ -394,7 +395,9 @@ export async function saveSession(
   filePath: string,
   flags: number,
   offset: number = 0,
-  length: number = 0
+  length: number = 0,
+  expectedOriginalFingerprint?: SessionContentFingerprint,
+  options: CancellableCallOptions = {}
 ): Promise<SaveSessionResponse> {
   const log = getLogger()
   const request: SaveSessionRequest = {
@@ -404,34 +407,54 @@ export async function saveSession(
   }
   if (offset > 0) request.offset = offset
   if (length > 0) request.length = length
+  if (expectedOriginalFingerprint) {
+    request.expectedOriginalFingerprint = expectedOriginalFingerprint
+  }
 
   debugLog(log, () => ({ fn: 'protobufTs.saveSession', rqst: request }))
+  if (options.signal?.aborted) {
+    throw makeCancellationError('saveSession')
+  }
   const client = await getClient()
+  if (options.signal?.aborted) {
+    throw makeCancellationError('saveSession')
+  }
 
   return new Promise<SaveSessionResponse>((resolve, reject) => {
-    callUnary(client, client.saveSession, request, (err, response) => {
-      if (err) {
-        log.error({
-          fn: 'protobufTs.saveSession',
-          rqst: request,
-          err: {
-            msg: err.message,
-            details: err.details,
-            code: err.code,
-            stack: err.stack,
-          },
-        })
-        return reject(makeWrappedError('saveSession', err))
-      }
+    let removeCancellationListener: () => void = () => undefined
+    const call = callUnary(
+      client,
+      client.saveSession,
+      request,
+      (err, response) => {
+        removeCancellationListener()
+        if (err) {
+          log.error({
+            fn: 'protobufTs.saveSession',
+            rqst: request,
+            err: {
+              msg: err.message,
+              details: err.details,
+              code: err.code,
+              stack: err.stack,
+            },
+          })
+          return reject(makeWrappedError('saveSession', err))
+        }
 
-      try {
-        const required = requireResponse(response, 'saveSession')
-        debugLog(log, () => ({ fn: 'protobufTs.saveSession', resp: required }))
-        return resolve(required)
-      } catch (error) {
-        return reject(makeWrappedError('saveSession', error))
+        try {
+          const required = requireResponse(response, 'saveSession')
+          debugLog(log, () => ({
+            fn: 'protobufTs.saveSession',
+            resp: required,
+          }))
+          return resolve(required)
+        } catch (error) {
+          return reject(makeWrappedError('saveSession', error))
+        }
       }
-    })
+    )
+    removeCancellationListener = cancelUnaryOnSignal(call, options.signal)
   })
 }
 

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -369,16 +369,23 @@ export async function saveSession(
   file_path: string,
   flags: number = IOFlags.UNSPECIFIED,
   offset: number = 0,
-  length: number = 0
+  length: number = 0,
+  expected_original_fingerprint?: SessionContentFingerprint,
+  options: CancellableCallOptions = {}
 ): Promise<SaveSessionResponse> {
   return await enqueueSessionMutation(session_id, async () => {
+    if (options.signal?.aborted) {
+      throw makeCancellationError('saveSession')
+    }
     return wrapSaveSessionResponse(
       await rawSaveSession(
         session_id,
         file_path,
         flags,
         requireSafeIntegerInput('saveSession offset', offset),
-        requireSafeIntegerInput('saveSession length', length)
+        requireSafeIntegerInput('saveSession length', length),
+        expected_original_fingerprint,
+        options
       )
     )
   })

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -497,6 +497,10 @@ message SaveSessionRequest {
     int32 io_flags = 3;       // Bitmask of IOFlags values.
     optional int64 offset = 4;// Start of the byte range to save (default: 0).
     optional int64 length = 5;// Length of the byte range to save (default: entire file).
+    // Fingerprint of the last content OmegaEdit successfully wrote to the original file. When core detects an
+    // original-file modification conflict, the native server may permit the overwrite only if the target still
+    // matches this fingerprint at core's final publish boundary.
+    optional SessionContentFingerprint expected_original_fingerprint = 6;
 }
 
 // Response after a save operation.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -783,6 +783,63 @@ namespace omega_edit {
             return grpc::Status::OK;
         }
 
+        struct overwrite_fingerprint_guard_context {
+            grpc::ServerContext *grpc_context{};
+            omega_transform_plugin_registry_t *registry{};
+            std::mutex *registry_mutex{};
+            std::string checkpoint_directory;
+            std::string algorithm;
+            std::string expected_digest;
+            int64_t expected_length{};
+            grpc::Status failure_status{};
+        };
+
+        static int verify_overwrite_fingerprint(const char *file_path, void *user_data_ptr) {
+            auto *context = static_cast<overwrite_fingerprint_guard_context *>(user_data_ptr);
+            if (!context || !file_path || !*file_path || !context->registry || !context->registry_mutex ||
+                context->expected_length < 0) {
+                return -1;
+            }
+            if (omega_util_file_size(file_path) != context->expected_length) { return 1; }
+
+            int64_t modification_time_before = 0;
+            if (omega_util_get_modification_time(file_path, &modification_time_before) != 0) { return 1; }
+
+            session_content_file_reader reader{file_path, 0, context->expected_length};
+            transform_plugin_response_guard plugin_response;
+            const auto options_json = make_digest_options_json(context->algorithm);
+            const auto status = inspect_with_streaming_plugin(
+                    context->grpc_context, context->registry, *context->registry_mutex,
+                    SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, options_json.c_str(), context->checkpoint_directory.c_str(),
+                    0, context->expected_length, read_session_content_file_chunk, &reader,
+                    grpc::StatusCode::FAILED_PRECONDITION,
+                    "save conflict digest plugin is not registered: " +
+                            std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                    "save conflict digest plugin must be a streaming inspect plugin",
+                    "unsupported save conflict digest algorithm: " + context->algorithm,
+                    "save conflict digest cancelled: " + std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                    grpc::StatusCode::ABORTED,
+                    "save conflict digest failed: " + std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                    &plugin_response.response);
+            if (!status.ok()) {
+                context->failure_status = status;
+                return -1;
+            }
+
+            int64_t modification_time_after = 0;
+            if (omega_util_get_modification_time(file_path, &modification_time_after) != 0 ||
+                modification_time_before != modification_time_after ||
+                omega_util_file_size(file_path) != context->expected_length ||
+                plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
+                return 1;
+            }
+            const std::string actual_digest(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
+                                            static_cast<size_t>(plugin_response.response.result_length));
+            const auto actual_algorithm = normalize_digest_algorithm(
+                    plugin_response.response.result_label ? plugin_response.response.result_label : context->algorithm);
+            return actual_algorithm == context->algorithm && actual_digest == context->expected_digest ? 0 : 1;
+        }
+
         struct transform_progress_context {
             SessionManager *session_manager{};
             grpc::ServerContext *grpc_context{};
@@ -1566,7 +1623,7 @@ namespace omega_edit {
             return grpc::Status::OK;
         }
 
-        grpc::Status EditorServiceImpl::SaveSession(grpc::ServerContext * /*context*/,
+        grpc::Status EditorServiceImpl::SaveSession(grpc::ServerContext *context,
                                                     const ::omega_edit::v1::SaveSessionRequest *request,
                                                     ::omega_edit::v1::SaveSessionResponse *response) {
             if (request->file_path().empty()) {
@@ -1585,13 +1642,43 @@ namespace omega_edit {
             int64_t offset = request->has_offset() ? request->offset() : 0;
             int64_t length = request->has_length() ? request->length() : 0;
 
+            omega_edit_save_options_t save_options{};
+            overwrite_fingerprint_guard_context guard_context;
+            const omega_edit_save_options_t *save_options_ptr = nullptr;
+            if (request->has_expected_original_fingerprint()) {
+                const auto &expected = request->expected_original_fingerprint();
+                if (!expected.has_digest() || expected.byte_length() < 0) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "expected_original_fingerprint must include a non-negative size and digest");
+                }
+                const auto algorithm = normalize_digest_algorithm(expected.digest().algorithm());
+                if (!digest_algorithm_is_json_safe(algorithm) || expected.digest().value().empty()) {
+                    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                        "expected_original_fingerprint contains invalid digest metadata");
+                }
+                const auto *checkpoint_directory = omega_session_get_checkpoint_directory(session);
+                guard_context.grpc_context = context;
+                guard_context.registry = transform_plugin_registry_;
+                guard_context.registry_mutex = &transform_plugin_registry_mutex_;
+                guard_context.checkpoint_directory = checkpoint_directory ? checkpoint_directory : "";
+                guard_context.algorithm = algorithm;
+                guard_context.expected_digest = expected.digest().value();
+                guard_context.expected_length = expected.byte_length();
+                save_options.overwrite_guard = verify_overwrite_fingerprint;
+                save_options.overwrite_guard_user_data = &guard_context;
+                save_options_ptr = &save_options;
+            }
+
             int result;
             if (offset != 0 || length != 0) {
-                result = omega_edit_save_segment(session, request->file_path().c_str(), request->io_flags(),
-                                                 saved_file_path, offset, length);
+                result =
+                        omega_edit_save_segment_with_options(session, request->file_path().c_str(), request->io_flags(),
+                                                             saved_file_path, offset, length, save_options_ptr);
             } else {
-                result = omega_edit_save(session, request->file_path().c_str(), request->io_flags(), saved_file_path);
+                result = omega_edit_save_with_options(session, request->file_path().c_str(), request->io_flags(),
+                                                      saved_file_path, save_options_ptr);
             }
+            if (!guard_context.failure_status.ok()) { return guard_context.failure_status; }
 
             response->set_session_id(request->session_id());
             response->set_save_status(result);

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -424,6 +424,12 @@ namespace omega_edit {
             return algorithm;
         }
 
+        static std::string normalize_digest_value(std::string digest) {
+            std::transform(digest.begin(), digest.end(), digest.begin(),
+                           [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            return digest;
+        }
+
         static bool digest_algorithm_is_json_safe(const std::string &algorithm) {
             return !algorithm.empty() && std::all_of(algorithm.begin(), algorithm.end(),
                                                      [](unsigned char c) { return std::isalnum(c) != 0 || c == '-'; });
@@ -833,8 +839,9 @@ namespace omega_edit {
                 plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
                 return 1;
             }
-            const std::string actual_digest(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
-                                            static_cast<size_t>(plugin_response.response.result_length));
+            const auto actual_digest = normalize_digest_value(
+                    std::string(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
+                                static_cast<size_t>(plugin_response.response.result_length)));
             const auto actual_algorithm = normalize_digest_algorithm(
                     plugin_response.response.result_label ? plugin_response.response.result_label : context->algorithm);
             return actual_algorithm == context->algorithm && actual_digest == context->expected_digest ? 0 : 1;
@@ -1662,7 +1669,7 @@ namespace omega_edit {
                 guard_context.registry_mutex = &transform_plugin_registry_mutex_;
                 guard_context.checkpoint_directory = checkpoint_directory ? checkpoint_directory : "";
                 guard_context.algorithm = algorithm;
-                guard_context.expected_digest = expected.digest().value();
+                guard_context.expected_digest = normalize_digest_value(expected.digest().value());
                 guard_context.expected_length = expected.byte_length();
                 save_options.overwrite_guard = verify_overwrite_fingerprint;
                 save_options.overwrite_guard_user_data = &guard_context;

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -153,6 +153,7 @@ This mode decision is made only when the user runs an explicit search. If a repl
 | `omegaEdit.language`    | `auto`  | Svelte data editor UI language (`auto` follows VS Code; explicit options include `en` and `es`) |
 | `omegaEdit.transformPluginDirectories` | `[]` | Native transform plugin directories; local build plugin folders are auto-detected when this is empty |
 | `omegaEdit.allowExperimentalTransformPlugins` | `false` | Load experimental transform plugins from configured or bundled plugin directories |
+| `omegaEdit.saveConflictFingerprintAlgorithm` | `sha256` | Digest used by the native guarded save path to confirm that an apparent conflict still matches OmegaEdit's last saved content |
 
 ## Keyboard Shortcuts
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -87,6 +87,21 @@
           "default": false,
           "description": "%omegaEdit.configuration.allowExperimentalTransformPlugins.description%"
         },
+        "omegaEdit.saveConflictFingerprintAlgorithm": {
+          "type": "string",
+          "default": "sha256",
+          "enum": [
+            "sha224",
+            "sha256",
+            "sha384",
+            "sha512",
+            "sha3-256",
+            "sha3-512",
+            "blake2b-512",
+            "blake2s-256"
+          ],
+          "description": "%omegaEdit.configuration.saveConflictFingerprintAlgorithm.description%"
+        },
         "omegaEdit.checkpointHistory.maxBytesPerSession": {
           "type": "number",
           "default": 1073741824,

--- a/vscode-extension/package.nls.json
+++ b/vscode-extension/package.nls.json
@@ -9,6 +9,7 @@
   "omegaEdit.configuration.language.description": "Language for the Svelte data editor UI. Use auto to follow VS Code's display language.",
   "omegaEdit.configuration.transformPluginDirectories.description": "Directories containing OmegaEdit transform plugin shared libraries",
   "omegaEdit.configuration.allowExperimentalTransformPlugins.description": "Load experimental OmegaEdit transform plugins from configured or bundled plugin directories.",
+  "omegaEdit.configuration.saveConflictFingerprintAlgorithm.description": "Digest algorithm used by the native guarded save path to verify that a conflict was caused by OmegaEdit's own Auto Save. SHA-256 is the recommended default.",
   "omegaEdit.configuration.checkpointHistory.maxBytesPerSession.description": "Maximum temporary checkpoint-history storage for one open editor session, in bytes.",
   "omegaEdit.configuration.checkpointHistory.maxBytesTotal.description": "Maximum temporary checkpoint-history storage across all editor sessions, in bytes.",
   "omegaEdit.configuration.checkpointHistory.maxCheckpoints.description": "Maximum number of archived checkpoints retained for one open editor session.",

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -178,6 +178,8 @@ interface EditorSession {
   pendingHistoryOperation?: 'undo' | 'redo'
   pendingHistoryCount?: number
   historyCommandTask?: Promise<void>
+  saveTask?: Promise<void>
+  savedDiskFingerprint?: ChangeLogFingerprint
   checkpointTimeline: CheckpointTimelineState
 }
 
@@ -403,6 +405,19 @@ const MAX_FILE_SPLICE_BYTES = 32 * 1024 * 1024
 const MAX_NON_FILE_CHANGE_LOG_BYTES = 64 * 1024 * 1024
 const MAX_NON_FILE_CHANGE_LOG_ENTRIES = 10_000
 const DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM = 'sha256'
+const DEFAULT_SAVE_CONFLICT_FINGERPRINT_ALGORITHM = 'sha256'
+const SAVE_CONFLICT_FINGERPRINT_ALGORITHMS = [
+  'sha224',
+  'sha256',
+  'sha384',
+  'sha512',
+  'sha3-256',
+  'sha3-512',
+  'blake2b-512',
+  'blake2s-256',
+] as const
+type SaveConflictFingerprintAlgorithm =
+  (typeof SAVE_CONFLICT_FINGERPRINT_ALGORITHMS)[number]
 const INTERNAL_REPLACE_ALL_REPLAY_ID = 'omega.internal.replace-all'
 const GRPC_NOT_FOUND = 5
 const MAX_INT64 = 9_223_372_036_854_775_807n
@@ -429,6 +444,23 @@ function describeSaveStatus(status: number): string {
   return vscode.l10n.t('status {status}', { status })
 }
 
+function resolveSaveConflictFingerprintAlgorithm(
+  resource?: vscode.Uri
+): SaveConflictFingerprintAlgorithm {
+  const configured = vscode.workspace
+    .getConfiguration('omegaEdit', resource)
+    .get<string>(
+      'saveConflictFingerprintAlgorithm',
+      DEFAULT_SAVE_CONFLICT_FINGERPRINT_ALGORITHM
+    )
+    .toLowerCase()
+  return (
+    SAVE_CONFLICT_FINGERPRINT_ALGORITHMS.find(
+      (algorithm) => algorithm === configured
+    ) ?? DEFAULT_SAVE_CONFLICT_FINGERPRINT_ALGORITHM
+  )
+}
+
 async function saveSessionOrThrow(
   sessionId: string,
   filePath: string,
@@ -444,6 +476,43 @@ async function saveSessionOrThrow(
       })
     )
   }
+}
+
+async function saveSessionWithKnownDiskVersion(
+  session: EditorSession,
+  cancellation: vscode.CancellationToken
+): Promise<void> {
+  if (cancellation.isCancellationRequested) {
+    throw new vscode.CancellationError()
+  }
+  const expected =
+    session.savedDiskFingerprint ?? session.checkpointTimeline.savedFingerprint
+  const expectedByteLength = Number(expected.byteLength)
+  if (!Number.isSafeInteger(expectedByteLength) || expectedByteLength < 0) {
+    throw new Error('Saved file fingerprint has an invalid byte length')
+  }
+  const response = await saveSession(
+    session.sessionId,
+    session.filePath,
+    IOFlags.OVERWRITE,
+    0,
+    0,
+    {
+      byteLength: expectedByteLength,
+      digest: expected.digest,
+    }
+  )
+  const status = response.getSaveStatus()
+  if (status === SaveStatus.SUCCESS) {
+    return
+  }
+
+  throw new Error(
+    vscode.l10n.t('OmegaEdit save failed for {path}: {reason}', {
+      path: session.filePath,
+      reason: describeSaveStatus(status),
+    })
+  )
 }
 
 function transformMutationBlockedMessage(): string {
@@ -2148,7 +2217,8 @@ export class HexEditorProvider
 
   public async dispatchWebviewMessageForTesting(
     uri: vscode.Uri,
-    msg: WebviewToHostMessage
+    msg: WebviewToHostMessage,
+    options?: { propagateErrors?: boolean }
   ): Promise<void> {
     if (process.env.NODE_ENV !== 'test') {
       throw new Error('Test-only message dispatch is unavailable outside tests')
@@ -2199,7 +2269,11 @@ export class HexEditorProvider
       }
     }
 
-    await this.handleWebviewMessage(session, msg)
+    await this.handleWebviewMessage(
+      session,
+      msg,
+      options?.propagateErrors === true
+    )
   }
 
   public async undoActive(): Promise<WebviewEditorState | undefined> {
@@ -2388,6 +2462,17 @@ export class HexEditorProvider
         digest: { algorithm: 'sha256', value: '0'.repeat(64) },
       }
     })
+    const saveConflictFingerprintAlgorithm =
+      resolveSaveConflictFingerprintAlgorithm(uri)
+    const savedDiskFingerprint =
+      !fingerprintFailure &&
+      originalFingerprint.digest.algorithm === saveConflictFingerprintAlgorithm
+        ? originalFingerprint
+        : await getChangeLogFingerprint(
+            scope.sessionId,
+            SessionFingerprintContent.COMPUTED,
+            saveConflictFingerprintAlgorithm
+          ).catch(() => undefined)
     const timelineStorage = fingerprintFailure
       ? undefined
       : await this.timelineStorage
@@ -2451,6 +2536,7 @@ export class HexEditorProvider
       transformPlugins: [],
       transformInFlight: false,
       restoredFromBackup: wasRestoredFromBackup,
+      savedDiskFingerprint,
       checkpointTimeline: {
         entries: [],
         storage: timelineStorage,
@@ -2532,19 +2618,34 @@ export class HexEditorProvider
 
   // --- CustomEditorProvider required methods ---
 
-  async saveCustomDocument(
-    document: HexDocument,
-    _cancellation: vscode.CancellationToken
+  private async runSerializedSave(
+    session: EditorSession,
+    cancellation: vscode.CancellationToken,
+    operation: () => Promise<void>
   ): Promise<void> {
-    const session = this.sessions.get(document.uri.toString())
-    if (!session) {
-      return
+    const previous = session.saveTask ?? Promise.resolve()
+    const task = previous
+      .catch(() => undefined)
+      .then(async () => {
+        if (cancellation.isCancellationRequested) {
+          throw new vscode.CancellationError()
+        }
+        await operation()
+      })
+    session.saveTask = task
+    try {
+      await task
+    } finally {
+      if (session.saveTask === task) {
+        session.saveTask = undefined
+      }
     }
-    await saveSessionOrThrow(
-      session.sessionId,
-      session.filePath,
-      IOFlags.OVERWRITE
-    )
+  }
+
+  private async recordSuccessfulSave(
+    session: EditorSession,
+    updateOriginalDiskFingerprint: boolean
+  ): Promise<void> {
     session.restoredFromBackup = false
     session.history.markSaved()
     session.checkpointTimeline.savedChangeCount = await getChangeCount(
@@ -2553,19 +2654,46 @@ export class HexEditorProvider
     const fingerprint = await getChangeLogFingerprint(
       session.sessionId,
       SessionFingerprintContent.COMPUTED,
-      'sha256'
+      DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM
     )
     session.checkpointTimeline.savedFingerprint = fingerprint
     session.checkpointTimeline.currentFingerprint = fingerprint
+    if (updateOriginalDiskFingerprint) {
+      const algorithm = resolveSaveConflictFingerprintAlgorithm(
+        session.document.uri
+      )
+      session.savedDiskFingerprint =
+        fingerprint.digest.algorithm === algorithm
+          ? fingerprint
+          : await getChangeLogFingerprint(
+              session.sessionId,
+              SessionFingerprintContent.COMPUTED,
+              algorithm
+            ).catch(() => undefined)
+    }
     await session.checkpointTimeline.storage?.setSavedFingerprint(fingerprint)
     this.postCheckpointTimeline(session)
     this.postEditState(session)
   }
 
+  async saveCustomDocument(
+    document: HexDocument,
+    cancellation: vscode.CancellationToken
+  ): Promise<void> {
+    const session = this.sessions.get(document.uri.toString())
+    if (!session) {
+      return
+    }
+    await this.runSerializedSave(session, cancellation, async () => {
+      await saveSessionWithKnownDiskVersion(session, cancellation)
+      await this.recordSuccessfulSave(session, true)
+    })
+  }
+
   async saveCustomDocumentAs(
     document: HexDocument,
     destination: vscode.Uri,
-    _cancellation: vscode.CancellationToken
+    cancellation: vscode.CancellationToken
   ): Promise<void> {
     const session = this.sessions.get(document.uri.toString())
     if (!session) {
@@ -2576,26 +2704,14 @@ export class HexEditorProvider
         vscode.l10n.t('OmegaEdit Data Editor can only save to local files')
       )
     }
-    await saveSessionOrThrow(
-      session.sessionId,
-      destination.fsPath,
-      IOFlags.OVERWRITE
-    )
-    session.restoredFromBackup = false
-    session.history.markSaved()
-    session.checkpointTimeline.savedChangeCount = await getChangeCount(
-      session.sessionId
-    )
-    const fingerprint = await getChangeLogFingerprint(
-      session.sessionId,
-      SessionFingerprintContent.COMPUTED,
-      'sha256'
-    )
-    session.checkpointTimeline.savedFingerprint = fingerprint
-    session.checkpointTimeline.currentFingerprint = fingerprint
-    await session.checkpointTimeline.storage?.setSavedFingerprint(fingerprint)
-    this.postCheckpointTimeline(session)
-    this.postEditState(session)
+    await this.runSerializedSave(session, cancellation, async () => {
+      await saveSessionOrThrow(
+        session.sessionId,
+        destination.fsPath,
+        IOFlags.OVERWRITE
+      )
+      await this.recordSuccessfulSave(session, false)
+    })
   }
 
   async revertCustomDocument(
@@ -6268,6 +6384,11 @@ export class HexEditorProvider
       return
     }
 
+    // A rollback changes the session baseline. Let any Auto Save that already
+    // captured the pre-rollback state finish publishing its disk fingerprint
+    // before the rollback makes the original content dirty again.
+    await session.saveTask?.catch(() => undefined)
+
     let resolveTimelineOperation: () => void = () => undefined
     session.checkpointTimeline.operation = new Promise<void>((resolve) => {
       resolveTimelineOperation = resolve
@@ -7213,7 +7334,8 @@ export class HexEditorProvider
 
   private async handleWebviewMessage(
     session: EditorSession,
-    rawMessage: unknown
+    rawMessage: unknown,
+    propagateErrors = false
   ): Promise<void> {
     const msg = normalizeWebviewMessage(
       { fileSize: session.fileSize, contentSources: session.contentSources },
@@ -7800,6 +7922,9 @@ export class HexEditorProvider
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       void vscode.window.showErrorMessage(omegaEditErrorMessage(message))
+      if (propagateErrors) {
+        throw err
+      }
     }
   }
 }

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -373,6 +373,33 @@ test('package.json matches shared extension constants', () => {
     ],
     'Load experimental OmegaEdit transform plugins from configured or bundled plugin directories.'
   )
+  assert.deepEqual(
+    packageJson.contributes.configuration.properties[
+      'omegaEdit.saveConflictFingerprintAlgorithm'
+    ].enum,
+    [
+      'sha224',
+      'sha256',
+      'sha384',
+      'sha512',
+      'sha3-256',
+      'sha3-512',
+      'blake2b-512',
+      'blake2s-256',
+    ]
+  )
+  assert.equal(
+    packageJson.contributes.configuration.properties[
+      'omegaEdit.saveConflictFingerprintAlgorithm'
+    ].default,
+    'sha256'
+  )
+  assert.equal(
+    packageNls[
+      'omegaEdit.configuration.saveConflictFingerprintAlgorithm.description'
+    ],
+    "Digest algorithm used by the native guarded save path to verify that a conflict was caused by OmegaEdit's own Auto Save. SHA-256 is the recommended default."
+  )
   assert.equal(
     Object.hasOwn(
       packageJson.contributes.configuration.properties,
@@ -486,6 +513,27 @@ test('package.json matches shared extension constants', () => {
       { command: OMEGA_EDIT_CLEAR_EXTERNAL_HIGHLIGHTS_COMMAND, when: 'false' },
     ]
   )
+})
+
+test('routes save-conflict fingerprinting through the native guarded save path', () => {
+  const extensionSource = fs.readFileSync(
+    path.resolve(__dirname, '../src/hexEditorProvider.ts'),
+    'utf8'
+  )
+  const coreSource = fs.readFileSync(
+    path.resolve(__dirname, '../../core/src/lib/edit.cpp'),
+    'utf8'
+  )
+  const serverSource = fs.readFileSync(
+    path.resolve(__dirname, '../../server/cpp/src/editor_service.cpp'),
+    'utf8'
+  )
+
+  assert.doesNotMatch(extensionSource, /createReadStream|createHash/)
+  assert.match(extensionSource, /expected\.digest/)
+  assert.match(coreSource, /overwrite_guard/)
+  assert.match(serverSource, /SESSION_FINGERPRINT_DIGEST_PLUGIN_ID/)
+  assert.match(serverSource, /verify_overwrite_fingerprint/)
 })
 
 test('VSIX packaging uses the server package as its native runtime', () => {

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -205,17 +205,23 @@ function assertAssistantContextPayloadBudget(context) {
 suite('OmegaEdit VS Code extension', () => {
   let testPort
   let extensionApi
+  let previousAllowExperimentalTransformPlugins
+  let updatedAllowExperimentalTransformPlugins = false
 
   suiteSetup(async () => {
     await vscode.commands.executeCommand('workbench.action.closeAllEditors')
 
-    await vscode.workspace
-      .getConfiguration('omegaEdit')
-      .update(
-        'allowExperimentalTransformPlugins',
-        true,
-        vscode.ConfigurationTarget.Global
-      )
+    const omegaEditConfiguration =
+      vscode.workspace.getConfiguration('omegaEdit')
+    previousAllowExperimentalTransformPlugins = omegaEditConfiguration.inspect(
+      'allowExperimentalTransformPlugins'
+    )?.globalValue
+    await omegaEditConfiguration.update(
+      'allowExperimentalTransformPlugins',
+      true,
+      vscode.ConfigurationTarget.Global
+    )
+    updatedAllowExperimentalTransformPlugins = true
 
     testPort = getConfiguredTestPort()
 
@@ -256,6 +262,19 @@ suite('OmegaEdit VS Code extension', () => {
 
   teardown(async () => {
     await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+  })
+
+  suiteTeardown(async () => {
+    if (!updatedAllowExperimentalTransformPlugins) {
+      return
+    }
+    await vscode.workspace
+      .getConfiguration('omegaEdit')
+      .update(
+        'allowExperimentalTransformPlugins',
+        previousAllowExperimentalTransformPlugins,
+        vscode.ConfigurationTarget.Global
+      )
   })
 
   test('registers the go to offset command', async () => {
@@ -2542,6 +2561,10 @@ suite('OmegaEdit VS Code extension', () => {
       await waitForFileBytes(samplePath, transformedBytes)
       await waitForOmegaEditTab(uri, { dirty: false })
 
+      // The regression requires rollback to leave the Auto Save bytes on disk
+      // until the explicit save below. Disable Auto Save after its transformed
+      // write completes so it cannot race the rollback assertions.
+      await files.update('autoSave', 'off', vscode.ConfigurationTarget.Global)
       await vscode.commands.executeCommand(OMEGA_EDIT_ROLLBACK_SESSION_COMMAND)
       assert.deepEqual(await readSessionBytes(session.sessionId), originalBytes)
       assert.equal(sha256(await fs.readFile(samplePath)), transformedHash)
@@ -2693,6 +2716,26 @@ suite('OmegaEdit VS Code extension', () => {
         /unsupported save conflict digest algorithm/
       )
       assert.deepEqual(await fs.readFile(samplePath), externalBytes)
+
+      const uppercaseDigest = await saveSession(
+        session.sessionId,
+        samplePath,
+        IOFlags.OVERWRITE,
+        0,
+        0,
+        {
+          byteLength: externalBytes.byteLength,
+          digest: {
+            algorithm: 'sha256',
+            value: sha256(externalBytes).toUpperCase(),
+          },
+        }
+      )
+      assert.equal(uppercaseDigest.getSaveStatus(), 0)
+      assert.deepEqual(
+        await fs.readFile(samplePath),
+        Buffer.from('Original', 'utf8')
+      )
     } finally {
       await panel.fireDidDispose()
       await fs.rm(tmpDir, { recursive: true, force: true })
@@ -3317,7 +3360,7 @@ async function waitForCompletedSaveStage(directory, expectedSize) {
         return
       }
     }
-    await delay(1)
+    await delay(10)
   }
   assert.fail('Timed out waiting for the guarded save staging file')
 }

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -8,6 +8,8 @@ const {
   getClient,
   getComputedFileSize,
   getSegment,
+  IOFlags,
+  saveSession,
 } = require('@omega-edit/client')
 
 const packageJson = require('../../package.json')
@@ -60,6 +62,10 @@ function makeUtf8Fingerprint(text) {
       value: createHash('sha256').update(data).digest('hex'),
     },
   }
+}
+
+function sha256(data) {
+  return createHash('sha256').update(data).digest('hex')
 }
 
 function canonicalizeTransformDescriptorValue(value) {
@@ -202,6 +208,14 @@ suite('OmegaEdit VS Code extension', () => {
 
   suiteSetup(async () => {
     await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+
+    await vscode.workspace
+      .getConfiguration('omegaEdit')
+      .update(
+        'allowExperimentalTransformPlugins',
+        true,
+        vscode.ConfigurationTarget.Global
+      )
 
     testPort = getConfiguredTestPort()
 
@@ -2445,6 +2459,353 @@ suite('OmegaEdit VS Code extension', () => {
     }
   })
 
+  test('restores an auto-saved OmegaEdit PNG after Zstandard transform rollback and save', async () => {
+    const provider = getHexEditorProviderForTesting()
+    assert.ok(
+      provider,
+      'Expected the activated extension to expose its provider'
+    )
+
+    const fixturePath = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'images',
+      'OmegaEditLogo.png'
+    )
+    const originalBytes = await fs.readFile(fixturePath)
+    const originalHash = sha256(originalBytes)
+    assert.equal(
+      originalHash,
+      '3eae0f11aabb39a5c64663d7c4a2ff076f570a7e41b12b770cb6456ecd8da792',
+      'The regression fixture must match the canonical OmegaEdit logo'
+    )
+
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-zstd-rollback-')
+    )
+    const samplePath = path.join(tmpDir, 'OmegaEditLogo.png')
+    await fs.writeFile(samplePath, originalBytes)
+    const uri = vscode.Uri.file(samplePath)
+    const files = vscode.workspace.getConfiguration('files')
+    const previousAutoSave = files.inspect('autoSave')?.globalValue
+    const previousDelay = files.inspect('autoSaveDelay')?.globalValue
+    const omegaEdit = vscode.workspace.getConfiguration('omegaEdit')
+    const previousFingerprintAlgorithm = omegaEdit.inspect(
+      'saveConflictFingerprintAlgorithm'
+    )?.globalValue
+
+    try {
+      await omegaEdit.update(
+        'saveConflictFingerprintAlgorithm',
+        'sha512',
+        vscode.ConfigurationTarget.Global
+      )
+      await files.update(
+        'autoSave',
+        'afterDelay',
+        vscode.ConfigurationTarget.Global
+      )
+      await files.update('autoSaveDelay', 50, vscode.ConfigurationTarget.Global)
+      await vscode.commands.executeCommand(
+        'vscode.openWith',
+        uri,
+        OMEGA_EDIT_VIEW_TYPE
+      )
+      await waitForOmegaEditTab(uri, { dirty: false })
+      const session = await waitForSession(provider, uri)
+      assert.ok(session, 'Expected a live session for the Zstandard test')
+      await provider.refreshActiveTransformPlugins()
+      assert.ok(
+        session.transformPlugins.some(
+          (plugin) => plugin.id === 'omega.example.zstd'
+        ),
+        'Expected the Zstandard action to be available'
+      )
+
+      await provider.dispatchWebviewMessageForTesting(
+        uri,
+        {
+          type: 'applyTransform',
+          pluginId: 'omega.example.zstd',
+          contentSource: 'computed',
+          offset: 0,
+          length: originalBytes.length,
+          optionsJson: JSON.stringify({ action: 'compress', level: 3 }),
+        },
+        { propagateErrors: true }
+      )
+      const transformedBytes = await readSessionBytes(session.sessionId)
+      const transformedHash = sha256(transformedBytes)
+      assert.notEqual(transformedHash, originalHash)
+      await waitForFileBytes(samplePath, transformedBytes)
+      await waitForOmegaEditTab(uri, { dirty: false })
+
+      await vscode.commands.executeCommand(OMEGA_EDIT_ROLLBACK_SESSION_COMMAND)
+      assert.deepEqual(await readSessionBytes(session.sessionId), originalBytes)
+      assert.equal(sha256(await fs.readFile(samplePath)), transformedHash)
+
+      await waitForOmegaEditTab(uri, { dirty: true })
+
+      await vscode.commands.executeCommand('workbench.action.files.save')
+      assert.equal(
+        sha256(await fs.readFile(samplePath)),
+        originalHash,
+        'Save after rollback must restore the original PNG bytes'
+      )
+      await waitForOmegaEditTab(uri, { dirty: false })
+    } finally {
+      await files.update(
+        'autoSave',
+        previousAutoSave,
+        vscode.ConfigurationTarget.Global
+      )
+      await files.update(
+        'autoSaveDelay',
+        previousDelay,
+        vscode.ConfigurationTarget.Global
+      )
+      await omegaEdit.update(
+        'saveConflictFingerprintAlgorithm',
+        previousFingerprintAlgorithm,
+        vscode.ConfigurationTarget.Global
+      )
+      await vscode.commands
+        .executeCommand('workbench.action.files.revert')
+        .then(undefined, () => undefined)
+      await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('does not force-overwrite genuinely different external file content', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-save-conflict-')
+    )
+    const samplePath = path.join(tmpDir, 'save-conflict.bin')
+    await fs.writeFile(samplePath, Buffer.from('original', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    try {
+      await provider.resolveCustomEditor(
+        document,
+        panel,
+        new vscode.CancellationTokenSource().token
+      )
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'overwrite',
+        offset: 0,
+        data: Buffer.from('O', 'utf8').toString('hex'),
+      })
+
+      const externalBytes = Buffer.from('external', 'utf8')
+      await fs.writeFile(samplePath, externalBytes)
+      const future = new Date(Date.now() + 5000)
+      await fs.utimes(samplePath, future, future)
+
+      await assert.rejects(
+        provider.saveCustomDocument(
+          document,
+          new vscode.CancellationTokenSource().token
+        ),
+        /original file was modified outside OmegaEdit/
+      )
+      assert.deepEqual(await fs.readFile(samplePath), externalBytes)
+    } finally {
+      await panel.fireDidDispose()
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('fails closed for invalid and mismatched save fingerprints', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-hostile-fingerprint-')
+    )
+    const samplePath = path.join(tmpDir, 'hostile-fingerprint.bin')
+    const externalBytes = Buffer.from('external', 'utf8')
+    await fs.writeFile(samplePath, Buffer.from('original', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    try {
+      await provider.resolveCustomEditor(
+        document,
+        panel,
+        new vscode.CancellationTokenSource().token
+      )
+      const session = provider.getSessionForTesting(document.uri)
+      assert.ok(session, 'Expected a live session for fingerprint validation')
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'overwrite',
+        offset: 0,
+        data: Buffer.from('O', 'utf8').toString('hex'),
+      })
+
+      await fs.writeFile(samplePath, externalBytes)
+      const future = new Date(Date.now() + 5000)
+      await fs.utimes(samplePath, future, future)
+
+      const sizeMismatch = await saveSession(
+        session.sessionId,
+        samplePath,
+        IOFlags.OVERWRITE,
+        0,
+        0,
+        {
+          byteLength: externalBytes.byteLength + 1,
+          digest: { algorithm: 'sha256', value: sha256(externalBytes) },
+        }
+      )
+      assert.notEqual(sizeMismatch.getSaveStatus(), 0)
+      assert.deepEqual(await fs.readFile(samplePath), externalBytes)
+
+      await assert.rejects(
+        saveSession(session.sessionId, samplePath, IOFlags.OVERWRITE, 0, 0, {
+          byteLength: externalBytes.byteLength,
+          digest: { algorithm: 'sha256', value: '' },
+        }),
+        /invalid digest metadata/
+      )
+      assert.deepEqual(await fs.readFile(samplePath), externalBytes)
+
+      await assert.rejects(
+        saveSession(session.sessionId, samplePath, IOFlags.OVERWRITE, 0, 0, {
+          byteLength: externalBytes.byteLength,
+          digest: {
+            algorithm: 'definitely-not-a-digest',
+            value: sha256(externalBytes),
+          },
+        }),
+        /unsupported save conflict digest algorithm/
+      )
+      assert.deepEqual(await fs.readFile(samplePath), externalBytes)
+    } finally {
+      await panel.fireDidDispose()
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cancels guarded hashing without publishing staged bytes', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-cancelled-save-')
+    )
+    const samplePath = path.join(tmpDir, 'cancelled-save.bin')
+    const originalBytes = Buffer.alloc(32 * 1024 * 1024, 0x5a)
+    await fs.writeFile(samplePath, originalBytes)
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    try {
+      await provider.resolveCustomEditor(
+        document,
+        panel,
+        new vscode.CancellationTokenSource().token
+      )
+      const session = provider.getSessionForTesting(document.uri)
+      assert.ok(session, 'Expected a live session for cancelled save')
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'overwrite',
+        offset: 0,
+        data: '00',
+      })
+
+      await fs.writeFile(samplePath, originalBytes)
+      const future = new Date(Date.now() + 5000)
+      await fs.utimes(samplePath, future, future)
+
+      const abortController = new AbortController()
+      const savePromise = saveSession(
+        session.sessionId,
+        samplePath,
+        IOFlags.OVERWRITE,
+        0,
+        0,
+        {
+          byteLength: originalBytes.byteLength,
+          digest: { algorithm: 'sha256', value: sha256(originalBytes) },
+        },
+        { signal: abortController.signal }
+      )
+      await waitForCompletedSaveStage(tmpDir, originalBytes.byteLength)
+      abortController.abort()
+
+      await assert.rejects(savePromise, /cancel/i)
+      await waitForNoSaveStages(tmpDir)
+      assert.deepEqual(await fs.readFile(samplePath), originalBytes)
+    } finally {
+      await panel.fireDidDispose()
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('waits for an in-flight save before rolling back the session', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-save-rollback-order-')
+    )
+    const samplePath = path.join(tmpDir, 'save-rollback-order.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    try {
+      await provider.resolveCustomEditor(
+        document,
+        panel,
+        new vscode.CancellationTokenSource().token
+      )
+      const session = provider.getSessionForTesting(document.uri)
+      assert.ok(session, 'Expected a live session for save ordering')
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'applyTransform',
+        pluginId: 'omega.example.base64',
+        offset: 0,
+        length: 3,
+      })
+      await assertSessionText(session.sessionId, 'YWJj')
+
+      let releaseSave
+      session.saveTask = new Promise((resolve) => {
+        releaseSave = resolve
+      })
+      const rollback = provider.rollbackActiveSession()
+      await delay(50)
+      await assertSessionText(session.sessionId, 'YWJj')
+
+      releaseSave()
+      await rollback
+      await assertSessionText(session.sessionId, 'abc')
+    } finally {
+      await panel.fireDidDispose()
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   test('refreshes viewport data when webview metrics arrive after initial load', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-ready-')
@@ -2930,6 +3291,48 @@ async function waitForFileText(filePath, expected, timeoutMs = 10000) {
   )
 }
 
+async function waitForFileBytes(filePath, expected, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const actual = await fs.readFile(filePath).catch(() => undefined)
+    if (actual?.equals(expected)) {
+      return
+    }
+    await delay(25)
+  }
+  assert.deepEqual(await fs.readFile(filePath), expected)
+}
+
+async function listSaveStages(directory) {
+  const names = await fs.readdir(directory).catch(() => [])
+  return names.filter((name) => name.startsWith('.OmegaEdit_'))
+}
+
+async function waitForCompletedSaveStage(directory, expectedSize) {
+  const deadline = Date.now() + 30000
+  while (Date.now() < deadline) {
+    for (const name of await listSaveStages(directory)) {
+      const stat = await fs.stat(path.join(directory, name)).catch(() => null)
+      if (stat?.size === expectedSize) {
+        return
+      }
+    }
+    await delay(1)
+  }
+  assert.fail('Timed out waiting for the guarded save staging file')
+}
+
+async function waitForNoSaveStages(directory) {
+  const deadline = Date.now() + 10000
+  while (Date.now() < deadline) {
+    if ((await listSaveStages(directory)).length === 0) {
+      return
+    }
+    await delay(10)
+  }
+  assert.deepEqual(await listSaveStages(directory), [])
+}
+
 async function assertSessionText(
   sessionId,
   expected,
@@ -2952,6 +3355,26 @@ async function assertSessionText(
   }
 
   assert.equal(lastValue, expectedBuffer.toString('utf8'))
+}
+
+async function readSessionBytes(sessionId) {
+  const size = await getComputedFileSize(sessionId)
+  const chunks = []
+  const maxSegmentLength = 1024 * 1024
+
+  for (let offset = 0; offset < size; offset += maxSegmentLength) {
+    chunks.push(
+      Buffer.from(
+        await getSegment(
+          sessionId,
+          offset,
+          Math.min(maxSegmentLength, size - offset)
+        )
+      )
+    )
+  }
+
+  return Buffer.concat(chunks)
 }
 
 async function assertEditState(


### PR DESCRIPTION
## Summary\n\n- Serialize save and rollback operations so rollback cannot race an in-flight Auto Save.\n- Add a core guarded-save boundary that invokes verification only when the original-file metadata check reports a conflict.\n- Route the configured fingerprint through gRPC and verify the existing target with the native streaming OpenSSL digest plugin.\n- Keep SHA-256 as the safe default while supporting the restricted safe digest choices.\n- Add Windows regressions for the real PNG plus Zstandard plus Auto Save workflow and hostile guarded-save conditions.\n\n## Root cause\n\nAfter Auto Save persisted transformed bytes, rollback restored the editing session but the native timestamp guard could classify the OmegaEdit Auto Save as an external mutation. The next save was rejected, leaving the transformed bytes on disk.\n\n## Architecture and safety\n\n- Node and the VS Code extension host never read or hash the file.\n- Ordinary saves perform no fingerprint work.\n- Core stages replacement content and rechecks its normal modification guard at the final publish boundary.\n- Only on a conflict does core invoke the server overwrite guard.\n- The guard streams the target through the existing native OpenSSL digest plugin using the configured algorithm.\n- Core publishes only when target size and digest match the last successful save.\n- Size mismatch, digest mismatch, invalid metadata, unsupported algorithms, verifier failure, and cancellation all fail closed and preserve the target.\n- Force overwrite remains an explicit bypass.\n- The guard does not lock the target between verification and atomic replacement. It detects conflicts but is not an OS-level transactional compare-and-swap against concurrent writers.\n\n## Brutal regression matrix\n\n- Real OmegaEdit PNG, Zstandard level 3, Auto Save, rollback, and save restores the canonical PNG.\n- Same-size external content with a different digest is preserved.\n- Expected-size mismatch is preserved.\n- Empty digest metadata is rejected.\n- Unsupported digest algorithm and plugin option validation failure are rejected.\n- Cancellation after the complete native staging file appears aborts guarded hashing, removes staging output, and preserves all 32 MiB of original bytes.\n- Direct core coverage exercises guard allow, denial, verifier error, a writer mutation detected inside verification, no-conflict fast path, and force-overwrite bypass.\n- Rollback waits for an in-flight save.\n- The API documents the unavoidable verification-to-atomic-replace race.\n\n## Validation\n\n- Windows core and C++ gRPC server builds: passed.\n- Full Windows core session suite: 1,546 assertions in 16 test cases passed.\n- Extension compile and Svelte checks: passed.\n- Extension unit tests: 28 passed.\n- Biome checks for touched TypeScript and JavaScript: passed.\n- Full Windows VS Code integration suite: 30 passing, 1 intentionally pending.\n- The integration suite uses a freshly packaged Windows native server, core DLL, OpenSSL digest plugin, and client.\n