### PR TITLE
fix: materialized checkpoint timeline navigation

### DIFF
--- a/core/src/include/omega_edit/edit.h
+++ b/core/src/include/omega_edit/edit.h
@@ -770,6 +770,24 @@ int omega_edit_create_checkpoint(omega_session_t *session_ptr);
 int omega_edit_destroy_last_checkpoint(omega_session_t *session_ptr);
 
 /**
+ * Moves the session to a checkpoint boundary without destroying later checkpoint models.
+ *
+ * Checkpoint zero is the original session snapshot. Later checkpoints remain available for a subsequent checkout
+ * until a successful edit creates a new branch or omega_edit_discard_checkpoint_future is called.
+ * @param session_ptr session to navigate
+ * @param checkpoint_count checkpoint boundary to make active, from zero through the active plus future checkpoint count
+ * @return zero on success, non-zero otherwise
+ */
+int omega_edit_checkout_checkpoint(omega_session_t *session_ptr, int64_t checkpoint_count);
+
+/**
+ * Permanently destroys all checkpoint models after the active checkpoint boundary.
+ * @param session_ptr session whose future checkpoint branch should be discarded
+ * @return number of discarded future checkpoints, or a negative value on error
+ */
+int64_t omega_edit_discard_checkpoint_future(omega_session_t *session_ptr);
+
+/**
  * Restores the current session content to the most recent checkpoint snapshot.
  *
  * Unlike omega_edit_destroy_last_checkpoint, this keeps the checkpoint model in

--- a/core/src/include/omega_edit/session.h
+++ b/core/src/include/omega_edit/session.h
@@ -287,6 +287,13 @@ int64_t omega_session_get_num_undone_change_transactions(const omega_session_t *
 int64_t omega_session_get_num_checkpoints(const omega_session_t *session_ptr);
 
 /**
+ * Given a session, return the number of preserved checkpoints after the active checkpoint boundary.
+ * @param session_ptr session to get the number of future checkpoints for
+ * @return number of future checkpoints
+ */
+int64_t omega_session_get_num_future_checkpoints(const omega_session_t *session_ptr);
+
+/**
  * Call the registered session event handler
  * @param session_ptr session whose event handler to call
  * @param session_event session event

--- a/core/src/lib/changelog.cpp
+++ b/core/src/lib/changelog.cpp
@@ -565,6 +565,7 @@ namespace {
                 break;
             case change_kind_t::CHANGE_TRANSFORM:
                 result.public_entry.kind = OMEGA_CHANGELOG_PLAN_TRANSFORM;
+                result.public_entry.length = change->length;
                 result.transform_owner = change;
                 result.public_entry.transform_id =
                         change->transform_data ? change->transform_data->transform_id.c_str() : nullptr;

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -1974,9 +1974,6 @@ void omega_edit_destroy_session(omega_session_t *session_ptr) {
     for (const auto &model_ptr : session_ptr->models_) {
         if (model_ptr->file_ptr) { FCLOSE(model_ptr->file_ptr); }
     }
-    for (const auto &model_ptr : session_ptr->checkpoint_future_models_) {
-        if (model_ptr->file_ptr) { FCLOSE(model_ptr->file_ptr); }
-    }
     while (!session_ptr->search_contexts_.empty()) {
         omega_search_destroy_context(session_ptr->search_contexts_.back().get());
     }
@@ -1987,13 +1984,7 @@ void omega_edit_destroy_session(omega_session_t *session_ptr) {
         if (0 != omega_util_remove_file(session_ptr->models_.back()->file_path.c_str())) { LOG_ERRNO(); }
         session_ptr->models_.pop_back();
     }
-    while (!session_ptr->checkpoint_future_models_.empty()) {
-        auto &model_ptr = session_ptr->checkpoint_future_models_.back();
-        free_model_changes_(model_ptr.get());
-        free_model_changes_undone_(model_ptr.get());
-        if (!model_ptr->file_path.empty() && 0 != omega_util_remove_file(model_ptr->file_path.c_str())) { LOG_ERRNO(); }
-        session_ptr->checkpoint_future_models_.pop_back();
-    }
+    discard_checkpoint_future_(session_ptr);
     if (!session_ptr->checkpoint_file_name_.empty() &&
         0 != omega_util_remove_file(session_ptr->checkpoint_file_name_.c_str())) {
         LOG_ERRNO();
@@ -3132,6 +3123,7 @@ int omega_edit_checkout_checkpoint(omega_session_t *session_ptr, int64_t checkpo
     const auto active_count = omega_session_get_num_checkpoints(session_ptr);
     const auto future_count = omega_session_get_num_future_checkpoints(session_ptr);
     if (checkpoint_count > active_count + future_count) { return -1; }
+    if (checkpoint_count == active_count) { return 0; }
 
     omega_model_segments_t original_segments;
     if (checkpoint_count == 0) {

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -893,6 +893,26 @@ namespace {
         for (auto &&model_ptr : session_ptr->models_) { free_model_changes_undone_(model_ptr.get()); }
     }
 
+    void discard_model_(omega_model_ptr_t &model_ptr) {
+        if (model_ptr->file_ptr) {
+            FCLOSE(model_ptr->file_ptr);
+            model_ptr->file_ptr = nullptr;
+        }
+        if (!model_ptr->file_path.empty() && 0 != omega_util_remove_file(model_ptr->file_path.c_str())) { LOG_ERRNO(); }
+        free_model_changes_(model_ptr.get());
+        free_model_changes_undone_(model_ptr.get());
+    }
+
+    int64_t discard_checkpoint_future_(omega_session_t *session_ptr) {
+        if (!session_ptr) { return -1; }
+        const auto discarded = static_cast<int64_t>(session_ptr->checkpoint_future_models_.size());
+        while (!session_ptr->checkpoint_future_models_.empty()) {
+            discard_model_(session_ptr->checkpoint_future_models_.back());
+            session_ptr->checkpoint_future_models_.pop_back();
+        }
+        return discarded;
+    }
+
     auto update_model_helper_(omega_model_t *model_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
         if (!change_ptr) { return -1; }
         assert(change_ptr->length > 0);
@@ -1176,6 +1196,7 @@ namespace {
                 if (serial_was_negative) { change_ptr->serial *= -1; }
                 return -1;
             }
+            discard_checkpoint_future_(session_ptr);
             if (session_ptr->undo_snapshot_interval_ > 0) {
                 const auto count = static_cast<int64_t>(model_ptr->changes.size());
                 if (count % session_ptr->undo_snapshot_interval_ == 0) {
@@ -1324,6 +1345,8 @@ namespace {
             omega_util_remove_file(checkpoint_filename);
             return -1;
         }
+
+        discard_checkpoint_future_(session_ptr);
 
         session_ptr->num_changes_adjustment_ = change_serial_base;
         omega_session_notify(session_ptr, SESSION_EVT_CREATE_CHECKPOINT, nullptr);
@@ -1841,14 +1864,7 @@ namespace {
     }
 
     void discard_top_model_(omega_session_t *session_ptr) {
-        auto *const model_ptr = session_ptr->models_.back().get();
-        if (model_ptr->file_ptr) {
-            FCLOSE(model_ptr->file_ptr);
-            model_ptr->file_ptr = nullptr;
-        }
-        if (!model_ptr->file_path.empty() && 0 != omega_util_remove_file(model_ptr->file_path.c_str())) { LOG_ERRNO(); }
-        free_model_changes_(model_ptr);
-        free_model_changes_undone_(model_ptr);
+        discard_model_(session_ptr->models_.back());
         session_ptr->models_.pop_back();
         session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
     }
@@ -1958,6 +1974,9 @@ void omega_edit_destroy_session(omega_session_t *session_ptr) {
     for (const auto &model_ptr : session_ptr->models_) {
         if (model_ptr->file_ptr) { FCLOSE(model_ptr->file_ptr); }
     }
+    for (const auto &model_ptr : session_ptr->checkpoint_future_models_) {
+        if (model_ptr->file_ptr) { FCLOSE(model_ptr->file_ptr); }
+    }
     while (!session_ptr->search_contexts_.empty()) {
         omega_search_destroy_context(session_ptr->search_contexts_.back().get());
     }
@@ -1967,6 +1986,13 @@ void omega_edit_destroy_session(omega_session_t *session_ptr) {
     while (omega_session_get_num_checkpoints(session_ptr) != 0) {
         if (0 != omega_util_remove_file(session_ptr->models_.back()->file_path.c_str())) { LOG_ERRNO(); }
         session_ptr->models_.pop_back();
+    }
+    while (!session_ptr->checkpoint_future_models_.empty()) {
+        auto &model_ptr = session_ptr->checkpoint_future_models_.back();
+        free_model_changes_(model_ptr.get());
+        free_model_changes_undone_(model_ptr.get());
+        if (!model_ptr->file_path.empty() && 0 != omega_util_remove_file(model_ptr->file_path.c_str())) { LOG_ERRNO(); }
+        session_ptr->checkpoint_future_models_.pop_back();
     }
     if (!session_ptr->checkpoint_file_name_.empty() &&
         0 != omega_util_remove_file(session_ptr->checkpoint_file_name_.c_str())) {
@@ -2930,6 +2956,7 @@ int omega_edit_clear_changes(omega_session_t *session_ptr) {
 
     omega_model_segments_t reset_segments;
     if (!initialize_model_segments_(reset_segments, length)) { return -1; }
+    discard_checkpoint_future_(session_ptr);
     while (session_ptr->models_.size() > 1) { discard_top_model_(session_ptr); }
     session_ptr->models_.front()->model_segments = std::move(reset_segments);
     free_session_changes_(session_ptr);
@@ -3080,6 +3107,7 @@ int omega_edit_create_checkpoint(omega_session_t *session_ptr) {
 
 int omega_edit_destroy_last_checkpoint(omega_session_t *session_ptr) {
     if (omega_session_get_num_checkpoints(session_ptr) > 0) {
+        discard_checkpoint_future_(session_ptr);
         auto *const last_checkpoint_ptr = session_ptr->models_.back().get();
         FCLOSE(last_checkpoint_ptr->file_ptr);
         if (0 != omega_util_remove_file(last_checkpoint_ptr->file_path.c_str())) { LOG_ERRNO(); }
@@ -3097,6 +3125,62 @@ int omega_edit_destroy_last_checkpoint(omega_session_t *session_ptr) {
         return 0;
     }
     return -1;
+}
+
+int omega_edit_checkout_checkpoint(omega_session_t *session_ptr, int64_t checkpoint_count) {
+    if (!session_ptr || checkpoint_count < 0) { return -1; }
+    const auto active_count = omega_session_get_num_checkpoints(session_ptr);
+    const auto future_count = omega_session_get_num_future_checkpoints(session_ptr);
+    if (checkpoint_count > active_count + future_count) { return -1; }
+
+    omega_model_segments_t original_segments;
+    if (checkpoint_count == 0) {
+        const auto original_length = omega_session_get_original_file_size(session_ptr);
+        if (original_length < 0 || !initialize_model_segments_(original_segments, original_length)) { return -1; }
+    }
+
+    try {
+        if (checkpoint_count < active_count) {
+            session_ptr->checkpoint_future_models_.reserve(session_ptr->checkpoint_future_models_.size() +
+                                                           static_cast<size_t>(active_count - checkpoint_count));
+        } else if (checkpoint_count > active_count) {
+            session_ptr->models_.reserve(static_cast<size_t>(checkpoint_count + 1));
+        }
+    } catch (const std::bad_alloc &) { return -1; }
+
+    while (omega_session_get_num_checkpoints(session_ptr) > checkpoint_count) {
+        session_ptr->checkpoint_future_models_.push_back(std::move(session_ptr->models_.back()));
+        session_ptr->models_.pop_back();
+    }
+    while (omega_session_get_num_checkpoints(session_ptr) < checkpoint_count) {
+        session_ptr->models_.push_back(std::move(session_ptr->checkpoint_future_models_.back()));
+        session_ptr->checkpoint_future_models_.pop_back();
+    }
+
+    if (checkpoint_count == 0) {
+        auto *const root_model_ptr = session_ptr->models_.front().get();
+        root_model_ptr->model_segments = std::move(original_segments);
+        free_model_changes_(root_model_ptr);
+        free_model_changes_undone_(root_model_ptr);
+        session_ptr->num_changes_adjustment_ = 0;
+    } else {
+        auto *const model_ptr = session_ptr->models_.back().get();
+        const auto keep_count = checkpoint_snapshot_change_count_(model_ptr);
+        if (model_ptr->changes.size() > keep_count) {
+            model_ptr->changes.erase(model_ptr->changes.begin() + static_cast<std::ptrdiff_t>(keep_count),
+                                     model_ptr->changes.end());
+        }
+        free_model_changes_undone_(model_ptr);
+        if (0 != rebuild_model_to_change_count_(session_ptr, static_cast<int64_t>(keep_count))) { return -1; }
+        session_ptr->num_changes_adjustment_ = model_ptr->change_serial_base;
+    }
+
+    notify_checkpoint_restore_(session_ptr);
+    return 0;
+}
+
+int64_t omega_edit_discard_checkpoint_future(omega_session_t *session_ptr) {
+    return discard_checkpoint_future_(session_ptr);
 }
 
 int omega_edit_restore_last_checkpoint(omega_session_t *session_ptr) {

--- a/core/src/lib/impl_/session_def.hpp
+++ b/core/src/lib/impl_/session_def.hpp
@@ -41,6 +41,7 @@ struct omega_session_struct {
     omega_viewports_t viewports_{};            ///< Collection of viewports in this session
     omega_search_contexts_t search_contexts_{};///< Collection of active search contexts
     omega_models_t models_{};                  ///< Edit models (internal)
+    omega_models_t checkpoint_future_models_{};///< Checkpoint models preserved by non-destructive timeline rewind
     int64_t num_changes_adjustment_{};         ///< Number of changes in checkpoints
     int64_t undo_snapshot_interval_{100};      ///< Undo model snapshot interval (0 = disabled, default 100)
     int64_t change_inline_payload_limit_{OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT}; ///< Inline primitive payload threshold

--- a/core/src/lib/payload_storage.cpp
+++ b/core/src/lib/payload_storage.cpp
@@ -10,6 +10,7 @@
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                    *
  **********************************************************************************************************************/
 
+#include "../include/omega_edit/config.h"
 #include "impl_/change_def.hpp"
 #include <algorithm>
 #include <cstdio>
@@ -22,13 +23,7 @@ namespace omega_edit::internal {
     namespace {
         constexpr int64_t PAYLOAD_BLOCK_SIZE = 1024 * 1024;
 
-        bool seek_(FILE *file, int64_t offset) {
-#ifdef HAVE_FSEEKO
-            return fseeko(file, static_cast<off_t>(offset), SEEK_SET) == 0;
-#else
-            return offset <= std::numeric_limits<long>::max() && fseek(file, static_cast<long>(offset), SEEK_SET) == 0;
-#endif
-        }
+        bool seek_(FILE *file, int64_t offset) { return FSEEK(file, offset, SEEK_SET) == 0; }
     }// namespace
 
     int omega_payload_compress_file_(omega_byte_payload_struct *payload) {

--- a/core/src/lib/payload_storage.cpp
+++ b/core/src/lib/payload_storage.cpp
@@ -23,7 +23,14 @@ namespace omega_edit::internal {
     namespace {
         constexpr int64_t PAYLOAD_BLOCK_SIZE = 1024 * 1024;
 
-        bool seek_(FILE *file, int64_t offset) { return FSEEK(file, offset, SEEK_SET) == 0; }
+        bool seek_(FILE *file, int64_t offset) {
+#if !defined(OMEGA_BUILD_WINDOWS) && !defined(HAVE_FSEEKO)
+            return offset <= (std::numeric_limits<long>::max)() &&
+                   FSEEK(file, static_cast<long>(offset), SEEK_SET) == 0;
+#else
+            return FSEEK(file, offset, SEEK_SET) == 0;
+#endif
+        }
     }// namespace
 
     int omega_payload_compress_file_(omega_byte_payload_struct *payload) {

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -305,6 +305,11 @@ int64_t omega_session_get_num_checkpoints(const omega_session_t *session_ptr) {
     return static_cast<int64_t>(session_ptr->models_.size()) - 1;
 }
 
+int64_t omega_session_get_num_future_checkpoints(const omega_session_t *session_ptr) {
+    if (!session_ptr) { return 0; }
+    return static_cast<int64_t>(session_ptr->checkpoint_future_models_.size());
+}
+
 void omega_edit::internal::omega_session_begin_event_batch_(omega_session_t *session_ptr,
                                                             omega_session_event_t session_event) {
     if (!session_ptr) { return; }

--- a/core/src/tests/changelog_tests.cpp
+++ b/core/src/tests/changelog_tests.cpp
@@ -278,16 +278,41 @@ TEST_CASE("transform boundaries are emitted exactly once", "[changelog][range][t
     REQUIRE(2 == omega_edit_replace_bytes_as_transform(session.get(), 1, 2, transformed, 2, "omega.test", "{\"x\":1}"));
     REQUIRE(3 == omega_edit_insert(session.get(), 4, "Z", 1));
 
-    const auto crossing = export_range_(session.get(), 2, 3);
-    REQUIRE(crossing.size() == 2);
-    CHECK(crossing[0].kind == OMEGA_CHANGELOG_PLAN_TRANSFORM);
-    CHECK(crossing[0].transform_id == "omega.test");
-    CHECK(crossing[0].options_json == "{\"x\":1}");
-    CHECK(crossing[1].kind == OMEGA_CHANGELOG_PLAN_INSERT);
+    for (const auto optimize : {false, true}) {
+        const auto crossing = export_mode_(session.get(), optimize, 2, 3);
+        REQUIRE(crossing.size() == 2);
+        CHECK(crossing[0].kind == OMEGA_CHANGELOG_PLAN_TRANSFORM);
+        CHECK(crossing[0].offset == 1);
+        CHECK(crossing[0].length == 2);
+        CHECK(crossing[0].transform_id == "omega.test");
+        CHECK(crossing[0].options_json == "{\"x\":1}");
+        CHECK(crossing[0].replacement_length == 2);
+        CHECK(crossing[0].computed_file_size_before == 4);
+        CHECK(crossing[0].computed_file_size_after == 4);
+        CHECK(crossing[1].kind == OMEGA_CHANGELOG_PLAN_INSERT);
+    }
 
     const auto after = export_range_(session.get(), 3, 3);
     REQUIRE(after.size() == 1);
     CHECK(after[0].kind == OMEGA_CHANGELOG_PLAN_INSERT);
+}
+
+TEST_CASE("whole-range transform exports its effective replay range",
+          "[BrutalCoverage][changelog][transform][replay]") {
+    auto session = from_text_("abc");
+    const omega_edit_transform_t upper_transform{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session.get(), upper_transform, 0, 0));
+
+    for (const auto optimize : {false, true}) {
+        const auto entries = export_mode_(session.get(), optimize);
+        REQUIRE(entries.size() == 1);
+        CHECK(entries[0].kind == OMEGA_CHANGELOG_PLAN_TRANSFORM);
+        CHECK(entries[0].offset == 0);
+        CHECK(entries[0].length == 3);
+        CHECK(entries[0].replacement_length == 3);
+        CHECK(entries[0].computed_file_size_before == 3);
+        CHECK(entries[0].computed_file_size_after == 3);
+    }
 }
 
 TEST_CASE("limits fail before callbacks and tiny spans stay correct", "[changelog][limits]") {

--- a/core/src/tests/differential_fuzz_tests.cpp
+++ b/core/src/tests/differential_fuzz_tests.cpp
@@ -801,12 +801,21 @@ namespace {
         omega_changelog_plan_kind_t kind{};
         int64_t offset{};
         int64_t length{};
+        int64_t replacement_length{};
+        int64_t computed_file_size_before{};
+        int64_t computed_file_size_after{};
         std::vector<omega_byte_t> payload{};
     };
 
     int capture_exported_op(const omega_changelog_plan_entry_t *entry, void *user_data) {
         auto &entries = *static_cast<std::vector<exported_op_t> *>(user_data);
-        exported_op_t captured{entry->kind, entry->offset, entry->length, {}};
+        exported_op_t captured;
+        captured.kind = entry->kind;
+        captured.offset = entry->offset;
+        captured.length = entry->length;
+        captured.replacement_length = entry->replacement_length;
+        captured.computed_file_size_before = entry->computed_file_size_before;
+        captured.computed_file_size_after = entry->computed_file_size_after;
         captured.payload.resize(static_cast<size_t>(entry->payload_length));
         int64_t offset = 0;
         while (offset < entry->payload_length) {
@@ -847,6 +856,19 @@ namespace {
         return true;
     }
 
+    bool transform_export_metadata_valid(const exported_op_t &entry) {
+        if (entry.kind != OMEGA_CHANGELOG_PLAN_TRANSFORM) { return true; }
+        if (entry.offset < 0 || entry.length < 0 || entry.replacement_length < 0 ||
+            entry.computed_file_size_before < 0 || entry.computed_file_size_after < 0 ||
+            entry.offset > entry.computed_file_size_before ||
+            entry.length > entry.computed_file_size_before - entry.offset) {
+            return false;
+        }
+        const auto retained_length = entry.computed_file_size_before - entry.length;
+        return entry.replacement_length <= std::numeric_limits<int64_t>::max() - retained_length &&
+               retained_length + entry.replacement_length == entry.computed_file_size_after;
+    }
+
     fuzz_run_result_t verify_optimized_export(const fuzz_script_t &script, const omega_session_t *source) {
         if (omega_session_get_num_changes(source) <= 0) { return {}; }
         omega_changelog_export_options_t options{};
@@ -874,6 +896,10 @@ namespace {
         }
         if (optimized.size() > raw.size()) {
             return fail_at(script.ops.size(), "optimized export contains more operations than raw export");
+        }
+        if (!std::all_of(raw.begin(), raw.end(), transform_export_metadata_valid) ||
+            !std::all_of(optimized.begin(), optimized.end(), transform_export_metadata_valid)) {
+            return fail_at(script.ops.size(), "transform export metadata is inconsistent with its file sizes");
         }
         if (std::any_of(optimized.begin(), optimized.end(),
                         [](const exported_op_t &entry) { return entry.kind == OMEGA_CHANGELOG_PLAN_TRANSFORM; })) {

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -40,6 +40,16 @@ typedef struct mask_info_struct {
     omega_mask_kind_t mask_kind;
 } mask_info_t;
 
+struct counting_upper_transform_state {
+    int64_t calls{};
+};
+
+static omega_byte_t counting_to_upper(omega_byte_t byte, void *user_data_ptr) {
+    auto *state = static_cast<counting_upper_transform_state *>(user_data_ptr);
+    if (state) { ++state->calls; }
+    return to_upper(byte, nullptr);
+}
+
 static inline omega_byte_t byte_mask_transform(omega_byte_t byte, void *user_data_ptr) {
     const auto mask_info_ptr = reinterpret_cast<mask_info_t *>(user_data_ptr);
     return omega_util_mask_byte(byte, mask_info_ptr->mask, mask_info_ptr->mask_kind);
@@ -294,6 +304,53 @@ TEST_CASE("Restore Last Transform Checkpoint Preserves Transform Change",
     REQUIRE(1 == omega_change_get_serial(transform_change));
     REQUIRE("abcxyz" ==
             omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
+TEST_CASE("Checkpoint checkout preserves redo models until a branch edit",
+          "[SessionCheckpointTests][CheckpointTimeline][BrutalCoverage]") {
+    const auto input = reinterpret_cast<const omega_byte_t *>("abc");
+    const auto session_ptr = omega_edit_create_session_from_bytes(input, 3, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    counting_upper_transform_state transform_state;
+    REQUIRE(0 == omega_edit_apply_transform(session_ptr, counting_to_upper, &transform_state, 0, 0));
+    REQUIRE(3 == transform_state.calls);
+    REQUIRE(2 == omega_edit_insert_string(session_ptr, 3, "!"));
+    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+    REQUIRE(3 == omega_edit_overwrite_string(session_ptr, 0, "X"));
+    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+    REQUIRE(3 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_num_future_checkpoints(session_ptr));
+    REQUIRE("XBC!" == omega_session_get_segment_string(session_ptr, 0, 4));
+
+    const auto require_checkpoint = [&](int64_t checkpoint, const char *expected, int64_t active, int64_t future) {
+        REQUIRE(0 == omega_edit_checkout_checkpoint(session_ptr, checkpoint));
+        REQUIRE(active == omega_session_get_num_checkpoints(session_ptr));
+        REQUIRE(future == omega_session_get_num_future_checkpoints(session_ptr));
+        REQUIRE(expected ==
+                omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+        REQUIRE(3 == transform_state.calls);
+    };
+
+    require_checkpoint(0, "abc", 0, 3);
+    require_checkpoint(1, "ABC", 1, 2);
+    require_checkpoint(2, "ABC!", 2, 1);
+    require_checkpoint(3, "XBC!", 3, 0);
+
+    for (auto iteration = 0; iteration < 1000; ++iteration) {
+        require_checkpoint(0, "abc", 0, 3);
+        require_checkpoint(3, "XBC!", 3, 0);
+    }
+
+    require_checkpoint(1, "ABC", 1, 2);
+    REQUIRE(2 == omega_edit_insert_string(session_ptr, 3, "?"));
+    REQUIRE("ABC?" == omega_session_get_segment_string(session_ptr, 0, 4));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_num_future_checkpoints(session_ptr));
+    REQUIRE(-1 == omega_edit_checkout_checkpoint(session_ptr, 2));
+    REQUIRE(3 == transform_state.calls);
 
     omega_edit_destroy_session(session_ptr);
 }

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -349,6 +349,7 @@ TEST_CASE("Checkpoint checkout preserves redo models until a branch edit",
     REQUIRE("ABC?" == omega_session_get_segment_string(session_ptr, 0, 4));
     REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
     REQUIRE(0 == omega_session_get_num_future_checkpoints(session_ptr));
+    require_checkpoint(1, "ABC?", 1, 0);
     REQUIRE(-1 == omega_edit_checkout_checkpoint(session_ptr, 2));
     REQUIRE(3 == transform_state.calls);
 

--- a/dev-notes/checkpoint-timeline-materialized-navigation.md
+++ b/dev-notes/checkpoint-timeline-materialized-navigation.md
@@ -1,0 +1,53 @@
+# Materialized checkpoint timeline navigation
+
+## Acceptance scenario
+
+The ApacheCon demo must support a massive file, thousands of edits and transforms, and repeated movement through the
+checkpoint timeline while the viewport updates. Moving between checkpoints that already exist in the live session must
+not re-run transforms or replay interval change logs.
+
+## Required behavior
+
+- Rewind and fast-forward switch between already materialized checkpoint models.
+- Navigation cost is independent of file size and interval change count, apart from viewport reads and fingerprint
+  verification.
+- Future checkpoints remain available after rewind until the user makes a branch mutation.
+- The first mutation away from the tip atomically discards the native future and truncates the durable timeline.
+- Durable change-log archives remain the reopen, recovery, and cross-process fallback. They are not the normal live
+  navigation path.
+- Checkpoint 0 continues to mean the immutable original file, not the edits that happened before checkpoint 1.
+
+## Implemented native model
+
+Add a future-checkpoint stack to `omega_session_t`. A rewind moves the active checkpoint model from the active model
+stack to the future stack without closing or unlinking its backing file. Fast-forward moves the next future model back
+to the active stack. Checkout invalidates viewports and emits the checkpoint-restore event.
+
+The core API is:
+
+- `omega_edit_checkout_checkpoint(session, checkpoint_count)`
+- `omega_edit_discard_checkpoint_future(session)`
+- `omega_session_get_num_future_checkpoints(session)`
+
+Session destruction must close and remove checkpoint files from both stacks. Existing destructive checkpoint rollback
+keeps its current semantics and must also invalidate any incompatible future.
+
+## Server and client contract
+
+`CheckoutCheckpoint` and `DiscardCheckpointFuture` run under the session mutation lock. Checkout returns active and
+future checkpoint counts so the extension can assert native/timeline alignment after every move.
+
+## Editor routing
+
+`navigateToCheckpoint` uses a single native checkout call. Durable interval availability and plugin availability remain
+visible as archive metadata, but neither disables live fast-forward because no replay is needed.
+
+## Performance and reliability tests
+
+- Core regression: 1,000 original-to-tip sweeps across mixed transform/plain checkpoints, with 10,041 assertions and an
+  invariant transform callback count.
+- Core regression: a branch edit after rewind removes the future and makes checkout beyond the branch fail.
+- Client regression: active/future counts and content remain aligned through rewind, fast-forward, and branch creation.
+- VS Code regression: a full-range transform moves `1 -> 0 -> 1` through materialized checkout.
+- VS Code regression: navigation succeeds with missing storage and with a deliberately corrupted durable archive.
+- VS Code scalability regression: one million checkpoint records produce a bounded metadata projection.

--- a/packages/client/src/editor_history.ts
+++ b/packages/client/src/editor_history.ts
@@ -121,6 +121,14 @@ export class EditorHistoryController {
     return [...this.changeLog]
   }
 
+  public willUndoCrossMilestone(): boolean {
+    return this.milestoneDepths.includes(this.transactionLog.length)
+  }
+
+  public willRedoCrossMilestone(): boolean {
+    return this.milestoneDepths.includes(this.transactionLog.length + 1)
+  }
+
   public snapshot(): EditorHistorySnapshot {
     return {
       version: 1,

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.grpc-client.ts
@@ -41,6 +41,10 @@ import type { ListTransformPluginsResponse } from './omega_edit'
 import type { ListTransformPluginsRequest } from './omega_edit'
 import type { RestoreLastCheckpointResponse } from './omega_edit'
 import type { RestoreLastCheckpointRequest } from './omega_edit'
+import type { DiscardCheckpointFutureResponse } from './omega_edit'
+import type { DiscardCheckpointFutureRequest } from './omega_edit'
+import type { CheckoutCheckpointResponse } from './omega_edit'
+import type { CheckoutCheckpointRequest } from './omega_edit'
 import type { DestroyLastCheckpointResponse } from './omega_edit'
 import type { DestroyLastCheckpointRequest } from './omega_edit'
 import type { CreateCheckpointResponse } from './omega_edit'
@@ -1607,6 +1611,80 @@ export interface IEditorServiceClient {
     callback: (
       err: grpc.ServiceError | null,
       value?: DestroyLastCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  /**
+   * Move to a checkpoint boundary while preserving later checkpoints for fast-forward.
+   *
+   * @generated from protobuf rpc: CheckoutCheckpoint
+   */
+  checkoutCheckpoint(
+    input: CheckoutCheckpointRequest,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: CheckoutCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  checkoutCheckpoint(
+    input: CheckoutCheckpointRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: CheckoutCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  checkoutCheckpoint(
+    input: CheckoutCheckpointRequest,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: CheckoutCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  checkoutCheckpoint(
+    input: CheckoutCheckpointRequest,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: CheckoutCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  /**
+   * Permanently discard checkpoints after the active checkpoint boundary.
+   *
+   * @generated from protobuf rpc: DiscardCheckpointFuture
+   */
+  discardCheckpointFuture(
+    input: DiscardCheckpointFutureRequest,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: DiscardCheckpointFutureResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  discardCheckpointFuture(
+    input: DiscardCheckpointFutureRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: DiscardCheckpointFutureResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  discardCheckpointFuture(
+    input: DiscardCheckpointFutureRequest,
+    options: grpc.CallOptions,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: DiscardCheckpointFutureResponse
+    ) => void
+  ): grpc.ClientUnaryCall
+  discardCheckpointFuture(
+    input: DiscardCheckpointFutureRequest,
+    callback: (
+      err: grpc.ServiceError | null,
+      value?: DiscardCheckpointFutureResponse
     ) => void
   ): grpc.ClientUnaryCall
   /**
@@ -3574,6 +3652,88 @@ export class EditorServiceClient
     )
   }
   /**
+   * Move to a checkpoint boundary while preserving later checkpoints for fast-forward.
+   *
+   * @generated from protobuf rpc: CheckoutCheckpoint
+   */
+  checkoutCheckpoint(
+    input: CheckoutCheckpointRequest,
+    metadata:
+      | grpc.Metadata
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: CheckoutCheckpointResponse
+        ) => void),
+    options?:
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: CheckoutCheckpointResponse
+        ) => void),
+    callback?: (
+      err: grpc.ServiceError | null,
+      value?: CheckoutCheckpointResponse
+    ) => void
+  ): grpc.ClientUnaryCall {
+    const method = EditorService.methods[39]
+    return this.makeUnaryRequest<
+      CheckoutCheckpointRequest,
+      CheckoutCheckpointResponse
+    >(
+      `/${EditorService.typeName}/${method.name}`,
+      (value: CheckoutCheckpointRequest): Buffer =>
+        Buffer.from(method.I.toBinary(value, this._binaryOptions)),
+      (value: Buffer): CheckoutCheckpointResponse =>
+        method.O.fromBinary(value, this._binaryOptions),
+      input,
+      metadata as any,
+      options as any,
+      callback as any
+    )
+  }
+  /**
+   * Permanently discard checkpoints after the active checkpoint boundary.
+   *
+   * @generated from protobuf rpc: DiscardCheckpointFuture
+   */
+  discardCheckpointFuture(
+    input: DiscardCheckpointFutureRequest,
+    metadata:
+      | grpc.Metadata
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: DiscardCheckpointFutureResponse
+        ) => void),
+    options?:
+      | grpc.CallOptions
+      | ((
+          err: grpc.ServiceError | null,
+          value?: DiscardCheckpointFutureResponse
+        ) => void),
+    callback?: (
+      err: grpc.ServiceError | null,
+      value?: DiscardCheckpointFutureResponse
+    ) => void
+  ): grpc.ClientUnaryCall {
+    const method = EditorService.methods[40]
+    return this.makeUnaryRequest<
+      DiscardCheckpointFutureRequest,
+      DiscardCheckpointFutureResponse
+    >(
+      `/${EditorService.typeName}/${method.name}`,
+      (value: DiscardCheckpointFutureRequest): Buffer =>
+        Buffer.from(method.I.toBinary(value, this._binaryOptions)),
+      (value: Buffer): DiscardCheckpointFutureResponse =>
+        method.O.fromBinary(value, this._binaryOptions),
+      input,
+      metadata as any,
+      options as any,
+      callback as any
+    )
+  }
+  /**
    * Restore session content to the most recent checkpoint snapshot while
    * keeping that checkpoint available.
    *
@@ -3599,7 +3759,7 @@ export class EditorServiceClient
       value?: RestoreLastCheckpointResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[39]
+    const method = EditorService.methods[41]
     return this.makeUnaryRequest<
       RestoreLastCheckpointRequest,
       RestoreLastCheckpointResponse
@@ -3640,7 +3800,7 @@ export class EditorServiceClient
       value?: ListTransformPluginsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[40]
+    const method = EditorService.methods[42]
     return this.makeUnaryRequest<
       ListTransformPluginsRequest,
       ListTransformPluginsResponse
@@ -3682,7 +3842,7 @@ export class EditorServiceClient
       value?: ApplyTransformPluginResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[41]
+    const method = EditorService.methods[43]
     return this.makeUnaryRequest<
       ApplyTransformPluginRequest,
       ApplyTransformPluginResponse
@@ -3724,7 +3884,7 @@ export class EditorServiceClient
       value?: GetByteFrequencyProfileResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[42]
+    const method = EditorService.methods[44]
     return this.makeUnaryRequest<
       GetByteFrequencyProfileRequest,
       GetByteFrequencyProfileResponse
@@ -3766,7 +3926,7 @@ export class EditorServiceClient
       value?: GetCharacterCountsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[43]
+    const method = EditorService.methods[45]
     return this.makeUnaryRequest<
       GetCharacterCountsRequest,
       GetCharacterCountsResponse
@@ -3811,7 +3971,7 @@ export class EditorServiceClient
       value?: ServerControlResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[44]
+    const method = EditorService.methods[46]
     return this.makeUnaryRequest<ServerControlRequest, ServerControlResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: ServerControlRequest): Buffer =>
@@ -3844,7 +4004,7 @@ export class EditorServiceClient
       value?: GetHeartbeatResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[45]
+    const method = EditorService.methods[47]
     return this.makeUnaryRequest<GetHeartbeatRequest, GetHeartbeatResponse>(
       `/${EditorService.typeName}/${method.name}`,
       (value: GetHeartbeatRequest): Buffer =>
@@ -3873,7 +4033,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToSessionEventsResponse> {
-    const method = EditorService.methods[46]
+    const method = EditorService.methods[48]
     return this.makeServerStreamRequest<
       SubscribeToSessionEventsRequest,
       SubscribeToSessionEventsResponse
@@ -3899,7 +4059,7 @@ export class EditorServiceClient
     metadata?: grpc.Metadata | grpc.CallOptions,
     options?: grpc.CallOptions
   ): grpc.ClientReadableStream<SubscribeToViewportEventsResponse> {
-    const method = EditorService.methods[47]
+    const method = EditorService.methods[49]
     return this.makeServerStreamRequest<
       SubscribeToViewportEventsRequest,
       SubscribeToViewportEventsResponse
@@ -3939,7 +4099,7 @@ export class EditorServiceClient
       value?: UnsubscribeToSessionEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[48]
+    const method = EditorService.methods[50]
     return this.makeUnaryRequest<
       UnsubscribeToSessionEventsRequest,
       UnsubscribeToSessionEventsResponse
@@ -3980,7 +4140,7 @@ export class EditorServiceClient
       value?: UnsubscribeToViewportEventsResponse
     ) => void
   ): grpc.ClientUnaryCall {
-    const method = EditorService.methods[49]
+    const method = EditorService.methods[51]
     return this.makeUnaryRequest<
       UnsubscribeToViewportEventsRequest,
       UnsubscribeToViewportEventsResponse

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -1912,6 +1912,74 @@ export interface DestroyLastCheckpointResponse {
   remainingCheckpoints: number // Remaining checkpoint count after revert.
 }
 /**
+ * Request to navigate to a materialized checkpoint boundary.
+ *
+ * @generated from protobuf message omega_edit.v1.CheckoutCheckpointRequest
+ */
+export interface CheckoutCheckpointRequest {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session to navigate.
+  /**
+   * @generated from protobuf field: int64 checkpoint_count = 2
+   */
+  checkpointCount: number // Checkpoint boundary to make active; zero is the original snapshot.
+}
+/**
+ * Result of non-destructive checkpoint navigation.
+ *
+ * @generated from protobuf message omega_edit.v1.CheckoutCheckpointResponse
+ */
+export interface CheckoutCheckpointResponse {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session that was navigated.
+  /**
+   * @generated from protobuf field: int64 checkpoint_count = 2
+   */
+  checkpointCount: number // Active checkpoint count after navigation.
+  /**
+   * @generated from protobuf field: int64 future_checkpoint_count = 3
+   */
+  futureCheckpointCount: number // Preserved checkpoint count available for fast-forward.
+  /**
+   * @generated from protobuf field: int64 change_count = 4
+   */
+  changeCount: number // Active session change count after navigation.
+}
+/**
+ * Request to destroy the preserved checkpoint branch after the active boundary.
+ *
+ * @generated from protobuf message omega_edit.v1.DiscardCheckpointFutureRequest
+ */
+export interface DiscardCheckpointFutureRequest {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session whose checkpoint future should be discarded.
+}
+/**
+ * Result of destroying a preserved checkpoint branch.
+ *
+ * @generated from protobuf message omega_edit.v1.DiscardCheckpointFutureResponse
+ */
+export interface DiscardCheckpointFutureResponse {
+  /**
+   * @generated from protobuf field: string session_id = 1
+   */
+  sessionId: string // Session whose future was discarded.
+  /**
+   * @generated from protobuf field: int64 discarded_checkpoint_count = 2
+   */
+  discardedCheckpointCount: number // Number of checkpoint models destroyed.
+  /**
+   * @generated from protobuf field: int64 checkpoint_count = 3
+   */
+  checkpointCount: number // Active checkpoint count, which is unchanged.
+}
+/**
  * Request to restore the most recent checkpoint snapshot without discarding it.
  *
  * @generated from protobuf message omega_edit.v1.RestoreLastCheckpointRequest
@@ -12444,6 +12512,384 @@ class DestroyLastCheckpointResponse$Type extends MessageType<DestroyLastCheckpoi
 export const DestroyLastCheckpointResponse =
   new DestroyLastCheckpointResponse$Type()
 // @generated message type with reflection information, may provide speed optimized methods
+class CheckoutCheckpointRequest$Type extends MessageType<CheckoutCheckpointRequest> {
+  constructor() {
+    super('omega_edit.v1.CheckoutCheckpointRequest', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'checkpoint_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<CheckoutCheckpointRequest>
+  ): CheckoutCheckpointRequest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.checkpointCount = 0
+    if (value !== undefined)
+      reflectionMergePartial<CheckoutCheckpointRequest>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: CheckoutCheckpointRequest
+  ): CheckoutCheckpointRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* int64 checkpoint_count */ 2:
+          message.checkpointCount = reader.int64().toNumber()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: CheckoutCheckpointRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* int64 checkpoint_count = 2; */
+    if (message.checkpointCount !== 0)
+      writer.tag(2, WireType.Varint).int64(message.checkpointCount)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.CheckoutCheckpointRequest
+ */
+export const CheckoutCheckpointRequest = new CheckoutCheckpointRequest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class CheckoutCheckpointResponse$Type extends MessageType<CheckoutCheckpointResponse> {
+  constructor() {
+    super('omega_edit.v1.CheckoutCheckpointResponse', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'checkpoint_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 3,
+        name: 'future_checkpoint_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 4,
+        name: 'change_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<CheckoutCheckpointResponse>
+  ): CheckoutCheckpointResponse {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.checkpointCount = 0
+    message.futureCheckpointCount = 0
+    message.changeCount = 0
+    if (value !== undefined)
+      reflectionMergePartial<CheckoutCheckpointResponse>(this, message, value)
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: CheckoutCheckpointResponse
+  ): CheckoutCheckpointResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* int64 checkpoint_count */ 2:
+          message.checkpointCount = reader.int64().toNumber()
+          break
+        case /* int64 future_checkpoint_count */ 3:
+          message.futureCheckpointCount = reader.int64().toNumber()
+          break
+        case /* int64 change_count */ 4:
+          message.changeCount = reader.int64().toNumber()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: CheckoutCheckpointResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* int64 checkpoint_count = 2; */
+    if (message.checkpointCount !== 0)
+      writer.tag(2, WireType.Varint).int64(message.checkpointCount)
+    /* int64 future_checkpoint_count = 3; */
+    if (message.futureCheckpointCount !== 0)
+      writer.tag(3, WireType.Varint).int64(message.futureCheckpointCount)
+    /* int64 change_count = 4; */
+    if (message.changeCount !== 0)
+      writer.tag(4, WireType.Varint).int64(message.changeCount)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.CheckoutCheckpointResponse
+ */
+export const CheckoutCheckpointResponse = new CheckoutCheckpointResponse$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class DiscardCheckpointFutureRequest$Type extends MessageType<DiscardCheckpointFutureRequest> {
+  constructor() {
+    super('omega_edit.v1.DiscardCheckpointFutureRequest', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+    ])
+  }
+  create(
+    value?: PartialMessage<DiscardCheckpointFutureRequest>
+  ): DiscardCheckpointFutureRequest {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    if (value !== undefined)
+      reflectionMergePartial<DiscardCheckpointFutureRequest>(
+        this,
+        message,
+        value
+      )
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: DiscardCheckpointFutureRequest
+  ): DiscardCheckpointFutureRequest {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: DiscardCheckpointFutureRequest,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.DiscardCheckpointFutureRequest
+ */
+export const DiscardCheckpointFutureRequest =
+  new DiscardCheckpointFutureRequest$Type()
+// @generated message type with reflection information, may provide speed optimized methods
+class DiscardCheckpointFutureResponse$Type extends MessageType<DiscardCheckpointFutureResponse> {
+  constructor() {
+    super('omega_edit.v1.DiscardCheckpointFutureResponse', [
+      { no: 1, name: 'session_id', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 2,
+        name: 'discarded_checkpoint_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+      {
+        no: 3,
+        name: 'checkpoint_count',
+        kind: 'scalar',
+        T: 3 /*ScalarType.INT64*/,
+        L: 2 /*LongType.NUMBER*/,
+      },
+    ])
+  }
+  create(
+    value?: PartialMessage<DiscardCheckpointFutureResponse>
+  ): DiscardCheckpointFutureResponse {
+    const message = globalThis.Object.create(this.messagePrototype!)
+    message.sessionId = ''
+    message.discardedCheckpointCount = 0
+    message.checkpointCount = 0
+    if (value !== undefined)
+      reflectionMergePartial<DiscardCheckpointFutureResponse>(
+        this,
+        message,
+        value
+      )
+    return message
+  }
+  internalBinaryRead(
+    reader: IBinaryReader,
+    length: number,
+    options: BinaryReadOptions,
+    target?: DiscardCheckpointFutureResponse
+  ): DiscardCheckpointFutureResponse {
+    let message = target ?? this.create(),
+      end = reader.pos + length
+    while (reader.pos < end) {
+      let [fieldNo, wireType] = reader.tag()
+      switch (fieldNo) {
+        case /* string session_id */ 1:
+          message.sessionId = reader.string()
+          break
+        case /* int64 discarded_checkpoint_count */ 2:
+          message.discardedCheckpointCount = reader.int64().toNumber()
+          break
+        case /* int64 checkpoint_count */ 3:
+          message.checkpointCount = reader.int64().toNumber()
+          break
+        default:
+          let u = options.readUnknownField
+          if (u === 'throw')
+            throw new globalThis.Error(
+              `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
+            )
+          let d = reader.skip(wireType)
+          if (u !== false)
+            (u === true ? UnknownFieldHandler.onRead : u)(
+              this.typeName,
+              message,
+              fieldNo,
+              wireType,
+              d
+            )
+      }
+    }
+    return message
+  }
+  internalBinaryWrite(
+    message: DiscardCheckpointFutureResponse,
+    writer: IBinaryWriter,
+    options: BinaryWriteOptions
+  ): IBinaryWriter {
+    /* string session_id = 1; */
+    if (message.sessionId !== '')
+      writer.tag(1, WireType.LengthDelimited).string(message.sessionId)
+    /* int64 discarded_checkpoint_count = 2; */
+    if (message.discardedCheckpointCount !== 0)
+      writer.tag(2, WireType.Varint).int64(message.discardedCheckpointCount)
+    /* int64 checkpoint_count = 3; */
+    if (message.checkpointCount !== 0)
+      writer.tag(3, WireType.Varint).int64(message.checkpointCount)
+    let u = options.writeUnknownFields
+    if (u !== false)
+      (u == true ? UnknownFieldHandler.onWrite : u)(
+        this.typeName,
+        message,
+        writer
+      )
+    return writer
+  }
+}
+/**
+ * @generated MessageType for protobuf message omega_edit.v1.DiscardCheckpointFutureResponse
+ */
+export const DiscardCheckpointFutureResponse =
+  new DiscardCheckpointFutureResponse$Type()
+// @generated message type with reflection information, may provide speed optimized methods
 class RestoreLastCheckpointRequest$Type extends MessageType<RestoreLastCheckpointRequest> {
   constructor() {
     super('omega_edit.v1.RestoreLastCheckpointRequest', [
@@ -15056,6 +15502,18 @@ export const EditorService = new ServiceType('omega_edit.v1.EditorService', [
     options: {},
     I: DestroyLastCheckpointRequest,
     O: DestroyLastCheckpointResponse,
+  },
+  {
+    name: 'CheckoutCheckpoint',
+    options: {},
+    I: CheckoutCheckpointRequest,
+    O: CheckoutCheckpointResponse,
+  },
+  {
+    name: 'DiscardCheckpointFuture',
+    options: {},
+    I: DiscardCheckpointFutureRequest,
+    O: DiscardCheckpointFutureResponse,
   },
   {
     name: 'RestoreLastCheckpoint',

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -24,6 +24,7 @@ import {
   SessionFingerprintContent,
   type ApplyTransformPluginResponse,
   type CheckSessionModelResponse,
+  type CheckoutCheckpointResponse,
   type CreateCheckpointResponse,
   type CreateSessionRequest,
   type CreateSessionResponse,
@@ -40,6 +41,7 @@ import {
   type ListTransformPluginsResponse,
   type NotifyChangedViewportsResponse,
   type DestroyLastCheckpointResponse,
+  type DiscardCheckpointFutureResponse,
   type ReplaceSessionRequest,
   type ReplaceSessionResponse,
   type ReplaceSessionCheckpointedRequest,
@@ -1438,6 +1440,100 @@ export async function restoreLastCheckpoint(
           return resolve(required)
         } catch (error) {
           return reject(makeWrappedError('restoreLastCheckpoint', error))
+        }
+      }
+    )
+  })
+}
+
+export async function checkoutCheckpoint(
+  sessionId: string,
+  checkpointCount: number
+): Promise<CheckoutCheckpointResponse> {
+  const log = getLogger()
+  const request = { sessionId, checkpointCount }
+  debugLog(log, () => ({
+    fn: 'protobufTs.checkoutCheckpoint',
+    rqst: request,
+  }))
+  const client = await getClient()
+
+  return new Promise<CheckoutCheckpointResponse>((resolve, reject) => {
+    callUnary(client, client.checkoutCheckpoint, request, (err, response) => {
+      if (err) {
+        log.error({
+          fn: 'protobufTs.checkoutCheckpoint',
+          rqst: request,
+          err: {
+            msg: err.message,
+            details: err.details,
+            code: err.code,
+            stack: err.stack,
+          },
+        })
+        return reject(makeWrappedError('checkoutCheckpoint', err))
+      }
+
+      try {
+        const required = requireResponse(
+          response as CheckoutCheckpointResponse | undefined,
+          'checkoutCheckpoint'
+        )
+        debugLog(log, () => ({
+          fn: 'protobufTs.checkoutCheckpoint',
+          resp: required,
+        }))
+        return resolve(required)
+      } catch (error) {
+        return reject(makeWrappedError('checkoutCheckpoint', error))
+      }
+    })
+  })
+}
+
+export async function discardCheckpointFuture(
+  sessionId: string
+): Promise<DiscardCheckpointFutureResponse> {
+  const log = getLogger()
+  const request = { sessionId }
+  debugLog(log, () => ({
+    fn: 'protobufTs.discardCheckpointFuture',
+    rqst: request,
+  }))
+  const client = await getClient()
+
+  return new Promise<DiscardCheckpointFutureResponse>((resolve, reject) => {
+    callUnary(
+      client,
+      client.discardCheckpointFuture,
+      request,
+      (err, response) => {
+        if (err) {
+          log.error({
+            fn: 'protobufTs.discardCheckpointFuture',
+            rqst: request,
+            err: {
+              msg: err.message,
+              details: err.details,
+              code: err.code,
+              stack: err.stack,
+            },
+          })
+          return reject(makeWrappedError('discardCheckpointFuture', err))
+        }
+
+        try {
+          const required = requireResponse(
+            response as DiscardCheckpointFutureResponse | undefined,
+            'discardCheckpointFuture'
+          )
+          debugLog(log, () => ({
+            fn: 'protobufTs.discardCheckpointFuture',
+            resp: required,
+          }))
+          return resolve(required)
+        } catch (error) {
+          return reject(makeWrappedError('discardCheckpointFuture', error))
         }
       }
     )

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -28,6 +28,8 @@ import {
   ViewportEventKind as RawProtoViewportEventKind,
   type ApplyTransformPluginResponse as RawApplyTransformPluginResponse,
   type CheckSessionModelResponse as RawCheckSessionModelResponse,
+  type CheckoutCheckpointResponse as RawCheckoutCheckpointResponse,
+  type DiscardCheckpointFutureResponse as RawDiscardCheckpointFutureResponse,
   type GetSessionContentInfoResponse as RawGetSessionContentInfoResponse,
   type GetSessionFingerprintResponse as RawGetSessionFingerprintResponse,
   type InspectSessionContentResponse as RawInspectSessionContentResponse,
@@ -42,10 +44,12 @@ import {
   applyTransformPlugin as rawApplyTransformPlugin,
   beginSessionTransaction as rawBeginSessionTransaction,
   checkSessionModel as rawCheckSessionModel,
+  checkoutCheckpoint as rawCheckoutCheckpoint,
   countCharacters as rawCountCharacters,
   createCheckpoint as rawCreateCheckpoint,
   createSession as rawCreateSession,
   destroyLastCheckpoint as rawDestroyLastCheckpoint,
+  discardCheckpointFuture as rawDiscardCheckpointFuture,
   destroySession as rawDestroySession,
   getByteOrderMark as rawGetByteOrderMark,
   getComputedFileSize as rawGetComputedFileSize,
@@ -198,6 +202,8 @@ export type TransformPluginSupport =
 export type TransformPluginInfo = RawTransformPluginInfo
 export type ApplyTransformPluginResponse = RawApplyTransformPluginResponse
 export type RestoreLastCheckpointResponse = RawRestoreLastCheckpointResponse
+export type CheckoutCheckpointResponse = RawCheckoutCheckpointResponse
+export type DiscardCheckpointFutureResponse = RawDiscardCheckpointFutureResponse
 export type RestoreToChangeCountResponse = RawRestoreToChangeCountResponse
 export type CheckSessionModelResponse = RawCheckSessionModelResponse
 export type SessionContentInfo = RawSessionContentInfo
@@ -334,6 +340,39 @@ export async function restoreLastCheckpoint(
       'discarded change count',
       response.discardedChangeCount
     )
+    return response
+  })
+}
+
+export async function checkoutCheckpoint(
+  session_id: string,
+  checkpoint_count: number
+): Promise<CheckoutCheckpointResponse> {
+  return await enqueueSessionMutation(session_id, async () => {
+    const response = await rawCheckoutCheckpoint(
+      session_id,
+      requireSafeIntegerInput('checkpoint count', checkpoint_count)
+    )
+    requireSafeIntegerOutput('checkpoint count', response.checkpointCount)
+    requireSafeIntegerOutput(
+      'future checkpoint count',
+      response.futureCheckpointCount
+    )
+    requireSafeIntegerOutput('change count', response.changeCount)
+    return response
+  })
+}
+
+export async function discardCheckpointFuture(
+  session_id: string
+): Promise<DiscardCheckpointFutureResponse> {
+  return await enqueueSessionMutation(session_id, async () => {
+    const response = await rawDiscardCheckpointFuture(session_id)
+    requireSafeIntegerOutput(
+      'discarded checkpoint count',
+      response.discardedCheckpointCount
+    )
+    requireSafeIntegerOutput('checkpoint count', response.checkpointCount)
     return response
   })
 }

--- a/packages/client/tests/specs/editorPatterns.spec.ts
+++ b/packages/client/tests/specs/editorPatterns.spec.ts
@@ -255,8 +255,14 @@ describe('Editor Patterns', () => {
       },
     }
 
+    expect(history.willUndoCrossMilestone()).to.be.true
+    expect(history.willRedoCrossMilestone()).to.be.false
     await history.undo(executor)
+    expect(history.willUndoCrossMilestone()).to.be.false
+    expect(history.willRedoCrossMilestone()).to.be.true
     await history.redo(executor)
+    expect(history.willUndoCrossMilestone()).to.be.true
+    expect(history.willRedoCrossMilestone()).to.be.false
     expect(calls).to.deep.equal([
       'undoMilestone',
       'undoLocal',

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -18,6 +18,7 @@
  */
 
 import { expect, expectOpaqueId, opaqueIdPattern, testPort } from './common.js'
+import { status as GrpcStatus } from '@grpc/grpc-js'
 import {
   applyTransformPlugin,
   del,
@@ -966,7 +967,12 @@ describe('Sessions', () => {
       let checkoutRejected = false
       try {
         await checkoutCheckpoint(session_id, 2)
-      } catch {
+      } catch (err) {
+        const wrapped = err as Error & { cause?: { code?: number } }
+        expect(wrapped.cause?.code).to.equal(GrpcStatus.OUT_OF_RANGE)
+        expect(wrapped.message).to.include(
+          'checkpoint boundary is outside the materialized timeline'
+        )
         checkoutRejected = true
       }
       expect(checkoutRejected).to.be.true

--- a/packages/client/tests/specs/session.spec.ts
+++ b/packages/client/tests/specs/session.spec.ts
@@ -26,9 +26,11 @@ import {
   createSessionFromBytes,
   createViewport,
   createCheckpoint,
+  checkoutCheckpoint,
   CountKind,
   destroySession,
   destroyLastCheckpoint,
+  discardCheckpointFuture,
   getByteOrderMark,
   getClient,
   getChangeCount,
@@ -917,6 +919,60 @@ describe('Sessions', () => {
       expect(await destroyLastCheckpoint(session_id)).to.equal(0)
       expect(await getSessionBytes(session_id)).to.deep.equal(seed)
       expect(await getChangeCount(session_id)).to.equal(0)
+    } finally {
+      if (session_id) {
+        await destroySession(session_id)
+      }
+    }
+  })
+
+  it('Should preserve checkpoint redo until a branch edit', async () => {
+    const seed = Buffer.from('timeline')
+    let session_id = ''
+
+    try {
+      const session = await createSessionFromBytes(
+        seed,
+        'checkpoint_checkout_test'
+      )
+      session_id = session.getSessionId()
+
+      await insert(session_id, seed.length, Buffer.from('1'))
+      expect(await createCheckpoint(session_id)).to.equal(1)
+      await insert(session_id, seed.length + 1, Buffer.from('2'))
+      expect(await createCheckpoint(session_id)).to.equal(2)
+
+      let checkout = await checkoutCheckpoint(session_id, 0)
+      expect(checkout.checkpointCount).to.equal(0)
+      expect(checkout.futureCheckpointCount).to.equal(2)
+      expect(await getSessionBytes(session_id)).to.deep.equal(seed)
+
+      checkout = await checkoutCheckpoint(session_id, 2)
+      expect(checkout.checkpointCount).to.equal(2)
+      expect(checkout.futureCheckpointCount).to.equal(0)
+      expect(await getSessionBytes(session_id)).to.deep.equal(
+        Buffer.from('timeline12')
+      )
+
+      checkout = await checkoutCheckpoint(session_id, 1)
+      expect(checkout.futureCheckpointCount).to.equal(1)
+      expect(await getSessionBytes(session_id)).to.deep.equal(
+        Buffer.from('timeline1')
+      )
+      await insert(session_id, seed.length + 1, Buffer.from('X'))
+      const discarded = await discardCheckpointFuture(session_id)
+      expect(discarded.discardedCheckpointCount).to.equal(0)
+      expect(discarded.checkpointCount).to.equal(1)
+      let checkoutRejected = false
+      try {
+        await checkoutCheckpoint(session_id, 2)
+      } catch {
+        checkoutRejected = true
+      }
+      expect(checkoutRejected).to.be.true
+      expect(await getSessionBytes(session_id)).to.deep.equal(
+        Buffer.from('timeline1X')
+      )
     } finally {
       if (session_id) {
         await destroySession(session_id)

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -212,6 +212,12 @@ service EditorService {
     // checkpoint model and exposing the previous model again.
     rpc DestroyLastCheckpoint(DestroyLastCheckpointRequest) returns (DestroyLastCheckpointResponse);
 
+    // Move to a checkpoint boundary while preserving later checkpoints for fast-forward.
+    rpc CheckoutCheckpoint(CheckoutCheckpointRequest) returns (CheckoutCheckpointResponse);
+
+    // Permanently discard checkpoints after the active checkpoint boundary.
+    rpc DiscardCheckpointFuture(DiscardCheckpointFutureRequest) returns (DiscardCheckpointFutureResponse);
+
     // Restore session content to the most recent checkpoint snapshot while
     // keeping that checkpoint available.
     rpc RestoreLastCheckpoint(RestoreLastCheckpointRequest) returns (RestoreLastCheckpointResponse);
@@ -1136,6 +1142,32 @@ message DestroyLastCheckpointRequest {
 message DestroyLastCheckpointResponse {
     string session_id = 1;          // Session that was reverted.
     int64 remaining_checkpoints = 2;// Remaining checkpoint count after revert.
+}
+
+// Request to navigate to a materialized checkpoint boundary.
+message CheckoutCheckpointRequest {
+    string session_id = 1;      // Session to navigate.
+    int64 checkpoint_count = 2; // Checkpoint boundary to make active; zero is the original snapshot.
+}
+
+// Result of non-destructive checkpoint navigation.
+message CheckoutCheckpointResponse {
+    string session_id = 1;              // Session that was navigated.
+    int64 checkpoint_count = 2;          // Active checkpoint count after navigation.
+    int64 future_checkpoint_count = 3;   // Preserved checkpoint count available for fast-forward.
+    int64 change_count = 4;              // Active session change count after navigation.
+}
+
+// Request to destroy the preserved checkpoint branch after the active boundary.
+message DiscardCheckpointFutureRequest {
+    string session_id = 1; // Session whose checkpoint future should be discarded.
+}
+
+// Result of destroying a preserved checkpoint branch.
+message DiscardCheckpointFutureResponse {
+    string session_id = 1;              // Session whose future was discarded.
+    int64 discarded_checkpoint_count = 2;// Number of checkpoint models destroyed.
+    int64 checkpoint_count = 3;          // Active checkpoint count, which is unchanged.
 }
 
 // Request to restore the most recent checkpoint snapshot without discarding it.

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -1146,26 +1146,26 @@ message DestroyLastCheckpointResponse {
 
 // Request to navigate to a materialized checkpoint boundary.
 message CheckoutCheckpointRequest {
-    string session_id = 1;      // Session to navigate.
-    int64 checkpoint_count = 2; // Checkpoint boundary to make active; zero is the original snapshot.
+    string session_id = 1;     // Session to navigate.
+    int64 checkpoint_count = 2;// Checkpoint boundary to make active; zero is the original snapshot.
 }
 
 // Result of non-destructive checkpoint navigation.
 message CheckoutCheckpointResponse {
-    string session_id = 1;              // Session that was navigated.
-    int64 checkpoint_count = 2;          // Active checkpoint count after navigation.
-    int64 future_checkpoint_count = 3;   // Preserved checkpoint count available for fast-forward.
-    int64 change_count = 4;              // Active session change count after navigation.
+    string session_id = 1;            // Session that was navigated.
+    int64 checkpoint_count = 2;       // Active checkpoint count after navigation.
+    int64 future_checkpoint_count = 3;// Preserved checkpoint count available for fast-forward.
+    int64 change_count = 4;           // Active session change count after navigation.
 }
 
 // Request to destroy the preserved checkpoint branch after the active boundary.
 message DiscardCheckpointFutureRequest {
-    string session_id = 1; // Session whose checkpoint future should be discarded.
+    string session_id = 1;// Session whose checkpoint future should be discarded.
 }
 
 // Result of destroying a preserved checkpoint branch.
 message DiscardCheckpointFutureResponse {
-    string session_id = 1;              // Session whose future was discarded.
+    string session_id = 1;               // Session whose future was discarded.
     int64 discarded_checkpoint_count = 2;// Number of checkpoint models destroyed.
     int64 checkpoint_count = 3;          // Active checkpoint count, which is unchanged.
 }

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -3027,9 +3027,17 @@ namespace omega_edit {
             }
             auto *session = locked_session.session();
 
-            if (0 != omega_edit_checkout_checkpoint(session, request->checkpoint_count())) {
+            const auto requested_checkpoint_count = request->checkpoint_count();
+            const auto active_checkpoint_count = omega_session_get_num_checkpoints(session);
+            const auto future_checkpoint_count = omega_session_get_num_future_checkpoints(session);
+            if (requested_checkpoint_count < 0 ||
+                requested_checkpoint_count > active_checkpoint_count + future_checkpoint_count) {
                 return grpc::Status(grpc::StatusCode::OUT_OF_RANGE,
                                     "checkpoint boundary is outside the materialized timeline");
+            }
+
+            if (0 != omega_edit_checkout_checkpoint(session, requested_checkpoint_count)) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "failed to checkout checkpoint");
             }
 
             response->set_session_id(request->session_id());

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -3012,6 +3012,59 @@ namespace omega_edit {
             return grpc::Status::OK;
         }
 
+        grpc::Status EditorServiceImpl::CheckoutCheckpoint(grpc::ServerContext * /*context*/,
+                                                           const ::omega_edit::v1::CheckoutCheckpointRequest *request,
+                                                           ::omega_edit::v1::CheckoutCheckpointResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "checkout checkpoint",
+                                                          request->session_id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+
+            if (0 != omega_edit_checkout_checkpoint(session, request->checkpoint_count())) {
+                return grpc::Status(grpc::StatusCode::OUT_OF_RANGE,
+                                    "checkpoint boundary is outside the materialized timeline");
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_checkpoint_count(omega_session_get_num_checkpoints(session));
+            response->set_future_checkpoint_count(omega_session_get_num_future_checkpoints(session));
+            response->set_change_count(omega_session_get_num_changes(session));
+            return grpc::Status::OK;
+        }
+
+        grpc::Status
+        EditorServiceImpl::DiscardCheckpointFuture(grpc::ServerContext * /*context*/,
+                                                   const ::omega_edit::v1::DiscardCheckpointFutureRequest *request,
+                                                   ::omega_edit::v1::DiscardCheckpointFutureResponse *response) {
+            auto mutation_guard = session_manager_.try_begin_mutation(request->session_id());
+            if (!mutation_guard) {
+                return status_for_session_operation_start(mutation_guard.result(), "discard checkpoint future",
+                                                          request->session_id());
+            }
+
+            auto locked_session = session_manager_.lock_session(request->session_id());
+            if (!locked_session) {
+                return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
+            }
+            auto *session = locked_session.session();
+            const auto discarded = omega_edit_discard_checkpoint_future(session);
+            if (discarded < 0) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "failed to discard checkpoint future");
+            }
+
+            response->set_session_id(request->session_id());
+            response->set_discarded_checkpoint_count(discarded);
+            response->set_checkpoint_count(omega_session_get_num_checkpoints(session));
+            return grpc::Status::OK;
+        }
+
         grpc::Status
         EditorServiceImpl::RestoreLastCheckpoint(grpc::ServerContext * /*context*/,
                                                  const ::omega_edit::v1::RestoreLastCheckpointRequest *request,

--- a/server/cpp/src/editor_service.h
+++ b/server/cpp/src/editor_service.h
@@ -206,6 +206,14 @@ namespace omega_edit {
                                                const ::omega_edit::v1::DestroyLastCheckpointRequest *request,
                                                ::omega_edit::v1::DestroyLastCheckpointResponse *response) override;
 
+            grpc::Status CheckoutCheckpoint(grpc::ServerContext *context,
+                                            const ::omega_edit::v1::CheckoutCheckpointRequest *request,
+                                            ::omega_edit::v1::CheckoutCheckpointResponse *response) override;
+
+            grpc::Status DiscardCheckpointFuture(grpc::ServerContext *context,
+                                                 const ::omega_edit::v1::DiscardCheckpointFutureRequest *request,
+                                                 ::omega_edit::v1::DiscardCheckpointFutureResponse *response) override;
+
             grpc::Status RestoreLastCheckpoint(grpc::ServerContext *context,
                                                const ::omega_edit::v1::RestoreLastCheckpointRequest *request,
                                                ::omega_edit::v1::RestoreLastCheckpointResponse *response) override;

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -6642,6 +6642,7 @@ export class HexEditorProvider
   }
 
   private makeHistoryExecutor(session: EditorSession): EditorHistoryExecutor {
+    const provider = this
     return {
       async undoLocal() {
         await undo(session.sessionId)
@@ -6650,9 +6651,22 @@ export class HexEditorProvider
         await redo(session.sessionId)
       },
       async undoMilestone() {
+        const checkpointCount = await provider.getCheckpointCount(session)
+        if (
+          checkpointCount > 0 &&
+          session.checkpointTimeline.entries.length > 0
+        ) {
+          await checkoutCheckpoint(session.sessionId, checkpointCount - 1)
+          return
+        }
         await destroyLastCheckpoint(session.sessionId)
       },
       async redoMilestone() {
+        const checkpointCount = await provider.getCheckpointCount(session)
+        if (checkpointCount < session.checkpointTimeline.entries.length) {
+          await checkoutCheckpoint(session.sessionId, checkpointCount + 1)
+          return
+        }
         await createCheckpoint(session.sessionId)
       },
       async undoCheckpoint() {

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -36,12 +36,14 @@ import {
   changeLogHeaderForExport,
   ChangeKind,
   checkSessionModel,
+  checkoutCheckpoint,
   clear,
   countCharacters,
   CountKind,
   createCheckpoint,
   del,
   destroyLastCheckpoint,
+  discardCheckpointFuture,
   editSimple,
   type EditorChangeRecord as ChangeRecord,
   type EditorHistoryExecutor,
@@ -127,6 +129,7 @@ import {
   type ServerHealthMessage,
   type WebviewToHostMessage,
   bytesPerRowFromSetting,
+  checkpointTimelineMetadataWindow,
   normalizeExternalHighlights,
   normalizeBytesPerRow,
   normalizeBytesPerRowSetting,
@@ -4310,11 +4313,10 @@ export class HexEditorProvider
     }
 
     await this.captureCheckpointTimelineTip(session)
-    const nativeCheckpointCount =
-      await this.assertCheckpointTimelineNativeAlignment(
-        session,
-        'before navigation'
-      )
+    await this.assertCheckpointTimelineNativeAlignment(
+      session,
+      'before navigation'
+    )
 
     timeline.navigating = true
     this.postCheckpointTimeline(session)
@@ -4328,45 +4330,30 @@ export class HexEditorProvider
     const originalCursor = timeline.cursor
     try {
       const sessionSyncVersion = session.sessionSyncVersion
-      if (targetCheckpointCount < timeline.cursor) {
-        // Rewind relies only on native checkpoints. Durable archives are
-        // validated when fast-forward crosses them, so an unavailable future
-        // interval never prevents returning to the original content.
-        let remaining = nativeCheckpointCount
-        while (remaining > targetCheckpointCount) {
-          remaining = await destroyLastCheckpoint(session.sessionId)
-        }
-        if (targetCheckpointCount > 0) {
-          await restoreLastCheckpoint(session.sessionId)
-        } else {
-          await clear(session.sessionId)
-        }
-        const expected =
-          targetCheckpointCount === 0
-            ? timeline.originalFingerprint
-            : timeline.entries[targetCheckpointCount - 1].interval.after
-        await assertCurrentSessionFingerprint(
-          session.sessionId,
-          expected,
-          'after'
+      const response = await checkoutCheckpoint(
+        session.sessionId,
+        targetCheckpointCount
+      )
+      if (
+        response.checkpointCount !== targetCheckpointCount ||
+        response.futureCheckpointCount !==
+          timeline.entries.length - targetCheckpointCount
+      ) {
+        throw new Error(
+          `Native checkpoint checkout reached ${response.checkpointCount} with ${response.futureCheckpointCount} future checkpoints; expected ${targetCheckpointCount} with ${timeline.entries.length - targetCheckpointCount} future checkpoints`
         )
-        timeline.cursor = targetCheckpointCount
-        await timeline.storage?.setCursor(targetCheckpointCount)
-      } else {
-        for (
-          let next = timeline.cursor + 1;
-          next <= targetCheckpointCount;
-          next += 1
-        ) {
-          const entry = timeline.entries[next - 1]
-          if (!entry || entry.interval.checkpoint !== next) {
-            throw new Error(`Checkpoint ${next} is missing from the timeline`)
-          }
-          await this.replayCheckpointTimelineInterval(session, next)
-          timeline.cursor = next
-          await timeline.storage?.setCursor(next)
-        }
       }
+      const expected =
+        targetCheckpointCount === 0
+          ? timeline.originalFingerprint
+          : timeline.entries[targetCheckpointCount - 1].interval.after
+      await assertCurrentSessionFingerprint(
+        session.sessionId,
+        expected,
+        'after'
+      )
+      timeline.cursor = targetCheckpointCount
+      await timeline.storage?.setCursor(targetCheckpointCount)
 
       await this.waitForSessionSync(session, sessionSyncVersion)
       const currentFingerprint = await getChangeLogFingerprint(
@@ -4409,14 +4396,7 @@ export class HexEditorProvider
       console.warn(`Checkpoint timeline navigation failed: ${failureMessage}`)
       let rollbackFailure: string | undefined
       try {
-        let nativeCursor = await this.getCheckpointCount(session)
-        while (nativeCursor > originalCursor) {
-          nativeCursor = await destroyLastCheckpoint(session.sessionId)
-        }
-        while (nativeCursor < originalCursor) {
-          await this.replayCheckpointTimelineInterval(session, nativeCursor + 1)
-          nativeCursor += 1
-        }
+        await checkoutCheckpoint(session.sessionId, originalCursor)
         const originalFingerprint =
           originalCursor === 0
             ? timeline.originalFingerprint
@@ -4457,108 +4437,6 @@ export class HexEditorProvider
       if (failureMessage) {
         this.postTransformStatus(session, false, undefined, failureMessage)
       }
-    }
-  }
-
-  private async preflightCheckpointTimelineInterval(
-    session: EditorSession,
-    checkpoint: number
-  ): Promise<void> {
-    const entry = session.checkpointTimeline.entries[checkpoint - 1]
-    if (!entry || entry.interval.checkpoint !== checkpoint) {
-      throw new TimelineStorageError(
-        'TIMELINE_INTERVAL_UNAVAILABLE',
-        `Checkpoint ${checkpoint} is missing from the timeline`
-      )
-    }
-    const availablePlugins = new Set(
-      session.transformPlugins.map((plugin) => plugin.id)
-    )
-    const missingPlugins = entry.interval.transformPluginIds.filter(
-      (id) => !availablePlugins.has(id)
-    )
-    if (missingPlugins.length > 0) {
-      throw new TimelineStorageError(
-        'TIMELINE_PLUGIN_UNAVAILABLE',
-        `Checkpoint ${checkpoint} requires unavailable transform plugin(s): ${missingPlugins.join(', ')}`
-      )
-    }
-    const storage = session.checkpointTimeline.storage
-    if (!storage) {
-      throw new TimelineStorageError(
-        'TIMELINE_INTERVAL_UNAVAILABLE',
-        `Checkpoint ${checkpoint} has no durable replay archive`
-      )
-    }
-    try {
-      await storage.openInterval(checkpoint)
-    } catch (error) {
-      const code =
-        error instanceof TimelineStorageError
-          ? error.code
-          : 'TIMELINE_PREFLIGHT_FAILED'
-      const message = error instanceof Error ? error.message : String(error)
-      entry.interval = {
-        ...entry.interval,
-        state: 'unavailable',
-        archive: undefined,
-        error: { code, message },
-      }
-      entry.interval = await storage
-        .markIntervalUnavailable(checkpoint, code, message)
-        .catch(() => entry.interval)
-      this.postCheckpointTimeline(session)
-      throw error
-    }
-  }
-
-  private async replayCheckpointTimelineInterval(
-    session: EditorSession,
-    checkpoint: number
-  ): Promise<void> {
-    await this.preflightCheckpointTimelineInterval(session, checkpoint)
-    const entry = session.checkpointTimeline.entries[checkpoint - 1]
-    const startChangeCount = await getChangeCount(session.sessionId)
-    const startCheckpointCount = await this.getCheckpointCount(session)
-    await assertCurrentSessionFingerprint(
-      session.sessionId,
-      entry.interval.before,
-      'before'
-    )
-    try {
-      const archive =
-        await session.checkpointTimeline.storage?.openInterval(checkpoint)
-      if (!archive) throw new Error(`Checkpoint ${checkpoint} is unavailable`)
-      await this.applyChangeLogEntries(
-        session,
-        preparedChangeLogToParsed(archive).entries(),
-        entry.interval.after
-      )
-      const replayCheckpointCount = await this.getCheckpointCount(session)
-      if (replayCheckpointCount < checkpoint) {
-        await createCheckpoint(session.sessionId)
-      } else if (replayCheckpointCount > checkpoint) {
-        throw new Error(
-          `Checkpoint replay reached ${replayCheckpointCount}, expected ${checkpoint}`
-        )
-      }
-      await assertCurrentSessionFingerprint(
-        session.sessionId,
-        entry.interval.after,
-        'after'
-      )
-    } catch (error) {
-      let nativeCheckpointCount = await this.getCheckpointCount(session)
-      while (nativeCheckpointCount > startCheckpointCount) {
-        nativeCheckpointCount = await destroyLastCheckpoint(session.sessionId)
-      }
-      await restoreToChangeCount(session.sessionId, startChangeCount)
-      await assertCurrentSessionFingerprint(
-        session.sessionId,
-        entry.interval.before,
-        'before'
-      )
-      throw error
     }
   }
 
@@ -4735,23 +4613,41 @@ export class HexEditorProvider
     const availablePlugins = new Set(
       session.transformPlugins.map((plugin) => plugin.id)
     )
-    const intervalAvailable = (checkpoint: number): boolean => {
+    const intervalAvailability = (checkpoint: number) => {
       const interval = timeline.entries[checkpoint - 1]?.interval
-      return (
+      const missingPluginIds =
+        interval?.transformPluginIds.filter(
+          (id) => !availablePlugins.has(id)
+        ) ?? []
+      const available =
         !!timeline.storage &&
         interval?.state === 'ready' &&
-        interval.transformPluginIds.every((id) => availablePlugins.has(id))
-      )
+        missingPluginIds.length === 0
+      return {
+        available,
+        missingPluginIds,
+        error:
+          interval?.error?.message ??
+          (!timeline.storage
+            ? 'Checkpoint history storage is unavailable'
+            : missingPluginIds.length > 0
+              ? `Missing transform plugin(s): ${missingPluginIds.join(', ')}`
+              : undefined),
+      }
     }
     const canRewind = timeline.cursor > 0
-    const canFastForward =
-      timeline.cursor < timeline.entries.length &&
-      intervalAvailable(timeline.cursor + 1)
+    const canFastForward = timeline.cursor < timeline.entries.length
+    const metadataCheckpoints = checkpointTimelineMetadataWindow(
+      timeline.entries.length,
+      timeline.cursor,
+      savedCheckpoint
+    )
     this.postWebviewMessage(session, {
       type: 'checkpointTimeline',
       visible: timeline.visible,
       cursor: timeline.cursor,
       checkpointCount: timeline.entries.length,
+      originalByteLength: String(timeline.originalFingerprint.byteLength),
       savedChangeCount: timeline.savedChangeCount,
       savedCheckpoint,
       savedOffBranch:
@@ -4764,15 +4660,30 @@ export class HexEditorProvider
       canRewind,
       canFastForward,
       navigating: timeline.navigating,
-      checkpoints: timeline.entries
-        .filter((entry) => entry.interval.boundaryKind !== 'tip')
-        .map((entry) => ({
-          checkpoint: entry.interval.checkpoint,
+      checkpoints: metadataCheckpoints.map((checkpoint) => {
+        const entry = timeline.entries[checkpoint - 1]
+        const availability = intervalAvailability(checkpoint)
+        return {
+          checkpoint,
           changeCount: entry.changeCount,
+          sourceChangeCount: entry.interval.sourceChangeCount,
+          ...(entry.interval.archive
+            ? {
+                replayChangeCount: entry.interval.archive.emittedChangeCount,
+                archiveByteLength: entry.interval.archive.byteLength,
+              }
+            : {}),
+          byteLengthBefore: entry.interval.before.byteLength,
+          byteLengthAfter: entry.interval.after.byteLength,
+          boundaryKind: entry.interval.boundaryKind,
+          transformPluginIds: entry.interval.transformPluginIds,
+          missingPluginIds: availability.missingPluginIds,
+          optimized: entry.interval.archive?.optimized ?? false,
           createdAt: Date.parse(entry.interval.createdAt),
-          available: intervalAvailable(entry.interval.checkpoint),
-          error: entry.interval.error?.message,
-        })),
+          available: availability.available,
+          error: availability.error,
+        }
+      }),
     })
   }
 
@@ -6107,6 +6018,12 @@ export class HexEditorProvider
       cursor >= timeline.entries.length
     ) {
       return
+    }
+    const discarded = await discardCheckpointFuture(session.sessionId)
+    if (discarded.checkpointCount < cursor) {
+      throw new Error(
+        `Native checkpoint branch is at ${discarded.checkpointCount}, before timeline cursor ${cursor}`
+      )
     }
     try {
       await timeline.storage?.truncateFuture(cursor)

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -6642,47 +6642,58 @@ export class HexEditorProvider
   }
 
   private makeHistoryExecutor(session: EditorSession): EditorHistoryExecutor {
-    const provider = this
-    const history = session.history.snapshot()
     const hasTimeline = session.checkpointTimeline.entries.length > 0
     const undoCrossesTimelineMilestone =
-      hasTimeline &&
-      history.milestoneDepths.includes(history.transactionLog.length)
+      hasTimeline && session.history.willUndoCrossMilestone()
     const redoCrossesTimelineMilestone =
-      hasTimeline &&
-      history.milestoneDepths.includes(history.transactionLog.length + 1)
+      hasTimeline && session.history.willRedoCrossMilestone()
+    const checkoutTimelineMilestone = async (direction: -1 | 1) => {
+      const targetCheckpoint = session.checkpointTimeline.cursor + direction
+      if (
+        targetCheckpoint < 0 ||
+        targetCheckpoint > session.checkpointTimeline.entries.length
+      ) {
+        throw new Error(
+          `Checkpoint milestone target ${targetCheckpoint} is outside the materialized timeline`
+        )
+      }
+      await checkoutCheckpoint(session.sessionId, targetCheckpoint)
+    }
     return {
       async undoLocal() {
-        if (undoCrossesTimelineMilestone) return
+        if (undoCrossesTimelineMilestone) {
+          await checkoutTimelineMilestone(-1)
+          return
+        }
         await undo(session.sessionId)
       },
       async redoLocal() {
-        if (redoCrossesTimelineMilestone) return
+        if (redoCrossesTimelineMilestone) {
+          await checkoutTimelineMilestone(1)
+          return
+        }
         await redo(session.sessionId)
       },
       async undoMilestone() {
-        const checkpointCount = await provider.getCheckpointCount(session)
-        if (
-          checkpointCount > 0 &&
-          session.checkpointTimeline.entries.length > 0
-        ) {
-          await checkoutCheckpoint(session.sessionId, checkpointCount - 1)
-          return
-        }
+        if (undoCrossesTimelineMilestone) return
         await destroyLastCheckpoint(session.sessionId)
       },
       async redoMilestone() {
-        const checkpointCount = await provider.getCheckpointCount(session)
-        if (checkpointCount < session.checkpointTimeline.entries.length) {
-          await checkoutCheckpoint(session.sessionId, checkpointCount + 1)
-          return
-        }
+        if (redoCrossesTimelineMilestone) return
         await createCheckpoint(session.sessionId)
       },
       async undoCheckpoint() {
+        if (hasTimeline) {
+          await checkoutTimelineMilestone(-1)
+          return
+        }
         await destroyLastCheckpoint(session.sessionId)
       },
       async redoCheckpoint(transaction) {
+        if (hasTimeline) {
+          await checkoutTimelineMilestone(1)
+          return
+        }
         const pattern = transaction.isHex
           ? Buffer.from(transaction.query, 'hex')
           : Buffer.from(transaction.query, 'utf8')

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -6643,11 +6643,21 @@ export class HexEditorProvider
 
   private makeHistoryExecutor(session: EditorSession): EditorHistoryExecutor {
     const provider = this
+    const history = session.history.snapshot()
+    const hasTimeline = session.checkpointTimeline.entries.length > 0
+    const undoCrossesTimelineMilestone =
+      hasTimeline &&
+      history.milestoneDepths.includes(history.transactionLog.length)
+    const redoCrossesTimelineMilestone =
+      hasTimeline &&
+      history.milestoneDepths.includes(history.transactionLog.length + 1)
     return {
       async undoLocal() {
+        if (undoCrossesTimelineMilestone) return
         await undo(session.sessionId)
       },
       async redoLocal() {
+        if (redoCrossesTimelineMilestone) return
         await redo(session.sessionId)
       },
       async undoMilestone() {

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -1138,8 +1138,15 @@ export function normalizeWebviewMessage(
         raw.contentSource === undefined
           ? 'computed'
           : safeSessionContentSource(raw.contentSource)
+      // Transform APIs use zero length as the sentinel for offset through EOF.
       const range = contentSource
-        ? safeContentLengthRange(context, contentSource, raw.offset, raw.length)
+        ? safeContentLengthRange(
+            context,
+            contentSource,
+            raw.offset,
+            raw.length,
+            true
+          )
         : undefined
       const optionsJson =
         raw.optionsJson === undefined

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -30,6 +30,54 @@ export const TEXT_ENCODING_OPTIONS = [
   'macroman',
 ] as const
 export const DEFAULT_TEXT_ENCODING = 'ascii'
+const TIMELINE_METADATA_EDGE_COUNT = 8
+const TIMELINE_METADATA_CONTEXT_RADIUS = 12
+const TIMELINE_METADATA_SAVED_RADIUS = 4
+const TIMELINE_METADATA_SAMPLE_COUNT = 24
+
+export function checkpointTimelineMetadataWindow(
+  checkpointCount: number,
+  cursor: number,
+  savedCheckpoint?: number
+): number[] {
+  const checkpoints = new Set<number>()
+  const add = (checkpoint: number) => {
+    if (checkpoint >= 1 && checkpoint <= checkpointCount) {
+      checkpoints.add(checkpoint)
+    }
+  }
+  const addRange = (first: number, last: number) => {
+    for (let checkpoint = first; checkpoint <= last; checkpoint += 1) {
+      add(checkpoint)
+    }
+  }
+
+  addRange(1, TIMELINE_METADATA_EDGE_COUNT)
+  addRange(checkpointCount - TIMELINE_METADATA_EDGE_COUNT + 1, checkpointCount)
+  addRange(
+    cursor - TIMELINE_METADATA_CONTEXT_RADIUS,
+    cursor + TIMELINE_METADATA_CONTEXT_RADIUS
+  )
+  if (savedCheckpoint !== undefined) {
+    addRange(
+      savedCheckpoint - TIMELINE_METADATA_SAVED_RADIUS,
+      savedCheckpoint + TIMELINE_METADATA_SAVED_RADIUS
+    )
+  }
+  if (checkpointCount > 1) {
+    for (let index = 0; index < TIMELINE_METADATA_SAMPLE_COUNT; index += 1) {
+      add(
+        1 +
+          Math.round(
+            ((checkpointCount - 1) * index) /
+              (TIMELINE_METADATA_SAMPLE_COUNT - 1)
+          )
+      )
+    }
+  }
+
+  return [...checkpoints].sort((left, right) => left - right)
+}
 
 export type BytesPerRow = number
 export type BytesPerRowMode = 'fixed' | 'auto'
@@ -348,6 +396,7 @@ export type HostToWebviewMessage =
       visible: boolean
       cursor: number
       checkpointCount: number
+      originalByteLength: string
       savedChangeCount: number
       savedCheckpoint?: number
       savedOffBranch: boolean
@@ -357,6 +406,15 @@ export type HostToWebviewMessage =
       checkpoints: Array<{
         checkpoint: number
         changeCount: number
+        sourceChangeCount: string
+        replayChangeCount?: string
+        byteLengthBefore: string
+        byteLengthAfter: string
+        archiveByteLength?: string
+        boundaryKind: 'plain' | 'transform' | 'tip'
+        transformPluginIds: string[]
+        missingPluginIds: string[]
+        optimized: boolean
         createdAt: number
         available: boolean
         error?: string

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -41,6 +41,7 @@ const {
 const {
   MAX_ANALYSIS_PROFILE_BYTES,
   MAX_TRANSFORM_OPTIONS_LENGTH,
+  checkpointTimelineMetadataWindow,
   normalizeExternalHighlights,
   normalizeBytesPerRow,
   normalizeWebviewMessage,
@@ -2541,6 +2542,29 @@ test('range map file-fit validation names the offending node', () => {
     () => assertRangeMapFitsFile(parsed, 6),
     /Range map node \/too-far \[6, 7\) is outside file bounds \(6 bytes\)/
   )
+})
+
+test('checkpoint timeline metadata stays bounded around important positions', () => {
+  const checkpoints = checkpointTimelineMetadataWindow(
+    1_000_000,
+    500_000,
+    750_000
+  )
+
+  assert.ok(checkpoints.length <= 75)
+  assert.deepEqual(
+    checkpoints,
+    checkpoints.toSorted((left, right) => left - right)
+  )
+  assert.equal(new Set(checkpoints).size, checkpoints.length)
+  for (const checkpoint of [
+    1, 8, 499_988, 500_000, 500_012, 750_000, 999_993, 1_000_000,
+  ]) {
+    assert.ok(
+      checkpoints.includes(checkpoint),
+      `expected checkpoint ${checkpoint}`
+    )
+  }
 })
 
 test('webview protocol normalizes editor commands and rejects invalid ranges', () => {

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -3132,14 +3132,21 @@ test('webview protocol normalizes analysis, search, and transform messages', () 
       optionsJson: '{ "operator": "xor", "mask": [255] }',
     }
   )
-  assert.equal(
+  assert.deepEqual(
     normalizeWebviewMessage(context, {
       type: 'applyTransform',
       pluginId: 'omega.example.bitwise',
-      offset: 1,
+      offset: 0,
       length: 0,
     }),
-    undefined
+    {
+      type: 'applyTransform',
+      pluginId: 'omega.example.bitwise',
+      contentSource: 'computed',
+      offset: 0,
+      length: 0,
+      optionsJson: undefined,
+    }
   )
   assert.equal(
     normalizeWebviewMessage(context, {

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -1377,7 +1377,7 @@ suite('OmegaEdit VS Code extension', () => {
     assert.equal(
       lastMessageOfType(panel.messages, 'checkpointTimeline').checkpoints
         .length,
-      2
+      3
     )
     await provider.dispatchWebviewMessageForTesting(document.uri, {
       type: 'navigateCheckpointTimeline',
@@ -1465,22 +1465,86 @@ suite('OmegaEdit VS Code extension', () => {
     )
     await provider.navigateToCheckpoint(session, 1)
     await assertSessionText(session.sessionId, 'Xbc')
-    await assert.rejects(
-      provider.navigateToCheckpoint(session, 2),
-      /archive length changed.*restored checkpoint 1/
-    )
-    await assertSessionText(session.sessionId, 'Xbc')
-    const unavailableTimeline = lastMessageOfType(
+    await provider.navigateToCheckpoint(session, 2)
+    await assertSessionText(session.sessionId, 'XYc')
+    const materializedTimeline = lastMessageOfType(
       panel.messages,
       'checkpointTimeline'
     )
-    assert.equal(unavailableTimeline.cursor, 1)
-    assert.equal(unavailableTimeline.canRewind, true)
-    assert.equal(unavailableTimeline.canFastForward, false)
-    assert.equal(unavailableTimeline.checkpoints[1].available, false)
+    assert.equal(materializedTimeline.cursor, 2)
+    assert.equal(materializedTimeline.canRewind, true)
+    assert.equal(materializedTimeline.canFastForward, false)
 
     await provider.navigateToCheckpoint(session, 0)
     await assertSessionText(session.sessionId, 'abc')
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('checks out a full-range Zstandard transform across the checkpoint timeline', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-transform-timeline-')
+    )
+    const samplePath = path.join(tmpDir, 'transform-timeline.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a session for transform timeline navigation')
+
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      {
+        type: 'applyTransform',
+        pluginId: 'omega.example.zstd',
+        offset: 0,
+        length: 0,
+        optionsJson: JSON.stringify({ action: 'compress', level: 3 }),
+      },
+      { propagateErrors: true }
+    )
+    const transformedBytes = await readSessionBytes(session.sessionId)
+    assert.notDeepEqual(transformedBytes, Buffer.from('abc', 'utf8'))
+    assert.equal(session.checkpointTimeline.entries.length, 1)
+    const transformedTimeline = lastMessageOfType(
+      panel.messages,
+      'checkpointTimeline'
+    )
+    assert.equal(transformedTimeline.originalByteLength, '3')
+    assert.equal(transformedTimeline.checkpoints[0].boundaryKind, 'transform')
+    assert.equal(transformedTimeline.checkpoints[0].sourceChangeCount, '1')
+    assert.equal(transformedTimeline.checkpoints[0].replayChangeCount, '1')
+    assert.equal(transformedTimeline.checkpoints[0].byteLengthBefore, '3')
+    assert.equal(
+      transformedTimeline.checkpoints[0].byteLengthAfter,
+      String(transformedBytes.length)
+    )
+    assert.deepEqual(transformedTimeline.checkpoints[0].transformPluginIds, [
+      'omega.example.zstd',
+    ])
+
+    await provider.navigateToCheckpoint(session, 0)
+    await assertSessionText(session.sessionId, 'abc')
+
+    await provider.navigateToCheckpoint(session, 1)
+    assert.deepEqual(
+      await readSessionBytes(session.sessionId),
+      transformedBytes
+    )
+    assert.equal(session.checkpointTimeline.cursor, 1)
 
     await panel.fireDidDispose()
     await fs.rm(tmpDir, { recursive: true, force: true })
@@ -1531,13 +1595,16 @@ suite('OmegaEdit VS Code extension', () => {
     await assertSessionText(session.sessionId, 'abefij')
     assert.equal(session.checkpointTimeline.cursor, 2)
 
-    // Rewind is native-only and must remain available even if replay storage
-    // is unavailable or damaged.
+    // Both directions use materialized native checkpoints and remain available
+    // even if the durable audit archive is unavailable or damaged.
     const timelineStorage = session.checkpointTimeline.storage
     session.checkpointTimeline.storage = undefined
     await provider.navigateToCheckpoint(session, 1)
     await assertSessionText(session.sessionId, 'abefghij')
     assert.equal(session.checkpointTimeline.cursor, 1)
+    await provider.navigateToCheckpoint(session, 2)
+    await assertSessionText(session.sessionId, 'abefij')
+    await provider.navigateToCheckpoint(session, 1)
     session.checkpointTimeline.storage = timelineStorage
 
     for (let cycle = 0; cycle < 3; cycle += 1) {

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -3146,6 +3146,24 @@ suite('OmegaEdit VS Code extension', () => {
     })
 
     await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'undo',
+    })
+    await assertSessionText(session.sessionId, original)
+    let timeline = lastMessageOfType(panel.messages, 'checkpointTimeline')
+    assert.equal(timeline.checkpointCount, 1)
+    assert.equal(timeline.cursor, 0)
+    assert.equal(timeline.canFastForward, true)
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'redo',
+    })
+    await assertSessionText(session.sessionId, replaced)
+    timeline = lastMessageOfType(panel.messages, 'checkpointTimeline')
+    assert.equal(timeline.checkpointCount, 1)
+    assert.equal(timeline.cursor, 1)
+    assert.equal(timeline.canRewind, true)
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
       type: 'insert',
       offset: 0,
       data: Buffer.from('!', 'utf8').toString('hex'),
@@ -3215,6 +3233,24 @@ suite('OmegaEdit VS Code extension', () => {
     await assertSessionText(session.sessionId, original)
     await provider.navigateToCheckpoint(session, 1)
     await assertSessionText(session.sessionId, replaced)
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'undo',
+    })
+    await assertSessionText(session.sessionId, original)
+    timeline = lastMessageOfType(panel.messages, 'checkpointTimeline')
+    assert.equal(timeline.checkpointCount, 2)
+    assert.equal(timeline.cursor, 0)
+    assert.equal(timeline.canFastForward, true)
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'redo',
+    })
+    await assertSessionText(session.sessionId, replaced)
+    timeline = lastMessageOfType(panel.messages, 'checkpointTimeline')
+    assert.equal(timeline.checkpointCount, 2)
+    assert.equal(timeline.cursor, 1)
+    assert.equal(timeline.canRewind, true)
 
     await panel.fireDidDispose()
     await fs.rm(tmpDir, { recursive: true, force: true })

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -231,6 +231,7 @@
     visible: false,
     cursor: 0,
     checkpointCount: 0,
+    originalByteLength: String(initialFileSize),
     savedChangeCount: 0,
     savedOffBranch: false,
     canRewind: false,
@@ -2972,6 +2973,7 @@
     <CheckpointTimeline
       cursor={checkpointTimeline.cursor}
       checkpointCount={checkpointTimeline.checkpointCount}
+      originalByteLength={checkpointTimeline.originalByteLength}
       savedChangeCount={checkpointTimeline.savedChangeCount}
       savedCheckpoint={checkpointTimeline.savedCheckpoint}
       savedOffBranch={checkpointTimeline.savedOffBranch}

--- a/vscode-extension/webview-ui/src/components/CheckpointTimeline.svelte
+++ b/vscode-extension/webview-ui/src/components/CheckpointTimeline.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
   import { formatNumber, strings } from '../i18n'
 
-  const MAX_VISIBLE_MARKERS = 40
+  const MAX_VISIBLE_MARKERS = 24
 
   interface CheckpointMarker {
     checkpoint: number
     changeCount: number
+    sourceChangeCount: string
+    replayChangeCount?: string
+    byteLengthBefore: string
+    byteLengthAfter: string
+    archiveByteLength?: string
+    boundaryKind: 'plain' | 'transform' | 'tip'
+    transformPluginIds: string[]
+    missingPluginIds: string[]
+    optimized: boolean
     createdAt: number
     available: boolean
     error?: string
@@ -14,6 +23,7 @@
   interface Props {
     cursor: number
     checkpointCount: number
+    originalByteLength: string
     savedChangeCount: number
     savedCheckpoint?: number
     savedOffBranch: boolean
@@ -28,6 +38,7 @@
   let {
     cursor,
     checkpointCount,
+    originalByteLength,
     savedChangeCount,
     savedCheckpoint,
     savedOffBranch,
@@ -51,21 +62,89 @@
     return checkpoints.filter((checkpoint) => !checkpoint.available).length
   }
 
+  function decimal(value: string): bigint {
+    try {
+      return BigInt(value)
+    } catch {
+      return 0n
+    }
+  }
+
+  function formatBytes(value: string): string {
+    return `${formatNumber(decimal(value))} B`
+  }
+
+  function formatDelta(before: string, after: string): string {
+    const delta = decimal(after) - decimal(before)
+    return `${delta > 0n ? '+' : ''}${formatNumber(delta)} B`
+  }
+
+  function boundaryLabel(kind: CheckpointMarker['boundaryKind']): string {
+    switch (kind) {
+      case 'transform':
+        return strings.timeline.boundaryTransform
+      case 'tip':
+        return strings.timeline.boundaryTip
+      default:
+        return strings.timeline.boundaryPlain
+    }
+  }
+
+  function markerTitle(checkpoint: CheckpointMarker): string {
+    const parts = [
+      strings.timeline.checkpoint(checkpoint.checkpoint),
+      boundaryLabel(checkpoint.boundaryKind),
+      strings.timeline.changesInInterval(decimal(checkpoint.sourceChangeCount)),
+      `${formatBytes(checkpoint.byteLengthBefore)} → ${formatBytes(checkpoint.byteLengthAfter)}`,
+    ]
+    if (checkpoint.checkpoint === savedCheckpoint) parts.push(strings.timeline.savedAtCheckpoint(checkpoint.checkpoint))
+    if (!checkpoint.available) parts.push(checkpoint.error ?? strings.timeline.unavailable)
+    return parts.join('; ')
+  }
+
   const visibleCheckpoints = $derived.by(() => {
     if (checkpoints.length <= MAX_VISIBLE_MARKERS) return checkpoints
-    const edgeCount = Math.floor(MAX_VISIBLE_MARKERS / 2)
-    const candidates = [
-      ...checkpoints.slice(0, edgeCount),
-      ...checkpoints.slice(-edgeCount),
-    ]
-    const saved = checkpoints.find(
-      (checkpoint) => checkpoint.checkpoint === savedCheckpoint
-    )
-    if (saved) candidates.push(saved)
-    return [...new Map(candidates.map((item) => [item.checkpoint, item])).values()].sort(
+    const candidates = new Map<number, CheckpointMarker>()
+    const add = (checkpoint: CheckpointMarker | undefined) => {
+      if (checkpoint) candidates.set(checkpoint.checkpoint, checkpoint)
+    }
+    checkpoints.slice(0, 4).forEach(add)
+    checkpoints.slice(-4).forEach(add)
+    const nearestCursor = [...checkpoints]
+      .sort(
+        (left, right) =>
+          Math.abs(left.checkpoint - cursor) - Math.abs(right.checkpoint - cursor)
+      )
+      .slice(0, 10)
+    nearestCursor.forEach(add)
+    if (savedCheckpoint !== undefined) {
+      const nearestSaved = [...checkpoints]
+        .sort(
+          (left, right) =>
+            Math.abs(left.checkpoint - savedCheckpoint) -
+            Math.abs(right.checkpoint - savedCheckpoint)
+        )
+        .slice(0, 3)
+      nearestSaved.forEach(add)
+    }
+    const remaining = MAX_VISIBLE_MARKERS - candidates.size
+    for (let index = 0; index < remaining; index += 1) {
+      add(
+        checkpoints[
+          Math.round(((checkpoints.length - 1) * index) / Math.max(1, remaining - 1))
+        ]
+      )
+    }
+    return [...candidates.values()].sort(
       (left, right) => left.checkpoint - right.checkpoint
     )
   })
+
+  const currentCheckpoint = $derived(
+    cursor === 0
+      ? undefined
+      : checkpoints.find((checkpoint) => checkpoint.checkpoint === cursor)
+  )
 
   const savedPositionText = $derived(
     savedOffBranch
@@ -84,12 +163,14 @@
   aria-busy={navigating}
 >
   <div class="timeline-heading">
-    <strong>{strings.timeline.label}</strong>
-    <span id="timeline-state" aria-live="polite">
-      {navigating
-        ? strings.timeline.navigating
-        : strings.timeline.position(cursor === 0 ? strings.timeline.original : strings.timeline.checkpoint(cursor), checkpointCount)}
-    </span>
+    <div class="timeline-title">
+      <strong>{strings.timeline.label}</strong>
+      <span id="timeline-state" aria-live="polite">
+        {navigating
+          ? strings.timeline.navigating
+          : strings.timeline.position(cursor === 0 ? strings.timeline.original : strings.timeline.checkpoint(cursor), checkpointCount)}
+      </span>
+    </div>
     <span id="timeline-saved" class:saved-off-branch={savedOffBranch} class="saved-position">
       {savedOffBranch
         ? strings.timeline.savedOffBranch
@@ -99,88 +180,153 @@
           ? strings.timeline.savedAtOriginal
           : strings.timeline.savedAtCheckpoint(savedCheckpoint)}
     </span>
+    <button
+      type="button"
+      class="panel-close timeline-close"
+      aria-label={strings.timeline.close}
+      title={strings.timeline.close}
+      onclick={onClose}
+    >&times;</button>
   </div>
-  <button
-    type="button"
-    class="timeline-step"
-    aria-label={strings.timeline.previous}
-    title={strings.timeline.previousTitle}
-    disabled={navigating || !canRewind}
-    onclick={() => onNavigate(cursor - 1)}
-  >&#x25C0;</button>
-  <input
-    class="timeline-slider"
-    type="range"
-    min="0"
-    max={checkpointCount}
-    step="1"
-    value={cursor}
-    aria-label={strings.timeline.current}
-    aria-describedby="timeline-state timeline-saved timeline-availability"
-    aria-valuetext={`${cursor === 0 ? strings.timeline.original : strings.timeline.checkpoint(cursor)}; ${savedPositionText}`}
-    disabled={navigating || checkpointCount === 0}
-    onchange={handleChange}
-  />
-  <button
-    type="button"
-    class="timeline-step"
-    aria-label={strings.timeline.next}
-    title={strings.timeline.nextTitle}
-    disabled={navigating || !canFastForward}
-    onclick={() => onNavigate(cursor + 1)}
-  >&#x25B6;</button>
-  <div class="timeline-markers" aria-hidden="true">
-    <span class:saved={savedCheckpoint === 0}>{strings.timeline.originalMarker}</span>
+
+  <div class="timeline-controls">
+    <button
+      type="button"
+      class="timeline-step"
+      aria-label={strings.timeline.previous}
+      title={strings.timeline.previousTitle}
+      disabled={navigating || !canRewind}
+      onclick={() => onNavigate(cursor - 1)}
+    >&#x25C0;</button>
+    <input
+      class="timeline-slider"
+      type="range"
+      min="0"
+      max={checkpointCount}
+      step="1"
+      value={cursor}
+      aria-label={strings.timeline.current}
+      aria-describedby="timeline-state timeline-saved timeline-availability timeline-details"
+      aria-valuetext={`${cursor === 0 ? strings.timeline.original : strings.timeline.checkpoint(cursor)}; ${savedPositionText}`}
+      disabled={navigating || checkpointCount === 0}
+      onchange={handleChange}
+    />
+    <button
+      type="button"
+      class="timeline-step"
+      aria-label={strings.timeline.next}
+      title={strings.timeline.nextTitle}
+      disabled={navigating || !canFastForward}
+      onclick={() => onNavigate(cursor + 1)}
+    >&#x25B6;</button>
+  </div>
+
+  <nav class="timeline-markers" aria-label={strings.timeline.label}>
+    <button
+      type="button"
+      class:current={cursor === 0}
+      class:saved={savedCheckpoint === 0}
+      title={`${strings.timeline.original}; ${formatBytes(originalByteLength)}`}
+      disabled={navigating}
+      aria-current={cursor === 0 ? 'step' : undefined}
+      onclick={() => cursor !== 0 && onNavigate(0)}
+    >{strings.timeline.originalMarker}</button>
     {#each visibleCheckpoints as checkpoint}
-      <span
+      <button
+        type="button"
+        class:current={checkpoint.checkpoint === cursor}
         class:saved={checkpoint.checkpoint === savedCheckpoint}
         class:unavailable={!checkpoint.available}
-        title={checkpoint.available
-          ? strings.timeline.marker(checkpoint.checkpoint, checkpoint.changeCount, checkpoint.checkpoint === savedCheckpoint)
-          : `${strings.timeline.marker(checkpoint.checkpoint, checkpoint.changeCount, checkpoint.checkpoint === savedCheckpoint)}; ${checkpoint.error ?? strings.timeline.unavailable}`}
-      >
-        {formatNumber(checkpoint.checkpoint)}
-      </span>
+        title={markerTitle(checkpoint)}
+        disabled={navigating}
+        aria-current={checkpoint.checkpoint === cursor ? 'step' : undefined}
+        onclick={() => checkpoint.checkpoint !== cursor && onNavigate(checkpoint.checkpoint)}
+      >{formatNumber(checkpoint.checkpoint)}</button>
     {/each}
-    {#if checkpoints.length > visibleCheckpoints.length}
-      <span title={strings.timeline.hiddenMarkers(checkpoints.length - visibleCheckpoints.length)}>
-        +{formatNumber(checkpoints.length - visibleCheckpoints.length)}
+    {#if checkpointCount > visibleCheckpoints.length}
+      <span class="hidden-markers" title={strings.timeline.hiddenMarkers(checkpointCount - visibleCheckpoints.length)}>
+        +{formatNumber(checkpointCount - visibleCheckpoints.length)}
       </span>
     {/if}
+  </nav>
+
+  <div id="timeline-details" class="timeline-details" aria-live="polite">
+    {#if cursor === 0}
+      <strong>{strings.timeline.original}</strong>
+      <span>{strings.timeline.originalDescription}</span>
+      <span class="timeline-metric"><b>{strings.timeline.size}</b> {formatBytes(originalByteLength)}</span>
+    {:else if currentCheckpoint}
+      <strong>{boundaryLabel(currentCheckpoint.boundaryKind)}</strong>
+      <span class:unavailable-text={!currentCheckpoint.available} class="timeline-readiness">
+        {currentCheckpoint.available ? strings.timeline.ready : currentCheckpoint.error ?? strings.timeline.unavailable}
+      </span>
+      <span class="timeline-metric">
+        {strings.timeline.changesInInterval(decimal(currentCheckpoint.sourceChangeCount))}
+      </span>
+      {#if currentCheckpoint.replayChangeCount !== undefined}
+        <span class="timeline-metric">
+          {strings.timeline.replayOperations(decimal(currentCheckpoint.replayChangeCount))}
+        </span>
+      {/if}
+      <span class="timeline-metric">
+        <b>{strings.timeline.size}</b>
+        {formatBytes(currentCheckpoint.byteLengthBefore)} → {formatBytes(currentCheckpoint.byteLengthAfter)}
+        <em>{formatDelta(currentCheckpoint.byteLengthBefore, currentCheckpoint.byteLengthAfter)}</em>
+      </span>
+      {#if currentCheckpoint.archiveByteLength !== undefined}
+        <span class="timeline-metric">
+          <b>{strings.timeline.archive}</b> {formatBytes(currentCheckpoint.archiveByteLength)}
+          ({currentCheckpoint.optimized ? strings.timeline.optimizedArchive : strings.timeline.rawArchive})
+        </span>
+      {/if}
+      {#if currentCheckpoint.transformPluginIds.length > 0}
+        <span class="timeline-metric" title={currentCheckpoint.transformPluginIds.join(', ')}>
+          <b>{strings.timeline.plugins}</b> {currentCheckpoint.transformPluginIds.join(', ')}
+        </span>
+      {/if}
+      <span class="timeline-metric">
+        <b>{strings.timeline.created}</b> {new Date(currentCheckpoint.createdAt).toLocaleString()}
+      </span>
+    {:else}
+      <span>{strings.timeline.metadataUnavailable}</span>
+    {/if}
   </div>
+
   <span id="timeline-availability" class="visually-hidden" aria-live="polite">
-    {unavailableCount() > 0 ? strings.timeline.unavailableCount(unavailableCount()) : ''}
+    {unavailableCount() > 0 ? strings.timeline.displayedUnavailableCount(unavailableCount()) : ''}
   </span>
-  <button
-    type="button"
-    class="panel-close timeline-close"
-    aria-label={strings.timeline.close}
-    title={strings.timeline.close}
-    onclick={onClose}
-  >&times;</button>
 </section>
 
 <style>
   .checkpoint-timeline {
-    display: grid;
-    grid-template-columns: auto auto minmax(10rem, 1fr) auto auto;
-    grid-template-rows: auto auto;
-    align-items: center;
-    gap: 0.35rem 0.6rem;
-    padding: 0.55rem 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 0.55rem 0.75rem 0.65rem;
     border-bottom: 1px solid var(--vscode-panel-border);
     background: var(--vscode-sideBar-background);
   }
 
   .timeline-heading {
-    display: flex;
-    flex-direction: column;
-    min-width: 9rem;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 0.75rem;
+    min-height: 1.35rem;
     font-size: 0.8rem;
   }
 
-  .timeline-heading span,
-  .timeline-markers {
+  .timeline-title {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    min-width: 0;
+  }
+
+  .timeline-title span,
+  .saved-position,
+  .timeline-markers,
+  .timeline-details {
     color: var(--vscode-descriptionForeground);
     font-size: 0.72rem;
   }
@@ -190,13 +336,20 @@
   }
 
   .saved-off-branch,
-  .timeline-markers .unavailable {
+  .timeline-markers .unavailable,
+  .unavailable-text {
     color: var(--vscode-errorForeground);
   }
 
   .timeline-markers .saved {
-    color: var(--vscode-charts-green);
-    font-weight: 700;
+    box-shadow: inset 0 -2px var(--vscode-charts-green);
+  }
+
+  .timeline-controls {
+    display: grid;
+    grid-template-columns: auto minmax(10rem, 1fr) auto;
+    align-items: center;
+    gap: 0.55rem;
   }
 
   .timeline-slider {
@@ -205,10 +358,84 @@
   }
 
   .timeline-markers {
-    grid-column: 3;
     display: flex;
-    justify-content: space-between;
+    align-items: center;
+    gap: 0.25rem;
+    min-height: 1.55rem;
+    overflow-x: auto;
+    scrollbar-width: thin;
+  }
+
+  .timeline-markers button {
+    flex: 0 0 auto;
+    min-width: 1.65rem;
+    padding: 0.18rem 0.38rem;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    color: var(--vscode-descriptionForeground);
+    background: var(--vscode-button-secondaryBackground);
+    cursor: pointer;
+  }
+
+  .timeline-markers button:hover:not(:disabled) {
+    color: var(--vscode-button-secondaryForeground);
+    background: var(--vscode-button-secondaryHoverBackground);
+  }
+
+  .timeline-markers button.current {
+    border-color: var(--vscode-focusBorder);
+    color: var(--vscode-button-foreground);
+    background: var(--vscode-button-background);
+    font-weight: 700;
+  }
+
+  .timeline-markers button:disabled:not(.current) {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .hidden-markers {
+    flex: 0 0 auto;
+    padding-inline: 0.25rem;
+  }
+
+  .timeline-details {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.3rem 0.75rem;
+    min-height: 1.5rem;
+    padding: 0.38rem 0.5rem;
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 0.3rem;
+    background: var(--vscode-editor-background);
+  }
+
+  .timeline-details > strong {
+    color: var(--vscode-foreground);
+  }
+
+  .timeline-metric,
+  .timeline-readiness {
+    min-width: 0;
     overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .timeline-metric + .timeline-metric {
+    padding-inline-start: 0.75rem;
+    border-inline-start: 1px solid var(--vscode-panel-border);
+  }
+
+  .timeline-metric b {
+    color: var(--vscode-foreground);
+    font-weight: 600;
+  }
+
+  .timeline-metric em {
+    color: var(--vscode-descriptionForeground);
+    font-style: normal;
   }
 
   .timeline-step {
@@ -224,15 +451,14 @@
   }
 
   .timeline-step:focus-visible,
-  .timeline-slider:focus-visible {
+  .timeline-slider:focus-visible,
+  .timeline-markers button:focus-visible {
     outline: 1px solid var(--vscode-focusBorder);
     outline-offset: 2px;
   }
 
   .timeline-close {
-    grid-column: 5;
-    grid-row: 1 / span 2;
-    align-self: start;
+    position: static;
   }
 
   .visually-hidden {
@@ -255,13 +481,36 @@
     .timeline-markers .saved,
     .timeline-markers .unavailable,
     .saved-position,
-    .saved-off-branch {
+    .saved-off-branch,
+    .unavailable-text {
       color: CanvasText;
     }
 
     .timeline-step:focus-visible,
-    .timeline-slider:focus-visible {
+    .timeline-slider:focus-visible,
+    .timeline-markers button:focus-visible {
       outline: 2px solid Highlight;
+    }
+  }
+
+  @media (max-width: 720px) {
+    .timeline-heading {
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .saved-position {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
+
+    .timeline-close {
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    .timeline-metric + .timeline-metric {
+      padding-inline-start: 0;
+      border-inline-start: 0;
     }
   }
 

--- a/vscode-extension/webview-ui/src/i18n.ts
+++ b/vscode-extension/webview-ui/src/i18n.ts
@@ -7,9 +7,7 @@ export function formatNumber(
   value: number | bigint,
   options?: Intl.NumberFormatOptions
 ): string {
-  return typeof value === 'bigint'
-    ? value.toLocaleString(activeLanguage)
-    : value.toLocaleString(activeLanguage, options)
+  return new Intl.NumberFormat(activeLanguage, options).format(value)
 }
 
 export function textDirectionForLanguage(language: string): 'ltr' | 'rtl' {

--- a/vscode-extension/webview-ui/src/i18n.ts
+++ b/vscode-extension/webview-ui/src/i18n.ts
@@ -4,10 +4,12 @@ const RTL_LANGUAGES = new Set(['ar', 'fa', 'he', 'ps', 'ur'])
 let activeLanguage = DEFAULT_LANGUAGE
 
 export function formatNumber(
-  value: number,
+  value: number | bigint,
   options?: Intl.NumberFormatOptions
 ): string {
-  return value.toLocaleString(activeLanguage, options)
+  return typeof value === 'bigint'
+    ? value.toLocaleString(activeLanguage)
+    : value.toLocaleString(activeLanguage, options)
 }
 
 export function textDirectionForLanguage(language: string): 'ltr' | 'rtl' {
@@ -562,6 +564,24 @@ const englishStrings = {
     originalMarker: 'Original',
     marker: (checkpoint: number, changes: number, saved: boolean) =>
       `Checkpoint ${formatNumber(checkpoint)}, ${formatNumber(changes)} changes${saved ? ', last saved' : ''}`,
+    boundaryPlain: 'Manual checkpoint',
+    boundaryTransform: 'Transform checkpoint',
+    boundaryTip: 'Captured working tip',
+    originalDescription: 'Starting content before checkpointed changes',
+    changesInInterval: (count: number | bigint) =>
+      `${formatNumber(count)} source change${count === 1 || count === 1n ? '' : 's'}`,
+    replayOperations: (count: number | bigint) =>
+      `${formatNumber(count)} replay operation${count === 1 || count === 1n ? '' : 's'}`,
+    size: 'Size',
+    archive: 'Archive',
+    optimizedArchive: 'optimized',
+    rawArchive: 'raw',
+    plugins: 'Actions',
+    created: 'Created',
+    ready: 'Replay ready',
+    metadataUnavailable: 'Checkpoint metadata is not loaded',
+    displayedUnavailableCount: (count: number) =>
+      `${formatNumber(count)} displayed checkpoint${count === 1 ? '' : 's'} unavailable`,
     unavailable: 'Replay unavailable',
     unavailableCount: (count: number) =>
       `${formatNumber(count)} checkpoint${count === 1 ? '' : 's'} unavailable`,
@@ -830,6 +850,24 @@ const localeOverrides: Record<string, LocaleStringOverrides> = {
       unavailable: 'Reproduccion no disponible',
       unavailableCount: (count: number) =>
         `${formatNumber(count)} punto${count === 1 ? '' : 's'} de control no disponible${count === 1 ? '' : 's'}`,
+      boundaryPlain: 'Punto de control manual',
+      boundaryTransform: 'Punto de control de transformacion',
+      boundaryTip: 'Punta de trabajo capturada',
+      originalDescription: 'Contenido inicial antes de los cambios con puntos de control',
+      changesInInterval: (count: number | bigint) =>
+        `${formatNumber(count)} cambio${count === 1 || count === 1n ? '' : 's'} de origen`,
+      replayOperations: (count: number | bigint) =>
+        `${formatNumber(count)} operacion${count === 1 || count === 1n ? '' : 'es'} de reproduccion`,
+      size: 'Tamano',
+      archive: 'Archivo',
+      optimizedArchive: 'optimizado',
+      rawArchive: 'sin optimizar',
+      plugins: 'Acciones',
+      created: 'Creado',
+      ready: 'Reproduccion lista',
+      metadataUnavailable: 'Los metadatos del punto de control no estan cargados',
+      displayedUnavailableCount: (count: number) =>
+        `${formatNumber(count)} punto${count === 1 ? '' : 's'} de control mostrado${count === 1 ? '' : 's'} no disponible${count === 1 ? '' : 's'}`,
       navigating: 'Moviendo por el historial de puntos de control',
       close: 'Cerrar la linea de tiempo de puntos de control',
       hiddenMarkers: (count: number) =>


### PR DESCRIPTION
## Summary

- preserve checkpoint redo by moving rewound checkpoint models into a materialized future stack
- fast-forward by restoring those models without replaying transforms or interval archives
- discard future checkpoints only after a branch mutation
- fix full-range transform replay metadata and revamp scalable timeline metadata and UI

## Root cause

Timeline rewind called the destructive checkpoint deletion API, so fast-forward had to reconstruct state from exported change logs. Transform export also omitted the effective transform length, causing a `length: 0` full-range transform to replay with a range mismatch.

## Impact

Live checkpoint movement is independent of file size and interval change count, apart from viewport refresh and fingerprint validation. Missing or damaged audit archives no longer disable live fast-forward, and the timeline now exposes bounded, richer checkpoint metadata.

## Validation

- Linux native suite: 151/151 tests passed after rebasing onto current `main`
- 10,041 assertions across 1,000 complete rewind/fast-forward sweeps, with an invariant transform callback count
- the same focused stress regression passed on Windows
- Windows C++ gRPC server compiled and linked
- real gRPC checkpoint tests passed
- client build and lint passed
- extension lint, TypeScript build, Svelte checks, webview build, and all 30 unit tests passed
