### PR TITLE
fix: preserve Action journal history across checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build*/
 !.github/workflows/build-middleware*
 !.github/workflows/build-native*
 cmake-build*/
+CMakeUserPresets.json
 core/src/include/omega_edit/features.h
 node_modules/
 venv/

--- a/core/src/include/omega_edit/session.h
+++ b/core/src/include/omega_edit/session.h
@@ -142,10 +142,10 @@ int64_t omega_session_get_num_search_contexts(const omega_session_t *session_ptr
 int64_t omega_session_get_num_changes(const omega_session_t *session_ptr);
 
 /**
- * Given a session, return the current number of retained forward changes eligible for being redone, including changes
- * preserved in future checkpoint models.
- * @param session_ptr session to get the number of retained forward changes for
- * @return number of retained forward changes eligible for being redone
+ * Given a session, return the current number of undone changes eligible for redo. This is the complete
+ * forward-retained suffix, including changes preserved in future checkpoint models.
+ * @param session_ptr session to get the number of redoable, forward-retained changes for
+ * @return number of redoable, forward-retained changes
  */
 int64_t omega_session_get_num_undone_changes(const omega_session_t *session_ptr);
 

--- a/core/src/include/omega_edit/session.h
+++ b/core/src/include/omega_edit/session.h
@@ -142,9 +142,10 @@ int64_t omega_session_get_num_search_contexts(const omega_session_t *session_ptr
 int64_t omega_session_get_num_changes(const omega_session_t *session_ptr);
 
 /**
- * Given a session, return the current number of undone changes eligible for being redone
- * @param session_ptr session to get the number of undone changes for
- * @return number of undone changes eligible for being redone
+ * Given a session, return the current number of retained forward changes eligible for being redone, including changes
+ * preserved in future checkpoint models.
+ * @param session_ptr session to get the number of retained forward changes for
+ * @return number of retained forward changes eligible for being redone
  */
 int64_t omega_session_get_num_undone_changes(const omega_session_t *session_ptr);
 

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -86,8 +86,9 @@ namespace {
         const auto positive_serial = -serial;
         for (auto iter = model->changes.crbegin(); iter != model->changes.crend(); ++iter) {
             const auto *change = iter->get();
+            if (!change) { continue; }
             if (omega_change_get_serial(change) == positive_serial) { return change; }
-            if (change && change->transform_data) {
+            if (change->transform_data) {
                 if (const auto *preserved =
                             find_undone_change_(change->transform_data->preserved_changes_undone, serial)) {
                     return preserved;

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -84,15 +84,17 @@ namespace {
         if (serial == (std::numeric_limits<int64_t>::min)()) { return nullptr; }
 
         const auto positive_serial = -serial;
-        for (auto iter = model->changes.crbegin(); iter != model->changes.crend(); ++iter) {
-            const auto *change = iter->get();
-            if (!change) { continue; }
-            if (omega_change_get_serial(change) == positive_serial) { return change; }
-            if (change->transform_data) {
-                if (const auto *preserved =
-                            find_undone_change_(change->transform_data->preserved_changes_undone, serial)) {
-                    return preserved;
-                }
+        const auto index = positive_serial - 1 - model->change_serial_base;
+        if (index >= 0 && static_cast<size_t>(index) < model->changes.size()) {
+            const auto *change = model->changes[static_cast<size_t>(index)].get();
+            if (change && omega_change_get_serial(change) == positive_serial) { return change; }
+        }
+
+        // A checkpointed transform, when present, is the first change in its model and may retain its own redo suffix.
+        if (!model->changes.empty()) {
+            const auto *change = model->changes.front().get();
+            if (change && change->transform_data) {
+                return find_undone_change_(change->transform_data->preserved_changes_undone, serial);
             }
         }
         return nullptr;
@@ -262,8 +264,8 @@ const omega_change_t *omega_session_get_change(const omega_session_t *session_pt
     } else if (change_serial < 0) {
         // Negative serials are retained forward changes. A materialized checkpoint model can carry both changes that
         // have already been moved to its undo stack and positive-serial changes beyond the active checkpoint cursor.
-        for (const auto &model : session_ptr->models_) {
-            if (const auto *change = find_undone_change_(model->changes_undone, change_serial)) { return change; }
+        for (auto iter = session_ptr->models_.crbegin(); iter != session_ptr->models_.crend(); ++iter) {
+            if (const auto *change = find_undone_change_((*iter)->changes_undone, change_serial)) { return change; }
         }
         for (auto iter = session_ptr->checkpoint_future_models_.crbegin();
              iter != session_ptr->checkpoint_future_models_.crend(); ++iter) {

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -56,7 +56,9 @@ namespace {
     int64_t count_future_model_changes_(const omega_model_t *model) {
         if (!model) { return 0; }
         int64_t result = static_cast<int64_t>(model->changes.size());
-        for (const auto &change : model->changes) {
+        // A checkpointed transform, when present, is the first change in its model and may retain its own redo suffix.
+        if (!model->changes.empty()) {
+            const auto &change = model->changes.front();
             if (change && change->transform_data) {
                 result += count_undone_changes_(change->transform_data->preserved_changes_undone);
             }

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <limits>
 
 using omega_edit::internal::change_kind_t;
 using omega_edit::internal::omega_change_get_kind_;
@@ -52,10 +53,40 @@ namespace {
         return result;
     }
 
+    int64_t count_future_model_changes_(const omega_model_t *model) {
+        if (!model) { return 0; }
+        int64_t result = static_cast<int64_t>(model->changes.size());
+        for (const auto &change : model->changes) {
+            if (change && change->transform_data) {
+                result += count_undone_changes_(change->transform_data->preserved_changes_undone);
+            }
+        }
+        return result + count_undone_changes_(model->changes_undone);
+    }
+
     const omega_change_t *find_undone_change_(const omega_changes_t &changes, int64_t serial) {
         for (auto iter = changes.crbegin(); iter != changes.crend(); ++iter) {
             const auto *change = iter->get();
             if (omega_change_get_serial(change) == serial) { return change; }
+            if (change && change->transform_data) {
+                if (const auto *preserved =
+                            find_undone_change_(change->transform_data->preserved_changes_undone, serial)) {
+                    return preserved;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    const omega_change_t *find_future_model_change_(const omega_model_t *model, int64_t serial) {
+        if (!model || serial >= 0) { return nullptr; }
+        if (const auto *change = find_undone_change_(model->changes_undone, serial)) { return change; }
+        if (serial == (std::numeric_limits<int64_t>::min)()) { return nullptr; }
+
+        const auto positive_serial = -serial;
+        for (auto iter = model->changes.crbegin(); iter != model->changes.crend(); ++iter) {
+            const auto *change = iter->get();
+            if (omega_change_get_serial(change) == positive_serial) { return change; }
             if (change && change->transform_data) {
                 if (const auto *preserved =
                             find_undone_change_(change->transform_data->preserved_changes_undone, serial)) {
@@ -159,6 +190,9 @@ int64_t omega_session_get_num_undone_changes(const omega_session_t *session_ptr)
     assert(session_ptr->models_.back());
     int64_t result = 0;
     for (const auto &model : session_ptr->models_) { result += count_undone_changes_(model->changes_undone); }
+    for (const auto &model : session_ptr->checkpoint_future_models_) {
+        result += count_future_model_changes_(model.get());
+    }
     return result;
 }
 
@@ -225,9 +259,14 @@ const omega_change_t *omega_session_get_change(const omega_session_t *session_pt
             }
         }
     } else if (change_serial < 0) {
-        // Negative serials are undone changes
+        // Negative serials are retained forward changes. A materialized checkpoint model can carry both changes that
+        // have already been moved to its undo stack and positive-serial changes beyond the active checkpoint cursor.
         for (const auto &model : session_ptr->models_) {
             if (const auto *change = find_undone_change_(model->changes_undone, change_serial)) { return change; }
+        }
+        for (auto iter = session_ptr->checkpoint_future_models_.crbegin();
+             iter != session_ptr->checkpoint_future_models_.crend(); ++iter) {
+            if (const auto *change = find_future_model_change_(iter->get(), change_serial)) { return change; }
         }
     }
     return nullptr;

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -411,6 +411,61 @@ TEST_CASE("Undo crosses materialized checkpoints one transaction at a time",
     omega_edit_destroy_session(session_ptr);
 }
 
+TEST_CASE("Checkpoint traversal keeps the complete forward history visible",
+          "[SessionCheckpointTests][CheckpointTimeline][Undo][ActionJournal]") {
+    const auto session_ptr = omega_edit_create_session_from_bytes(nullptr, 0, nullptr, nullptr, NO_EVENTS, nullptr);
+    REQUIRE(session_ptr);
+
+    for (int64_t serial = 1; serial <= 6; ++serial) {
+        REQUIRE(serial == omega_edit_insert_string(session_ptr, serial - 1, "a"));
+    }
+    REQUIRE(0 == omega_edit_create_checkpoint(session_ptr));
+    for (int64_t serial = 7; serial <= 9; ++serial) {
+        REQUIRE(serial == omega_edit_insert_string(session_ptr, serial - 1, "a"));
+    }
+    const omega_edit_transform_t to_upper{OMEGA_EDIT_TRANSFORM_ASCII_TO_UPPER, 0};
+    REQUIRE(0 == omega_edit_apply_builtin_transform(session_ptr, to_upper, 0, 0));
+    REQUIRE(10 == omega_session_get_num_changes(session_ptr));
+
+    for (int64_t serial = 10; serial >= 6; --serial) { REQUIRE(-serial == omega_edit_undo_last_change(session_ptr)); }
+    REQUIRE(5 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(5 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE(1 == omega_session_get_num_future_checkpoints(session_ptr));
+    for (int64_t serial = 6; serial <= 10; ++serial) {
+        INFO("forward serial=" << serial);
+        REQUIRE(omega_session_get_change(session_ptr, -serial));
+    }
+
+    REQUIRE(6 == omega_edit_redo_last_undo(session_ptr));
+    REQUIRE(6 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(4 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_future_checkpoints(session_ptr));
+    for (int64_t serial = 7; serial <= 10; ++serial) {
+        INFO("forward serial=" << serial);
+        REQUIRE(omega_session_get_change(session_ptr, -serial));
+    }
+
+    for (int64_t serial = 7; serial <= 10; ++serial) { REQUIRE(serial == omega_edit_redo_last_undo(session_ptr)); }
+    REQUIRE(10 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE(2 == omega_session_get_num_checkpoints(session_ptr));
+
+    REQUIRE(0 == omega_edit_checkout_checkpoint(session_ptr, 0));
+    REQUIRE(0 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(10 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE(2 == omega_session_get_num_future_checkpoints(session_ptr));
+    for (int64_t serial = 1; serial <= 10; ++serial) {
+        INFO("future checkpoint serial=" << serial);
+        REQUIRE(omega_session_get_change(session_ptr, -serial));
+    }
+    REQUIRE(0 == omega_edit_checkout_checkpoint(session_ptr, 2));
+    REQUIRE(10 == omega_session_get_num_changes(session_ptr));
+    REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE(0 == omega_check_model(session_ptr));
+
+    omega_edit_destroy_session(session_ptr);
+}
+
 TEST_CASE("Checkpoint boundary lookup selects the newest duplicate", "[SessionCheckpointTests][CheckpointTimeline]") {
     const auto input = reinterpret_cast<const omega_byte_t *>("abc");
     const auto session_ptr = omega_edit_create_session_from_bytes(input, 3, nullptr, nullptr, NO_EVENTS, nullptr);

--- a/packages/client/src/editor_history.ts
+++ b/packages/client/src/editor_history.ts
@@ -212,6 +212,70 @@ export class EditorHistoryController {
     return history
   }
 
+  public reconcileNativeTransactionCounts(
+    activeTransactionCount: number,
+    undoneTransactionCount: number,
+    currentStateIsSaved: boolean
+  ): boolean {
+    if (
+      !Number.isSafeInteger(activeTransactionCount) ||
+      activeTransactionCount < 0 ||
+      !Number.isSafeInteger(undoneTransactionCount) ||
+      undoneTransactionCount < 0
+    ) {
+      throw new RangeError(
+        'Native transaction counts must be non-negative safe integers'
+      )
+    }
+    const nativeBackedActiveCount = this.transactionLog.filter(
+      (transaction) => transaction.kind !== 'CHECKPOINT_REPLACE_ALL'
+    ).length
+    const nativeBackedUndoneCount = this.undoneTransactionLog.filter(
+      (transaction) => transaction.kind !== 'CHECKPOINT_REPLACE_ALL'
+    ).length
+    if (
+      nativeBackedActiveCount === activeTransactionCount &&
+      nativeBackedUndoneCount === undoneTransactionCount
+    ) {
+      return false
+    }
+    if (
+      this.transactionLog.some(
+        (transaction) => transaction.kind === 'CHECKPOINT_REPLACE_ALL'
+      ) ||
+      this.undoneTransactionLog.some(
+        (transaction) => transaction.kind === 'CHECKPOINT_REPLACE_ALL'
+      )
+    ) {
+      return false
+    }
+
+    // Another client can attach to the same native file session and mutate it
+    // without contributing records to this controller. Once the native stack
+    // depths diverge, retaining typed local records would associate them with
+    // the wrong native transactions. Preserve correct undo/redo ordering by
+    // rebuilding both stacks as opaque transactions.
+    this.changeLog.length = 0
+    this.undoneChangeLog.length = 0
+    this.transactionLog.length = 0
+    this.undoneTransactionLog.length = 0
+    this.transactionLog.push(
+      ...Array.from(
+        { length: activeTransactionCount },
+        (): EditorTransactionRecord => ({ kind: 'LOCAL_UNTRACKED' })
+      )
+    )
+    this.undoneTransactionLog.push(
+      ...Array.from(
+        { length: undoneTransactionCount },
+        (): EditorTransactionRecord => ({ kind: 'LOCAL_UNTRACKED' })
+      )
+    )
+    this.savedChangeDepth = currentStateIsSaved ? activeTransactionCount : 0
+    this.milestoneDepths.length = 0
+    return true
+  }
+
   public recordLocalChange(change: EditorChangeRecord): void {
     this.recordLocalChanges([change])
   }

--- a/packages/client/src/editor_history.ts
+++ b/packages/client/src/editor_history.ts
@@ -227,26 +227,30 @@ export class EditorHistoryController {
         'Native transaction counts must be non-negative safe integers'
       )
     }
-    const nativeBackedActiveCount = this.transactionLog.filter(
-      (transaction) => transaction.kind !== 'CHECKPOINT_REPLACE_ALL'
-    ).length
-    const nativeBackedUndoneCount = this.undoneTransactionLog.filter(
-      (transaction) => transaction.kind !== 'CHECKPOINT_REPLACE_ALL'
-    ).length
+    let nativeBackedActiveCount = 0
+    let nativeBackedUndoneCount = 0
+    let hasCheckpointReplaceAll = false
+    for (const transaction of this.transactionLog) {
+      if (transaction.kind === 'CHECKPOINT_REPLACE_ALL') {
+        hasCheckpointReplaceAll = true
+      } else {
+        nativeBackedActiveCount += 1
+      }
+    }
+    for (const transaction of this.undoneTransactionLog) {
+      if (transaction.kind === 'CHECKPOINT_REPLACE_ALL') {
+        hasCheckpointReplaceAll = true
+      } else {
+        nativeBackedUndoneCount += 1
+      }
+    }
     if (
       nativeBackedActiveCount === activeTransactionCount &&
       nativeBackedUndoneCount === undoneTransactionCount
     ) {
       return false
     }
-    if (
-      this.transactionLog.some(
-        (transaction) => transaction.kind === 'CHECKPOINT_REPLACE_ALL'
-      ) ||
-      this.undoneTransactionLog.some(
-        (transaction) => transaction.kind === 'CHECKPOINT_REPLACE_ALL'
-      )
-    ) {
+    if (hasCheckpointReplaceAll) {
       return false
     }
 
@@ -259,18 +263,12 @@ export class EditorHistoryController {
     this.undoneChangeLog.length = 0
     this.transactionLog.length = 0
     this.undoneTransactionLog.length = 0
-    this.transactionLog.push(
-      ...Array.from(
-        { length: activeTransactionCount },
-        (): EditorTransactionRecord => ({ kind: 'LOCAL_UNTRACKED' })
-      )
-    )
-    this.undoneTransactionLog.push(
-      ...Array.from(
-        { length: undoneTransactionCount },
-        (): EditorTransactionRecord => ({ kind: 'LOCAL_UNTRACKED' })
-      )
-    )
+    for (let index = 0; index < activeTransactionCount; index += 1) {
+      this.transactionLog.push({ kind: 'LOCAL_UNTRACKED' })
+    }
+    for (let index = 0; index < undoneTransactionCount; index += 1) {
+      this.undoneTransactionLog.push({ kind: 'LOCAL_UNTRACKED' })
+    }
     this.savedChangeDepth = currentStateIsSaved ? activeTransactionCount : 0
     this.milestoneDepths.length = 0
     return true

--- a/packages/client/tests/specs/actionJournalIntegration.spec.ts
+++ b/packages/client/tests/specs/actionJournalIntegration.spec.ts
@@ -186,6 +186,7 @@ describe('Action journal integration', () => {
 
   it('keeps the full redo suffix visible while crossing a checkpoint', async () => {
     const payload = Buffer.from('a')
+    const expectedSerials = ['10', '9', '8', '7', '6', '5', '4', '3', '2', '1']
     for (let serial = 1; serial <= 6; serial += 1) {
       await insert(sessionId, serial - 1, payload)
     }
@@ -207,18 +208,9 @@ describe('Action journal integration', () => {
       changeCount: '5',
       undoCount: '5',
     })
-    expect(beforeCheckpoint.entries.map((entry) => entry.firstSerial)).toEqual([
-      '10',
-      '9',
-      '8',
-      '7',
-      '6',
-      '5',
-      '4',
-      '3',
-      '2',
-      '1',
-    ])
+    expect(beforeCheckpoint.entries.map((entry) => entry.firstSerial)).toEqual(
+      expectedSerials
+    )
 
     await redo(sessionId)
     const atCheckpoint = await getActionJournalViewport({
@@ -231,17 +223,8 @@ describe('Action journal integration', () => {
       changeCount: '6',
       undoCount: '4',
     })
-    expect(atCheckpoint.entries.map((entry) => entry.firstSerial)).toEqual([
-      '10',
-      '9',
-      '8',
-      '7',
-      '6',
-      '5',
-      '4',
-      '3',
-      '2',
-      '1',
-    ])
+    expect(atCheckpoint.entries.map((entry) => entry.firstSerial)).toEqual(
+      expectedSerials
+    )
   })
 })

--- a/packages/client/tests/specs/actionJournalIntegration.spec.ts
+++ b/packages/client/tests/specs/actionJournalIntegration.spec.ts
@@ -183,4 +183,64 @@ describe('Action journal integration', () => {
     ])
     await redo(sessionId)
   })
+
+  it('keeps the full redo suffix visible while crossing a checkpoint', async () => {
+    for (let serial = 1; serial <= 6; serial += 1) {
+      await insert(sessionId, serial - 1, Buffer.from('a'))
+    }
+    await createCheckpoint(sessionId)
+    for (let serial = 7; serial <= 10; serial += 1) {
+      await insert(sessionId, serial - 1, Buffer.from('a'))
+    }
+
+    for (let serial = 10; serial >= 6; serial -= 1) {
+      await undo(sessionId)
+    }
+    const beforeCheckpoint = await getActionJournalViewport({
+      sessionId,
+      capacity: 20,
+      direction: 'older',
+    })
+    expect(beforeCheckpoint).toMatchObject({
+      activeTipSerial: '5',
+      changeCount: '5',
+      undoCount: '5',
+    })
+    expect(beforeCheckpoint.entries.map((entry) => entry.firstSerial)).toEqual([
+      '10',
+      '9',
+      '8',
+      '7',
+      '6',
+      '5',
+      '4',
+      '3',
+      '2',
+      '1',
+    ])
+
+    await redo(sessionId)
+    const atCheckpoint = await getActionJournalViewport({
+      sessionId,
+      capacity: 20,
+      direction: 'older',
+    })
+    expect(atCheckpoint).toMatchObject({
+      activeTipSerial: '6',
+      changeCount: '6',
+      undoCount: '4',
+    })
+    expect(atCheckpoint.entries.map((entry) => entry.firstSerial)).toEqual([
+      '10',
+      '9',
+      '8',
+      '7',
+      '6',
+      '5',
+      '4',
+      '3',
+      '2',
+      '1',
+    ])
+  })
 })

--- a/packages/client/tests/specs/actionJournalIntegration.spec.ts
+++ b/packages/client/tests/specs/actionJournalIntegration.spec.ts
@@ -185,12 +185,13 @@ describe('Action journal integration', () => {
   })
 
   it('keeps the full redo suffix visible while crossing a checkpoint', async () => {
+    const payload = Buffer.from('a')
     for (let serial = 1; serial <= 6; serial += 1) {
-      await insert(sessionId, serial - 1, Buffer.from('a'))
+      await insert(sessionId, serial - 1, payload)
     }
     await createCheckpoint(sessionId)
     for (let serial = 7; serial <= 10; serial += 1) {
-      await insert(sessionId, serial - 1, Buffer.from('a'))
+      await insert(sessionId, serial - 1, payload)
     }
 
     for (let serial = 10; serial >= 6; serial -= 1) {

--- a/packages/client/tests/specs/editorPatterns.spec.ts
+++ b/packages/client/tests/specs/editorPatterns.spec.ts
@@ -412,6 +412,79 @@ describe('Editor Patterns', () => {
     expect(restored.snapshot()).to.deep.equal(snapshot)
   })
 
+  it('should reconcile history when another client changes native transaction stacks', async () => {
+    const history = new EditorHistoryController()
+    history.recordLocalChange({
+      serial: 17,
+      kind: 'INSERT',
+      offset: 649,
+      length: 0,
+      data: '42',
+    })
+
+    expect(history.reconcileNativeTransactionCounts(16, 1, true)).to.be.true
+    expect(history.getChangeLog()).to.deep.equal([])
+    expect(history.getEditState()).to.deep.equal({
+      canUndo: true,
+      canRedo: true,
+      undoCount: 16,
+      redoCount: 1,
+      isDirty: false,
+      savedChangeDepth: 16,
+    })
+    expect(history.reconcileNativeTransactionCounts(16, 1, true)).to.be.false
+
+    const calls: string[] = []
+    const executor = {
+      async undoLocal() {
+        calls.push('undoLocal')
+      },
+      async redoLocal() {
+        calls.push('redoLocal')
+      },
+      async undoCheckpoint() {
+        calls.push('undoCheckpoint')
+      },
+      async redoCheckpoint() {
+        calls.push('redoCheckpoint')
+      },
+    }
+    await history.undo(executor)
+    await history.redo(executor)
+    expect(calls).to.deep.equal(['undoLocal', 'redoLocal'])
+  })
+
+  it('should reject invalid native transaction counts', () => {
+    const history = new EditorHistoryController()
+    expect(() =>
+      history.reconcileNativeTransactionCounts(-1, 0, false)
+    ).to.throw(RangeError)
+    expect(() =>
+      history.reconcileNativeTransactionCounts(
+        0,
+        Number.MAX_SAFE_INTEGER + 1,
+        false
+      )
+    ).to.throw(RangeError)
+  })
+
+  it('should not mistake checkpoint-backed steps for native transactions', () => {
+    const history = new EditorHistoryController()
+    history.recordCheckpointReplaceAll({
+      kind: 'CHECKPOINT_REPLACE_ALL',
+      query: 'PD',
+      isHex: false,
+      caseFolding: SearchCaseFolding.NONE,
+      data: '504446',
+    })
+
+    expect(history.reconcileNativeTransactionCounts(0, 0, false)).to.be.false
+    expect(history.getEditState()).to.deep.include({
+      canUndo: true,
+      undoCount: 1,
+    })
+  })
+
   it('should undo multi-record local transactions as a single unit', async () => {
     const history = new EditorHistoryController()
     const calls: string[] = []

--- a/packages/client/tests/specs/editorPatterns.spec.ts
+++ b/packages/client/tests/specs/editorPatterns.spec.ts
@@ -468,6 +468,19 @@ describe('Editor Patterns', () => {
     ).to.throw(RangeError)
   })
 
+  it('should reconcile native transaction counts above argument limits', () => {
+    const history = new EditorHistoryController()
+    const activeTransactionCount = 200_000
+
+    expect(
+      history.reconcileNativeTransactionCounts(activeTransactionCount, 0, false)
+    ).to.be.true
+    expect(history.getEditState()).to.deep.include({
+      undoCount: activeTransactionCount,
+      redoCount: 0,
+    })
+  })
+
   it('should not mistake checkpoint-backed steps for native transactions', () => {
     const history = new EditorHistoryController()
     history.recordCheckpointReplaceAll({

--- a/plugins/CMakeUserPresets.json
+++ b/plugins/CMakeUserPresets.json
@@ -1,9 +1,0 @@
-{
-    "version": 4,
-    "vendor": {
-        "conan": {}
-    },
-    "include": [
-        "../_build_plugin_conan/CMakePresets.json"
-    ]
-}

--- a/server/cpp/CMakeUserPresets.json
+++ b/server/cpp/CMakeUserPresets.json
@@ -1,9 +1,0 @@
-{
-    "version": 4,
-    "vendor": {
-        "conan": {}
-    },
-    "include": [
-        "build/CMakePresets.json"
-    ]
-}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -638,12 +638,13 @@ async function stopServerConnectionGraceful(
     // normal process-stop path when the RPC has not completed shutdown yet.
     if (serverPid !== undefined && serverPid) {
       const stopped = await stopProcessUsingPID(serverPid)
-      if (!stopped) {
+      const shutdownCompleted = result.status === 'completed'
+      if (!stopped && !shutdownCompleted) {
         console.warn(
           `Failed to stop OmegaEdit server process ${serverPid} after graceful shutdown returned ${result.status}`
         )
       }
-      return stopped
+      return stopped || shutdownCompleted
     }
 
     return result.status === 'completed'

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -76,6 +76,8 @@ let activeServerPid: number | undefined
 let activeServerSocketPath: string | undefined
 
 const DEFAULT_SERVER_PORT = 9000
+const SERVER_SESSION_TIMEOUT_MS = 60_000
+const SERVER_CLEANUP_INTERVAL_MS = 5_000
 const DARWIN_UNIX_SOCKET_PATH_MAX_BYTES = 103
 const SERVER_PORT_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_PORT'
 const SERVER_SOCKET_OVERRIDE_ENV = 'OMEGA_EDIT_SERVER_SOCKET'
@@ -558,6 +560,9 @@ async function startTcpServerConnection(
 ): Promise<StartedServer> {
   const tcpConnection = toTcpConnection(connection)
   const serverOptions = {
+    sessionTimeoutMs: SERVER_SESSION_TIMEOUT_MS,
+    cleanupIntervalMs: SERVER_CLEANUP_INTERVAL_MS,
+    shutdownWhenNoSessions: true,
     transformPluginDirectories,
     allowExperimentalTransformPlugins,
   }
@@ -586,6 +591,9 @@ async function startServerConnection(
   }
 
   const serverOptions = {
+    sessionTimeoutMs: SERVER_SESSION_TIMEOUT_MS,
+    cleanupIntervalMs: SERVER_CLEANUP_INTERVAL_MS,
+    shutdownWhenNoSessions: true,
     transformPluginDirectories,
     allowExperimentalTransformPlugins,
   }
@@ -621,8 +629,24 @@ async function stopServerConnectionGraceful(
     if (connection) {
       await connectToServer(connection)
     }
-    await stopServerGraceful()
-    return true
+    const result = await stopServerGraceful()
+
+    // The native server is deliberately detached from the extension host.
+    // A graceful request can therefore leave it alive while sessions drain,
+    // and Windows will keep the executable (and extension directory) locked.
+    // Wait for the known child PID to exit, escalating through the client's
+    // normal process-stop path when the RPC has not completed shutdown yet.
+    if (serverPid !== undefined && serverPid) {
+      const stopped = await stopProcessUsingPID(serverPid)
+      if (!stopped) {
+        console.warn(
+          `Failed to stop OmegaEdit server process ${serverPid} after graceful shutdown returned ${result.status}`
+        )
+      }
+      return stopped
+    }
+
+    return result.status === 'completed'
   } catch (err) {
     if (serverPid !== undefined && serverPid) {
       try {

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -56,6 +56,7 @@ import {
   getActionJournalViewport as requestActionJournalViewport,
   getChangeCount,
   getChangeDetails,
+  getChangeTransactionCount,
   getClientVersion,
   getComputedFileSize,
   getCounts,
@@ -63,6 +64,7 @@ import {
   getServerInfo,
   getSessionContentInfo,
   getSessionFingerprint,
+  getUndoTransactionCount,
   getViewportData,
   IOFlags,
   inspectSessionContent,
@@ -2605,6 +2607,7 @@ export class HexEditorProvider
     resolvedSession = session
     this.activeSession = session
     this.updateEditCommandContexts(session)
+    await this.reconcileNativeHistory(session)
 
     // Send initial data to the webview. The message listener must be in place
     // first because the webview posts its first metrics update as soon as it
@@ -4445,6 +4448,7 @@ export class HexEditorProvider
             targetHistorySnapshot?.transactionLog.length ?? 0
           )
         : new EditorHistoryController()
+      await this.reconcileNativeHistory(session)
       await this.resetSessionState(session, isDirty, isDirty, false, true)
       await this.refreshSessionContentInfo(session)
       this.clearSearchState(session)
@@ -4623,6 +4627,9 @@ export class HexEditorProvider
       session.scope.isDisposed
     ) {
       return
+    }
+    if (await this.reconcileNativeHistory(session)) {
+      this.postEditState(session)
     }
     const webviewViewport: WebviewActionJournalViewport = {
       version: 1,
@@ -5929,6 +5936,30 @@ export class HexEditorProvider
     timeoutMs: number = SESSION_SYNC_TIMEOUT_MS
   ): Promise<void> {
     return session.scope.model.waitForSync(minimumVersion, timeoutMs)
+  }
+
+  private async reconcileNativeHistory(
+    session: EditorSession
+  ): Promise<boolean> {
+    const [activeTransactionCount, undoneTransactionCount, currentFingerprint] =
+      await Promise.all([
+        getChangeTransactionCount(session.sessionId),
+        getUndoTransactionCount(session.sessionId),
+        getChangeLogFingerprint(
+          session.sessionId,
+          SessionFingerprintContent.COMPUTED,
+          'sha256'
+        ),
+      ])
+    session.checkpointTimeline.currentFingerprint = currentFingerprint
+    return session.history.reconcileNativeTransactionCounts(
+      activeTransactionCount,
+      undoneTransactionCount,
+      timelineFingerprintsEqual(
+        session.checkpointTimeline.currentFingerprint,
+        session.checkpointTimeline.savedFingerprint
+      )
+    )
   }
 
   private async getCheckpointCount(session: EditorSession): Promise<number> {

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -2606,8 +2606,8 @@ export class HexEditorProvider
     this.pendingHealthWebviews.delete(webviewPanel.webview)
     resolvedSession = session
     this.activeSession = session
-    this.updateEditCommandContexts(session)
     await this.reconcileNativeHistory(session)
+    this.updateEditCommandContexts(session)
 
     // Send initial data to the webview. The message listener must be in place
     // first because the webview posts its first metrics update as soon as it
@@ -4629,6 +4629,7 @@ export class HexEditorProvider
       return
     }
     if (await this.reconcileNativeHistory(session)) {
+      this.updateEditCommandContexts(session)
       this.postEditState(session)
     }
     const webviewViewport: WebviewActionJournalViewport = {
@@ -6286,6 +6287,10 @@ export class HexEditorProvider
         created: false,
       }
     }
+    // Auto Save can publish the file before it finishes updating the durable
+    // saved fingerprint. Do not let checkpoint manifest publication overlap
+    // that final save bookkeeping.
+    await session.saveTask?.catch(() => undefined)
     await this.assertCheckpointTimelineNativeAlignment(
       session,
       'before checkpoint creation'

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -2514,10 +2514,11 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(extensionJs, /startTcpServerConnection/)
   assert.doesNotMatch(extensionSource, /fallbackReason/)
   assert.match(extensionJs, /startServerUnixSocket/)
-  assert.match(
-    extensionSource,
-    /const serverOptions = \{\s*sessionTimeoutMs: SERVER_SESSION_TIMEOUT_MS,\s*cleanupIntervalMs: SERVER_CLEANUP_INTERVAL_MS,\s*shutdownWhenNoSessions: true,\s*transformPluginDirectories,\s*allowExperimentalTransformPlugins/
-  )
+  assert.match(extensionSource, /sessionTimeoutMs: SERVER_SESSION_TIMEOUT_MS/)
+  assert.match(extensionSource, /cleanupIntervalMs: SERVER_CLEANUP_INTERVAL_MS/)
+  assert.match(extensionSource, /shutdownWhenNoSessions: true/)
+  assert.match(extensionSource, /transformPluginDirectories/)
+  assert.match(extensionSource, /allowExperimentalTransformPlugins/)
   assert.match(extensionSource, /const SERVER_SESSION_TIMEOUT_MS = 60_000/)
   assert.match(extensionSource, /const SERVER_CLEANUP_INTERVAL_MS = 5_000/)
   assert.match(

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -812,6 +812,10 @@ test('compiled extension entrypoints exist after build', () => {
     ),
     'utf8'
   )
+  const vscodeApiSource = fs.readFileSync(
+    path.resolve(__dirname, '../webview-ui/src/vscodeApi.ts'),
+    'utf8'
+  )
   const byteInspectorSource = fs.readFileSync(
     path.resolve(
       __dirname,
@@ -1604,6 +1608,19 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(svelteAppSource, /onScrollTo=\{requestVisibleOffset\}/)
   assert.match(svelteAppSource, /function toggleInspectorEndian/)
   assert.match(svelteAppSource, /function toggleInspectorExpanded/)
+  assert.match(
+    svelteAppSource,
+    /inspectorExpanded = \$state\(restoredState\?\.inspectorExpanded \?\? false\)/
+  )
+  assert.match(
+    svelteAppSource,
+    /profilerExpanded = \$state\(restoredState\?\.profilerExpanded \?\? false\)/
+  )
+  assert.match(svelteAppSource, /savePreviewState\(\{ inspectorExpanded \}\)/)
+  assert.match(vscodeApiSource, /inspectorExpanded\?: boolean/)
+  assert.match(byteInspectorSource, /expanded = false/)
+  assert.match(editorWorkspaceSource, /profilerExpanded = false/)
+  assert.match(profilerPanelSource, /expanded = false/)
   assert.match(svelteAppSource, /function setOffsetRadix/)
   assert.match(svelteAppSource, /offsetRadix = \$state<'hex' \| 'dec'>/)
   assert.match(svelteAppSource, /textEncoding = \$state<TextEncoding>/)
@@ -2499,7 +2516,13 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(extensionJs, /startServerUnixSocket/)
   assert.match(
     extensionSource,
-    /const serverOptions = \{\s*transformPluginDirectories,\s*allowExperimentalTransformPlugins/
+    /const serverOptions = \{\s*sessionTimeoutMs: SERVER_SESSION_TIMEOUT_MS,\s*cleanupIntervalMs: SERVER_CLEANUP_INTERVAL_MS,\s*shutdownWhenNoSessions: true,\s*transformPluginDirectories,\s*allowExperimentalTransformPlugins/
+  )
+  assert.match(extensionSource, /const SERVER_SESSION_TIMEOUT_MS = 60_000/)
+  assert.match(extensionSource, /const SERVER_CLEANUP_INTERVAL_MS = 5_000/)
+  assert.match(
+    extensionSource,
+    /const result = await stopServerGraceful\(\)[\s\S]*stopProcessUsingPID\(serverPid\)/
   )
   assert.match(
     extensionSource,

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -8,6 +8,7 @@ const {
   getClient,
   getComputedFileSize,
   getSegment,
+  insert,
   IOFlags,
   saveSession,
 } = require('@omega-edit/client')
@@ -3319,6 +3320,60 @@ suite('OmegaEdit VS Code extension', () => {
 
     const saved = await fs.readFile(samplePath, 'utf8')
     assert.equal(saved, 'qux qux qux qux')
+
+    await panel.fireDidDispose()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('reconciles action journal history changed by another attached client', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-shared-history-')
+    )
+    const samplePath = path.join(tmpDir, 'shared-history.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    await provider.resolveCustomEditor(
+      document,
+      panel,
+      new vscode.CancellationTokenSource().token
+    )
+
+    const session = provider.getSessionForTesting(document.uri)
+    assert.ok(session, 'Expected a live session for shared history')
+
+    await insert(session.sessionId, 0, Buffer.from('!', 'utf8'))
+    await assertSessionText(session.sessionId, '!abc')
+    assert.equal(session.history.getEditState().canUndo, false)
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'requestActionJournalViewport',
+      capacity: 20,
+      direction: 'older',
+    })
+
+    const editState = lastMessageOfType(panel.messages, 'editState')
+    assert.deepEqual(editState, {
+      type: 'editState',
+      canUndo: true,
+      canRedo: false,
+      undoCount: 1,
+      redoCount: 0,
+      isDirty: true,
+      savedChangeDepth: 0,
+    })
+
+    await provider.dispatchWebviewMessageForTesting(document.uri, {
+      type: 'undo',
+    })
+    await assertSessionText(session.sessionId, 'abc')
 
     await panel.fireDidDispose()
     await fs.rm(tmpDir, { recursive: true, force: true })

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -3150,6 +3150,59 @@ suite('OmegaEdit VS Code extension', () => {
     }
   })
 
+  test('waits for an in-flight save before creating a checkpoint', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-save-checkpoint-order-')
+    )
+    const samplePath = path.join(tmpDir, 'save-checkpoint-order.bin')
+    await fs.writeFile(samplePath, Buffer.from('abc', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    try {
+      await provider.resolveCustomEditor(
+        document,
+        panel,
+        new vscode.CancellationTokenSource().token
+      )
+      const session = provider.getSessionForTesting(document.uri)
+      assert.ok(session, 'Expected a live session for checkpoint ordering')
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'overwrite',
+        offset: 0,
+        data: Buffer.from('X', 'utf8').toString('hex'),
+      })
+
+      let releaseSave
+      session.saveTask = new Promise((resolve) => {
+        releaseSave = resolve
+      })
+      let alignmentStarted = false
+      const getCheckpointCount = provider.getCheckpointCount.bind(provider)
+      provider.getCheckpointCount = async (...args) => {
+        alignmentStarted = true
+        return await getCheckpointCount(...args)
+      }
+
+      const checkpoint = provider.createCheckpoint({ uri: document.uri })
+      await Promise.resolve()
+      assert.equal(alignmentStarted, false)
+
+      releaseSave()
+      assert.equal((await checkpoint)?.checkpointCount, 1)
+      assert.equal(alignmentStarted, true)
+    } finally {
+      await panel.fireDidDispose()
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   test('refreshes viewport data when webview metrics arrive after initial load', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-ready-')

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -182,9 +182,9 @@
   let inspectorLittleEndian = $state(true)
   let inspectorHighlightStart = $state(-1)
   let inspectorHighlightEnd = $state(-1)
-  let inspectorExpanded = $state(true)
+  let inspectorExpanded = $state(restoredState?.inspectorExpanded ?? false)
   let searchPanelVisible = $state(restoredState?.searchPanelVisible ?? false)
-  let profilerExpanded = $state(restoredState?.profilerExpanded ?? true)
+  let profilerExpanded = $state(restoredState?.profilerExpanded ?? false)
   let profilerMode = $state<AnalysisMode>('profile')
   let analysisSectionOrder = $state<AnalysisSectionOrder>(
     normalizeAnalysisSectionOrder(restoredState?.analysisSectionOrder)
@@ -462,6 +462,7 @@
       insertDirection: InsertDirection
       searchPanelVisible: boolean
       replaceVisible: boolean
+      inspectorExpanded: boolean
       profilerExpanded: boolean
       analysisSectionOrder: AnalysisSectionOrder
       selectionAnchor: number
@@ -477,6 +478,7 @@
       insertDirection,
       searchPanelVisible,
       replaceVisible,
+      inspectorExpanded,
       profilerExpanded,
       analysisSectionOrder,
       selectionAnchor,
@@ -1567,6 +1569,7 @@
 
   function toggleInspectorExpanded(): void {
     inspectorExpanded = !inspectorExpanded
+    savePreviewState({ inspectorExpanded })
   }
 
   function toggleSearchPanelVisible(): void {

--- a/vscode-extension/webview-ui/src/components/ByteInspector.svelte
+++ b/vscode-extension/webview-ui/src/components/ByteInspector.svelte
@@ -60,7 +60,7 @@
     littleEndian = true,
     offsetRadix = 'hex',
     textEncoding = 'ascii',
-    expanded = true,
+    expanded = false,
     disabled = false,
     onToggleExpanded,
     onToggleEndian,

--- a/vscode-extension/webview-ui/src/components/EditorWorkspace.svelte
+++ b/vscode-extension/webview-ui/src/components/EditorWorkspace.svelte
@@ -139,7 +139,7 @@
     pendingHexLabel = '',
     canScrollUp = false,
     canScrollDown = false,
-    profilerExpanded = true,
+    profilerExpanded = false,
     profilerMode = 'profile',
     analysisSectionOrder,
     fileSize = 0,

--- a/vscode-extension/webview-ui/src/components/ProfilerPanel.svelte
+++ b/vscode-extension/webview-ui/src/components/ProfilerPanel.svelte
@@ -145,7 +145,7 @@
   }
 
   let {
-    expanded = true,
+    expanded = false,
     mode = 'profile',
     sectionOrder = DEFAULT_ANALYSIS_SECTION_ORDER,
     fileSize = 0,

--- a/vscode-extension/webview-ui/src/vscodeApi.ts
+++ b/vscode-extension/webview-ui/src/vscodeApi.ts
@@ -22,6 +22,7 @@ export interface PersistedPreviewState {
   insertDirection?: 'forward' | 'backward'
   searchPanelVisible?: boolean
   replaceVisible?: boolean
+  inspectorExpanded?: boolean
   profilerExpanded?: boolean
   analysisSectionOrder?: Record<string, string[]>
   selectionAnchor?: number


### PR DESCRIPTION
## Summary

- include retained future checkpoint models in forward-history counts and change lookup
- keep Action journal entries and accounting stable while crossing checkpoint boundaries
- reconcile extension-local undo/redo history with native transaction stacks when another client mutates the same session, including VS Code command contexts
- configure extension-managed server session cleanup and detached-process shutdown behavior
- default the Byte Inspector and Profiler to collapsed and persist their expanded state

## Root cause

Checkpoint rewind can move a model containing later redoable changes from the active model stack to `checkpoint_future_models_`. The session count and change lookup only inspected active models, so the Action journal temporarily reported only the immediately undone change and hid the remainder of the retained suffix.

The extension could also attach to a native session whose transaction stacks had been changed by another client. Its typed local history then no longer matched native undo/redo ordering, leaving the journal and command contexts stale.

## User impact

Rewinding from change 6 to change 5 now reports `5 changes · 5 undone`; fast-forwarding back reports `6 changes · 4 undone`. All ten retained journal entries remain visible on both sides of the checkpoint.

Shared-session changes are reconciled as opaque native transactions so undo/redo availability and VS Code command enablement remain accurate. Extension-owned servers now use bounded session cleanup and explicit detached-process shutdown handling. The Inspector and Profiler start collapsed for new previews and remember subsequent expansion choices.

## Review follow-up

- align future-model counting and lookup with the invariant that a checkpoint transform is the first change in its model
- count native-backed history entries and detect checkpoint replacements in single passes
- make server-option source assertions independent of property order
- treat a completed graceful-shutdown response as success if PID cleanup races with process exit

## Validation

- native `session_tests`: 14,711 assertions passed
- focused client editor-history suite: 13 tests passed
- VS Code extension compile: TypeScript, Svelte diagnostics, and production webview build passed
- VS Code extension unit suite: 34 tests passed
- clang-format, Biome, and `git diff --check` passed
- prior full client suite: 215 tests passed across 22 files; 1 skipped
- prior Action journal integration suite: 4 tests passed
- prior Windows native core and gRPC server builds passed
