### PR TITLE
chore: reduce TypeScript byte-processing overhead

### DIFF
--- a/packages/client/src/changeLog/codec.ts
+++ b/packages/client/src/changeLog/codec.ts
@@ -234,7 +234,10 @@ function normalizeHex(value: unknown, name: string): string {
 function decodeHexUtf8(value: string, name: string): string {
   const bytes = new Uint8Array(value.length / 2)
   for (let index = 0; index < bytes.length; index += 1) {
-    bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16)
+    const offset = index * 2
+    bytes[index] =
+      (hexCodeUnitToNibble(value.charCodeAt(offset)) << 4) |
+      hexCodeUnitToNibble(value.charCodeAt(offset + 1))
   }
   try {
     return new TextDecoder('utf-8', { fatal: true }).decode(bytes)
@@ -245,6 +248,10 @@ function decodeHexUtf8(value: string, name: string): string {
       error
     )
   }
+}
+
+function hexCodeUnitToNibble(codeUnit: number): number {
+  return codeUnit <= 57 ? codeUnit - 48 : (codeUnit & 0xdf) - 55
 }
 
 function parseTransformDescriptor(

--- a/packages/client/tests/specs/changeLogCodec.spec.ts
+++ b/packages/client/tests/specs/changeLogCodec.spec.ts
@@ -181,6 +181,40 @@ describe('shared change-log codec', () => {
     ).toThrow(/transformId exceeds 3 UTF-8 bytes/)
   })
 
+  it('decodes mixed-case transform descriptor hex without per-byte parsing', async () => {
+    const descriptor = Buffer.from(
+      JSON.stringify({
+        transformId: 'ωmega.transform',
+        args: { mode: 'ω' },
+      })
+    )
+      .toString('hex')
+      .replace(/[a-f]/g, (digit, index) =>
+        index % 2 === 0 ? digit.toUpperCase() : digit
+      )
+    const document = documentWithEntries(1)
+    document.changes = [
+      {
+        serial: '1',
+        kind: 'TRANSFORM',
+        offset: '0',
+        length: '1',
+        data: descriptor,
+      },
+    ]
+
+    const prepared = normalizeChangeLogDocument(document)
+    const entries: NormalizedChangeLogEntry[] = []
+    for await (const entry of prepared.entries()) {
+      entries.push(entry)
+    }
+
+    expect(entries[0].transformDescriptor).toEqual({
+      transformId: 'ωmega.transform',
+      optionsJson: '{"mode":"ω"}',
+    })
+  })
+
   it('rejects duplicate headers, trailing data, malformed UTF-8, and unsafe integers', async () => {
     const valid = documentWithEntries(0)
     const duplicate = JSON.stringify(valid).replace(

--- a/vscode-extension/src/textEncoding.ts
+++ b/vscode-extension/src/textEncoding.ts
@@ -168,6 +168,26 @@ export function decodeTextByte(
   return codePoint === undefined ? undefined : String.fromCodePoint(codePoint)
 }
 
+const HEX2 = '0123456789ABCDEF'
+
+/** Single byte as two uppercase hex digits. Hot path for hex rendering. */
+export function byteToHex2(byte: number): string {
+  return HEX2[byte >> 4] + HEX2[byte & 0xf]
+}
+
+/** Compact uppercase hex string for a byte sequence. */
+export function bytesToHex(bytes: ArrayLike<number>): string {
+  let out = ''
+  for (let index = 0; index < bytes.length; index += 1) {
+    out += byteToHex2(bytes[index])
+  }
+  return out
+}
+
+export function isPrintableAscii(byte: number): boolean {
+  return byte >= 0x20 && byte <= 0x7e
+}
+
 export function isPrintableTextByte(
   byte: number,
   encoding: TextEncoding

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -49,6 +49,11 @@ const {
   assertRangeMapFitsFile,
   parseRangeMapContent,
 } = require('../out/rangeMap.js')
+const {
+  byteToHex2,
+  bytesToHex,
+  isPrintableAscii,
+} = require('../out/textEncoding.js')
 
 function encodeRangeMap(rangeMap) {
   return Buffer.from(
@@ -554,6 +559,17 @@ test('text encoding lookup tables cover supported single-byte code pages', () =>
   assert.equal(ebcdic037[0x81], 0x0061)
   assert.equal(ebcdic037[0xad], 0x00dd)
   assert.equal(ebcdic037[0xc1], 0x0041)
+})
+
+test('shared byte formatting helpers cover inspector presentation', () => {
+  assert.equal(byteToHex2(0), '00')
+  assert.equal(byteToHex2(0xaf), 'AF')
+  assert.equal(byteToHex2(0xff), 'FF')
+  assert.equal(bytesToHex(Uint8Array.from([0, 0x12, 0xab, 0xff])), '0012ABFF')
+  assert.equal(isPrintableAscii(0x1f), false)
+  assert.equal(isPrintableAscii(0x20), true)
+  assert.equal(isPrintableAscii(0x7e), true)
+  assert.equal(isPrintableAscii(0x7f), false)
 })
 
 test('compiled extension entrypoints exist after build', () => {

--- a/vscode-extension/webview-ui/src/components/ByteInspector.svelte
+++ b/vscode-extension/webview-ui/src/components/ByteInspector.svelte
@@ -5,6 +5,9 @@
     decodeTextByte,
     encodeTextToHex,
     isPrintableTextByte,
+    byteToHex2,
+    bytesToHex,
+    isPrintableAscii,
   } from '../../../src/textEncoding'
 
   interface InspectorField {
@@ -90,20 +93,8 @@
       : `0x${offset.toString(16).toUpperCase()}`
   }
 
-  function toHex2(byte: number): string {
-    return byte.toString(16).toUpperCase().padStart(2, '0')
-  }
-
-  function bytesToHex(value: number[]): string {
-    return value.map(toHex2).join('')
-  }
-
   function makeDataView(value: number[]): DataView {
     return new DataView(Uint8Array.from(value).buffer)
-  }
-
-  function isPrintableAscii(byte: number): boolean {
-    return byte >= 0x20 && byte <= 0x7e
   }
 
   function textEncodingLabel(): string {
@@ -338,13 +329,13 @@
       label: strings.inspector.byteValue,
       minBytes: 1,
       editable: true,
-      read: (value) => `0x${toHex2(value[0])}`,
+      read: (value) => `0x${byteToHex2(value[0])}`,
       write: (raw) => {
         const text = raw.trim().replace(/^0x/i, '')
         if (!/^[0-9a-f]{1,2}$/i.test(text)) {
           throw new Error(strings.inspector.invalidHexByte)
         }
-        return toHex2(parseInt(text, 16))
+        return byteToHex2(parseInt(text, 16))
       },
     },
     {
@@ -362,7 +353,7 @@
         if (raw.length !== 1 || !isPrintableAscii(raw.charCodeAt(0))) {
           throw new Error(strings.inspector.invalidAsciiByte)
         }
-        return toHex2(raw.charCodeAt(0))
+        return byteToHex2(raw.charCodeAt(0))
       },
     },
     {
@@ -376,7 +367,7 @@
         if (!/^[01]{1,8}$/.test(text)) {
           throw new Error(strings.inspector.invalidBinaryByte)
         }
-        return toHex2(parseInt(text, 2))
+        return byteToHex2(parseInt(text, 2))
       },
     },
     {
@@ -392,7 +383,7 @@
         }
         const value = parseInt(text, 8)
         if (value > 0xff) throw new Error(strings.inspector.outOfRange)
-        return toHex2(value)
+        return byteToHex2(value)
       },
     },
   ]


### PR DESCRIPTION
## What changed

- centralize byte-to-hex and printable-ASCII helpers in the extension encoding module
- reuse those helpers in ByteInspector instead of maintaining duplicate hot-path formatters
- decode transform descriptor hex with direct character-to-nibble conversion, avoiding a substring and `parseInt` allocation for every byte
- add focused coverage for shared byte formatting and mixed-case UTF-8 transform metadata

## Audit outcome

The remaining findings did not justify moving work into the C++ server/core:

- change-log import parses user-selected external data and client-side gRPC validation protects a public trust boundary
- range maps are extension-owned presentation documents, not server-produced session data
- checkpoint timeline persistence owns extension history, locking, atomic publication, and retention above native checkpoint bytes
- editor history snapshots are durability/rollback boundaries and include extension transaction semantics absent from native history
- search windowing, numeric inspection, and clipboard decoding are bounded presentation operations

The untracked `dev-notes/HEAVY-LIFTS.md` working document was removed after the audit.

## Validation

- `yarn workspace @omega-edit/client test:codec` (13 tests)
- `yarn workspace @omega-edit/client lint`
- `npm run compile` in `vscode-extension`
- `npm run test:unit` in `vscode-extension` (28 tests)
- `npm run lint` in `vscode-extension`
