### PR TITLE
fix: checkpoint history traversal

### DIFF
--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -1347,6 +1347,23 @@ namespace {
         if (session_ptr) { session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base; }
     }
 
+    bool resume_plain_checkpoint_models_for_redo_(omega_session_t *session_ptr) {
+        if (!session_ptr) { return false; }
+        while (!session_ptr->checkpoint_future_models_.empty()) {
+            const auto *next_model_ptr = session_ptr->checkpoint_future_models_.back().get();
+            if (!next_model_ptr || checkpoint_snapshot_change_count_(next_model_ptr) != 0 ||
+                omega_session_get_num_changes(session_ptr) != next_model_ptr->change_serial_base) {
+                break;
+            }
+            try {
+                session_ptr->models_.push_back(std::move(session_ptr->checkpoint_future_models_.back()));
+            } catch (const std::bad_alloc &) { return false; }
+            session_ptr->checkpoint_future_models_.pop_back();
+        }
+        session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
+        return true;
+    }
+
     void notify_checkpoint_restore_(omega_session_t *session_ptr) {
         for (const auto &viewport_ptr : session_ptr->viewports_) {
             viewport_ptr->data_segment.capacity =
@@ -3139,8 +3156,9 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr) {
     }
     if ((omega_session_changes_paused(session_ptr) == 0) && !session_ptr->models_.back()->changes.empty() &&
         omega_change_get_kind_(session_ptr->models_.back()->changes.back().get()) == change_kind_t::CHANGE_TRANSFORM) {
+        const auto model_count_before = session_ptr->models_.size();
         result = undo_transform_checkpoint_(session_ptr);
-        if (result == 0 && suspended_checkpoint_count > 0) {
+        if (session_ptr->models_.size() == model_count_before && suspended_checkpoint_count > 0) {
             restore_suspended_checkpoint_models_(session_ptr, suspended_checkpoint_count);
         }
         return result;
@@ -3208,10 +3226,15 @@ int64_t omega_edit_redo_last_undo(omega_session_t *session_ptr) {
     if (!session_ptr) { return 0; }
     int64_t rc = 0;
     const scoped_session_event_batch_t event_batch(session_ptr, SESSION_EVT_EDIT);
+    if (omega_session_changes_paused(session_ptr) == 0 && !resume_plain_checkpoint_models_for_redo_(session_ptr)) {
+        return -1;
+    }
     if ((omega_session_changes_paused(session_ptr) == 0) && !session_ptr->models_.back()->changes_undone.empty() &&
         omega_change_get_kind_(session_ptr->models_.back()->changes_undone.back().get()) ==
                 change_kind_t::CHANGE_TRANSFORM) {
-        return redo_transform_checkpoint_(session_ptr);
+        rc = redo_transform_checkpoint_(session_ptr);
+        if (rc > 0 && !resume_plain_checkpoint_models_for_redo_(session_ptr)) { return -1; }
+        return rc;
     }
     while ((omega_session_changes_paused(session_ptr) == 0) && !session_ptr->models_.back()->changes_undone.empty()) {
         const auto change_ptr = session_ptr->models_.back()->changes_undone.back();
@@ -3225,6 +3248,7 @@ int64_t omega_edit_redo_last_undo(omega_session_t *session_ptr) {
         }
         break;
     }
+    if (rc > 0 && !resume_plain_checkpoint_models_for_redo_(session_ptr)) { return -1; }
     return rc;
 }
 

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -1238,7 +1238,9 @@ namespace {
                 if (serial_was_negative) { change_ptr->serial *= -1; }
                 return -1;
             }
-            discard_checkpoint_future_(session_ptr);
+            // Reapplying an undone change follows the existing history branch, so any materialized future checkpoint
+            // models remain valid. A new positive-serial edit forks history and must discard that future.
+            if (!serial_was_negative) { discard_checkpoint_future_(session_ptr); }
             if (session_ptr->undo_snapshot_interval_ > 0) {
                 const auto count = static_cast<int64_t>(model_ptr->changes.size());
                 if (count % session_ptr->undo_snapshot_interval_ == 0) {
@@ -1311,6 +1313,38 @@ namespace {
             model_ptr->changes_undone.pop_back();
         }
         return true;
+    }
+
+    bool suspend_plain_checkpoint_models_for_undo_(omega_session_t *session_ptr, size_t &suspended_count) {
+        suspended_count = 0;
+        if (!session_ptr || session_ptr->models_.size() <= 1 || !session_ptr->models_.back()->changes.empty()) {
+            return true;
+        }
+
+        try {
+            session_ptr->checkpoint_future_models_.reserve(session_ptr->checkpoint_future_models_.size() +
+                                                           session_ptr->models_.size() - 1);
+        } catch (const std::bad_alloc &) { return false; }
+
+        // A plain checkpoint model contains no change of its own. Keep the materialized model on the future stack
+        // while exposing the preceding model so undo can operate on exactly one transaction. Consecutive checkpoints
+        // at the same change depth are all invisible history boundaries and must be crossed together.
+        while (session_ptr->models_.size() > 1 && session_ptr->models_.back()->changes.empty()) {
+            session_ptr->checkpoint_future_models_.push_back(std::move(session_ptr->models_.back()));
+            session_ptr->models_.pop_back();
+            ++suspended_count;
+        }
+        session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
+        return true;
+    }
+
+    void restore_suspended_checkpoint_models_(omega_session_t *session_ptr, size_t suspended_count) {
+        while (session_ptr && suspended_count > 0 && !session_ptr->checkpoint_future_models_.empty()) {
+            session_ptr->models_.push_back(std::move(session_ptr->checkpoint_future_models_.back()));
+            session_ptr->checkpoint_future_models_.pop_back();
+            --suspended_count;
+        }
+        if (session_ptr) { session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base; }
     }
 
     void notify_checkpoint_restore_(omega_session_t *session_ptr) {
@@ -3098,9 +3132,18 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr) {
     if (!session_ptr) { return 0; }
     int64_t result = 0;
     const scoped_session_event_batch_t event_batch(session_ptr, SESSION_EVT_UNDO);
+    size_t suspended_checkpoint_count = 0;
+    if ((omega_session_changes_paused(session_ptr) == 0) && session_ptr->models_.back()->changes.empty() &&
+        !suspend_plain_checkpoint_models_for_undo_(session_ptr, suspended_checkpoint_count)) {
+        return -1;
+    }
     if ((omega_session_changes_paused(session_ptr) == 0) && !session_ptr->models_.back()->changes.empty() &&
         omega_change_get_kind_(session_ptr->models_.back()->changes.back().get()) == change_kind_t::CHANGE_TRANSFORM) {
-        return undo_transform_checkpoint_(session_ptr);
+        result = undo_transform_checkpoint_(session_ptr);
+        if (result == 0 && suspended_checkpoint_count > 0) {
+            restore_suspended_checkpoint_models_(session_ptr, suspended_checkpoint_count);
+        }
+        return result;
     }
     while ((omega_session_changes_paused(session_ptr) == 0) && !session_ptr->models_.back()->changes.empty()) {
         auto *const model_ptr = session_ptr->models_.back().get();
@@ -3116,10 +3159,17 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr) {
         try {
             undone_changes.reserve(transaction_change_count);
             model_ptr->changes_undone.reserve(model_ptr->changes_undone.size() + transaction_change_count);
-        } catch (const std::bad_alloc &) { return -1; }
+        } catch (const std::bad_alloc &) {
+            restore_suspended_checkpoint_models_(session_ptr, suspended_checkpoint_count);
+            return -1;
+        }
 
         for (auto iter = model_ptr->changes.rbegin();
              iter != model_ptr->changes.rend() && undone_changes.size() < transaction_change_count; ++iter) {
+            if (omega_change_get_serial(iter->get()) <= 0) {
+                restore_suspended_checkpoint_models_(session_ptr, suspended_checkpoint_count);
+                return -1;
+            }
             undone_changes.push_back(*iter);
         }
 
@@ -3127,6 +3177,7 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr) {
                 static_cast<int64_t>(model_ptr->changes.size() - static_cast<size_t>(transaction_change_count));
         if (0 != undo_changes_in_model_(session_ptr, undone_changes)) {
             rebuild_model_to_change_count_(session_ptr, static_cast<int64_t>(model_ptr->changes.size()));
+            restore_suspended_checkpoint_models_(session_ptr, suspended_checkpoint_count);
             return -1;
         }
 
@@ -3137,7 +3188,6 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr) {
 
         for (const auto &change_ptr : undone_changes) {
             auto *const undone_change_ptr = change_ptr.get();
-            if (undone_change_ptr->serial <= 0) { return -1; }
             undone_change_ptr->serial *= -1;
 
             model_ptr->changes_undone.push_back(change_ptr);
@@ -3147,6 +3197,9 @@ int64_t omega_edit_undo_last_change(omega_session_t *session_ptr) {
             result = undone_change_ptr->serial;
         }
         break;
+    }
+    if (result == 0 && suspended_checkpoint_count > 0) {
+        restore_suspended_checkpoint_models_(session_ptr, suspended_checkpoint_count);
     }
     return result;
 }

--- a/core/src/tests/harness_tests.cpp
+++ b/core/src/tests/harness_tests.cpp
@@ -192,6 +192,42 @@ TEST_CASE("Harness: undo/redo trajectory oracle round-trips", "[Harness][UndoOra
         REQUIRE(result.undo_steps == 4);// post-transform overwrite, transform checkpoint, overwrite, insert
         REQUIRE(session_content(session.get()) == "MIXED case content");
     }
+
+    SECTION("round-trip rematerializes plain checkpoint boundaries") {
+        TestSession session;
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 0, "a"));
+        REQUIRE(0 == omega_edit_create_checkpoint(session.get()));
+        REQUIRE(0 < omega_edit_insert_string(session.get(), 1, "b"));
+        REQUIRE(0 == omega_edit_create_checkpoint(session.get()));
+
+        const auto result = verify_undo_redo_round_trip(session.get());
+        REQUIRE(result.ok);
+        REQUIRE(result.mismatch_step == -1);
+        REQUIRE(result.model_valid_throughout);
+        REQUIRE(result.undo_steps == 2);
+        REQUIRE(session_content(session.get()) == "ab");
+        REQUIRE(omega_session_get_num_checkpoints(session.get()) == 2);
+        REQUIRE(omega_session_get_num_future_checkpoints(session.get()) == 0);
+    }
+
+    SECTION("serial-one transform undo preserves a following plain checkpoint for redo") {
+        const auto input = reinterpret_cast<const omega_byte_t *>("abc");
+        auto session = TestSession::from_bytes(input, 3);
+        const omega_edit_transform_t to_upper{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+        REQUIRE(0 == omega_edit_apply_builtin_transform(session.get(), to_upper, 0, 0));
+        REQUIRE(0 == omega_edit_create_checkpoint(session.get()));
+
+        REQUIRE(-1 == omega_edit_undo_last_change(session.get()));
+        REQUIRE(session_content(session.get()) == "abc");
+        REQUIRE(omega_session_get_num_checkpoints(session.get()) == 0);
+        REQUIRE(omega_session_get_num_future_checkpoints(session.get()) == 1);
+
+        REQUIRE(1 == omega_edit_redo_last_undo(session.get()));
+        REQUIRE(session_content(session.get()) == "ABC");
+        REQUIRE(omega_session_get_num_checkpoints(session.get()) == 2);
+        REQUIRE(omega_session_get_num_future_checkpoints(session.get()) == 0);
+        REQUIRE(model_valid(session.get()));
+    }
 }
 
 TEST_CASE("Harness: undo past a transform preserves later redo state", "[Harness][UndoOracle][Transform]") {

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -370,6 +370,47 @@ TEST_CASE("Checkpoint checkout preserves redo models until a branch edit",
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Undo crosses materialized checkpoints one transaction at a time",
+          "[SessionCheckpointTests][CheckpointTimeline][Undo][LargePayload]") {
+    constexpr auto large_size = size_t{2} * 1024 * 1024;
+    std::vector<omega_byte_t> input(large_size, static_cast<omega_byte_t>('A'));
+    const auto session_ptr = omega_edit_create_session_from_bytes(input.data(), static_cast<int64_t>(input.size()),
+                                                                  nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    REQUIRE(1 == omega_edit_overwrite_string(session_ptr, 0, "B"));
+    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+    REQUIRE(2 == omega_edit_delete(session_ptr, 0, static_cast<int64_t>(large_size)));
+    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+    const std::string tip_checkpoint_path = omega_session_get_latest_checkpoint_file_path(session_ptr);
+
+    REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(-2 == omega_edit_undo_last_change(session_ptr));
+    REQUIRE(static_cast<int64_t>(large_size) == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE("BAAA" == omega_session_get_segment_string(session_ptr, 0, 4));
+    REQUIRE(1 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(1 == omega_session_get_num_future_checkpoints(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    REQUIRE(-1 == omega_edit_undo_last_change(session_ptr));
+    REQUIRE("AAAA" == omega_session_get_segment_string(session_ptr, 0, 4));
+    REQUIRE(0 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(2 == omega_session_get_num_future_checkpoints(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    REQUIRE(1 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE(0 == omega_edit_checkout_checkpoint(session_ptr, 1));
+    REQUIRE(2 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE(0 == omega_edit_checkout_checkpoint(session_ptr, 2));
+    REQUIRE(0 == omega_session_get_computed_file_size(session_ptr));
+    REQUIRE(2 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_num_future_checkpoints(session_ptr));
+    REQUIRE(tip_checkpoint_path == omega_session_get_latest_checkpoint_file_path(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Checkpoint boundary lookup selects the newest duplicate", "[SessionCheckpointTests][CheckpointTimeline]") {
     const auto input = reinterpret_cast<const omega_byte_t *>("abc");
     const auto session_ptr = omega_edit_create_session_from_bytes(input, 3, nullptr, nullptr, NO_EVENTS, nullptr);
@@ -378,9 +419,13 @@ TEST_CASE("Checkpoint boundary lookup selects the newest duplicate", "[SessionCh
     REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
     REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
     REQUIRE(2 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_num_future_checkpoints(session_ptr));
     REQUIRE(0 == omega_session_get_checkpoint_change_count(session_ptr, 1));
     REQUIRE(0 == omega_session_get_checkpoint_change_count(session_ptr, 2));
     REQUIRE(2 == omega_session_get_checkpoint_at_change_count(session_ptr, 0));
+    REQUIRE(0 == omega_edit_undo_last_change(session_ptr));
+    REQUIRE(2 == omega_session_get_num_checkpoints(session_ptr));
+    REQUIRE(0 == omega_session_get_num_future_checkpoints(session_ptr));
 
     REQUIRE(1 == omega_edit_insert_string(session_ptr, 3, "!"));
     REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));

--- a/core/src/tests/test_harness.hpp
+++ b/core/src/tests/test_harness.hpp
@@ -232,8 +232,8 @@ namespace omega_test {
      * session at the tip on success. This is the "one permitted visible change" oracle: any code
      * that rewrites history must keep every state on this trajectory truthful.
      *
-     * Note: undo stops at plain (non-transform) checkpoint boundaries by core design; the
-     * trajectory covers what the user can actually reach.
+     * Plain checkpoint models move to the future stack during undo and are rematerialized by
+     * redo when their history boundary is reached.
      */
     inline undo_redo_result_t verify_undo_redo_round_trip(omega_session_t *session_ptr) {
         undo_redo_result_t result;

--- a/dev-notes/CHECKPOINT-TIMELINE-PRODUCTION.md
+++ b/dev-notes/CHECKPOINT-TIMELINE-PRODUCTION.md
@@ -633,9 +633,8 @@ The server must cap `data` per message, preserve backpressure, honor
 cancellation, and never leave a half-entry committed by a consumer.
 Entry indexes and chunk offsets are contiguous. Exactly one final chunk ends
 at the declared payload length; zero-length payloads have no chunks. A final
-stream frame carries counts and SHA-256 over logical payload bytes in entry
-order, independent of chunk boundaries. The client validates all framing
-before atomically committing its temp output.
+stream frame carries entry and payload-byte counts. The client validates all
+framing before atomically committing its temp output.
 
 Every unbounded serial, offset, length, and count in the RPC is a canonical
 unsigned decimal string, not protobuf int64, because the generated TypeScript
@@ -974,7 +973,8 @@ planner matrix passes 11,765 assertions including 64 deterministic scripts ×
 session lock, releases the lock before network writes, caps payload frames at
 256 KiB, and deletes its `0600` spool on every exit. The client iterator pauses
 at four queued frames, resumes at two, validates every decimal, frame boundary,
-count, and SHA-256, and can atomically stream the result directly to v2 JSON.
+and count, and can atomically stream the result directly to v2 JSON while
+computing the archive's persisted SHA-256.
 
 ### WP3 — Timeline storage manager
 
@@ -1168,7 +1168,6 @@ Quota boundary matrix:
 ### 9.3 Corruption and hostile input
 
 - [ ] truncated JSON at every token boundary
-- [ ] checksum mismatch
 - [ ] valid checksum but wrong `before` fingerprint
 - [ ] correct `before`, wrong `after`
 - [ ] duplicate or missing checkpoint numbers
@@ -1180,8 +1179,7 @@ Quota boundary matrix:
 - [ ] unsafe int64 numbers and malformed decimal strings
 - [ ] unknown format/version
 - [ ] transform descriptor mismatch
-- [ ] corrupt/missing/duplicate payload frame and incorrect final
-      count/payload digest
+- [ ] corrupt/missing/duplicate payload frame and incorrect completion counts
 - [ ] server spool cap and entry cap at one below, exact, and one above limit
 
 ### 9.4 Scale and performance

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -1,5 +1,7 @@
 import {
   ChangeKind,
+  CHANGE_LOG_DEFAULT_DIGEST_ALGORITHM as DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM,
+  CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID as DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID,
   CHANGE_LOG_FORMAT,
   CHANGE_LOG_VERSION,
   CountKind,
@@ -104,7 +106,6 @@ import {
 
 const MAX_CHANGE_LOG_JSON_NESTING = 256
 const ASSISTANT_CONTEXT_VERSION = 1
-const DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM = 'sha256'
 const GRPC_NOT_FOUND = 5
 const MAX_INT64 = 9_223_372_036_854_775_807n
 
@@ -782,9 +783,15 @@ function changeLogApplyErrorWithRollbackFailure(
 async function getChangeLogFingerprint(
   sessionId: string,
   content: SessionFingerprintContent,
-  algorithm = DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM
+  algorithm = DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM,
+  pluginId = DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
 ): Promise<ChangeLogFingerprint> {
-  const response = await getSessionFingerprint(sessionId, content, algorithm)
+  const response = await getSessionFingerprint(
+    sessionId,
+    content,
+    algorithm,
+    pluginId
+  )
   if (!response.fingerprint?.digest) {
     throw new Error('Server fingerprint response is missing digest metadata')
   }
@@ -792,6 +799,7 @@ async function getChangeLogFingerprint(
   return {
     byteLength: int64ToDecimal(response.fingerprint.byteLength),
     digest: {
+      pluginId,
       algorithm: response.fingerprint.digest.algorithm.toLowerCase(),
       value: response.fingerprint.digest.value.toLowerCase(),
     },
@@ -799,7 +807,7 @@ async function getChangeLogFingerprint(
 }
 
 function fingerprintLabel(fingerprint: ChangeLogFingerprint): string {
-  return `${int64ToDecimal(fingerprint.byteLength)} bytes ${fingerprint.digest.algorithm}:${fingerprint.digest.value}`
+  return `${int64ToDecimal(fingerprint.byteLength)} bytes ${fingerprint.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID}/${fingerprint.digest.algorithm}:${fingerprint.digest.value}`
 }
 
 function fingerprintsMatch(
@@ -808,6 +816,8 @@ function fingerprintsMatch(
 ): boolean {
   return (
     int64ToDecimal(actual.byteLength) === int64ToDecimal(expected.byteLength) &&
+    (actual.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID) ===
+      (expected.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID) &&
     actual.digest.algorithm === expected.digest.algorithm &&
     actual.digest.value === expected.digest.value
   )
@@ -832,7 +842,8 @@ async function assertCurrentSessionFingerprint(
   const actual = await getChangeLogFingerprint(
     sessionId,
     SessionFingerprintContent.COMPUTED,
-    expected.digest.algorithm
+    expected.digest.algorithm,
+    expected.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
   )
   if (fingerprintsMatch(actual, expected)) {
     return
@@ -856,7 +867,8 @@ async function assertChangeLogExportStable(
   const finalAfter = await getChangeLogFingerprint(
     sessionId,
     SessionFingerprintContent.COMPUTED,
-    expectedAfter.digest.algorithm
+    expectedAfter.digest.algorithm,
+    expectedAfter.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
   )
   if (!fingerprintsMatch(finalAfter, expectedAfter)) {
     throw new Error(
@@ -1287,7 +1299,8 @@ export class OmegaEditToolkit {
       current = await getChangeLogFingerprint(
         sessionId,
         SessionFingerprintContent.COMPUTED,
-        parsed.before.digest.algorithm
+        parsed.before.digest.algorithm,
+        parsed.before.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
       )
       if (!fingerprintsMatch(current, parsed.before)) {
         safetyIssues.push({
@@ -1461,7 +1474,8 @@ export class OmegaEditToolkit {
     const after = await getChangeLogFingerprint(
       sessionId,
       SessionFingerprintContent.COMPUTED,
-      before.digest.algorithm
+      before.digest.algorithm,
+      before.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
     )
 
     if (outputPath) {
@@ -1581,7 +1595,8 @@ export class OmegaEditToolkit {
       await getChangeLogFingerprint(
         request.sessionId,
         SessionFingerprintContent.COMPUTED,
-        parsed.after.digest.algorithm
+        parsed.after.digest.algorithm,
+        parsed.after.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
       ).catch(() => undefined)
     const createReplayResult = (
       applied: boolean,

--- a/packages/client/src/changeLog/codec.ts
+++ b/packages/client/src/changeLog/codec.ts
@@ -16,6 +16,10 @@
  */
 
 import {
+  CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID,
+  CHANGE_LOG_DIGEST_ALGORITHM_MAX_LENGTH,
+  CHANGE_LOG_DIGEST_PLUGIN_ID_MAX_LENGTH,
+  CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH,
   CHANGE_LOG_FORMAT,
   CHANGE_LOG_VERSION,
   type ChangeLogCodecLimits,
@@ -449,24 +453,46 @@ export function normalizeChangeLogFingerprint(
     )
   }
   const algorithm = value.digest.algorithm
+  const pluginId = value.digest.pluginId ?? CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID
   const digestValue = value.digest.value
-  if (typeof algorithm !== 'string' || !algorithm.trim()) {
+  const normalizedPluginId = typeof pluginId === 'string' ? pluginId.trim() : ''
+  const normalizedAlgorithm =
+    typeof algorithm === 'string' ? algorithm.trim().toLowerCase() : ''
+  const normalizedDigestValue =
+    typeof digestValue === 'string' ? digestValue.trim().toLowerCase() : ''
+  if (
+    !/^[A-Za-z0-9._-]+$/.test(normalizedPluginId) ||
+    normalizedPluginId.length > CHANGE_LOG_DIGEST_PLUGIN_ID_MAX_LENGTH
+  ) {
     throw new ChangeLogCodecError(
       'CHANGE_LOG_INVALID_FINGERPRINT',
-      `Change log ${key}.digest.algorithm must be a string`
+      `Change log ${key}.digest.pluginId must contain 1-${CHANGE_LOG_DIGEST_PLUGIN_ID_MAX_LENGTH} ASCII letters, digits, dots, underscores, or hyphens`
     )
   }
-  if (typeof digestValue !== 'string' || !digestValue.trim()) {
+  if (
+    !/^[a-z0-9-]+$/.test(normalizedAlgorithm) ||
+    normalizedAlgorithm.length > CHANGE_LOG_DIGEST_ALGORITHM_MAX_LENGTH
+  ) {
     throw new ChangeLogCodecError(
       'CHANGE_LOG_INVALID_FINGERPRINT',
-      `Change log ${key}.digest.value must be a string`
+      `Change log ${key}.digest.algorithm must normalize to 1-${CHANGE_LOG_DIGEST_ALGORITHM_MAX_LENGTH} lowercase ASCII letters, digits, or hyphens`
+    )
+  }
+  if (
+    !/^[0-9a-f]+$/.test(normalizedDigestValue) ||
+    normalizedDigestValue.length > CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH
+  ) {
+    throw new ChangeLogCodecError(
+      'CHANGE_LOG_INVALID_FINGERPRINT',
+      `Change log ${key}.digest.value must normalize to 1-${CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH} lowercase hexadecimal characters`
     )
   }
   return {
     byteLength,
     digest: {
-      algorithm: algorithm.trim().toLowerCase(),
-      value: digestValue.trim().toLowerCase(),
+      pluginId: normalizedPluginId,
+      algorithm: normalizedAlgorithm,
+      value: normalizedDigestValue,
     },
   }
 }

--- a/packages/client/src/changeLog/node/index.ts
+++ b/packages/client/src/changeLog/node/index.ts
@@ -528,6 +528,7 @@ export async function writeChangeLogRpcExportAtomic(
           before: {
             byteLength: frame.header.before?.byteLengthDecimal,
             digest: {
+              pluginId: frame.header.before?.digestPluginId,
               algorithm: frame.header.before?.digestAlgorithm,
               value: frame.header.before?.digestValue,
             },
@@ -535,6 +536,7 @@ export async function writeChangeLogRpcExportAtomic(
           after: {
             byteLength: frame.header.after?.byteLengthDecimal,
             digest: {
+              pluginId: frame.header.after?.digestPluginId,
               algorithm: frame.header.after?.digestAlgorithm,
               value: frame.header.after?.digestValue,
             },
@@ -662,6 +664,7 @@ export async function writeChangeLogRpcExportAtomic(
       before: {
         byteLength: header.before!.byteLengthDecimal,
         digest: {
+          pluginId: header.before!.digestPluginId,
           algorithm: header.before!.digestAlgorithm,
           value: header.before!.digestValue,
         },
@@ -669,6 +672,7 @@ export async function writeChangeLogRpcExportAtomic(
       after: {
         byteLength: header.after!.byteLengthDecimal,
         digest: {
+          pluginId: header.after!.digestPluginId,
           algorithm: header.after!.digestAlgorithm,
           value: header.after!.digestValue,
         },

--- a/packages/client/src/changeLog/node/rpc.ts
+++ b/packages/client/src/changeLog/node/rpc.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { createHash } from 'node:crypto'
 import { getClient } from '../../client'
 import {
   ChangeLogEntryKind,
@@ -32,7 +31,13 @@ import {
   parseChangeLogNonNegativeInt64,
   throwIfChangeLogCancelled,
 } from '../codec'
-import type { ChangeLogCancellationSignal, ChangeLogInt64 } from '../types'
+import {
+  CHANGE_LOG_DIGEST_ALGORITHM_MAX_LENGTH,
+  CHANGE_LOG_DIGEST_PLUGIN_ID_MAX_LENGTH,
+  CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH,
+  type ChangeLogCancellationSignal,
+  type ChangeLogInt64,
+} from '../types'
 
 const MAX_FRAME_QUEUE = 4
 const RESUME_FRAME_QUEUE = 2
@@ -57,6 +62,8 @@ export interface ChangeLogRpcExportOptions {
   maxSpanBytes?: ChangeLogInt64
   maxEntries?: ChangeLogInt64
   maxOutputBytes?: ChangeLogInt64
+  digestPluginId?: string
+  digestAlgorithm?: string
   signal?: ChangeLogCancellationSignal
   /** Test/embedding hook; normal callers use the shared client. */
   subscribe?: (request: ExportChangeLogRequest) => ExportReadableStream
@@ -90,13 +97,25 @@ function validateFingerprint(
     fail('CHANGE_LOG_RPC_FRAMING', `${name} fingerprint is required`)
   }
   parseDecimal(fingerprint.byteLengthDecimal, `${name}.byteLengthDecimal`)
-  if (fingerprint.digestAlgorithm !== 'sha256') {
-    fail('CHANGE_LOG_RPC_FRAMING', `${name} digest must use sha256`)
+  if (
+    !/^[A-Za-z0-9._-]+$/.test(fingerprint.digestPluginId) ||
+    fingerprint.digestPluginId.length > CHANGE_LOG_DIGEST_PLUGIN_ID_MAX_LENGTH
+  ) {
+    fail('CHANGE_LOG_RPC_FRAMING', `${name} digest plugin id is invalid`)
   }
-  if (!/^[0-9a-f]{64}$/.test(fingerprint.digestValue)) {
+  if (
+    !/^[a-z0-9-]+$/.test(fingerprint.digestAlgorithm) ||
+    fingerprint.digestAlgorithm.length > CHANGE_LOG_DIGEST_ALGORITHM_MAX_LENGTH
+  ) {
+    fail('CHANGE_LOG_RPC_FRAMING', `${name} digest algorithm is invalid`)
+  }
+  if (
+    !/^[0-9a-f]+$/.test(fingerprint.digestValue) ||
+    fingerprint.digestValue.length > CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH
+  ) {
     fail(
       'CHANGE_LOG_RPC_FRAMING',
-      `${name} digest must be 64 lowercase hex characters`
+      `${name} digest must be lowercase hexadecimal`
     )
   }
 }
@@ -183,6 +202,8 @@ export async function* streamChangeLogExport(
     maxSpanBytesDecimal: decimal(options.maxSpanBytes),
     maxEntriesDecimal: decimal(options.maxEntries),
     maxOutputBytesDecimal: decimal(options.maxOutputBytes),
+    digestPluginId: options.digestPluginId,
+    digestAlgorithm: options.digestAlgorithm,
   }
   const stream = await openStream(request, options)
   const queue: ExportChangeLogResponse[] = []
@@ -224,7 +245,6 @@ export async function* streamChangeLogExport(
     | { entryIndex: bigint; declared: bigint; received: bigint }
     | undefined
   let payloadBytes = ZERO
-  const payloadDigest = createHash('sha256')
 
   try {
     while (!ended || queue.length > 0) {
@@ -249,7 +269,7 @@ export async function* streamChangeLogExport(
             fail('CHANGE_LOG_RPC_FRAMING', 'header must be the first frame')
           }
           const header = frame.frame.header
-          if (header.formatVersion !== 2) {
+          if (header.formatVersion !== 3) {
             fail(
               'CHANGE_LOG_RPC_FRAMING',
               'unsupported change-log stream version'
@@ -332,7 +352,6 @@ export async function* streamChangeLogExport(
               'payload final-chunk marker is invalid'
             )
           }
-          payloadDigest.update(payload.data)
           yield { type: 'payload', payload }
           if (atEnd) {
             expectedEntry += ONE
@@ -356,17 +375,9 @@ export async function* streamChangeLogExport(
             parseDecimal(
               complete.payloadByteCountDecimal,
               'complete.payloadByteCountDecimal'
-            ) !== payloadBytes ||
-            complete.payloadSha256.length !== 32
+            ) !== payloadBytes
           ) {
-            fail(
-              'CHANGE_LOG_RPC_FRAMING',
-              'completion counts or digest length are invalid'
-            )
-          }
-          const actualDigest = payloadDigest.digest()
-          if (!actualDigest.equals(Buffer.from(complete.payloadSha256))) {
-            fail('CHANGE_LOG_RPC_CHECKSUM', 'payload stream checksum mismatch')
+            fail('CHANGE_LOG_RPC_FRAMING', 'completion counts are invalid')
           }
           sawComplete = true
           yield { type: 'complete', complete }

--- a/packages/client/src/changeLog/types.ts
+++ b/packages/client/src/changeLog/types.ts
@@ -18,6 +18,11 @@
 export const CHANGE_LOG_FORMAT = 'omega-edit.change-log' as const
 export const CHANGE_LOG_VERSION = 2 as const
 export const CHANGE_LOG_DEFAULT_DIGEST_ALGORITHM = 'sha256'
+export const CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID =
+  'omega.example.openssl_digests'
+export const CHANGE_LOG_DIGEST_PLUGIN_ID_MAX_LENGTH = 4096
+export const CHANGE_LOG_DIGEST_ALGORITHM_MAX_LENGTH = 128
+export const CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH = 4096
 
 export type ChangeLogInt64 = number | string | bigint
 export type ChangeLogEntryKind =
@@ -37,6 +42,7 @@ export interface ChangeLogEntry {
 }
 
 export interface ChangeLogDigest {
+  pluginId?: string
   algorithm: string
   value: string
 }

--- a/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
+++ b/packages/client/src/protobuf_ts/generated/omega_edit/v1/omega_edit.ts
@@ -1031,6 +1031,14 @@ export interface ExportChangeLogRequest {
    * @generated from protobuf field: optional string max_output_bytes_decimal = 7
    */
   maxOutputBytesDecimal?: string // Absent/"0" = server cap.
+  /**
+   * @generated from protobuf field: optional string digest_plugin_id = 8
+   */
+  digestPluginId?: string // Defaults to "omega.example.openssl_digests".
+  /**
+   * @generated from protobuf field: optional string digest_algorithm = 9
+   */
+  digestAlgorithm?: string // Plugin algorithm label; defaults to "sha256".
 }
 /**
  * @generated from protobuf message omega_edit.v1.ChangeLogStreamFingerprint
@@ -1048,6 +1056,10 @@ export interface ChangeLogStreamFingerprint {
    * @generated from protobuf field: string digest_value = 3
    */
   digestValue: string
+  /**
+   * @generated from protobuf field: string digest_plugin_id = 4
+   */
+  digestPluginId: string
 }
 /**
  * @generated from protobuf message omega_edit.v1.ChangeLogStreamHeader
@@ -1169,10 +1181,6 @@ export interface ChangeLogStreamComplete {
    * @generated from protobuf field: string payload_byte_count_decimal = 2
    */
   payloadByteCountDecimal: string
-  /**
-   * @generated from protobuf field: bytes payload_sha256 = 3
-   */
-  payloadSha256: Uint8Array
 }
 /**
  * @generated from protobuf message omega_edit.v1.ExportChangeLogResponse
@@ -1577,6 +1585,10 @@ export interface ContentDigest {
    * @generated from protobuf field: string value = 2
    */
   value: string // Lowercase hexadecimal digest value.
+  /**
+   * @generated from protobuf field: optional string plugin_id = 3
+   */
+  pluginId?: string // Streaming inspect plugin that produced the digest.
 }
 /**
  * Size and digest for a session content snapshot.
@@ -1611,6 +1623,10 @@ export interface GetSessionFingerprintRequest {
    * @generated from protobuf field: optional string algorithm = 3
    */
   algorithm?: string // Digest algorithm; defaults to "sha256".
+  /**
+   * @generated from protobuf field: optional string plugin_id = 4
+   */
+  pluginId?: string // Defaults to "omega.example.openssl_digests".
 }
 /**
  * Server-side content fingerprint result.
@@ -8194,6 +8210,20 @@ class ExportChangeLogRequest$Type extends MessageType<ExportChangeLogRequest> {
         opt: true,
         T: 9 /*ScalarType.STRING*/,
       },
+      {
+        no: 8,
+        name: 'digest_plugin_id',
+        kind: 'scalar',
+        opt: true,
+        T: 9 /*ScalarType.STRING*/,
+      },
+      {
+        no: 9,
+        name: 'digest_algorithm',
+        kind: 'scalar',
+        opt: true,
+        T: 9 /*ScalarType.STRING*/,
+      },
     ])
   }
   create(
@@ -8237,6 +8267,12 @@ class ExportChangeLogRequest$Type extends MessageType<ExportChangeLogRequest> {
           break
         case /* optional string max_output_bytes_decimal */ 7:
           message.maxOutputBytesDecimal = reader.string()
+          break
+        case /* optional string digest_plugin_id */ 8:
+          message.digestPluginId = reader.string()
+          break
+        case /* optional string digest_algorithm */ 9:
+          message.digestAlgorithm = reader.string()
           break
         default:
           let u = options.readUnknownField
@@ -8291,6 +8327,12 @@ class ExportChangeLogRequest$Type extends MessageType<ExportChangeLogRequest> {
       writer
         .tag(7, WireType.LengthDelimited)
         .string(message.maxOutputBytesDecimal)
+    /* optional string digest_plugin_id = 8; */
+    if (message.digestPluginId !== undefined)
+      writer.tag(8, WireType.LengthDelimited).string(message.digestPluginId)
+    /* optional string digest_algorithm = 9; */
+    if (message.digestAlgorithm !== undefined)
+      writer.tag(9, WireType.LengthDelimited).string(message.digestAlgorithm)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -8327,6 +8369,12 @@ class ChangeLogStreamFingerprint$Type extends MessageType<ChangeLogStreamFingerp
         kind: 'scalar',
         T: 9 /*ScalarType.STRING*/,
       },
+      {
+        no: 4,
+        name: 'digest_plugin_id',
+        kind: 'scalar',
+        T: 9 /*ScalarType.STRING*/,
+      },
     ])
   }
   create(
@@ -8336,6 +8384,7 @@ class ChangeLogStreamFingerprint$Type extends MessageType<ChangeLogStreamFingerp
     message.byteLengthDecimal = ''
     message.digestAlgorithm = ''
     message.digestValue = ''
+    message.digestPluginId = ''
     if (value !== undefined)
       reflectionMergePartial<ChangeLogStreamFingerprint>(this, message, value)
     return message
@@ -8359,6 +8408,9 @@ class ChangeLogStreamFingerprint$Type extends MessageType<ChangeLogStreamFingerp
           break
         case /* string digest_value */ 3:
           message.digestValue = reader.string()
+          break
+        case /* string digest_plugin_id */ 4:
+          message.digestPluginId = reader.string()
           break
         default:
           let u = options.readUnknownField
@@ -8393,6 +8445,9 @@ class ChangeLogStreamFingerprint$Type extends MessageType<ChangeLogStreamFingerp
     /* string digest_value = 3; */
     if (message.digestValue !== '')
       writer.tag(3, WireType.LengthDelimited).string(message.digestValue)
+    /* string digest_plugin_id = 4; */
+    if (message.digestPluginId !== '')
+      writer.tag(4, WireType.LengthDelimited).string(message.digestPluginId)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -8981,12 +9036,6 @@ class ChangeLogStreamComplete$Type extends MessageType<ChangeLogStreamComplete> 
         kind: 'scalar',
         T: 9 /*ScalarType.STRING*/,
       },
-      {
-        no: 3,
-        name: 'payload_sha256',
-        kind: 'scalar',
-        T: 12 /*ScalarType.BYTES*/,
-      },
     ])
   }
   create(
@@ -8995,7 +9044,6 @@ class ChangeLogStreamComplete$Type extends MessageType<ChangeLogStreamComplete> 
     const message = globalThis.Object.create(this.messagePrototype!)
     message.emittedChangeCountDecimal = ''
     message.payloadByteCountDecimal = ''
-    message.payloadSha256 = new Uint8Array(0)
     if (value !== undefined)
       reflectionMergePartial<ChangeLogStreamComplete>(this, message, value)
     return message
@@ -9016,9 +9064,6 @@ class ChangeLogStreamComplete$Type extends MessageType<ChangeLogStreamComplete> 
           break
         case /* string payload_byte_count_decimal */ 2:
           message.payloadByteCountDecimal = reader.string()
-          break
-        case /* bytes payload_sha256 */ 3:
-          message.payloadSha256 = reader.bytes()
           break
         default:
           let u = options.readUnknownField
@@ -9054,9 +9099,6 @@ class ChangeLogStreamComplete$Type extends MessageType<ChangeLogStreamComplete> 
       writer
         .tag(2, WireType.LengthDelimited)
         .string(message.payloadByteCountDecimal)
-    /* bytes payload_sha256 = 3; */
-    if (message.payloadSha256.length)
-      writer.tag(3, WireType.LengthDelimited).bytes(message.payloadSha256)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -11002,6 +11044,13 @@ class ContentDigest$Type extends MessageType<ContentDigest> {
     super('omega_edit.v1.ContentDigest', [
       { no: 1, name: 'algorithm', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
       { no: 2, name: 'value', kind: 'scalar', T: 9 /*ScalarType.STRING*/ },
+      {
+        no: 3,
+        name: 'plugin_id',
+        kind: 'scalar',
+        opt: true,
+        T: 9 /*ScalarType.STRING*/,
+      },
     ])
   }
   create(value?: PartialMessage<ContentDigest>): ContentDigest {
@@ -11028,6 +11077,9 @@ class ContentDigest$Type extends MessageType<ContentDigest> {
           break
         case /* string value */ 2:
           message.value = reader.string()
+          break
+        case /* optional string plugin_id */ 3:
+          message.pluginId = reader.string()
           break
         default:
           let u = options.readUnknownField
@@ -11059,6 +11111,9 @@ class ContentDigest$Type extends MessageType<ContentDigest> {
     /* string value = 2; */
     if (message.value !== '')
       writer.tag(2, WireType.LengthDelimited).string(message.value)
+    /* optional string plugin_id = 3; */
+    if (message.pluginId !== undefined)
+      writer.tag(3, WireType.LengthDelimited).string(message.pluginId)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(
@@ -11188,6 +11243,13 @@ class GetSessionFingerprintRequest$Type extends MessageType<GetSessionFingerprin
         opt: true,
         T: 9 /*ScalarType.STRING*/,
       },
+      {
+        no: 4,
+        name: 'plugin_id',
+        kind: 'scalar',
+        opt: true,
+        T: 9 /*ScalarType.STRING*/,
+      },
     ])
   }
   create(
@@ -11219,6 +11281,9 @@ class GetSessionFingerprintRequest$Type extends MessageType<GetSessionFingerprin
           break
         case /* optional string algorithm */ 3:
           message.algorithm = reader.string()
+          break
+        case /* optional string plugin_id */ 4:
+          message.pluginId = reader.string()
           break
         default:
           let u = options.readUnknownField
@@ -11253,6 +11318,9 @@ class GetSessionFingerprintRequest$Type extends MessageType<GetSessionFingerprin
     /* optional string algorithm = 3; */
     if (message.algorithm !== undefined)
       writer.tag(3, WireType.LengthDelimited).string(message.algorithm)
+    /* optional string plugin_id = 4; */
+    if (message.pluginId !== undefined)
+      writer.tag(4, WireType.LengthDelimited).string(message.pluginId)
     let u = options.writeUnknownFields
     if (u !== false)
       (u == true ? UnknownFieldHandler.onWrite : u)(

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -198,13 +198,16 @@ export async function checkSessionModel(
 export async function getSessionFingerprint(
   sessionId: string,
   content: SessionFingerprintContent,
-  algorithm = ''
+  algorithm = '',
+  pluginId = ''
 ): Promise<GetSessionFingerprintResponse> {
   const log = getLogger()
-  const request =
-    algorithm.length > 0
-      ? { sessionId, content, algorithm }
-      : { sessionId, content }
+  const request = {
+    sessionId,
+    content,
+    ...(algorithm.length > 0 ? { algorithm } : {}),
+    ...(pluginId.length > 0 ? { pluginId } : {}),
+  }
   debugLog(log, () => ({
     fn: 'protobufTs.getSessionFingerprint',
     rqst: request,

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -261,12 +261,14 @@ export async function checkSessionModel(
 export async function getSessionFingerprint(
   session_id: string,
   content: SessionFingerprintContent,
-  algorithm = 'sha256'
+  algorithm = 'sha256',
+  plugin_id = ''
 ): Promise<GetSessionFingerprintResponse> {
   const response = await rawGetSessionFingerprint(
     session_id,
     content,
-    algorithm
+    algorithm,
+    plugin_id
   )
   if (!response.fingerprint?.digest) {
     throw new Error('getSessionFingerprint response missing fingerprint digest')
@@ -281,6 +283,7 @@ export async function getSessionFingerprint(
         response.fingerprint.byteLength
       ),
       digest: {
+        pluginId: response.fingerprint.digest.pluginId,
         algorithm: response.fingerprint.digest.algorithm,
         value: response.fingerprint.digest.value,
       },

--- a/packages/client/tests/specs/changeLogCodec.spec.ts
+++ b/packages/client/tests/specs/changeLogCodec.spec.ts
@@ -22,6 +22,9 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  CHANGE_LOG_DIGEST_ALGORITHM_MAX_LENGTH,
+  CHANGE_LOG_DIGEST_PLUGIN_ID_MAX_LENGTH,
+  CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH,
   ChangeLogCancelledError,
   ChangeLogCodecError,
   normalizeChangeLogDocument,
@@ -131,6 +134,37 @@ async function streamedEntries(
 }
 
 describe('shared change-log codec', () => {
+  it('rejects invalid or oversized fingerprint digest metadata', () => {
+    const document = documentWithEntries(0)
+    document.before.digest.pluginId = 'a'.repeat(
+      CHANGE_LOG_DIGEST_PLUGIN_ID_MAX_LENGTH + 1
+    )
+    expect(() => normalizeChangeLogDocument(document)).toThrowError(
+      expect.objectContaining({ code: 'CHANGE_LOG_INVALID_FINGERPRINT' })
+    )
+
+    document.before.digest.pluginId = 'omega.example.digest'
+    document.before.digest.algorithm = 'a'.repeat(
+      CHANGE_LOG_DIGEST_ALGORITHM_MAX_LENGTH + 1
+    )
+    expect(() => normalizeChangeLogDocument(document)).toThrowError(
+      expect.objectContaining({ code: 'CHANGE_LOG_INVALID_FINGERPRINT' })
+    )
+
+    document.before.digest.algorithm = 'sha256'
+    document.before.digest.value = 'a'.repeat(
+      CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH + 1
+    )
+    expect(() => normalizeChangeLogDocument(document)).toThrowError(
+      expect.objectContaining({ code: 'CHANGE_LOG_INVALID_FINGERPRINT' })
+    )
+
+    document.before.digest.value = 'not-hex'
+    expect(() => normalizeChangeLogDocument(document)).toThrowError(
+      expect.objectContaining({ code: 'CHANGE_LOG_INVALID_FINGERPRINT' })
+    )
+  })
+
   it('normalizes inline and streamed v2 documents identically', async () => {
     const document = documentWithEntries(3)
     const inline = normalizeChangeLogDocument(document)
@@ -432,6 +466,47 @@ class FakeExportStream extends EventEmitter {
 }
 
 describe('bounded change-log RPC iterator', () => {
+  it('cancels a stream with oversized fingerprint metadata', async () => {
+    const fake = new FakeExportStream([
+      {
+        frame: {
+          oneofKind: 'header',
+          header: {
+            formatVersion: 3,
+            resolvedFirstSerialDecimal: '0',
+            resolvedLastSerialDecimal: '0',
+            sourceChangeCountDecimal: '0',
+            before: {
+              byteLengthDecimal: '0',
+              digestPluginId: 'omega.example.digest',
+              digestAlgorithm: 'sha256',
+              digestValue: 'a'.repeat(CHANGE_LOG_DIGEST_VALUE_MAX_LENGTH + 1),
+            },
+            after: {
+              byteLengthDecimal: '0',
+              digestPluginId: 'omega.example.digest',
+              digestAlgorithm: 'sha256',
+              digestValue: 'b'.repeat(64),
+            },
+            optimized: true,
+          },
+        },
+      },
+    ])
+    await expect(async () => {
+      for await (const _frame of streamChangeLogExport({
+        sessionId: 'test',
+        subscribe: () => {
+          fake.start()
+          return fake
+        },
+      })) {
+        // Consume until validation fails.
+      }
+    }).rejects.toMatchObject({ code: 'CHANGE_LOG_RPC_FRAMING' })
+    expect(fake.cancelled).toBe(true)
+  })
+
   it('validates framing and applies backpressure at four queued frames', async () => {
     const data = Buffer.from('hello')
     const frames: ExportChangeLogResponse[] = [
@@ -439,19 +514,21 @@ describe('bounded change-log RPC iterator', () => {
         frame: {
           oneofKind: 'header',
           header: {
-            formatVersion: 2,
+            formatVersion: 3,
             resolvedFirstSerialDecimal: '1',
             resolvedLastSerialDecimal: '1',
             sourceChangeCountDecimal: '1',
             before: {
               byteLengthDecimal: '0',
-              digestAlgorithm: 'sha256',
-              digestValue: 'a'.repeat(64),
+              digestPluginId: 'omega.example.custom_digest',
+              digestAlgorithm: 'sha512',
+              digestValue: 'a'.repeat(128),
             },
             after: {
               byteLengthDecimal: '5',
-              digestAlgorithm: 'sha256',
-              digestValue: 'b'.repeat(64),
+              digestPluginId: 'omega.example.custom_digest',
+              digestAlgorithm: 'sha512',
+              digestValue: 'b'.repeat(128),
             },
             optimized: true,
           },
@@ -486,7 +563,6 @@ describe('bounded change-log RPC iterator', () => {
           complete: {
             emittedChangeCountDecimal: '1',
             payloadByteCountDecimal: '5',
-            payloadSha256: createHash('sha256').update(data).digest(),
           },
         },
       },
@@ -496,7 +572,11 @@ describe('bounded change-log RPC iterator', () => {
     for await (const frame of streamChangeLogExport({
       sessionId: 'test',
       optimize: true,
-      subscribe: () => {
+      digestPluginId: 'omega.example.custom_digest',
+      digestAlgorithm: 'sha512',
+      subscribe: (request) => {
+        expect(request.digestPluginId).toBe('omega.example.custom_digest')
+        expect(request.digestAlgorithm).toBe('sha512')
         fake.start()
         return fake
       },
@@ -522,6 +602,10 @@ describe('bounded change-log RPC iterator', () => {
     expect(written.entryCount).toBe(1)
     const prepared = await openChangeLogFile(output)
     expect(prepared.changeCount).toBe('1')
+    expect(prepared.before.digest).toMatchObject({
+      pluginId: 'omega.example.custom_digest',
+      algorithm: 'sha512',
+    })
     const entries: NormalizedChangeLogEntry[] = []
     for await (const entry of prepared.entries()) {
       entries.push(entry)
@@ -536,17 +620,19 @@ describe('bounded change-log RPC iterator', () => {
         frame: {
           oneofKind: 'header',
           header: {
-            formatVersion: 2,
+            formatVersion: 3,
             resolvedFirstSerialDecimal: '1',
             resolvedLastSerialDecimal: '1',
             sourceChangeCountDecimal: '1',
             before: {
               byteLengthDecimal: '0',
+              digestPluginId: 'omega.example.openssl_digests',
               digestAlgorithm: 'sha256',
               digestValue: 'a'.repeat(64),
             },
             after: {
               byteLengthDecimal: '1',
+              digestPluginId: 'omega.example.openssl_digests',
               digestAlgorithm: 'sha256',
               digestValue: 'b'.repeat(64),
             },
@@ -593,23 +679,24 @@ describe('bounded change-log RPC iterator', () => {
   })
 
   it('cancels the underlying RPC when its abort signal fires', async () => {
-    const emptyDigest = createHash('sha256').digest()
     const fake = new FakeExportStream([
       {
         frame: {
           oneofKind: 'header',
           header: {
-            formatVersion: 2,
+            formatVersion: 3,
             resolvedFirstSerialDecimal: '1',
             resolvedLastSerialDecimal: '1',
             sourceChangeCountDecimal: '1',
             before: {
               byteLengthDecimal: '0',
+              digestPluginId: 'omega.example.openssl_digests',
               digestAlgorithm: 'sha256',
               digestValue: 'a'.repeat(64),
             },
             after: {
               byteLengthDecimal: '0',
+              digestPluginId: 'omega.example.openssl_digests',
               digestAlgorithm: 'sha256',
               digestValue: 'b'.repeat(64),
             },
@@ -623,7 +710,6 @@ describe('bounded change-log RPC iterator', () => {
           complete: {
             emittedChangeCountDecimal: '0',
             payloadByteCountDecimal: '0',
-            payloadSha256: emptyDigest,
           },
         },
       },

--- a/proto/omega_edit/v1/omega_edit.proto
+++ b/proto/omega_edit/v1/omega_edit.proto
@@ -814,12 +814,15 @@ message ExportChangeLogRequest {
     optional string max_span_bytes_decimal = 5;     // Absent/"0" = 64 MiB.
     optional string max_entries_decimal = 6;        // Absent/"0" = server cap.
     optional string max_output_bytes_decimal = 7;   // Absent/"0" = server cap.
+    optional string digest_plugin_id = 8;           // Defaults to "omega.example.openssl_digests".
+    optional string digest_algorithm = 9;           // Plugin algorithm label; defaults to "sha256".
 }
 
 message ChangeLogStreamFingerprint {
     string byte_length_decimal = 1;
     string digest_algorithm = 2;
     string digest_value = 3;
+    string digest_plugin_id = 4;
 }
 
 message ChangeLogStreamHeader {
@@ -857,9 +860,10 @@ message ChangeLogPayloadChunk {
 }
 
 message ChangeLogStreamComplete {
+    reserved 3;
+    reserved "payload_sha256";
     string emitted_change_count_decimal = 1;
     string payload_byte_count_decimal = 2;
-    bytes payload_sha256 = 3;
 }
 
 message ExportChangeLogResponse {
@@ -1028,8 +1032,9 @@ message GetSessionContentInfoResponse {
 
 // Digest metadata for a content fingerprint.
 message ContentDigest {
-    string algorithm = 1;// Digest algorithm identifier, e.g. "sha256".
-    string value = 2;    // Lowercase hexadecimal digest value.
+    string algorithm = 1;         // Digest algorithm identifier, e.g. "sha256".
+    string value = 2;             // Lowercase hexadecimal digest value.
+    optional string plugin_id = 3;// Streaming inspect plugin that produced the digest.
 }
 
 // Size and digest for a session content snapshot.
@@ -1043,6 +1048,7 @@ message GetSessionFingerprintRequest {
     string session_id = 1;                // Session to fingerprint.
     SessionFingerprintContent content = 2;// Original or computed content.
     optional string algorithm = 3;        // Digest algorithm; defaults to "sha256".
+    optional string plugin_id = 4;        // Defaults to "omega.example.openssl_digests".
 }
 
 // Server-side content fingerprint result.

--- a/server/cpp/CMakeLists.txt
+++ b/server/cpp/CMakeLists.txt
@@ -42,7 +42,6 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 find_package(Protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 find_package(Threads REQUIRED)
-find_package(OpenSSL REQUIRED COMPONENTS Crypto)
 
 # ── Resolve protoc and grpc_cpp_plugin executables ────────────────────────────
 # Try target property first, fall back to find_program.
@@ -241,32 +240,24 @@ target_include_directories(omega-edit-grpc-server PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-# Check if gRPC reflection is available (not always present in vcpkg builds)
-if(TARGET gRPC::grpc++_reflection)
-    target_compile_definitions(omega-edit-grpc-server PRIVATE HAS_GRPC_REFLECTION)
-    set(_GRPC_REFLECTION_LIB gRPC::grpc++_reflection)
-else()
-    set(_GRPC_REFLECTION_LIB "")
+if(NOT TARGET gRPC::grpc++_unsecure)
+    message(FATAL_ERROR "gRPC::grpc++_unsecure is required because the native server exposes only insecure endpoints")
 endif()
 
 if(omega_edit_FOUND)
     target_link_libraries(omega-edit-grpc-server PRIVATE
         omega_edit::omega_edit
-        gRPC::grpc++
-        ${_GRPC_REFLECTION_LIB}
+        gRPC::grpc++_unsecure
         protobuf::libprotobuf
         Threads::Threads
-        OpenSSL::Crypto
     )
 else()
     target_include_directories(omega-edit-grpc-server PRIVATE ${OMEGA_EDIT_INCLUDE})
     target_link_libraries(omega-edit-grpc-server PRIVATE
         ${OMEGA_EDIT_LIB}
-        gRPC::grpc++
-        ${_GRPC_REFLECTION_LIB}
+        gRPC::grpc++_unsecure
         protobuf::libprotobuf
         Threads::Threads
-        OpenSSL::Crypto
     )
 endif()
 

--- a/server/cpp/conanfile.py
+++ b/server/cpp/conanfile.py
@@ -25,7 +25,6 @@ class OmegaEditGrpcServerConan(ConanFile):
 
     def requirements(self):
         self.requires("grpc/1.72.0")
-        self.requires("openssl/3.3.2")
         self.requires("zstd/1.5.6")
         # protobuf is a transitive dependency of grpc and will be pulled in
         # automatically.

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -21,8 +21,6 @@
 #include <omega_edit/utility.h>
 #include <omega_edit/version.h>
 
-#include <openssl/evp.h>
-
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -35,7 +33,6 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
-#include <memory>
 #include <optional>
 #include <sstream>
 #include <thread>
@@ -84,12 +81,22 @@ namespace omega_edit {
             return n > 0 ? static_cast<int>(n) : 1;
         }
 
-        static constexpr char SESSION_FINGERPRINT_DIGEST_PLUGIN_ID[] = "omega.example.openssl_digests";
+        static constexpr char DEFAULT_DIGEST_PLUGIN_ID[] = "omega.example.openssl_digests";
         static constexpr char DEFAULT_SESSION_FINGERPRINT_ALGORITHM[] = "sha256";
         static constexpr int64_t SESSION_CONTENT_INSPECTION_CHUNK_SIZE = 1024 * 1024;
         static constexpr int64_t CHANGELOG_PAYLOAD_CHUNK_SIZE = 256 * 1024;
         static constexpr size_t CHANGELOG_TRANSFORM_ID_LIMIT = 4096;
         static constexpr size_t CHANGELOG_TRANSFORM_OPTIONS_LIMIT = 1024 * 1024;
+        static constexpr size_t DIGEST_PLUGIN_ID_LIMIT = 4096;
+        static constexpr size_t DIGEST_ALGORITHM_LIMIT = 128;
+        static constexpr size_t DIGEST_VALUE_LIMIT = 4096;
+
+        static bool digest_plugin_id_is_safe(const std::string &plugin_id) {
+            return !plugin_id.empty() && plugin_id.size() <= DIGEST_PLUGIN_ID_LIMIT &&
+                   std::all_of(plugin_id.begin(), plugin_id.end(), [](unsigned char c) {
+                       return std::isalnum(c) != 0 || c == '.' || c == '_' || c == '-';
+                   });
+        }
 
         static bool parse_canonical_decimal(const std::string &value, const char *field_name, int64_t &result,
                                             grpc::Status &status) {
@@ -110,56 +117,6 @@ namespace omega_edit {
                 parsed = parsed * 10 + digit;
             }
             result = static_cast<int64_t>(parsed);
-            return true;
-        }
-
-        static std::string digest_hex(const unsigned char *digest, unsigned int length) {
-            static constexpr char HEX[] = "0123456789abcdef";
-            std::string result(length * 2, '0');
-            for (unsigned int index = 0; index < length; ++index) {
-                result[index * 2] = HEX[digest[index] >> 4U];
-                result[index * 2 + 1] = HEX[digest[index] & 0x0FU];
-            }
-            return result;
-        }
-
-        class sha256_context {
-        public:
-            sha256_context() : context_(EVP_MD_CTX_new(), EVP_MD_CTX_free) {
-                valid_ = context_ && EVP_DigestInit_ex(context_.get(), EVP_sha256(), nullptr) == 1;
-            }
-
-            bool update(const void *data, size_t length) {
-                return valid_ && EVP_DigestUpdate(context_.get(), data, length) == 1;
-            }
-
-            bool finish(std::array<unsigned char, EVP_MAX_MD_SIZE> &digest, unsigned int &length) {
-                if (!valid_ || EVP_DigestFinal_ex(context_.get(), digest.data(), &length) != 1 || length != 32) {
-                    return false;
-                }
-                valid_ = false;
-                return true;
-            }
-
-        private:
-            std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> context_;
-            bool valid_{};
-        };
-
-        static bool digest_changelog_source(const omega_changelog_content_source_t &source, std::string &hex) {
-            sha256_context digest;
-            std::vector<omega_byte_t> buffer(static_cast<size_t>(CHANGELOG_PAYLOAD_CHUNK_SIZE));
-            int64_t offset = 0;
-            while (offset < source.length) {
-                const auto read = source.read(source.context, offset, buffer.data(),
-                                              std::min<int64_t>(source.length - offset, CHANGELOG_PAYLOAD_CHUNK_SIZE));
-                if (read <= 0 || !digest.update(buffer.data(), static_cast<size_t>(read))) { return false; }
-                offset += read;
-            }
-            std::array<unsigned char, EVP_MAX_MD_SIZE> bytes{};
-            unsigned int length = 0;
-            if (!digest.finish(bytes, length)) { return false; }
-            hex = digest_hex(bytes.data(), length);
             return true;
         }
 
@@ -282,12 +239,27 @@ namespace omega_edit {
         struct changelog_export_context {
             grpc::ServerContext *rpc_context{};
             changelog_spool *spool{};
-            sha256_context payload_digest{};
+            omega_transform_plugin_registry_t *plugin_registry{};
+            std::mutex *plugin_registry_mutex{};
+            std::string checkpoint_directory;
+            std::string digest_plugin_id;
+            std::string digest_algorithm;
+            grpc::Status failure_status{};
             int64_t entry_count{};
             int64_t payload_bytes{};
             bool optimized{};
             int failure{};
         };
+
+        struct changelog_digest {
+            std::string plugin_id;
+            std::string algorithm;
+            std::string value;
+        };
+
+        static grpc::Status digest_changelog_source(changelog_export_context &context,
+                                                    const omega_changelog_content_source_t &source,
+                                                    changelog_digest &digest);
 
         static int write_changelog_summary(const omega_changelog_export_summary_t *summary, void *user_data) {
             auto &context = *static_cast<changelog_export_context *>(user_data);
@@ -295,28 +267,33 @@ namespace omega_edit {
                 context.failure = -10;
                 return context.failure;
             }
-            std::string before_digest;
-            std::string after_digest;
-            if (!digest_changelog_source(summary->before, before_digest) ||
-                !digest_changelog_source(summary->after, after_digest)) {
+            changelog_digest before_digest;
+            changelog_digest after_digest;
+            context.failure_status = digest_changelog_source(context, summary->before, before_digest);
+            if (context.failure_status.ok()) {
+                context.failure_status = digest_changelog_source(context, summary->after, after_digest);
+            }
+            if (!context.failure_status.ok()) {
                 context.failure = -12;
                 return context.failure;
             }
             ::omega_edit::v1::ExportChangeLogResponse frame;
             auto *header = frame.mutable_header();
-            header->set_format_version(2);
+            header->set_format_version(3);
             header->set_resolved_first_serial_decimal(std::to_string(summary->resolved_first_change_serial));
             header->set_resolved_last_serial_decimal(std::to_string(summary->resolved_last_change_serial));
             header->set_source_change_count_decimal(std::to_string(summary->source_change_count));
             header->set_optimized(context.optimized);
             auto *before = header->mutable_before();
             before->set_byte_length_decimal(std::to_string(summary->before.length));
-            before->set_digest_algorithm("sha256");
-            before->set_digest_value(before_digest);
+            before->set_digest_plugin_id(before_digest.plugin_id);
+            before->set_digest_algorithm(before_digest.algorithm);
+            before->set_digest_value(before_digest.value);
             auto *after = header->mutable_after();
             after->set_byte_length_decimal(std::to_string(summary->after.length));
-            after->set_digest_algorithm("sha256");
-            after->set_digest_value(after_digest);
+            after->set_digest_plugin_id(after_digest.plugin_id);
+            after->set_digest_algorithm(after_digest.algorithm);
+            after->set_digest_value(after_digest.value);
             if (!context.spool->write(frame)) {
                 context.failure = context.spool->exhausted() ? -11 : -12;
                 return context.failure;
@@ -383,7 +360,7 @@ namespace omega_edit {
                 const auto read = entry->read_payload(
                         entry->payload_context, offset, buffer.data(),
                         std::min<int64_t>(entry->payload_length - offset, CHANGELOG_PAYLOAD_CHUNK_SIZE));
-                if (read <= 0 || !context.payload_digest.update(buffer.data(), static_cast<size_t>(read))) {
+                if (read <= 0) {
                     context.failure = -12;
                     return context.failure;
                 }
@@ -431,8 +408,29 @@ namespace omega_edit {
         }
 
         static bool digest_algorithm_is_json_safe(const std::string &algorithm) {
-            return !algorithm.empty() && std::all_of(algorithm.begin(), algorithm.end(),
-                                                     [](unsigned char c) { return std::isalnum(c) != 0 || c == '-'; });
+            return !algorithm.empty() && algorithm.size() <= DIGEST_ALGORITHM_LIMIT &&
+                   std::all_of(algorithm.begin(), algorithm.end(), [](unsigned char c) {
+                       return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-';
+                   });
+        }
+
+        static bool digest_value_is_safe(const std::string &digest) {
+            return !digest.empty() && digest.size() <= DIGEST_VALUE_LIMIT &&
+                   std::all_of(digest.begin(), digest.end(),
+                               [](unsigned char c) { return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'); });
+        }
+
+        static bool normalize_plugin_digest_algorithm(const char *label, const std::string &fallback,
+                                                      std::string &algorithm) {
+            if (!label || !*label) {
+                algorithm = normalize_digest_algorithm(fallback);
+                return digest_algorithm_is_json_safe(algorithm);
+            }
+            size_t length = 0;
+            while (length <= DIGEST_ALGORITHM_LIMIT && label[length] != '\0') { ++length; }
+            if (length > DIGEST_ALGORITHM_LIMIT) { return false; }
+            algorithm = normalize_digest_algorithm(std::string(label, length));
+            return digest_algorithm_is_json_safe(algorithm);
         }
 
         static std::string make_digest_options_json(const std::string &algorithm) {
@@ -789,11 +787,64 @@ namespace omega_edit {
             return grpc::Status::OK;
         }
 
+        static int64_t read_changelog_source_chunk(int64_t relative_offset, omega_byte_t *buffer, int64_t length,
+                                                   void *user_data_ptr) {
+            const auto *source = static_cast<const omega_changelog_content_source_t *>(user_data_ptr);
+            if (!source || !source->read || !buffer || relative_offset < 0 || length < 0 || source->length < 0 ||
+                relative_offset > source->length) {
+                return -1;
+            }
+            const auto remaining = source->length - relative_offset;
+            const auto requested = std::min(length, remaining);
+            return requested == 0 ? 0 : source->read(source->context, relative_offset, buffer, requested);
+        }
+
+        static grpc::Status digest_changelog_source(changelog_export_context &context,
+                                                    const omega_changelog_content_source_t &source,
+                                                    changelog_digest &digest) {
+            if (!context.plugin_registry || !context.plugin_registry_mutex || !source.read || source.length < 0) {
+                return grpc::Status(grpc::StatusCode::INTERNAL, "invalid change-log digest source");
+            }
+
+            const auto options_json = make_digest_options_json(context.digest_algorithm);
+            transform_plugin_response_guard plugin_response;
+            const auto status = inspect_with_streaming_plugin(
+                    context.rpc_context, context.plugin_registry, *context.plugin_registry_mutex,
+                    context.digest_plugin_id, options_json.c_str(), context.checkpoint_directory.c_str(), 0,
+                    source.length, read_changelog_source_chunk, const_cast<omega_changelog_content_source_t *>(&source),
+                    grpc::StatusCode::FAILED_PRECONDITION,
+                    "change-log digest plugin is not registered: " + context.digest_plugin_id,
+                    "change-log digest plugin must be a streaming inspect plugin",
+                    "unsupported change-log digest algorithm: " + context.digest_algorithm,
+                    "change-log digest cancelled: " + context.digest_plugin_id, grpc::StatusCode::ABORTED,
+                    "change-log digest plugin failed: " + context.digest_plugin_id, &plugin_response.response);
+            if (!status.ok()) { return status; }
+            if (plugin_response.response.result_length <= 0 ||
+                plugin_response.response.result_length > static_cast<int64_t>(DIGEST_VALUE_LIMIT) ||
+                plugin_response.response.result_bytes == nullptr) {
+                return grpc::Status(grpc::StatusCode::INTERNAL,
+                                    "change-log digest plugin returned an invalid digest length");
+            }
+
+            digest.plugin_id = context.digest_plugin_id;
+            digest.value = normalize_digest_value(
+                    std::string(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
+                                static_cast<size_t>(plugin_response.response.result_length)));
+            if (!normalize_plugin_digest_algorithm(plugin_response.response.result_label, context.digest_algorithm,
+                                                   digest.algorithm) ||
+                !digest_value_is_safe(digest.value)) {
+                return grpc::Status(grpc::StatusCode::INTERNAL,
+                                    "change-log digest plugin returned invalid digest metadata");
+            }
+            return grpc::Status::OK;
+        }
+
         struct overwrite_fingerprint_guard_context {
             grpc::ServerContext *grpc_context{};
             omega_transform_plugin_registry_t *registry{};
             std::mutex *registry_mutex{};
             std::string checkpoint_directory;
+            std::string plugin_id;
             std::string algorithm;
             std::string expected_digest;
             int64_t expected_length{};
@@ -815,18 +866,14 @@ namespace omega_edit {
             transform_plugin_response_guard plugin_response;
             const auto options_json = make_digest_options_json(context->algorithm);
             const auto status = inspect_with_streaming_plugin(
-                    context->grpc_context, context->registry, *context->registry_mutex,
-                    SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, options_json.c_str(), context->checkpoint_directory.c_str(),
-                    0, context->expected_length, read_session_content_file_chunk, &reader,
-                    grpc::StatusCode::FAILED_PRECONDITION,
-                    "save conflict digest plugin is not registered: " +
-                            std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                    context->grpc_context, context->registry, *context->registry_mutex, context->plugin_id,
+                    options_json.c_str(), context->checkpoint_directory.c_str(), 0, context->expected_length,
+                    read_session_content_file_chunk, &reader, grpc::StatusCode::FAILED_PRECONDITION,
+                    "save conflict digest plugin is not registered: " + context->plugin_id,
                     "save conflict digest plugin must be a streaming inspect plugin",
                     "unsupported save conflict digest algorithm: " + context->algorithm,
-                    "save conflict digest cancelled: " + std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                    grpc::StatusCode::ABORTED,
-                    "save conflict digest failed: " + std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                    &plugin_response.response);
+                    "save conflict digest cancelled: " + context->plugin_id, grpc::StatusCode::ABORTED,
+                    "save conflict digest failed: " + context->plugin_id, &plugin_response.response);
             if (!status.ok()) {
                 context->failure_status = status;
                 return -1;
@@ -839,12 +886,17 @@ namespace omega_edit {
                 plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
                 return 1;
             }
+            if (plugin_response.response.result_length > static_cast<int64_t>(DIGEST_VALUE_LIMIT)) { return 1; }
             const auto actual_digest = normalize_digest_value(
                     std::string(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
                                 static_cast<size_t>(plugin_response.response.result_length)));
-            const auto actual_algorithm = normalize_digest_algorithm(
-                    plugin_response.response.result_label ? plugin_response.response.result_label : context->algorithm);
-            return actual_algorithm == context->algorithm && actual_digest == context->expected_digest ? 0 : 1;
+            std::string actual_algorithm;
+            return normalize_plugin_digest_algorithm(plugin_response.response.result_label, context->algorithm,
+                                                     actual_algorithm) &&
+                                   digest_value_is_safe(actual_digest) && actual_algorithm == context->algorithm &&
+                                   actual_digest == context->expected_digest
+                           ? 0
+                           : 1;
         }
 
         struct transform_progress_context {
@@ -1659,7 +1711,11 @@ namespace omega_edit {
                                         "expected_original_fingerprint must include a non-negative size and digest");
                 }
                 const auto algorithm = normalize_digest_algorithm(expected.digest().algorithm());
-                if (!digest_algorithm_is_json_safe(algorithm) || expected.digest().value().empty()) {
+                const auto plugin_id = expected.digest().has_plugin_id() ? expected.digest().plugin_id()
+                                                                         : std::string(DEFAULT_DIGEST_PLUGIN_ID);
+                const auto digest_value = normalize_digest_value(expected.digest().value());
+                if (!digest_plugin_id_is_safe(plugin_id) || !digest_algorithm_is_json_safe(algorithm) ||
+                    !digest_value_is_safe(digest_value)) {
                     return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                                         "expected_original_fingerprint contains invalid digest metadata");
                 }
@@ -1668,8 +1724,9 @@ namespace omega_edit {
                 guard_context.registry = transform_plugin_registry_;
                 guard_context.registry_mutex = &transform_plugin_registry_mutex_;
                 guard_context.checkpoint_directory = checkpoint_directory ? checkpoint_directory : "";
+                guard_context.plugin_id = plugin_id;
                 guard_context.algorithm = algorithm;
-                guard_context.expected_digest = normalize_digest_value(expected.digest().value());
+                guard_context.expected_digest = digest_value;
                 guard_context.expected_length = expected.byte_length();
                 save_options.overwrite_guard = verify_overwrite_fingerprint;
                 save_options.overwrite_guard_user_data = &guard_context;
@@ -2220,6 +2277,19 @@ namespace omega_edit {
                 return parse_status;
             }
 
+            const auto digest_plugin_id = request->has_digest_plugin_id() ? request->digest_plugin_id()
+                                                                          : std::string(DEFAULT_DIGEST_PLUGIN_ID);
+            const auto digest_algorithm =
+                    normalize_digest_algorithm(request->has_digest_algorithm() ? request->digest_algorithm() : "");
+            if (!digest_plugin_id_is_safe(digest_plugin_id)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "invalid change-log digest plugin id: " + digest_plugin_id);
+            }
+            if (!digest_algorithm_is_json_safe(digest_algorithm)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "unsupported change-log digest algorithm: " + digest_algorithm);
+            }
+
             const auto entry_cap = requested_entries == 0
                                            ? resource_limits_.max_changelog_export_entries
                                            : std::min(requested_entries, resource_limits_.max_changelog_export_entries);
@@ -2238,12 +2308,18 @@ namespace omega_edit {
             }
             changelog_export_context export_context{context, &spool};
             export_context.optimized = request->optimize();
+            export_context.digest_plugin_id = digest_plugin_id;
+            export_context.digest_algorithm = digest_algorithm;
 
             {
                 auto locked_session = session_manager_.lock_session(request->session_id());
                 if (!locked_session) {
                     return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found: " + request->session_id());
                 }
+                export_context.plugin_registry = transform_plugin_registry_;
+                export_context.plugin_registry_mutex = &transform_plugin_registry_mutex_;
+                const auto *checkpoint_directory = omega_session_get_checkpoint_directory(locked_session.session());
+                export_context.checkpoint_directory = checkpoint_directory ? checkpoint_directory : "";
                 omega_changelog_export_options_t options{};
                 options.first_change_serial = first;
                 options.last_change_serial = last;
@@ -2266,6 +2342,7 @@ namespace omega_edit {
                     if (export_context.failure == -10 || context->IsCancelled()) {
                         return grpc::Status(grpc::StatusCode::CANCELLED, "change-log export cancelled");
                     }
+                    if (!export_context.failure_status.ok()) { return export_context.failure_status; }
                     if (result == -2 || export_context.failure == -11 || spool.exhausted()) {
                         return grpc::Status(grpc::StatusCode::RESOURCE_EXHAUSTED,
                                             "change-log export exceeded a configured resource limit");
@@ -2274,16 +2351,10 @@ namespace omega_edit {
                                         "change-log range validation, planning, or spool write failed");
                 }
 
-                std::array<unsigned char, EVP_MAX_MD_SIZE> payload_digest{};
-                unsigned int payload_digest_length = 0;
-                if (!export_context.payload_digest.finish(payload_digest, payload_digest_length)) {
-                    return grpc::Status(grpc::StatusCode::INTERNAL, "failed to finalize change-log payload digest");
-                }
                 ::omega_edit::v1::ExportChangeLogResponse complete_frame;
                 auto *complete = complete_frame.mutable_complete();
                 complete->set_emitted_change_count_decimal(std::to_string(export_context.entry_count));
                 complete->set_payload_byte_count_decimal(std::to_string(export_context.payload_bytes));
-                complete->set_payload_sha256(payload_digest.data(), payload_digest_length);
                 if (!spool.write(complete_frame)) {
                     return grpc::Status(spool.exhausted() ? grpc::StatusCode::RESOURCE_EXHAUSTED
                                                           : grpc::StatusCode::INTERNAL,
@@ -2684,6 +2755,12 @@ namespace omega_edit {
                 return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                                     "unsupported fingerprint digest algorithm: " + algorithm);
             }
+            const auto plugin_id =
+                    request->has_plugin_id() ? request->plugin_id() : std::string(DEFAULT_DIGEST_PLUGIN_ID);
+            if (!digest_plugin_id_is_safe(plugin_id)) {
+                return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                    "invalid fingerprint digest plugin id: " + plugin_id);
+            }
             const auto options_json = make_digest_options_json(algorithm);
 
             const auto inspection_content = fingerprint_content_to_session_content(content);
@@ -2695,36 +2772,41 @@ namespace omega_edit {
 
             session_content_file_reader reader{source.file_path, source.reader_file_offset, source.effective_length};
             const auto inspect_status = inspect_with_streaming_plugin(
-                    context, transform_plugin_registry_, transform_plugin_registry_mutex_,
-                    SESSION_FINGERPRINT_DIGEST_PLUGIN_ID, options_json.c_str(), source.checkpoint_directory.c_str(), 0,
-                    source.effective_length, read_session_content_file_chunk, &reader,
-                    grpc::StatusCode::FAILED_PRECONDITION,
-                    "session fingerprint digest plugin is not registered: " +
-                            std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
+                    context, transform_plugin_registry_, transform_plugin_registry_mutex_, plugin_id,
+                    options_json.c_str(), source.checkpoint_directory.c_str(), 0, source.effective_length,
+                    read_session_content_file_chunk, &reader, grpc::StatusCode::FAILED_PRECONDITION,
+                    "session fingerprint digest plugin is not registered: " + plugin_id,
                     "session fingerprint digest plugin must be a streaming inspect plugin",
                     "unsupported fingerprint digest algorithm: " + algorithm,
-                    "session fingerprint digest plugin cancelled: " + std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                    grpc::StatusCode::ABORTED,
-                    "session fingerprint digest plugin failed: " + std::string(SESSION_FINGERPRINT_DIGEST_PLUGIN_ID),
-                    &plugin_response.response);
+                    "session fingerprint digest plugin cancelled: " + plugin_id, grpc::StatusCode::ABORTED,
+                    "session fingerprint digest plugin failed: " + plugin_id, &plugin_response.response);
             if (!inspect_status.ok()) { return inspect_status; }
 
-            if (plugin_response.response.result_length <= 0 || plugin_response.response.result_bytes == nullptr) {
+            if (plugin_response.response.result_length <= 0 ||
+                plugin_response.response.result_length > static_cast<int64_t>(DIGEST_VALUE_LIMIT) ||
+                plugin_response.response.result_bytes == nullptr) {
                 return grpc::Status(grpc::StatusCode::INTERNAL,
-                                    "session fingerprint digest plugin returned an empty digest");
+                                    "session fingerprint digest plugin returned an invalid digest length");
             }
 
-            std::string digest_value(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
-                                     static_cast<size_t>(plugin_response.response.result_length));
-            if (plugin_response.response.result_label && *plugin_response.response.result_label) {
-                algorithm = normalize_digest_algorithm(plugin_response.response.result_label);
+            auto digest_value = normalize_digest_value(
+                    std::string(reinterpret_cast<const char *>(plugin_response.response.result_bytes),
+                                static_cast<size_t>(plugin_response.response.result_length)));
+            std::string output_algorithm;
+            if (!normalize_plugin_digest_algorithm(plugin_response.response.result_label, algorithm,
+                                                   output_algorithm) ||
+                !digest_value_is_safe(digest_value)) {
+                return grpc::Status(grpc::StatusCode::INTERNAL,
+                                    "session fingerprint digest plugin returned invalid digest metadata");
             }
+            algorithm = std::move(output_algorithm);
 
             response->set_session_id(request->session_id());
             response->set_content(content);
             auto *fingerprint = response->mutable_fingerprint();
             fingerprint->set_byte_length(source.content_byte_length);
             auto *digest_response = fingerprint->mutable_digest();
+            digest_response->set_plugin_id(plugin_id);
             digest_response->set_algorithm(algorithm);
             digest_response->set_value(digest_value);
             return grpc::Status::OK;

--- a/server/cpp/src/main.cpp
+++ b/server/cpp/src/main.cpp
@@ -14,9 +14,6 @@
 
 #include "editor_service.h"
 
-#ifdef HAS_GRPC_REFLECTION
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
-#endif
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 
@@ -721,9 +718,6 @@ int main(int argc, char **argv) {
             transform_plugin_host_path, allow_experimental_transform_plugins, allow_test_transform_plugins);
 
     grpc::EnableDefaultHealthCheckService(true);
-#ifdef HAS_GRPC_REFLECTION
-    grpc::reflection::InitProtoReflectionServerBuilderPlugin();
-#endif
 
     grpc::ServerBuilder builder;
 

--- a/vscode-extension/src/api.ts
+++ b/vscode-extension/src/api.ts
@@ -107,6 +107,7 @@ export interface OmegaEditRestoreCheckpointResult {
 }
 
 export interface OmegaEditChangeLogDigest {
+  pluginId?: string
   algorithm: string
   value: string
 }

--- a/vscode-extension/src/checkpointTimelineStorage.ts
+++ b/vscode-extension/src/checkpointTimelineStorage.ts
@@ -7,6 +7,7 @@ import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import { basename, dirname, join, relative, resolve, sep } from 'node:path'
 import {
+  CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID,
   type ChangeLogFileReadResult,
   type ChangeLogFingerprint,
   type EditorHistorySnapshot,
@@ -26,6 +27,9 @@ const DEFAULT_LOCK_WAIT_MS = 5000
 const HEARTBEAT_INTERVAL_MS = 60 * 1000
 const MAX_METADATA_BYTES = 4 * 1024 * 1024
 const RESERVATION_CHUNK_BYTES = 16 * 1024 * 1024
+const DIGEST_PLUGIN_ID_MAX_LENGTH = 4096
+const DIGEST_ALGORITHM_MAX_LENGTH = 128
+const DIGEST_VALUE_MAX_LENGTH = 4096
 
 export const CHECKPOINT_HISTORY_DEFAULTS = {
   maxBytesPerSession: 1_073_741_824,
@@ -45,7 +49,7 @@ export type CheckpointBoundaryKind = 'plain' | 'transform' | 'tip'
 
 export interface NormalizedTimelineFingerprint {
   byteLength: string
-  digest: { algorithm: string; value: string }
+  digest: { pluginId?: string; algorithm: string; value: string }
 }
 
 export interface CheckpointIntervalManifestEntryV1 {
@@ -205,18 +209,27 @@ function normalizeFingerprint(
   value: ChangeLogFingerprint
 ): NormalizedTimelineFingerprint {
   const byteLength = decimal(value.byteLength, 'fingerprint.byteLength')
+  const pluginId = value.digest.pluginId ?? CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID
   if (
-    value.digest.algorithm !== 'sha256' ||
-    !/^[0-9a-f]{64}$/.test(value.digest.value)
+    !/^[A-Za-z0-9._-]+$/.test(pluginId) ||
+    pluginId.length > DIGEST_PLUGIN_ID_MAX_LENGTH ||
+    !/^[a-z0-9-]+$/.test(value.digest.algorithm) ||
+    value.digest.algorithm.length > DIGEST_ALGORITHM_MAX_LENGTH ||
+    !/^[0-9a-f]+$/.test(value.digest.value) ||
+    value.digest.value.length > DIGEST_VALUE_MAX_LENGTH
   ) {
     throw new TimelineStorageError(
       'TIMELINE_INVALID_FINGERPRINT',
-      'Timeline fingerprints must use lowercase SHA-256'
+      'Timeline fingerprint digest metadata is invalid'
     )
   }
   return {
     byteLength,
-    digest: { algorithm: 'sha256', value: value.digest.value },
+    digest: {
+      pluginId,
+      algorithm: value.digest.algorithm,
+      value: value.digest.value,
+    },
   }
 }
 
@@ -226,6 +239,8 @@ function fingerprintsEqual(
 ): boolean {
   return (
     left.byteLength === right.byteLength &&
+    (left.digest.pluginId ?? CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID) ===
+      (right.digest.pluginId ?? CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID) &&
     left.digest.algorithm === right.digest.algorithm &&
     left.digest.value === right.digest.value
   )

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -6790,10 +6790,6 @@ export class HexEditorProvider
 
   private makeHistoryExecutor(session: EditorSession): EditorHistoryExecutor {
     const hasTimeline = session.checkpointTimeline.entries.length > 0
-    const undoCrossesTimelineMilestone =
-      hasTimeline && session.history.willUndoCrossMilestone()
-    const redoCrossesTimelineMilestone =
-      hasTimeline && session.history.willRedoCrossMilestone()
     const checkoutTimelineMilestone = async (direction: -1 | 1) => {
       const targetCheckpoint = session.checkpointTimeline.cursor + direction
       if (
@@ -6806,27 +6802,54 @@ export class HexEditorProvider
       }
       await checkoutCheckpoint(session.sessionId, targetCheckpoint)
     }
+    const checkoutTimelineAtHistoryDepth = async (historyDepth: number) => {
+      const entries = session.checkpointTimeline.entries
+      let low = 0
+      let high = entries.length
+      while (low < high) {
+        const middle = low + Math.floor((high - low) / 2)
+        const entry = entries[middle]
+        if (!entry) {
+          high = middle
+          continue
+        }
+        const checkpointHistory = entry.interval.history
+        if (!checkpointHistory) {
+          throw new Error(
+            `Checkpoint ${middle + 1} is missing editor history metadata`
+          )
+        }
+        const checkpointDepth = checkpointHistory.transactionLog.length
+        if (checkpointDepth <= historyDepth) {
+          low = middle + 1
+        } else {
+          high = middle
+        }
+      }
+      const targetCheckpoint = low
+      if (targetCheckpoint <= session.checkpointTimeline.cursor) return
+      await checkoutCheckpoint(session.sessionId, targetCheckpoint)
+    }
     return {
       async undoLocal() {
-        if (undoCrossesTimelineMilestone) {
-          await checkoutTimelineMilestone(-1)
-          return
-        }
         await undo(session.sessionId)
       },
       async redoLocal() {
-        if (redoCrossesTimelineMilestone) {
-          await checkoutTimelineMilestone(1)
-          return
-        }
         await redo(session.sessionId)
       },
       async undoMilestone() {
-        if (undoCrossesTimelineMilestone) return
+        // Native undo suspends plain materialized checkpoints on the future
+        // stack before undoing exactly one transaction from the prior model.
+        if (hasTimeline) return
         await destroyLastCheckpoint(session.sessionId)
       },
       async redoMilestone() {
-        if (redoCrossesTimelineMilestone) return
+        if (hasTimeline) {
+          await checkoutTimelineAtHistoryDepth(
+            session.history.getEditState().undoCount
+          )
+          return
+        }
         await createCheckpoint(session.sessionId)
       },
       async undoCheckpoint() {

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -30,6 +30,8 @@
 import {
   ALL_EVENTS,
   applyTransformPlugin,
+  CHANGE_LOG_DEFAULT_DIGEST_ALGORITHM as DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM,
+  CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID as DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID,
   CHANGE_LOG_FORMAT,
   CHANGE_LOG_VERSION,
   ChangeLogCancelledError,
@@ -228,6 +230,8 @@ function timelineFingerprintsEqual(
 ): boolean {
   return (
     String(left.byteLength) === String(right.byteLength) &&
+    (left.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID) ===
+      (right.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID) &&
     left.digest.algorithm === right.digest.algorithm &&
     left.digest.value === right.digest.value
   )
@@ -255,6 +259,7 @@ interface CollectedChangeLogRecords {
 }
 
 interface ChangeLogDigest {
+  pluginId?: string
   algorithm: string
   value: string
 }
@@ -424,7 +429,6 @@ const MAX_TRANSFORM_RESULT_PREVIEW_BYTES = 4 * 1024
 const MAX_FILE_SPLICE_BYTES = 32 * 1024 * 1024
 const MAX_NON_FILE_CHANGE_LOG_BYTES = 64 * 1024 * 1024
 const MAX_NON_FILE_CHANGE_LOG_ENTRIES = 10_000
-const DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM = 'sha256'
 const DEFAULT_SAVE_CONFLICT_FINGERPRINT_ALGORITHM = 'sha256'
 const SAVE_CONFLICT_FINGERPRINT_ALGORITHMS = [
   'sha224',
@@ -1787,9 +1791,15 @@ function assertCompleteChangeLog(
 async function getChangeLogFingerprint(
   sessionId: string,
   content: SessionFingerprintContent,
-  algorithm = DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM
+  algorithm = DEFAULT_CHANGE_LOG_DIGEST_ALGORITHM,
+  pluginId = DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
 ): Promise<ChangeLogFingerprint> {
-  const response = await getSessionFingerprint(sessionId, content, algorithm)
+  const response = await getSessionFingerprint(
+    sessionId,
+    content,
+    algorithm,
+    pluginId
+  )
   if (!response.fingerprint?.digest) {
     throw new Error('Server fingerprint response is missing digest metadata')
   }
@@ -1797,6 +1807,7 @@ async function getChangeLogFingerprint(
   return {
     byteLength: int64ToDecimal(response.fingerprint.byteLength),
     digest: {
+      pluginId,
       algorithm: response.fingerprint.digest.algorithm.toLowerCase(),
       value: response.fingerprint.digest.value.toLowerCase(),
     },
@@ -1804,7 +1815,7 @@ async function getChangeLogFingerprint(
 }
 
 function fingerprintLabel(fingerprint: ChangeLogFingerprint): string {
-  return `${int64ToDecimal(fingerprint.byteLength)} bytes ${fingerprint.digest.algorithm}:${fingerprint.digest.value}`
+  return `${int64ToDecimal(fingerprint.byteLength)} bytes ${fingerprint.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID}/${fingerprint.digest.algorithm}:${fingerprint.digest.value}`
 }
 
 function fingerprintsMatch(
@@ -1813,6 +1824,8 @@ function fingerprintsMatch(
 ): boolean {
   return (
     int64ToDecimal(actual.byteLength) === int64ToDecimal(expected.byteLength) &&
+    (actual.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID) ===
+      (expected.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID) &&
     actual.digest.algorithm === expected.digest.algorithm &&
     actual.digest.value === expected.digest.value
   )
@@ -1837,7 +1850,8 @@ async function assertCurrentSessionFingerprint(
   const actual = await getChangeLogFingerprint(
     sessionId,
     SessionFingerprintContent.COMPUTED,
-    expected.digest.algorithm
+    expected.digest.algorithm,
+    expected.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
   )
   if (fingerprintsMatch(actual, expected)) {
     return
@@ -1861,7 +1875,8 @@ async function assertChangeLogExportStable(
   const finalAfter = await getChangeLogFingerprint(
     sessionId,
     SessionFingerprintContent.COMPUTED,
-    expectedAfter.digest.algorithm
+    expectedAfter.digest.algorithm,
+    expectedAfter.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
   )
   if (!fingerprintsMatch(finalAfter, expectedAfter)) {
     throw new Error(
@@ -3172,7 +3187,8 @@ export class HexEditorProvider
     const current = await getChangeLogFingerprint(
       session.sessionId,
       SessionFingerprintContent.COMPUTED,
-      parsed.before.digest.algorithm
+      parsed.before.digest.algorithm,
+      parsed.before.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
     )
     if (!fingerprintsMatch(current, parsed.before)) {
       safetyIssues.push({
@@ -3434,7 +3450,8 @@ export class HexEditorProvider
     const after = await getChangeLogFingerprint(
       session.sessionId,
       SessionFingerprintContent.COMPUTED,
-      before.digest.algorithm
+      before.digest.algorithm,
+      before.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
     )
     const controller = new AbortController()
     const withExportProgress = async <T>(
@@ -3861,7 +3878,8 @@ export class HexEditorProvider
     const finalFingerprint = await getChangeLogFingerprint(
       session.sessionId,
       SessionFingerprintContent.COMPUTED,
-      parsed.after.digest.algorithm
+      parsed.after.digest.algorithm,
+      parsed.after.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
     )
     if (appliedChangeCount > 0) {
       await this.truncateCheckpointTimelineFuture(session)
@@ -6789,7 +6807,8 @@ export class HexEditorProvider
   }
 
   private makeHistoryExecutor(session: EditorSession): EditorHistoryExecutor {
-    const hasTimeline = session.checkpointTimeline.entries.length > 0
+    const hasTimelineEntries = () =>
+      session.checkpointTimeline.entries.length > 0
     const checkoutTimelineMilestone = async (direction: -1 | 1) => {
       const targetCheckpoint = session.checkpointTimeline.cursor + direction
       if (
@@ -6810,8 +6829,9 @@ export class HexEditorProvider
         const middle = low + Math.floor((high - low) / 2)
         const entry = entries[middle]
         if (!entry) {
-          high = middle
-          continue
+          throw new Error(
+            `Checkpoint timeline entry ${middle + 1} is unexpectedly missing`
+          )
         }
         const checkpointHistory = entry.interval.history
         if (!checkpointHistory) {
@@ -6838,13 +6858,14 @@ export class HexEditorProvider
         await redo(session.sessionId)
       },
       async undoMilestone() {
-        // Native undo suspends plain materialized checkpoints on the future
-        // stack before undoing exactly one transaction from the prior model.
-        if (hasTimeline) return
+        // With a materialized timeline, native undo moves plain checkpoint
+        // models to the future stack before undoing exactly one transaction.
+        // Only the legacy non-timeline path destroys the boundary explicitly.
+        if (hasTimelineEntries()) return
         await destroyLastCheckpoint(session.sessionId)
       },
       async redoMilestone() {
-        if (hasTimeline) {
+        if (hasTimelineEntries()) {
           await checkoutTimelineAtHistoryDepth(
             session.history.getEditState().undoCount
           )
@@ -6853,14 +6874,14 @@ export class HexEditorProvider
         await createCheckpoint(session.sessionId)
       },
       async undoCheckpoint() {
-        if (hasTimeline) {
+        if (hasTimelineEntries()) {
           await checkoutTimelineMilestone(-1)
           return
         }
         await destroyLastCheckpoint(session.sessionId)
       },
       async redoCheckpoint(transaction) {
-        if (hasTimeline) {
+        if (hasTimelineEntries()) {
           await checkoutTimelineMilestone(1)
           return
         }
@@ -7040,7 +7061,8 @@ export class HexEditorProvider
         ? await getChangeLogFingerprint(
             session.sessionId,
             SessionFingerprintContent.COMPUTED,
-            expectedAfter.digest.algorithm
+            expectedAfter.digest.algorithm,
+            expectedAfter.digest.pluginId ?? DEFAULT_CHANGE_LOG_DIGEST_PLUGIN_ID
           ).catch(() => undefined)
         : undefined
     const recordAppliedChanges = async () => {

--- a/vscode-extension/tests/checkpointTimelineStorage.test.js
+++ b/vscode-extension/tests/checkpointTimelineStorage.test.js
@@ -7,15 +7,29 @@ const {
   CheckpointTimelineStorageManager,
   TimelineStorageError,
 } = require('../out/checkpointTimelineStorage.js')
-const { writeChangeLogFileAtomic } = require('@omega-edit/client')
+const {
+  CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID,
+  writeChangeLogFileAtomic,
+} = require('@omega-edit/client')
+const DIGEST_PLUGIN_ID_MAX_LENGTH = 4096
+const DIGEST_ALGORITHM_MAX_LENGTH = 128
+const DIGEST_VALUE_MAX_LENGTH = 4096
 
 const before = {
   byteLength: '0',
-  digest: { algorithm: 'sha256', value: 'a'.repeat(64) },
+  digest: {
+    pluginId: CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID,
+    algorithm: 'sha256',
+    value: 'a'.repeat(64),
+  },
 }
 const after = {
   byteLength: '2',
-  digest: { algorithm: 'sha256', value: 'b'.repeat(64) },
+  digest: {
+    pluginId: CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID,
+    algorithm: 'sha256',
+    value: 'b'.repeat(64),
+  },
 }
 
 async function temporaryRoot(t) {
@@ -84,6 +98,39 @@ async function sessionFor(t, options = {}) {
   )
   return { root, manager, session }
 }
+
+test('rejects oversized timeline fingerprint digest metadata', async (t) => {
+  const root = await temporaryRoot(t)
+  const manager = new CheckpointTimelineStorageManager(root)
+  await manager.initialize()
+
+  for (const digest of [
+    {
+      pluginId: 'a'.repeat(DIGEST_PLUGIN_ID_MAX_LENGTH + 1),
+      algorithm: 'sha256',
+      value: 'a'.repeat(64),
+    },
+    {
+      pluginId: CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID,
+      algorithm: 'a'.repeat(DIGEST_ALGORITHM_MAX_LENGTH + 1),
+      value: 'a'.repeat(64),
+    },
+    {
+      pluginId: CHANGE_LOG_DEFAULT_DIGEST_PLUGIN_ID,
+      algorithm: 'sha256',
+      value: 'a'.repeat(DIGEST_VALUE_MAX_LENGTH + 1),
+    },
+  ]) {
+    await assert.rejects(
+      manager.createSession(
+        'file:///oversized.bin',
+        { byteLength: '0', digest },
+        'oversized.bin'
+      ),
+      (error) => error?.code === 'TIMELINE_INVALID_FINGERPRINT'
+    )
+  }
+})
 
 test('validates production quota settings without an unlimited fallback', async () => {
   assert.throws(

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -583,7 +583,7 @@ test('routes save-conflict fingerprinting through the native guarded save path',
   assert.doesNotMatch(extensionSource, /createReadStream|createHash/)
   assert.match(extensionSource, /expected\.digest/)
   assert.match(coreSource, /overwrite_guard/)
-  assert.match(serverSource, /SESSION_FINGERPRINT_DIGEST_PLUGIN_ID/)
+  assert.match(serverSource, /DEFAULT_DIGEST_PLUGIN_ID/)
   assert.match(serverSource, /verify_overwrite_fingerprint/)
 })
 

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -1752,6 +1752,95 @@ suite('OmegaEdit VS Code extension', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
+  test('undo traverses a multi-action materialized checkpoint one action at a time', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-checkpoint-action-undo-')
+    )
+    const samplePath = path.join(tmpDir, 'checkpoint-action-undo.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session)
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'insert',
+      offset: 3,
+      data: Buffer.from('1', 'utf8').toString('hex'),
+    })
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'insert',
+      offset: 4,
+      data: Buffer.from('2', 'utf8').toString('hex'),
+    })
+    assert.equal(
+      (await provider.createCheckpoint({ uri: document.uri }))?.checkpointCount,
+      1
+    )
+    await assertSessionText(session.sessionId, 'abc12')
+
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      { type: 'undo' },
+      { propagateErrors: true }
+    )
+    await assertSessionText(session.sessionId, 'abc1')
+    assert.equal(session.checkpointTimeline.cursor, 0)
+    assert.deepEqual(session.history.getEditState(), {
+      canUndo: true,
+      canRedo: true,
+      undoCount: 1,
+      redoCount: 1,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      { type: 'undo' },
+      { propagateErrors: true }
+    )
+    await assertSessionText(session.sessionId, 'abc')
+
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      { type: 'redo' },
+      { propagateErrors: true }
+    )
+    await assertSessionText(session.sessionId, 'abc1')
+    assert.equal(session.checkpointTimeline.cursor, 0)
+
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      { type: 'redo' },
+      { propagateErrors: true }
+    )
+    await assertSessionText(session.sessionId, 'abc12')
+    assert.equal(session.checkpointTimeline.cursor, 1)
+    assert.deepEqual(session.history.getEditState(), {
+      canUndo: true,
+      canRedo: false,
+      undoCount: 2,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
   test('reports search matches and keeps undo/redo disabled state in sync', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-state-')

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -1756,89 +1756,101 @@ suite('OmegaEdit VS Code extension', () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-checkpoint-action-undo-')
     )
-    const samplePath = path.join(tmpDir, 'checkpoint-action-undo.bin')
-    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
-
-    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
     const panel = createMockWebviewPanel()
-    const document = await provider.openCustomDocument(
-      vscode.Uri.file(samplePath),
-      { backupId: undefined, untitledDocumentData: undefined },
-      new vscode.CancellationTokenSource().token
-    )
-    await provider.resolveCustomEditor(
-      document,
-      panel,
-      new vscode.CancellationTokenSource().token
-    )
-    const session = provider.getSessionForTesting(document.uri)
-    assert.ok(session)
+    const openCancellation = new vscode.CancellationTokenSource()
+    const resolveCancellation = new vscode.CancellationTokenSource()
+    let document
+    try {
+      const samplePath = path.join(tmpDir, 'checkpoint-action-undo.bin')
+      await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
 
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'insert',
-      offset: 3,
-      data: Buffer.from('1', 'utf8').toString('hex'),
-    })
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'insert',
-      offset: 4,
-      data: Buffer.from('2', 'utf8').toString('hex'),
-    })
-    assert.equal(
-      (await provider.createCheckpoint({ uri: document.uri }))?.checkpointCount,
-      1
-    )
-    await assertSessionText(session.sessionId, 'abc12')
+      const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+      document = await provider.openCustomDocument(
+        vscode.Uri.file(samplePath),
+        { backupId: undefined, untitledDocumentData: undefined },
+        openCancellation.token
+      )
+      await provider.resolveCustomEditor(
+        document,
+        panel,
+        resolveCancellation.token
+      )
+      const session = provider.getSessionForTesting(document.uri)
+      assert.ok(session)
 
-    await provider.dispatchWebviewMessageForTesting(
-      document.uri,
-      { type: 'undo' },
-      { propagateErrors: true }
-    )
-    await assertSessionText(session.sessionId, 'abc1')
-    assert.equal(session.checkpointTimeline.cursor, 0)
-    assert.deepEqual(session.history.getEditState(), {
-      canUndo: true,
-      canRedo: true,
-      undoCount: 1,
-      redoCount: 1,
-      isDirty: true,
-      savedChangeDepth: 0,
-    })
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'insert',
+        offset: 3,
+        data: Buffer.from('1', 'utf8').toString('hex'),
+      })
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'insert',
+        offset: 4,
+        data: Buffer.from('2', 'utf8').toString('hex'),
+      })
+      assert.equal(
+        (await provider.createCheckpoint({ uri: document.uri }))
+          ?.checkpointCount,
+        1
+      )
+      await assertSessionText(session.sessionId, 'abc12')
 
-    await provider.dispatchWebviewMessageForTesting(
-      document.uri,
-      { type: 'undo' },
-      { propagateErrors: true }
-    )
-    await assertSessionText(session.sessionId, 'abc')
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        { type: 'undo' },
+        { propagateErrors: true }
+      )
+      await assertSessionText(session.sessionId, 'abc1')
+      assert.equal(session.checkpointTimeline.cursor, 0)
+      assert.deepEqual(session.history.getEditState(), {
+        canUndo: true,
+        canRedo: true,
+        undoCount: 1,
+        redoCount: 1,
+        isDirty: true,
+        savedChangeDepth: 0,
+      })
 
-    await provider.dispatchWebviewMessageForTesting(
-      document.uri,
-      { type: 'redo' },
-      { propagateErrors: true }
-    )
-    await assertSessionText(session.sessionId, 'abc1')
-    assert.equal(session.checkpointTimeline.cursor, 0)
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        { type: 'undo' },
+        { propagateErrors: true }
+      )
+      await assertSessionText(session.sessionId, 'abc')
 
-    await provider.dispatchWebviewMessageForTesting(
-      document.uri,
-      { type: 'redo' },
-      { propagateErrors: true }
-    )
-    await assertSessionText(session.sessionId, 'abc12')
-    assert.equal(session.checkpointTimeline.cursor, 1)
-    assert.deepEqual(session.history.getEditState(), {
-      canUndo: true,
-      canRedo: false,
-      undoCount: 2,
-      redoCount: 0,
-      isDirty: true,
-      savedChangeDepth: 0,
-    })
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        { type: 'redo' },
+        { propagateErrors: true }
+      )
+      await assertSessionText(session.sessionId, 'abc1')
+      assert.equal(session.checkpointTimeline.cursor, 0)
 
-    await panel.fireDidDispose()
-    await fs.rm(tmpDir, { recursive: true, force: true })
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        { type: 'redo' },
+        { propagateErrors: true }
+      )
+      await assertSessionText(session.sessionId, 'abc12')
+      assert.equal(session.checkpointTimeline.cursor, 1)
+      assert.deepEqual(session.history.getEditState(), {
+        canUndo: true,
+        canRedo: false,
+        undoCount: 2,
+        redoCount: 0,
+        isDirty: true,
+        savedChangeDepth: 0,
+      })
+    } finally {
+      openCancellation.dispose()
+      resolveCancellation.dispose()
+      try {
+        await panel.fireDidDispose()
+      } finally {
+        document?.dispose()
+        await fs.rm(tmpDir, { recursive: true, force: true })
+      }
+    }
   })
 
   test('reports search matches and keeps undo/redo disabled state in sync', async () => {

--- a/wiki/Change-Log-Optimizer.md
+++ b/wiki/Change-Log-Optimizer.md
@@ -585,6 +585,8 @@ message ExportChangeLogRequest {
     optional string max_span_bytes_decimal = 5;      // absent/"0" = 64 MiB
     optional string max_entries_decimal = 6;         // absent/"0" = server cap
     optional string max_output_bytes_decimal = 7;    // may lower server cap
+    optional string digest_plugin_id = 8;             // default: omega.example.openssl_digests
+    optional string digest_algorithm = 9;             // default: sha256
 }
 
 message ExportChangeLogResponse {
@@ -597,7 +599,7 @@ message ExportChangeLogResponse {
 }
 
 message ChangeLogStreamHeader {
-    int32 format_version = 1;       // 2
+    int32 format_version = 1;       // 3
     string resolved_first_serial_decimal = 2;
     string resolved_last_serial_decimal = 3;
     string source_change_count_decimal = 4;
@@ -610,6 +612,7 @@ message ChangeLogStreamFingerprint {
     string byte_length_decimal = 1;
     string digest_algorithm = 2;
     string digest_value = 3;
+    string digest_plugin_id = 4;
 }
 
 message ChangeLogEntryHeader {
@@ -639,7 +642,6 @@ message ChangeLogPayloadChunk {
 message ChangeLogStreamComplete {
     string emitted_change_count_decimal = 1;
     string payload_byte_count_decimal = 2;
-    bytes payload_sha256 = 3;       // payload bytes in entry order
 }
 
 rpc CompactChanges(CompactChangesRequest) returns (CompactChangesResponse);
@@ -668,8 +670,8 @@ Server implementation notes (`server/cpp/src/editor_service.cpp`):
 - `ExportChangeLog` is read-only: `lock_session` only. While holding that lock,
   resolve the range and fingerprints, plan the complete export, and write
   length-delimited canonical frames to a `0600` exclusive temporary spool in
-  a server-managed directory. Copy payloads through a 256 KiB buffer. Flush,
-  close, and finalize the frame digest before releasing the lock.
+  a server-managed directory. Copy payloads through a 256 KiB buffer, then
+  flush and close the spool before releasing the lock.
 - After releasing the lock, reopen the immutable spool read-only and stream
   its frames. No borrowed core pointer survives lock release. Network stalls
   therefore block only the RPC worker, not edits to the session.
@@ -680,10 +682,7 @@ Server implementation notes (`server/cpp/src/editor_service.cpp`):
   entry with `payload_length_decimal == "0"` has no payload frames. Otherwise
   chunk offsets are contiguous, exactly one chunk has `final_chunk`, and its
   end is exactly `payload_length_decimal`. The complete frame is last.
-  `payload_sha256` is
-  SHA-256 over the logical payload bytes in entry order, independent of chunk
-  boundaries; for no payload it is SHA-256 of empty input. Its counts and
-  digest must match. Any violation is `DATA_LOSS`; invalid ranges are
+  Its counts must match. Any violation is `DATA_LOSS`; invalid ranges are
   `INVALID_ARGUMENT`; limit or disk exhaustion is `RESOURCE_EXHAUSTED`;
   cancellation is `CANCELLED`.
 - Every `*_decimal` field uses canonical unsigned decimal grammar
@@ -692,14 +691,16 @@ Server implementation notes (`server/cpp/src/editor_service.cpp`):
   `INVALID_ARGUMENT` in requests and `DATA_LOSS` in responses/spools. This is
   deliberate: generated TypeScript currently maps protobuf int64 to unsafe
   JavaScript numbers. No unbounded numeric stream field uses protobuf int64.
-  Fingerprint byte length follows the same grammar; SHA-256 digest values are
-  exactly 64 lowercase hexadecimal characters.
+  Fingerprint byte length follows the same grammar. Digest values are
+  lowercase hexadecimal and carry both their fully qualified plugin ID and
+  result algorithm label. The OpenSSL digest plugin is only the default;
+  callers may select any registered streaming inspect plugin implementing the
+  digest options/result contract.
 - Entry headers are bounded too: UTF-8 `transform_id` is at most 4096 bytes
-  and UTF-8 `options_json` is at most 1 MiB. Digest algorithm is exactly
-  `sha256` for v2. An existing transform over either metadata limit makes
-  export `RESOURCE_EXHAUSTED`; it is never truncated. All other header fields
-  are fixed-size or bounded decimal text, keeping every response safely below
-  gRPC's 4 MiB default.
+  and UTF-8 `options_json` is at most 1 MiB. An existing transform over either
+  metadata limit makes export `RESOURCE_EXHAUSTED`; it is never truncated. All
+  other header fields are fixed-size or bounded decimal text, keeping every
+  response safely below gRPC's 4 MiB default.
 - The server applies `min(request.max_entries_decimal, configured entry cap)`
   and `min(request.max_output_bytes_decimal, configured spool cap)`, treating
   absent/zero request values as the server cap. Defaults are 1,000,000 entries


### PR DESCRIPTION
## Summary

- make native undo/redo cross materialized checkpoint boundaries one transaction at a time while preserving and rematerializing checkpoint models at their exact history depth
- restore timeline milestones with an O(log n) boundary lookup and cover the real VS Code multi-action undo/redo path
- make content fingerprints end-user pluggable by carrying a fully qualified digest plugin ID; `omega.example.openssl_digests` is the default and callers can override it
- validate and bound plugin IDs, algorithm labels, and lowercase-hex digest values at server, RPC, codec, and persisted-timeline boundaries
- remove the redundant `payload_sha256` stream field and stop linking the server directly to OpenSSL/reflection; the server now uses `gRPC::grpc++_unsecure`, while digest implementations remain plugins

## Root cause

The VS Code history controller popped one editor transaction while its checkpoint executor checked out an entire materialized interval. That left editor history ahead of the native undo stack, so the next ordinary undo reached the server with nothing to undo and surfaced as `2 UNKNOWN`.

The sanitizer matrix also exposed the inverse transition: redo could cross a suspended checkpoint boundary through stale redo entries in the preceding model. Redo now rematerializes the checkpoint model exactly when its change boundary is reached, including a final checkpoint with no following edit.

## Digest and dependency rationale

Change-log fingerprints describe their algorithm and fully qualified plugin producer, so the format is not locked to OpenSSL or SHA-256. The OpenSSL digest plugin remains the default but is replaceable per request.

The removed payload checksum duplicated transport framing and byte-count validation, covered only streamed payload bytes rather than the complete archive, and hard-wired a second SHA-256 implementation/dependency into the client/server path. Integrity of the represented edit is checked with the declared before/after fingerprints; archive writers still compute the persisted file SHA-256 for storage bookkeeping. This is intentional rather than an omitted migration.

Using `grpc++_unsecure` is a deliberate dependency/toolchain change for this local middleware server and removes direct server linkage to OpenSSL and gRPC reflection. Deployments that require transport authentication/integrity must provide it at the transport/deployment boundary; a payload-only checksum is not a substitute for authenticated transport.

## Validation

- 155/155 native core tests
- deterministic differential fuzz matrix: 24 seeds × 256 operations
- client codec suite: 23/23 tests
- VS Code extension compile and 34/34 focused unit tests
- clang-format 18 and Biome checks
- Windows C++ gRPC server build
