### PR TITLE
fix: action journal checkpoint navigation

### DIFF
--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -1264,6 +1264,55 @@ namespace {
         return first_change_ptr->transform_data->checkpoint_file_path == model_ptr->file_path ? 1U : 0U;
     }
 
+    bool move_changes_to_undo_(omega_model_t *model_ptr, size_t keep_count) {
+        if (!model_ptr || keep_count > model_ptr->changes.size()) { return false; }
+        const auto move_count = model_ptr->changes.size() - keep_count;
+        if (move_count == 0) { return true; }
+        for (auto iter = model_ptr->changes.rbegin();
+             iter != model_ptr->changes.rbegin() + static_cast<std::ptrdiff_t>(move_count); ++iter) {
+            if (!*iter || omega_change_get_serial(iter->get()) <= 0) { return false; }
+        }
+        try {
+            model_ptr->changes_undone.reserve(model_ptr->changes_undone.size() + move_count);
+        } catch (const std::bad_alloc &) { return false; }
+
+        for (auto iter = model_ptr->changes.rbegin();
+             iter != model_ptr->changes.rbegin() + static_cast<std::ptrdiff_t>(move_count); ++iter) {
+            (*iter)->serial *= -1;
+            model_ptr->changes_undone.push_back(*iter);
+        }
+        model_ptr->changes.erase(model_ptr->changes.begin() + static_cast<std::ptrdiff_t>(keep_count),
+                                 model_ptr->changes.end());
+        model_ptr->model_snapshots.erase(model_ptr->model_snapshots.upper_bound(static_cast<int64_t>(keep_count)),
+                                         model_ptr->model_snapshots.end());
+        return true;
+    }
+
+    bool restore_changes_from_undo_(omega_model_t *model_ptr, size_t target_count) {
+        if (!model_ptr || target_count < model_ptr->changes.size()) { return false; }
+        const auto restore_count = target_count - model_ptr->changes.size();
+        if (restore_count > model_ptr->changes_undone.size()) { return false; }
+        for (size_t restored = 0; restored < restore_count; ++restored) {
+            const auto &change_ptr = model_ptr->changes_undone[model_ptr->changes_undone.size() - 1 - restored];
+            const auto expected_serial =
+                    model_ptr->change_serial_base + static_cast<int64_t>(model_ptr->changes.size() + restored) + 1;
+            if (!change_ptr || omega_change_get_serial(change_ptr.get()) != -expected_serial) { return false; }
+        }
+        try {
+            model_ptr->changes.reserve(target_count);
+        } catch (const std::bad_alloc &) { return false; }
+
+        for (size_t restored = 0; restored < restore_count; ++restored) {
+            const auto &change_ptr = model_ptr->changes_undone.back();
+            const auto expected_serial =
+                    model_ptr->change_serial_base + static_cast<int64_t>(model_ptr->changes.size()) + 1;
+            change_ptr->serial = expected_serial;
+            model_ptr->changes.push_back(change_ptr);
+            model_ptr->changes_undone.pop_back();
+        }
+        return true;
+    }
+
     void notify_checkpoint_restore_(omega_session_t *session_ptr) {
         for (const auto &viewport_ptr : session_ptr->viewports_) {
             viewport_ptr->data_segment.capacity =
@@ -3192,20 +3241,24 @@ int omega_edit_checkout_checkpoint(omega_session_t *session_ptr, int64_t checkpo
         session_ptr->checkpoint_future_models_.pop_back();
     }
 
+    for (size_t model_index = 0; model_index + 1 < session_ptr->models_.size(); ++model_index) {
+        auto *const model_ptr = session_ptr->models_[model_index].get();
+        const auto *const next_model_ptr = session_ptr->models_[model_index + 1].get();
+        const auto target_count = next_model_ptr->change_serial_base - model_ptr->change_serial_base;
+        if (target_count < 0 || !restore_changes_from_undo_(model_ptr, static_cast<size_t>(target_count))) {
+            return -1;
+        }
+    }
+
     if (checkpoint_count == 0) {
         auto *const root_model_ptr = session_ptr->models_.front().get();
+        if (!move_changes_to_undo_(root_model_ptr, 0)) { return -1; }
         root_model_ptr->model_segments = std::move(original_segments);
-        free_model_changes_(root_model_ptr);
-        free_model_changes_undone_(root_model_ptr);
         session_ptr->num_changes_adjustment_ = 0;
     } else {
         auto *const model_ptr = session_ptr->models_.back().get();
         const auto keep_count = checkpoint_snapshot_change_count_(model_ptr);
-        if (model_ptr->changes.size() > keep_count) {
-            model_ptr->changes.erase(model_ptr->changes.begin() + static_cast<std::ptrdiff_t>(keep_count),
-                                     model_ptr->changes.end());
-        }
-        free_model_changes_undone_(model_ptr);
+        if (!move_changes_to_undo_(model_ptr, keep_count)) { return -1; }
         if (0 != rebuild_model_to_change_count_(session_ptr, static_cast<int64_t>(keep_count))) { return -1; }
         session_ptr->num_changes_adjustment_ = model_ptr->change_serial_base;
     }

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -339,6 +339,11 @@ TEST_CASE("Checkpoint checkout preserves redo models until a branch edit",
         REQUIRE(future == omega_session_get_num_future_checkpoints(session_ptr));
         REQUIRE(expected ==
                 omega_session_get_segment_string(session_ptr, 0, omega_session_get_computed_file_size(session_ptr)));
+        const auto change_count = omega_session_get_num_changes(session_ptr);
+        for (int64_t serial = 1; serial <= change_count; ++serial) {
+            INFO("checkpoint=" << checkpoint << ", serial=" << serial);
+            REQUIRE(omega_session_get_change(session_ptr, serial));
+        }
         REQUIRE(3 == transform_state.calls);
     };
 
@@ -357,6 +362,7 @@ TEST_CASE("Checkpoint checkout preserves redo models until a branch edit",
     REQUIRE("ABC?" == omega_session_get_segment_string(session_ptr, 0, 4));
     REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
     REQUIRE(0 == omega_session_get_num_future_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
     require_checkpoint(1, "ABC?", 1, 0);
     REQUIRE(-1 == omega_edit_checkout_checkpoint(session_ptr, 2));
     REQUIRE(3 == transform_state.calls);

--- a/packages/client/tests/specs/actionJournalIntegration.spec.ts
+++ b/packages/client/tests/specs/actionJournalIntegration.spec.ts
@@ -6,12 +6,15 @@
  */
 
 import {
+  checkoutCheckpoint,
   createCheckpoint,
   del,
   getActionJournalViewport,
   insert,
   overwrite,
+  redo,
   runSessionTransaction,
+  undo,
 } from '@omega-edit/client'
 import {
   createTestSession,
@@ -130,5 +133,54 @@ describe('Action journal integration', () => {
       lastSerial: '3',
       kind: 'REPLACE',
     })
+  })
+
+  it('keeps redo history readable across undo and checkpoint checkout', async () => {
+    await insert(sessionId, 0, Buffer.from('abc'))
+    await createCheckpoint(sessionId)
+    await overwrite(sessionId, 0, Buffer.from('X'))
+    await createCheckpoint(sessionId)
+
+    await checkoutCheckpoint(sessionId, 1)
+    const rewound = await getActionJournalViewport({
+      sessionId,
+      capacity: 10,
+      direction: 'older',
+    })
+    expect(rewound).toMatchObject({
+      activeTipSerial: '1',
+      changeCount: '1',
+      undoCount: '1',
+    })
+    expect(rewound.entries.map((entry) => entry.firstSerial)).toEqual([
+      '2',
+      '1',
+    ])
+
+    await checkoutCheckpoint(sessionId, 2)
+    const forwarded = await getActionJournalViewport({
+      sessionId,
+      capacity: 10,
+      direction: 'older',
+    })
+    expect(forwarded.entries.map((entry) => entry.firstSerial)).toEqual([
+      '2',
+      '1',
+    ])
+
+    await overwrite(sessionId, 1, Buffer.from('Y'))
+    await undo(sessionId)
+    const undone = await getActionJournalViewport({
+      sessionId,
+      capacity: 10,
+      direction: 'older',
+    })
+    expect(undone.undoCount).toBe('1')
+    expect(undone.entries.map((entry) => entry.firstSerial)).toEqual([
+      '3',
+      '2',
+      '1',
+    ])
+    await redo(sessionId)
   })
 })

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -2372,6 +2372,10 @@ namespace omega_edit {
             }
             const auto active_tip = omega_session_get_num_changes(locked_session.session());
             const auto undo_count = omega_session_get_num_undone_changes(locked_session.session());
+            if (active_tip < 0 || undo_count < 0 || undo_count > (std::numeric_limits<int64_t>::max)() - active_tip) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "action journal history size overflow");
+            }
+            const auto history_tip = active_tip + undo_count;
             const auto checkpoint_count = omega_session_get_num_checkpoints(locked_session.session());
             response->set_format_version(1);
             response->set_session_id(request->session_id());
@@ -2381,15 +2385,19 @@ namespace omega_edit {
             response->set_checkpoint_count_decimal(std::to_string(checkpoint_count));
             response->set_direction(request->direction());
             response->set_capacity(request->capacity());
-            if (active_tip == 0) {
+            if (history_tip == 0) {
                 response->set_resolved_anchor_serial_decimal("0");
                 return grpc::Status::OK;
             }
 
-            auto anchor = requested_anchor == 0 ? (older ? active_tip : 1) : requested_anchor;
-            if (anchor <= 0 || anchor > active_tip || !omega_session_get_change(locked_session.session(), anchor)) {
+            const auto get_history_change = [&](int64_t serial) {
+                const auto *change = omega_session_get_change(locked_session.session(), serial);
+                return change ? change : omega_session_get_change(locked_session.session(), -serial);
+            };
+            auto anchor = requested_anchor == 0 ? (older ? history_tip : 1) : requested_anchor;
+            if (anchor <= 0 || anchor > history_tip || !get_history_change(anchor)) {
                 return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                                    "action journal anchor must identify an active change serial");
+                                    "action journal anchor must identify a retained change serial");
             }
 
             const auto is_replacement_pair = [](const omega_change_t *delete_change,
@@ -2400,13 +2408,10 @@ namespace omega_edit {
                                omega_change_get_transaction_bit(insert_change) &&
                        omega_change_get_offset(delete_change) == omega_change_get_offset(insert_change);
             };
-            const auto *anchor_change = omega_session_get_change(locked_session.session(), anchor);
-            if (older && anchor < active_tip &&
-                is_replacement_pair(anchor_change, omega_session_get_change(locked_session.session(), anchor + 1))) {
+            const auto *anchor_change = get_history_change(anchor);
+            if (older && anchor < history_tip && is_replacement_pair(anchor_change, get_history_change(anchor + 1))) {
                 ++anchor;
-            } else if (!older && anchor > 1 &&
-                       is_replacement_pair(omega_session_get_change(locked_session.session(), anchor - 1),
-                                           anchor_change)) {
+            } else if (!older && anchor > 1 && is_replacement_pair(get_history_change(anchor - 1), anchor_change)) {
                 --anchor;
             }
             response->set_resolved_anchor_serial_decimal(std::to_string(anchor));
@@ -2515,11 +2520,11 @@ namespace omega_edit {
                 return true;
             };
 
-            for (int64_t serial = anchor; older ? serial >= 1 : serial <= active_tip;) {
+            for (int64_t serial = anchor; older ? serial >= 1 : serial <= history_tip;) {
                 if (context->IsCancelled()) {
                     return grpc::Status(grpc::StatusCode::CANCELLED, "action journal request was cancelled");
                 }
-                const auto *change = omega_session_get_change(locked_session.session(), serial);
+                const auto *change = get_history_change(serial);
                 if (!change) {
                     return grpc::Status(grpc::StatusCode::ABORTED,
                                         "action journal changed while its viewport was being read");
@@ -2529,15 +2534,15 @@ namespace omega_edit {
                 int64_t continuation_anchor = serial;
                 int64_t step = 1;
                 if (older && omega_change_get_kind_as_char(change) == 'I' && serial > 1) {
-                    const auto *delete_change = omega_session_get_change(locked_session.session(), serial - 1);
+                    const auto *delete_change = get_history_change(serial - 1);
                     if (delete_change && omega_change_get_kind_as_char(delete_change) == 'D' &&
                         omega_change_get_transaction_bit(delete_change) == transaction_bit &&
                         omega_change_get_offset(delete_change) == omega_change_get_offset(change)) {
                         canonical = {{delete_change, serial - 1}, journal_source_entry{change, serial}};
                         step = 2;
                     }
-                } else if (!older && omega_change_get_kind_as_char(change) == 'D' && serial < active_tip) {
-                    const auto *insert_change = omega_session_get_change(locked_session.session(), serial + 1);
+                } else if (!older && omega_change_get_kind_as_char(change) == 'D' && serial < history_tip) {
+                    const auto *insert_change = get_history_change(serial + 1);
                     if (insert_change && omega_change_get_kind_as_char(insert_change) == 'I' &&
                         omega_change_get_transaction_bit(insert_change) == transaction_bit &&
                         omega_change_get_offset(insert_change) == omega_change_get_offset(change)) {

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -2391,8 +2391,7 @@ namespace omega_edit {
             }
 
             const auto get_history_change = [&](int64_t serial) {
-                const auto *change = omega_session_get_change(locked_session.session(), serial);
-                return change ? change : omega_session_get_change(locked_session.session(), -serial);
+                return omega_session_get_change(locked_session.session(), serial <= active_tip ? serial : -serial);
             };
             auto anchor = requested_anchor == 0 ? (older ? history_tip : 1) : requested_anchor;
             if (anchor <= 0 || anchor > history_tip || !get_history_change(anchor)) {

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -186,6 +186,7 @@ export interface WebviewActionJournalViewport {
 export interface WebviewActionJournalCheckpoint {
   checkpoint: number
   changeCount: number
+  sourceChangeCount?: string
   byteLengthAfter: string
   boundaryKind: 'plain' | 'transform' | 'tip'
   createdAt: number

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -183,6 +183,15 @@ export interface WebviewActionJournalViewport {
   nextAnchorSerial?: string
 }
 
+export interface WebviewActionJournalCheckpoint {
+  checkpoint: number
+  changeCount: number
+  byteLengthAfter: string
+  boundaryKind: 'plain' | 'transform' | 'tip'
+  createdAt: number
+  available: boolean
+}
+
 export interface WebviewExternalHighlight {
   id: string
   offset: number
@@ -460,22 +469,18 @@ export type HostToWebviewMessage =
       canRewind: boolean
       canFastForward: boolean
       navigating: boolean
-      checkpoints: Array<{
-        checkpoint: number
-        changeCount: number
-        sourceChangeCount: string
-        replayChangeCount?: string
-        byteLengthBefore: string
-        byteLengthAfter: string
-        archiveByteLength?: string
-        boundaryKind: 'plain' | 'transform' | 'tip'
-        transformPluginIds: string[]
-        missingPluginIds: string[]
-        optimized: boolean
-        createdAt: number
-        available: boolean
-        error?: string
-      }>
+      checkpoints: Array<
+        WebviewActionJournalCheckpoint & {
+          sourceChangeCount: string
+          replayChangeCount?: string
+          byteLengthBefore: string
+          archiveByteLength?: string
+          transformPluginIds: string[]
+          missingPluginIds: string[]
+          optimized: boolean
+          error?: string
+        }
+      >
     }
   | {
       type: 'actionJournalViewport'

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -877,6 +877,11 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(actionJournalSource, /strings\.actionJournal\.noChanges/)
   assert.match(actionJournalSource, /class="checkpoint-card"/)
   assert.match(
+    actionJournalSource,
+    /checkpoint\.sourceChangeCount\s*\?\?\s*String\(checkpoint\.changeCount\)/
+  )
+  assert.match(actionJournalSource, /checkpointChanges\(row\.coordinate\)/)
+  assert.match(
     svelteAppSource,
     /checkpoints=\{checkpointTimeline\.checkpoints\}/
   )

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -870,9 +870,20 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerSource, /ACTION_JOURNAL_REQUEST_TIMEOUT_MS = 15_000/)
   assert.match(actionJournalSource, /onUndo/)
   assert.match(actionJournalSource, /onRedo/)
+  assert.match(actionJournalSource, /disabled=\{!canUndo\}/)
+  assert.match(actionJournalSource, /disabled=\{!canRedo\}/)
   assert.doesNotMatch(actionJournalSource, /selectedKinds|transactionFilter/)
   assert.match(actionJournalSource, /onscroll=\{loadOlderNearEnd\}/)
   assert.match(actionJournalSource, /strings\.actionJournal\.noChanges/)
+  assert.match(actionJournalSource, /class="checkpoint-card"/)
+  assert.match(
+    svelteAppSource,
+    /checkpoints=\{checkpointTimeline\.checkpoints\}/
+  )
+  assert.match(
+    svelteAppSource,
+    /checkpointCursor=\{checkpointTimeline\.cursor\}/
+  )
   assert.match(actionJournalSource, /role="alert"/)
 
   const externalHighlightColorCountSources = [

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -3163,6 +3163,8 @@
         viewport={actionJournalViewport}
         loading={actionJournalLoading}
         error={actionJournalError}
+        checkpoints={checkpointTimeline.checkpoints}
+        checkpointCursor={checkpointTimeline.cursor}
         canUndo={canUndo && !transformInFlight}
         canRedo={canRedo && !transformInFlight}
         onUndo={() => postToHost({ type: 'undo' })}

--- a/vscode-extension/webview-ui/src/components/ActionJournal.svelte
+++ b/vscode-extension/webview-ui/src/components/ActionJournal.svelte
@@ -115,6 +115,8 @@
         return strings.actionJournal.checkpointTransform
       case 'tip':
         return strings.actionJournal.checkpointTip
+      default:
+        return strings.actionJournal.checkpointPlain
     }
   }
 

--- a/vscode-extension/webview-ui/src/components/ActionJournal.svelte
+++ b/vscode-extension/webview-ui/src/components/ActionJournal.svelte
@@ -94,7 +94,9 @@
       ...checkpoints.map((checkpoint) => ({
         type: 'checkpoint' as const,
         key: `checkpoint:${checkpoint.checkpoint}`,
-        coordinate: BigInt(checkpoint.changeCount),
+        coordinate: decimal(
+          checkpoint.sourceChangeCount ?? String(checkpoint.changeCount)
+        ),
         checkpoint,
       })),
     ]
@@ -192,7 +194,7 @@
             <div>
               <strong>{strings.actionJournal.checkpointCard(row.checkpoint.checkpoint)}</strong>
               <span>{checkpointKind(row.checkpoint.boundaryKind)}</span>
-              <span>{strings.actionJournal.checkpointChanges(row.checkpoint.changeCount)}</span>
+              <span>{strings.actionJournal.checkpointChanges(row.coordinate)}</span>
               <span>{strings.actionJournal.checkpointBytes(decimal(row.checkpoint.byteLengthAfter))}</span>
               {#if row.checkpoint.checkpoint === checkpointCursor}<span class="checkpoint-state">{strings.actionJournal.checkpointCurrent}</span>{/if}
               {#if row.checkpoint.checkpoint > checkpointCursor}<span class="checkpoint-state">{strings.actionJournal.checkpointFuture}</span>{/if}

--- a/vscode-extension/webview-ui/src/components/ActionJournal.svelte
+++ b/vscode-extension/webview-ui/src/components/ActionJournal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { formatNumber, strings } from '../i18n'
   import type {
+    WebviewActionJournalCheckpoint,
     WebviewActionJournalEntry,
     WebviewActionJournalViewport,
   } from '../protocol'
@@ -9,6 +10,8 @@
     viewport?: WebviewActionJournalViewport
     loading?: boolean
     error?: string
+    checkpoints?: WebviewActionJournalCheckpoint[]
+    checkpointCursor?: number
     canUndo: boolean
     canRedo: boolean
     onUndo: () => void
@@ -22,6 +25,8 @@
     viewport,
     loading = false,
     error = '',
+    checkpoints = [],
+    checkpointCursor = 0,
     canUndo,
     canRedo,
     onUndo,
@@ -32,6 +37,10 @@
   }: Props = $props()
 
   let requestedAnchor = $state('')
+
+  type JournalRow =
+    | { type: 'change'; key: string; coordinate: bigint; entry: WebviewActionJournalEntry }
+    | { type: 'checkpoint'; key: string; coordinate: bigint; checkpoint: WebviewActionJournalCheckpoint }
 
   function decimal(value: string): bigint {
     try {
@@ -72,6 +81,41 @@
   function retry(): void {
     requestedAnchor = ''
     onRetry()
+  }
+
+  function journalRows(): JournalRow[] {
+    const rows: JournalRow[] = [
+      ...((viewport?.entries ?? []).map((entry) => ({
+        type: 'change' as const,
+        key: `change:${entry.firstSerial}:${entry.lastSerial}`,
+        coordinate: decimal(entry.changeCountAfter),
+        entry,
+      }))),
+      ...checkpoints.map((checkpoint) => ({
+        type: 'checkpoint' as const,
+        key: `checkpoint:${checkpoint.checkpoint}`,
+        coordinate: BigInt(checkpoint.changeCount),
+        checkpoint,
+      })),
+    ]
+    return rows.sort((left, right) => {
+      if (left.coordinate !== right.coordinate) {
+        return left.coordinate > right.coordinate ? -1 : 1
+      }
+      if (left.type === right.type) return 0
+      return left.type === 'checkpoint' ? -1 : 1
+    })
+  }
+
+  function checkpointKind(kind: WebviewActionJournalCheckpoint['boundaryKind']): string {
+    switch (kind) {
+      case 'plain':
+        return strings.actionJournal.checkpointPlain
+      case 'transform':
+        return strings.actionJournal.checkpointTransform
+      case 'tip':
+        return strings.actionJournal.checkpointTip
+    }
   }
 
   function range(entry: WebviewActionJournalEntry): string {
@@ -131,28 +175,47 @@
     </div>
   {:else if !viewport && loading}
     <div class="empty">{strings.actionJournal.loadingHistory}</div>
-  {:else if !viewport || viewport.entries.length === 0}
+  {:else if (!viewport || viewport.entries.length === 0) && checkpoints.length === 0}
     <div class="empty">{strings.actionJournal.noChanges}</div>
   {:else}
     <ol onscroll={loadOlderNearEnd}>
-      {#each viewport.entries as entry (`${entry.firstSerial}:${entry.lastSerial}`)}
-        <li>
-          <div class="entry-main">
-            <span class="serial">#{formatted(entry.firstSerial)}{entry.lastSerial === entry.firstSerial ? '' : `–${formatted(entry.lastSerial)}`}</span>
-            <strong class:transform={entry.kind === 'TRANSFORM'}>{entry.kind}</strong>
-            <span>{range(entry)}</span>
-            <span>{strings.actionJournal.dataLength(decimal(entry.dataLength))}</span>
-            <span class:positive={decimal(entry.sizeDelta) > 0n} class:negative={decimal(entry.sizeDelta) < 0n}>Δ {delta(entry.sizeDelta)} B</span>
-            {#if entry.transactionId}<code>{entry.transactionId}</code>{/if}
-            {#if entry.checkpointBefore !== undefined}<span class="checkpoint">{strings.actionJournal.checkpointBefore(decimal(entry.checkpointBefore))}</span>{/if}
-            {#if entry.checkpointAfter !== undefined}<span class="checkpoint">{strings.actionJournal.checkpointAfter(decimal(entry.checkpointAfter))}</span>{/if}
-            <span class="payload">{payloadHint(entry)}</span>
-            {#if entry.transform}<code>{entry.transform.transformId}</code>{/if}
-          </div>
-        </li>
+      {#each journalRows() as row (row.key)}
+        {#if row.type === 'checkpoint'}
+          <li
+            class="checkpoint-card"
+            class:active={row.checkpoint.checkpoint === checkpointCursor}
+            class:future={row.checkpoint.checkpoint > checkpointCursor}
+          >
+            <span class="checkpoint-symbol" aria-hidden="true">◆</span>
+            <div>
+              <strong>{strings.actionJournal.checkpointCard(row.checkpoint.checkpoint)}</strong>
+              <span>{checkpointKind(row.checkpoint.boundaryKind)}</span>
+              <span>{strings.actionJournal.checkpointChanges(row.checkpoint.changeCount)}</span>
+              <span>{strings.actionJournal.checkpointBytes(decimal(row.checkpoint.byteLengthAfter))}</span>
+              {#if row.checkpoint.checkpoint === checkpointCursor}<span class="checkpoint-state">{strings.actionJournal.checkpointCurrent}</span>{/if}
+              {#if row.checkpoint.checkpoint > checkpointCursor}<span class="checkpoint-state">{strings.actionJournal.checkpointFuture}</span>{/if}
+              {#if !row.checkpoint.available}<span class="checkpoint-state unavailable">{strings.actionJournal.checkpointUnavailable}</span>{/if}
+            </div>
+          </li>
+        {:else}
+          <li>
+            <div class="entry-main">
+              <span class="serial">#{formatted(row.entry.firstSerial)}{row.entry.lastSerial === row.entry.firstSerial ? '' : `–${formatted(row.entry.lastSerial)}`}</span>
+              <strong class:transform={row.entry.kind === 'TRANSFORM'}>{row.entry.kind}</strong>
+              <span>{range(row.entry)}</span>
+              <span>{strings.actionJournal.dataLength(decimal(row.entry.dataLength))}</span>
+              <span class:positive={decimal(row.entry.sizeDelta) > 0n} class:negative={decimal(row.entry.sizeDelta) < 0n}>Δ {delta(row.entry.sizeDelta)} B</span>
+              {#if row.entry.transactionId}<code>{row.entry.transactionId}</code>{/if}
+              {#if row.entry.checkpointBefore !== undefined}<span class="checkpoint">{strings.actionJournal.checkpointBefore(decimal(row.entry.checkpointBefore))}</span>{/if}
+              {#if row.entry.checkpointAfter !== undefined}<span class="checkpoint">{strings.actionJournal.checkpointAfter(decimal(row.entry.checkpointAfter))}</span>{/if}
+              <span class="payload">{payloadHint(row.entry)}</span>
+              {#if row.entry.transform}<code>{row.entry.transform.transformId}</code>{/if}
+            </div>
+          </li>
+        {/if}
       {/each}
     </ol>
-    {#if viewport.hasMore && viewport.nextAnchorSerial}
+    {#if viewport?.hasMore && viewport.nextAnchorSerial}
       <button class="load-more" type="button" disabled={loading} onclick={() => loadOlder(viewport.nextAnchorSerial!)}>
         {loading ? strings.actionJournal.loading : strings.actionJournal.loadOlderChanges}
       </button>
@@ -178,6 +241,15 @@
   .entry-main { flex: 1; display: flex; flex-wrap: wrap; align-items: center; gap: .55rem; min-width: 0; padding: .38rem .5rem; text-align: left; }
   .entry-main strong { color: var(--vscode-charts-blue); }
   .entry-main strong.transform { color: var(--vscode-charts-purple); }
+  .checkpoint-card { gap: .6rem; padding: .48rem .55rem; border-left: 3px solid var(--vscode-charts-yellow); background: color-mix(in srgb, var(--vscode-charts-yellow) 8%, transparent); }
+  .checkpoint-card > div { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; min-width: 0; }
+  .checkpoint-card.active { border-left-color: var(--vscode-charts-green); background: color-mix(in srgb, var(--vscode-charts-green) 10%, transparent); }
+  .checkpoint-card.future { opacity: .72; border-left-style: dashed; }
+  .checkpoint-symbol { color: var(--vscode-charts-yellow); }
+  .checkpoint-card.active .checkpoint-symbol { color: var(--vscode-charts-green); }
+  .checkpoint-card span { color: var(--vscode-descriptionForeground); font-size: .7rem; }
+  .checkpoint-state { padding: .05rem .3rem; border: 1px solid var(--vscode-panel-border); border-radius: .3rem; }
+  .checkpoint-state.unavailable { color: var(--vscode-errorForeground); }
   .serial, code, .payload, .checkpoint { font-size: .7rem; }
   code, .payload, .checkpoint { color: var(--vscode-descriptionForeground); }
   .positive { color: var(--vscode-charts-green); }

--- a/vscode-extension/webview-ui/src/i18n.ts
+++ b/vscode-extension/webview-ui/src/i18n.ts
@@ -563,6 +563,17 @@ const englishStrings = {
       `CP ${formatNumber(checkpoint)} before`,
     checkpointAfter: (checkpoint: number | bigint) =>
       `CP ${formatNumber(checkpoint)} after`,
+    checkpointCard: (checkpoint: number | bigint) =>
+      `Checkpoint ${formatNumber(checkpoint)}`,
+    checkpointChanges: (changes: number | bigint) =>
+      `${formatNumber(changes)} changes`,
+    checkpointBytes: (bytes: number | bigint) => `${formatNumber(bytes)} B`,
+    checkpointPlain: 'manual checkpoint',
+    checkpointTransform: 'transform checkpoint',
+    checkpointTip: 'history tip',
+    checkpointCurrent: 'current',
+    checkpointFuture: 'forward history',
+    checkpointUnavailable: 'unavailable',
     payloadNone: 'none',
     payloadInline: 'inline',
     payloadFileBacked: 'file-backed',
@@ -830,6 +841,17 @@ const localeOverrides: Record<string, LocaleStringOverrides> = {
         `PC ${formatNumber(checkpoint)} antes`,
       checkpointAfter: (checkpoint: number | bigint) =>
         `PC ${formatNumber(checkpoint)} después`,
+      checkpointCard: (checkpoint: number | bigint) =>
+        `Punto de control ${formatNumber(checkpoint)}`,
+      checkpointChanges: (changes: number | bigint) =>
+        `${formatNumber(changes)} cambios`,
+      checkpointBytes: (bytes: number | bigint) => `${formatNumber(bytes)} B`,
+      checkpointPlain: 'punto de control manual',
+      checkpointTransform: 'punto de control de transformación',
+      checkpointTip: 'fin del historial',
+      checkpointCurrent: 'actual',
+      checkpointFuture: 'historial futuro',
+      checkpointUnavailable: 'no disponible',
       payloadNone: 'ninguno',
       payloadInline: 'integrado',
       payloadFileBacked: 'respaldado por archivo',

--- a/vscode-extension/webview-ui/src/protocol.ts
+++ b/vscode-extension/webview-ui/src/protocol.ts
@@ -9,6 +9,7 @@ export type {
   ServerHealthMessage,
   TextEncoding,
   WebviewEditorUiState,
+  WebviewActionJournalCheckpoint,
   WebviewActionJournalEntry,
   WebviewActionJournalKind,
   WebviewActionJournalViewport,


### PR DESCRIPTION
## What changed

- preserve checkpoint and redo change records while navigating backward and forward
- let the action-journal viewport read both active and retained forward history
- add checkpoint cards, current/future states, and button-state regression coverage
- add core and client integration tests for checkpoint, undo, redo, and branch behavior

## Why

Checkpoint checkout removed change records while leaving the session's reported history count intact. The journal then encountered a missing serial and returned `ABORTED: action journal changed while its viewport was being read`. It also meant forward history could not be displayed reliably.

The updated model moves rewound changes into retained undo history, restores them when moving forward, and lets a new editor change clear that forward branch through the existing update path.

## Impact

Users can move backward and forward through journal history until making a new edit. The Action Journal now includes checkpoint cards, and its rewind/forward controls remain disabled when no corresponding history exists.

## Validation

- all 153 core tests
- targeted checkpoint regression: 13,056 assertions
- C++ gRPC server rebuild
- webview diagnostics: 0 errors and 0 warnings
- all 33 extension unit tests
- live checkpoint/undo/redo/branch integration scenario
