### PR TITLE
fix: analyzer history after checkpoint branching

### DIFF
--- a/packages/client/src/editor_history.ts
+++ b/packages/client/src/editor_history.ts
@@ -224,9 +224,8 @@ export class EditorHistoryController {
   }
 
   public recordLocalMutation(): void {
-    this.undoneChangeLog.length = 0
+    this.discardRedoBranch()
     this.transactionLog.push({ kind: 'LOCAL_UNTRACKED' })
-    this.undoneTransactionLog.length = 0
   }
 
   public recordLocalChanges(changes: EditorChangeRecord[]): void {
@@ -234,10 +233,9 @@ export class EditorHistoryController {
       return
     }
 
+    this.discardRedoBranch()
     this.changeLog.push(...changes)
-    this.undoneChangeLog.length = 0
     this.transactionLog.push({ kind: 'LOCAL', changeCount: changes.length })
-    this.undoneTransactionLog.length = 0
   }
 
   public recordLocalReplaceAll(
@@ -266,9 +264,8 @@ export class EditorHistoryController {
   public recordCheckpointReplaceAll(
     transaction: EditorCheckpointReplaceAllTransaction
   ): void {
-    this.undoneChangeLog.length = 0
+    this.discardRedoBranch()
     this.transactionLog.push(transaction)
-    this.undoneTransactionLog.length = 0
   }
 
   public markSaved(): void {
@@ -346,6 +343,18 @@ export class EditorHistoryController {
       await executor.redoMilestone()
     }
     return true
+  }
+
+  private discardRedoBranch(): void {
+    this.undoneChangeLog.length = 0
+    this.undoneTransactionLog.length = 0
+
+    const branchDepth = this.transactionLog.length
+    for (let index = this.milestoneDepths.length - 1; index >= 0; index -= 1) {
+      if (this.milestoneDepths[index] > branchDepth) {
+        this.milestoneDepths.splice(index, 1)
+      }
+    }
   }
 }
 

--- a/packages/client/src/editor_history.ts
+++ b/packages/client/src/editor_history.ts
@@ -350,6 +350,7 @@ export class EditorHistoryController {
     this.undoneTransactionLog.length = 0
 
     const branchDepth = this.transactionLog.length
+    this.savedChangeDepth = Math.min(this.savedChangeDepth, branchDepth)
     for (let index = this.milestoneDepths.length - 1; index >= 0; index -= 1) {
       if (this.milestoneDepths[index] > branchDepth) {
         this.milestoneDepths.splice(index, 1)

--- a/packages/client/tests/specs/editorPatterns.spec.ts
+++ b/packages/client/tests/specs/editorPatterns.spec.ts
@@ -368,6 +368,50 @@ describe('Editor Patterns', () => {
     })
   })
 
+  it('should clamp the saved depth when discarding a saved future branch', () => {
+    const history = new EditorHistoryController()
+    history.recordLocalChange({
+      serial: 1,
+      kind: 'INSERT',
+      offset: 0,
+      length: 0,
+      data: '41',
+    })
+    history.recordLocalChange({
+      serial: 2,
+      kind: 'INSERT',
+      offset: 1,
+      length: 0,
+      data: '42',
+    })
+    history.markSaved()
+
+    const branch = EditorHistoryController.fromSnapshotAtDepth(
+      history.snapshot(),
+      0
+    )
+    branch.recordLocalChange({
+      serial: 1,
+      kind: 'INSERT',
+      offset: 0,
+      length: 0,
+      data: '58',
+    })
+
+    expect(branch.getEditState()).to.deep.equal({
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    const snapshot = branch.snapshot()
+    const restored = EditorHistoryController.fromSnapshot(snapshot)
+    expect(restored.snapshot()).to.deep.equal(snapshot)
+  })
+
   it('should undo multi-record local transactions as a single unit', async () => {
     const history = new EditorHistoryController()
     const calls: string[] = []

--- a/packages/client/tests/specs/editorPatterns.spec.ts
+++ b/packages/client/tests/specs/editorPatterns.spec.ts
@@ -311,6 +311,63 @@ describe('Editor Patterns', () => {
     ).to.deep.equal(['4546', '4344'])
   })
 
+  it('should discard future milestones when branching from the original depth', async () => {
+    const history = new EditorHistoryController()
+    history.recordLocalChange({
+      serial: 1,
+      kind: 'INSERT',
+      offset: 0,
+      length: 0,
+      data: '41',
+    })
+    history.recordMilestone()
+    history.recordLocalChange({
+      serial: 2,
+      kind: 'INSERT',
+      offset: 1,
+      length: 0,
+      data: '42',
+    })
+    history.recordMilestone()
+
+    const branch = EditorHistoryController.fromSnapshotAtDepth(
+      history.snapshot(),
+      0
+    )
+    branch.recordLocalChange({
+      serial: 1,
+      kind: 'INSERT',
+      offset: 0,
+      length: 0,
+      data: '58',
+    })
+
+    expect(branch.snapshot().milestoneDepths).to.deep.equal([])
+    expect(branch.getChangeLog().map((change) => change.serial)).to.deep.equal([
+      1,
+    ])
+
+    const calls: string[] = []
+    await branch.undo({
+      async undoLocal() {
+        calls.push('undoLocal')
+      },
+      async redoLocal() {
+        calls.push('redoLocal')
+      },
+      async undoCheckpoint() {},
+      async redoCheckpoint() {},
+      async undoMilestone() {
+        calls.push('undoMilestone')
+      },
+    })
+    expect(calls).to.deep.equal(['undoLocal'])
+    expect(branch.getEditState()).to.deep.include({
+      undoCount: 0,
+      redoCount: 1,
+    })
+  })
+
   it('should undo multi-record local transactions as a single unit', async () => {
     const history = new EditorHistoryController()
     const calls: string[] = []

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -1482,6 +1482,118 @@ suite('OmegaEdit VS Code extension', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
+  test('resets analyzer history and change serials when branching from the original checkpoint', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-checkpoint-branch-history-')
+    )
+    const samplePath = path.join(tmpDir, 'branch-history.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a session for checkpoint branch history')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'insert',
+      offset: 3,
+      data: Buffer.from('1', 'utf8').toString('hex'),
+    })
+    assert.equal(
+      (await provider.createCheckpoint({ uri: document.uri }))?.checkpointCount,
+      1
+    )
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'insert',
+      offset: 4,
+      data: Buffer.from('2', 'utf8').toString('hex'),
+    })
+    assert.equal(
+      (await provider.createCheckpoint({ uri: document.uri }))?.checkpointCount,
+      2
+    )
+    await assertSessionText(session.sessionId, 'abc12')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'navigateCheckpointTimeline',
+      checkpoint: 0,
+    })
+    await assertSessionText(session.sessionId, 'abc')
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'insert',
+      offset: 3,
+      data: Buffer.from('X', 'utf8').toString('hex'),
+    })
+    await assertSessionText(session.sessionId, 'abcX')
+
+    assert.deepEqual(lastMessageOfType(panel.messages, 'editState'), {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+    assert.equal(session.checkpointTimeline.entries.length, 0)
+    assert.equal(session.changeCount, 1)
+    assert.deepEqual(
+      session.history.getChangeLog().map((change) => change.serial),
+      [1]
+    )
+
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      { type: 'undo' },
+      { propagateErrors: true }
+    )
+    await assertSessionText(session.sessionId, 'abc')
+    assert.deepEqual(lastMessageOfType(panel.messages, 'editState'), {
+      type: 'editState',
+      canUndo: false,
+      canRedo: true,
+      undoCount: 0,
+      redoCount: 1,
+      isDirty: false,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      { type: 'redo' },
+      { propagateErrors: true }
+    )
+    await assertSessionText(session.sessionId, 'abcX')
+    assert.deepEqual(lastMessageOfType(panel.messages, 'editState'), {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+    assert.deepEqual(
+      session.history.getChangeLog().map((change) => change.serial),
+      [1]
+    )
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
   test('checks out a full-range Zstandard transform across the checkpoint timeline', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-transform-timeline-')


### PR DESCRIPTION
## Summary

- discard redo transactions, redo changes, and future checkpoint milestones when a new history branch is created
- keep the Analyzer History pane UNDO/REDO counts aligned with executable history
- verify a branch from the original checkpoint restarts change serials at 1 with no gaps

## Regression coverage

The end-to-end test creates two checkpoints, returns to the original, makes one change, and verifies:

- later checkpoints are removed
- Analyzer history reports UNDO 1 / REDO 0
- UNDO and REDO both execute and update the displayed counts
- the surviving change log contains serials [1]

## Validation

- client editorPatterns suite: 9 passed
- VS Code extension unit suite: 30 passed
- focused VS Code integration regression: 1 passed
- Biome checks for all changed files
- git diff --check