### PR TITLE
feat: make core model updates transactional

### DIFF
--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -862,6 +862,21 @@ namespace {
         return result;
     }
 
+    template<typename UpdateFn>
+    auto update_model_transactionally_(omega_model_t *model_ptr, const UpdateFn &update_fn) -> int {
+        if (!model_ptr) { return -1; }
+
+        omega_model_t candidate_model;
+        try {
+            candidate_model.model_segments = clone_model_segments_(model_ptr->model_segments);
+            const auto rc = update_fn(&candidate_model);
+            if (rc != 0) { return rc; }
+        } catch (const std::bad_alloc &) { return -1; }
+
+        model_ptr->model_segments.swap(candidate_model.model_segments);
+        return 0;
+    }
+
     inline void free_model_changes_(omega_model_struct *model_ptr) {
         model_ptr->model_snapshots.clear();
         model_ptr->changes.clear();
@@ -913,7 +928,7 @@ namespace {
         return discarded;
     }
 
-    auto update_model_helper_(omega_model_t *model_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
+    auto update_model_helper_in_place_(omega_model_t *model_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
         if (!change_ptr) { return -1; }
         assert(change_ptr->length > 0);
         try {
@@ -1009,6 +1024,13 @@ namespace {
             if (!safe_add_int64_(read_offset, (*iter)->computed_length, read_offset)) { return -1; }
         }
         return -1;
+    }
+
+    auto update_model_helper_(omega_model_t *model_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
+        if (!change_ptr) { return -1; }
+        return update_model_transactionally_(model_ptr, [&](omega_model_t *candidate_model_ptr) {
+            return update_model_helper_in_place_(candidate_model_ptr, change_ptr);
+        });
     }
 
     auto insert_payload_segment_(omega_model_t *model_ptr, const const_omega_change_ptr_t &change_ptr,
@@ -1122,14 +1144,16 @@ namespace {
     auto update_model_(omega_session_t *session_ptr, const const_omega_change_ptr_t &change_ptr) -> int {
         if (omega_change_get_kind_(change_ptr.get()) == change_kind_t::CHANGE_TRANSFORM) { return 0; }
         const auto model_ptr = session_ptr->models_.back().get();
-        if (omega_change_get_kind_(change_ptr.get()) == change_kind_t::CHANGE_OVERWRITE) {
-            const_omega_change_ptr_t const_change_ptr =
-                    del_(0, change_ptr->offset, change_ptr->length, !omega_session_get_transaction_bit_(session_ptr));
-            if (!const_change_ptr) { return -1; }
-            const auto rc = update_model_helper_(model_ptr, const_change_ptr);
-            if (0 != rc) { return rc; }
-        }
-        return update_model_helper_(model_ptr, change_ptr);
+        return update_model_transactionally_(model_ptr, [&](omega_model_t *candidate_model_ptr) {
+            if (omega_change_get_kind_(change_ptr.get()) == change_kind_t::CHANGE_OVERWRITE) {
+                const_omega_change_ptr_t const_change_ptr = del_(0, change_ptr->offset, change_ptr->length,
+                                                                 !omega_session_get_transaction_bit_(session_ptr));
+                if (!const_change_ptr) { return -1; }
+                const auto rc = update_model_helper_in_place_(candidate_model_ptr, const_change_ptr);
+                if (0 != rc) { return rc; }
+            }
+            return update_model_helper_in_place_(candidate_model_ptr, change_ptr);
+        });
     }
 
     auto rebuild_model_to_change_count_(omega_session_t *session_ptr, int64_t remaining_count) -> int {

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -866,12 +866,14 @@ namespace {
     auto update_model_transactionally_(omega_model_t *model_ptr, const UpdateFn &update_fn) -> int {
         if (!model_ptr) { return -1; }
 
-        omega_model_t candidate_model;
+        omega_model_t candidate_model{};
         try {
             candidate_model.model_segments = clone_model_segments_(model_ptr->model_segments);
             const auto rc = update_fn(&candidate_model);
             if (rc != 0) { return rc; }
-        } catch (const std::bad_alloc &) { return -1; }
+        } catch (const std::bad_alloc &) { return -1; } catch (...) {
+            return -1;
+        }
 
         model_ptr->model_segments.swap(candidate_model.model_segments);
         return 0;

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -871,11 +871,18 @@ TEST_CASE("Failed Model Update Preserves Segment Metadata", "[EdgeCase][Overflow
     auto *const overflow_segment_ptr = segments[1].get();
     overflow_segment_ptr->computed_offset = (std::numeric_limits<int64_t>::max)();
 
-    std::vector<omega_model_segment_t> segment_snapshots;
-    std::vector<omega_model_segment_t *> segment_ptrs;
+    struct segment_snapshot_t {
+        omega_model_segment_t *segment_ptr;
+        int64_t computed_offset;
+        int64_t computed_length;
+        int64_t change_offset;
+        const_omega_change_ptr_t change_ptr;
+        omega_change_payload_role_t payload_role;
+    };
+    std::vector<segment_snapshot_t> segment_snapshots;
     for (const auto &segment_ptr : segments) {
-        segment_snapshots.push_back(*segment_ptr);
-        segment_ptrs.push_back(segment_ptr.get());
+        segment_snapshots.push_back({segment_ptr.get(), segment_ptr->computed_offset, segment_ptr->computed_length,
+                                     segment_ptr->change_offset, segment_ptr->change_ptr, segment_ptr->payload_role});
     }
     const auto change_count = omega_session_get_num_changes(session_ptr);
 
@@ -883,7 +890,7 @@ TEST_CASE("Failed Model Update Preserves Segment Metadata", "[EdgeCase][Overflow
 
     REQUIRE(segment_snapshots.size() == segments.size());
     for (size_t i = 0; i < segments.size(); ++i) {
-        CHECK(segment_ptrs[i] == segments[i].get());
+        CHECK(segment_snapshots[i].segment_ptr == segments[i].get());
         CHECK(segment_snapshots[i].computed_offset == segments[i]->computed_offset);
         CHECK(segment_snapshots[i].computed_length == segments[i]->computed_length);
         CHECK(segment_snapshots[i].change_offset == segments[i]->change_offset);

--- a/core/src/tests/edge_case_tests.cpp
+++ b/core/src/tests/edge_case_tests.cpp
@@ -859,6 +859,42 @@ TEST_CASE("Computed File Size Returns -1 On Segment Overflow", "[EdgeCase][Overf
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Failed Model Update Preserves Segment Metadata", "[EdgeCase][Overflow][ModelUpdate]") {
+    const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
+    REQUIRE(session_ptr);
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 0, "abcd"));
+    REQUIRE(0 < omega_edit_insert_string(session_ptr, 2, "X"));
+
+    auto &segments = session_ptr->models_.back()->model_segments;
+    REQUIRE(3 == segments.size());
+
+    auto *const overflow_segment_ptr = segments[1].get();
+    overflow_segment_ptr->computed_offset = (std::numeric_limits<int64_t>::max)();
+
+    std::vector<omega_model_segment_t> segment_snapshots;
+    std::vector<omega_model_segment_t *> segment_ptrs;
+    for (const auto &segment_ptr : segments) {
+        segment_snapshots.push_back(*segment_ptr);
+        segment_ptrs.push_back(segment_ptr.get());
+    }
+    const auto change_count = omega_session_get_num_changes(session_ptr);
+
+    REQUIRE(-1 == omega_edit_insert_string(session_ptr, 0, "Y"));
+
+    REQUIRE(segment_snapshots.size() == segments.size());
+    for (size_t i = 0; i < segments.size(); ++i) {
+        CHECK(segment_ptrs[i] == segments[i].get());
+        CHECK(segment_snapshots[i].computed_offset == segments[i]->computed_offset);
+        CHECK(segment_snapshots[i].computed_length == segments[i]->computed_length);
+        CHECK(segment_snapshots[i].change_offset == segments[i]->change_offset);
+        CHECK(segment_snapshots[i].change_ptr == segments[i]->change_ptr);
+        CHECK(segment_snapshots[i].payload_role == segments[i]->payload_role);
+    }
+    CHECK(change_count == omega_session_get_num_changes(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Viewport Offset Overflow Returns Safe Sentinels", "[EdgeCase][Overflow]") {
     const auto session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, 0, nullptr);
     REQUIRE(session_ptr);


### PR DESCRIPTION
## Summary

- apply core model segment changes to a cloned candidate model
- swap candidate segments into the live model only after the complete update succeeds
- keep overwrite delete-and-insert handling within one model transaction
- add regression coverage for a mid-update arithmetic overflow

## Root cause

`update_model_helper_()` mutated segment offsets, lengths, and vector contents in place while iterating. If later offset arithmetic failed, `update_()` removed the change-log entry but could not restore the already-mutated model segments, leaving the session internally inconsistent.

## Impact

Failed model updates now leave the live segment vector and change count unchanged. Compound overwrite updates are committed atomically as a single candidate-model swap.

Closes #1425.

## Validation

- `clang-format --dry-run --Werror core/src/lib/edit.cpp core/src/tests/edge_case_tests.cpp`
- `git diff --check`
- focused `[ModelUpdate]` regression test
- full `edge_case_tests` suite (5,531 assertions)
- `omegaEdit_tests`
- `session_tests`
- `brutal_coverage_tests`
- `viewport_stress_tests`
- `differential_fuzz_tests`
