### PR TITLE
Persist bytes-per-row settings and consolidate change history

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "cmake.configureOnOpen": false
+  "cmake.configureOnOpen": false,
+  "files.watcherExclude": {
+    "**/target/**": true
+  },
+  "omegaEdit.bytesPerRow": 32
 }

--- a/core/src/include/omega_edit/visit.h
+++ b/core/src/include/omega_edit/visit.h
@@ -34,6 +34,9 @@ extern "C" {
  * Return 0 to continue visiting changes and non-zero to stop.*/
 typedef int (*omega_session_change_visitor_cbk_t)(const omega_change_t *, void *);
 
+/** Callback for visiting retained active/redo history. The serial argument is the positive logical history serial. */
+typedef int (*omega_retained_history_visitor_cbk_t)(const omega_change_t *, int64_t serial, void *);
+
 /**
  * Visit changes in the given session in chronological order (oldest first), if the callback returns an integer other
  * than 0, visitation will stop and the return value of the callback will be this function's return value
@@ -54,6 +57,19 @@ int omega_visit_changes(const omega_session_t *session_ptr, omega_session_change
  */
 int omega_visit_changes_reverse(const omega_session_t *session_ptr, omega_session_change_visitor_cbk_t cbk,
                                 void *user_data);
+
+/**
+ * Visit a bounded inclusive range of active and redoable retained history in logical serial order.
+ * @param session_ptr session whose retained history should be visited
+ * @param first_serial first positive logical serial to include
+ * @param last_serial last positive logical serial to include
+ * @param reverse non-zero to visit newest-to-oldest, otherwise oldest-to-newest
+ * @param cbk user-provided callback
+ * @param user_data user-provided callback data
+ * @return 0 when the range was visited, -1 for invalid history/range, or the callback's non-zero return value
+ */
+int omega_visit_retained_history(const omega_session_t *session_ptr, int64_t first_serial, int64_t last_serial,
+                                 int reverse, omega_retained_history_visitor_cbk_t cbk, void *user_data);
 
 /**
  * Opaque visit change context

--- a/core/src/lib/changelog.cpp
+++ b/core/src/lib/changelog.cpp
@@ -488,10 +488,7 @@ namespace {
         } else {
             result.public_entry.kind = OMEGA_CHANGELOG_PLAN_REPLACE;
         }
-        if (result.public_entry.payload_length > 0) {
-            result.public_entry.read_payload = payload_read_;
-            result.public_entry.payload_context = &result;
-        }
+        if (result.public_entry.payload_length > 0) { result.public_entry.read_payload = payload_read_; }
         return result;
     }
 
@@ -541,7 +538,6 @@ namespace {
             }
         });
         flush(baseline_length);
-        repair_payload_contexts_(result);
         return result;
     }
 
@@ -588,15 +584,15 @@ namespace {
             source.length = change->data.length;
             result.payload.push_back(std::move(source));
             result.public_entry.read_payload = payload_read_;
-            result.public_entry.payload_context = &result;
         }
         return result;
     }
 
     class planner_t {
     public:
-        planner_t(int64_t max_span_bytes, bool prefer_overwrite, bool optimize)
-            : max_span_bytes_(max_span_bytes), prefer_overwrite_(prefer_overwrite), optimize_(optimize) {}
+        planner_t(int64_t max_span_bytes, int64_t max_entries, bool prefer_overwrite, bool optimize)
+            : max_span_bytes_(max_span_bytes), max_entries_(max_entries), prefer_overwrite_(prefer_overwrite),
+              optimize_(optimize) {}
 
         bool reset_to_model(const omega_session_t *session, size_t model_index, size_t prefix_count) {
             if (!session || model_index >= session->models_.size()) { return false; }
@@ -670,12 +666,12 @@ namespace {
 
         bool barrier(const const_omega_change_ptr_t &transform) {
             if (!finish_span_()) { return false; }
-            output_.push_back(raw_entry_(transform));
-            repair_payload_contexts_(output_);
-            return true;
+            return append_output_(raw_entry_(transform));
         }
 
         bool finish() { return finish_span_(); }
+
+        bool entry_limit_exceeded() const { return entry_limit_exceeded_; }
 
         content_source_context_t snapshot_content() const {
             content_source_context_t result;
@@ -684,12 +680,18 @@ namespace {
             return result;
         }
 
-        std::vector<planned_entry_t> take_output() {
-            repair_payload_contexts_(output_);
-            return std::move(output_);
-        }
+        std::vector<planned_entry_t> take_output() { return std::move(output_); }
 
     private:
+        bool append_output_(planned_entry_t entry) {
+            if (max_entries_ > 0 && static_cast<uint64_t>(output_.size()) >= static_cast<uint64_t>(max_entries_)) {
+                entry_limit_exceeded_ = true;
+                return false;
+            }
+            output_.push_back(std::move(entry));
+            return true;
+        }
+
         bool apply_(const const_omega_change_ptr_t &change) {
             const auto kind = omega_change_get_kind_(change.get());
             const auto remove_length = kind == change_kind_t::CHANGE_INSERT
@@ -737,19 +739,24 @@ namespace {
                 optimized = diff_rope_(rope_, baseline_, baseline_length_, prefer_overwrite_);
             }
             if (!optimize_ || force_raw_ || optimized.size() > raw_.size()) {
-                for (const auto &change : raw_) { output_.push_back(raw_entry_(change)); }
+                for (const auto &change : raw_) {
+                    if (!append_output_(raw_entry_(change))) { return false; }
+                }
             } else {
-                for (auto &entry : optimized) { output_.push_back(std::move(entry)); }
+                for (auto &entry : optimized) {
+                    if (!append_output_(std::move(entry))) { return false; }
+                }
             }
             raw_.clear();
             relabel_baseline_();
-            repair_payload_contexts_(output_);
             return true;
         }
 
         int64_t max_span_bytes_{};
+        int64_t max_entries_{};
         bool prefer_overwrite_{};
         bool optimize_{};
+        bool entry_limit_exceeded_{};
         rope_ptr_t rope_{};
         std::vector<source_slice_t> baseline_{};
         int64_t baseline_length_{};
@@ -802,7 +809,7 @@ int omega_edit_export_changelog(const omega_session_t *session_ptr, const omega_
 
     try {
         planner_t planner(resolved.max_span_bytes == 0 ? DEFAULT_MAX_SPAN_BYTES : resolved.max_span_bytes,
-                          resolved.prefer_overwrite_form != 0, optimize != 0);
+                          resolved.max_entries, resolved.prefer_overwrite_form != 0, optimize != 0);
         const auto &first_model = session_ptr->models_[first_location.model];
         const auto first_is_transform =
                 first_location.change == 0 &&
@@ -833,13 +840,13 @@ int omega_edit_export_changelog(const omega_session_t *session_ptr, const omega_
             for (size_t change_index = begin; change_index < end; ++change_index) {
                 const auto &change = model->changes[change_index];
                 if (omega_change_get_kind_(change.get()) == change_kind_t::CHANGE_TRANSFORM) {
-                    if (!planner.barrier(change)) { return -1; }
+                    if (!planner.barrier(change)) { return planner.entry_limit_exceeded() ? -2 : -1; }
                     if (!planner.reset_to_model(session_ptr, model_index, change_index + 1)) { return -1; }
                 } else if (!planner.accept(change)) {
-                    return -1;
+                    return planner.entry_limit_exceeded() ? -2 : -1;
                 }
             }
-            if (!planner.finish()) { return -1; }
+            if (!planner.finish()) { return planner.entry_limit_exceeded() ? -2 : -1; }
         }
 
         auto after = planner.snapshot_content();

--- a/core/src/lib/edit.cpp
+++ b/core/src/lib/edit.cpp
@@ -285,7 +285,6 @@ namespace {
             session_ptr->event_handler = cbk;
             session_ptr->user_data_ptr = user_data_ptr;
             session_ptr->event_interest_ = event_interest;
-            session_ptr->num_changes_adjustment_ = 0;
             session_ptr->original_file_modification_time_ = original_file_modification_time;
             session_ptr->original_file_modification_time_valid_ = original_file_modification_time_valid;
             session_ptr->models_.push_back(std::make_unique<omega_model_t>());
@@ -1246,7 +1245,11 @@ namespace {
                 if (count % session_ptr->undo_snapshot_interval_ == 0) {
                     try {
                         model_ptr->model_snapshots[count] = clone_model_segments_(model_ptr->model_segments);
-                    } catch (const std::bad_alloc &) { model_ptr->model_snapshots.erase(count); }
+                    } catch (const std::bad_alloc &) {
+                        model_ptr->model_snapshots.erase(count);
+                        LOG_ERROR("warning: unable to capture undo snapshot at change "
+                                  << count << "; undo replay may be slower");
+                    }
                 }
             }
             update_viewports_(session_ptr, change_ptr.get());
@@ -1334,7 +1337,6 @@ namespace {
             session_ptr->models_.pop_back();
             ++suspended_count;
         }
-        session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
         return true;
     }
 
@@ -1344,7 +1346,6 @@ namespace {
             session_ptr->checkpoint_future_models_.pop_back();
             --suspended_count;
         }
-        if (session_ptr) { session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base; }
     }
 
     bool resume_plain_checkpoint_models_for_redo_(omega_session_t *session_ptr) {
@@ -1360,7 +1361,6 @@ namespace {
             } catch (const std::bad_alloc &) { return false; }
             session_ptr->checkpoint_future_models_.pop_back();
         }
-        session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
         return true;
     }
 
@@ -1495,7 +1495,6 @@ namespace {
         if (transform_change_ptr) { free_session_changes_undone_(session_ptr); }
         discard_checkpoint_future_(session_ptr);
 
-        session_ptr->num_changes_adjustment_ = change_serial_base;
         omega_session_notify(session_ptr, SESSION_EVT_CREATE_CHECKPOINT, nullptr);
 
         if (notify_transform) {
@@ -1952,8 +1951,6 @@ namespace {
         change_ptr->transform_data->preserved_changes_undone.swap(transform_model_ptr->changes_undone);
         FCLOSE(transform_model_ptr->file_ptr);
         session_ptr->models_.pop_back();
-        session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
-
         auto *const undone_change_ptr = change_ptr.get();
         if (undone_change_ptr->serial <= 0) { return -1; }
         undone_change_ptr->serial *= -1;
@@ -2003,8 +2000,6 @@ namespace {
         session_ptr->models_.back()->changes_undone.swap(redone_change_ptr->transform_data->preserved_changes_undone);
         redone_change_ptr->serial = redone_serial;
         undone_changes.pop_back();
-        session_ptr->num_changes_adjustment_ = change_serial_base;
-
         mark_all_viewports_changed_(session_ptr, VIEWPORT_EVT_EDIT, redone_change_ptr);
         omega_session_notify(session_ptr, SESSION_EVT_EDIT, redone_change_ptr);
         return redone_change_ptr->serial;
@@ -2013,7 +2008,6 @@ namespace {
     void discard_top_model_(omega_session_t *session_ptr) {
         discard_model_(session_ptr->models_.back());
         session_ptr->models_.pop_back();
-        session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
     }
 }// namespace
 
@@ -3099,7 +3093,6 @@ int omega_edit_clear_changes(omega_session_t *session_ptr) {
     session_ptr->models_.front()->model_segments = std::move(reset_segments);
     free_session_changes_(session_ptr);
     free_session_changes_undone_(session_ptr);
-    session_ptr->num_changes_adjustment_ = 0;
     mark_all_viewports_changed_(session_ptr, VIEWPORT_EVT_CLEAR, nullptr);
     omega_session_notify(session_ptr, SESSION_EVT_CLEAR, nullptr);
     return 0;
@@ -3137,7 +3130,6 @@ int omega_edit_restore_to_change_count(omega_session_t *session_ptr, int64_t cha
     }
     if (0 != rebuild_model_to_change_count_(session_ptr, keep_count)) { return -1; }
 
-    session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
     if (restored) {
         mark_all_viewports_changed_(session_ptr, VIEWPORT_EVT_CHANGES, nullptr);
         omega_session_notify(session_ptr, SESSION_EVT_UNDO, nullptr);
@@ -3278,7 +3270,6 @@ int omega_edit_destroy_last_checkpoint(omega_session_t *session_ptr) {
         free_model_changes_(last_checkpoint_ptr);
         free_model_changes_undone_(last_checkpoint_ptr);
         session_ptr->models_.pop_back();
-        session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
         omega_session_notify(session_ptr, SESSION_EVT_DESTROY_CHECKPOINT, nullptr);
         for (const auto &viewport_ptr : session_ptr->viewports_) {
             viewport_ptr->data_segment.capacity =
@@ -3335,13 +3326,11 @@ int omega_edit_checkout_checkpoint(omega_session_t *session_ptr, int64_t checkpo
         auto *const root_model_ptr = session_ptr->models_.front().get();
         if (!move_changes_to_undo_(root_model_ptr, 0)) { return -1; }
         root_model_ptr->model_segments = std::move(original_segments);
-        session_ptr->num_changes_adjustment_ = 0;
     } else {
         auto *const model_ptr = session_ptr->models_.back().get();
         const auto keep_count = checkpoint_snapshot_change_count_(model_ptr);
         if (!move_changes_to_undo_(model_ptr, keep_count)) { return -1; }
         if (0 != rebuild_model_to_change_count_(session_ptr, static_cast<int64_t>(keep_count))) { return -1; }
-        session_ptr->num_changes_adjustment_ = model_ptr->change_serial_base;
     }
 
     notify_checkpoint_restore_(session_ptr);
@@ -3364,7 +3353,6 @@ int omega_edit_restore_last_checkpoint(omega_session_t *session_ptr) {
     free_model_changes_undone_(model_ptr);
     if (0 != rebuild_model_to_change_count_(session_ptr, static_cast<int64_t>(keep_count))) { return -1; }
 
-    session_ptr->num_changes_adjustment_ = session_ptr->models_.back()->change_serial_base;
     notify_checkpoint_restore_(session_ptr);
     return 0;
 }

--- a/core/src/lib/impl_/retained_history.hpp
+++ b/core/src/lib/impl_/retained_history.hpp
@@ -1,0 +1,151 @@
+/**********************************************************************************************************************
+ * Copyright (c) 2021 Concurrent Technologies Corporation.                                                            *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at                                                         *
+ *                                                                                                                    *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                                                     *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed *
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                    *
+ * See the License for the specific language governing permissions and limitations under the License.                *
+ *                                                                                                                    *
+ **********************************************************************************************************************/
+
+#ifndef OMEGA_EDIT_RETAINED_HISTORY_HPP
+#define OMEGA_EDIT_RETAINED_HISTORY_HPP
+
+#include "change_def.hpp"
+#include "model_def.hpp"
+#include "session_def.hpp"
+
+#include <cstdint>
+#include <limits>
+
+namespace omega_edit::internal {
+
+    inline bool retained_history_serial_(const omega_change_t *change, int64_t &serial) {
+        if (!change || change->serial == 0 || change->serial == (std::numeric_limits<int64_t>::min)()) { return false; }
+        serial = change->serial < 0 ? -change->serial : change->serial;
+        return true;
+    }
+
+    template<typename Visitor>
+    int visit_retained_undo_sequence_(const omega_changes_t &changes, bool reverse, Visitor &visitor);
+
+    template<typename Visitor>
+    int visit_retained_change_(const omega_change_t *change, bool reverse, Visitor &visitor) {
+        if (!change) { return -1; }
+        if (reverse && change->transform_data) {
+            const auto result =
+                    visit_retained_undo_sequence_(change->transform_data->preserved_changes_undone, true, visitor);
+            if (result != 0) { return result; }
+        }
+        int64_t serial = 0;
+        if (!retained_history_serial_(change, serial)) { return -1; }
+        const auto result = visitor(change, serial);
+        if (result != 0) { return result; }
+        if (!reverse && change->transform_data) {
+            return visit_retained_undo_sequence_(change->transform_data->preserved_changes_undone, false, visitor);
+        }
+        return 0;
+    }
+
+    template<typename Visitor>
+    int visit_retained_undo_sequence_(const omega_changes_t &changes, bool reverse, Visitor &visitor) {
+        if (reverse) {
+            for (const auto &change : changes) {
+                const auto result = visit_retained_change_(change.get(), true, visitor);
+                if (result != 0) { return result; }
+            }
+        } else {
+            for (auto iterator = changes.crbegin(); iterator != changes.crend(); ++iterator) {
+                const auto result = visit_retained_change_(iterator->get(), false, visitor);
+                if (result != 0) { return result; }
+            }
+        }
+        return 0;
+    }
+
+    template<typename Visitor>
+    int visit_future_model_(const omega_model_t *model, bool reverse, Visitor &visitor) {
+        if (!model) { return -1; }
+        if (reverse) {
+            const auto undone_result = visit_retained_undo_sequence_(model->changes_undone, true, visitor);
+            if (undone_result != 0) { return undone_result; }
+            for (auto iterator = model->changes.crbegin(); iterator != model->changes.crend(); ++iterator) {
+                const auto result = visit_retained_change_(iterator->get(), true, visitor);
+                if (result != 0) { return result; }
+            }
+        } else {
+            for (const auto &change : model->changes) {
+                const auto result = visit_retained_change_(change.get(), false, visitor);
+                if (result != 0) { return result; }
+            }
+            return visit_retained_undo_sequence_(model->changes_undone, false, visitor);
+        }
+        return 0;
+    }
+
+    /**
+     * Visit the complete redoable suffix in logical serial order. Logical serials are always positive even when the
+     * underlying change is currently stored with a negative serial.
+     */
+    template<typename Visitor>
+    int visit_retained_history_(const omega_session_t *session, bool reverse, Visitor &&visitor) {
+        if (!session) { return -1; }
+        if (reverse) {
+            for (const auto &model : session->checkpoint_future_models_) {
+                const auto result = visit_future_model_(model.get(), true, visitor);
+                if (result != 0) { return result; }
+            }
+            for (const auto &model : session->models_) {
+                const auto result = visit_retained_undo_sequence_(model->changes_undone, true, visitor);
+                if (result != 0) { return result; }
+            }
+        } else {
+            for (auto iterator = session->models_.crbegin(); iterator != session->models_.crend(); ++iterator) {
+                const auto result = visit_retained_undo_sequence_((*iterator)->changes_undone, false, visitor);
+                if (result != 0) { return result; }
+            }
+            for (auto iterator = session->checkpoint_future_models_.crbegin();
+                 iterator != session->checkpoint_future_models_.crend(); ++iterator) {
+                const auto result = visit_future_model_(iterator->get(), false, visitor);
+                if (result != 0) { return result; }
+            }
+        }
+        return 0;
+    }
+
+    /** Visit active changes followed by the retained redo suffix as one logical history. */
+    template<typename Visitor>
+    int visit_complete_history_(const omega_session_t *session, bool reverse, Visitor &&visitor) {
+        if (!session) { return -1; }
+        if (reverse) {
+            const auto retained_result = visit_retained_history_(session, true, visitor);
+            if (retained_result != 0) { return retained_result; }
+            for (auto model = session->models_.crbegin(); model != session->models_.crend(); ++model) {
+                for (auto change = (*model)->changes.crbegin(); change != (*model)->changes.crend(); ++change) {
+                    int64_t serial = 0;
+                    if (!retained_history_serial_(change->get(), serial)) { return -1; }
+                    const auto result = visitor(change->get(), serial);
+                    if (result != 0) { return result; }
+                }
+            }
+        } else {
+            for (const auto &model : session->models_) {
+                for (const auto &change : model->changes) {
+                    int64_t serial = 0;
+                    if (!retained_history_serial_(change.get(), serial)) { return -1; }
+                    const auto result = visitor(change.get(), serial);
+                    if (result != 0) { return result; }
+                }
+            }
+            return visit_retained_history_(session, false, visitor);
+        }
+        return 0;
+    }
+
+}// namespace omega_edit::internal
+
+#endif//OMEGA_EDIT_RETAINED_HISTORY_HPP

--- a/core/src/lib/impl_/session_def.hpp
+++ b/core/src/lib/impl_/session_def.hpp
@@ -42,7 +42,6 @@ struct omega_session_struct {
     omega_search_contexts_t search_contexts_{};///< Collection of active search contexts
     omega_models_t models_{};                  ///< Edit models (internal)
     omega_models_t checkpoint_future_models_{};///< Checkpoint models preserved by non-destructive timeline rewind
-    int64_t num_changes_adjustment_{};         ///< Number of changes in checkpoints
     int64_t undo_snapshot_interval_{100};      ///< Undo model snapshot interval (0 = disabled, default 100)
     int64_t change_inline_payload_limit_{OMEGA_CHANGE_INLINE_PAYLOAD_LIMIT}; ///< Inline primitive payload threshold
     int8_t session_flags_{};                                                 ///< Internal state flags

--- a/core/src/lib/session.cpp
+++ b/core/src/lib/session.cpp
@@ -18,6 +18,7 @@
 #include "impl_/internal_fun.hpp"
 #include "impl_/macros.h"
 #include "impl_/model_def.hpp"
+#include "impl_/retained_history.hpp"
 #include "impl_/safe_math.hpp"
 #include "impl_/segment_def.hpp"
 #include "impl_/session_def.hpp"
@@ -41,66 +42,6 @@ using omega_edit::internal::safe_add_int64_;
 
 namespace {
     constexpr int64_t OMEGA_SESSION_SCAN_BUFFER_SIZE = 65536;
-
-    int64_t count_undone_changes_(const omega_changes_t &changes) {
-        int64_t result = 0;
-        for (const auto &change : changes) {
-            ++result;
-            if (change && change->transform_data) {
-                result += count_undone_changes_(change->transform_data->preserved_changes_undone);
-            }
-        }
-        return result;
-    }
-
-    int64_t count_future_model_changes_(const omega_model_t *model) {
-        if (!model) { return 0; }
-        int64_t result = static_cast<int64_t>(model->changes.size());
-        // A checkpointed transform, when present, is the first change in its model and may retain its own redo suffix.
-        if (!model->changes.empty()) {
-            const auto &change = model->changes.front();
-            if (change && change->transform_data) {
-                result += count_undone_changes_(change->transform_data->preserved_changes_undone);
-            }
-        }
-        return result + count_undone_changes_(model->changes_undone);
-    }
-
-    const omega_change_t *find_undone_change_(const omega_changes_t &changes, int64_t serial) {
-        for (auto iter = changes.crbegin(); iter != changes.crend(); ++iter) {
-            const auto *change = iter->get();
-            if (omega_change_get_serial(change) == serial) { return change; }
-            if (change && change->transform_data) {
-                if (const auto *preserved =
-                            find_undone_change_(change->transform_data->preserved_changes_undone, serial)) {
-                    return preserved;
-                }
-            }
-        }
-        return nullptr;
-    }
-
-    const omega_change_t *find_future_model_change_(const omega_model_t *model, int64_t serial) {
-        if (!model || serial >= 0) { return nullptr; }
-        if (const auto *change = find_undone_change_(model->changes_undone, serial)) { return change; }
-        if (serial == (std::numeric_limits<int64_t>::min)()) { return nullptr; }
-
-        const auto positive_serial = -serial;
-        const auto index = positive_serial - 1 - model->change_serial_base;
-        if (index >= 0 && static_cast<size_t>(index) < model->changes.size()) {
-            const auto *change = model->changes[static_cast<size_t>(index)].get();
-            if (change && omega_change_get_serial(change) == positive_serial) { return change; }
-        }
-
-        // A checkpointed transform, when present, is the first change in its model and may retain its own redo suffix.
-        if (!model->changes.empty()) {
-            const auto *change = model->changes.front().get();
-            if (change && change->transform_data) {
-                return find_undone_change_(change->transform_data->preserved_changes_undone, serial);
-            }
-        }
-        return nullptr;
-    }
 
     int64_t count_change_transactions_(const omega_changes_t &changes) {
         int64_t result = 0;
@@ -194,11 +135,13 @@ int64_t omega_session_get_num_undone_changes(const omega_session_t *session_ptr)
     if (!session_ptr) { return 0; }
     assert(session_ptr->models_.back());
     int64_t result = 0;
-    for (const auto &model : session_ptr->models_) { result += count_undone_changes_(model->changes_undone); }
-    for (const auto &model : session_ptr->checkpoint_future_models_) {
-        result += count_future_model_changes_(model.get());
-    }
-    return result;
+    const auto visit_result =
+            omega_edit::internal::visit_retained_history_(session_ptr, false, [&](const omega_change_t *, int64_t) {
+                if (result == (std::numeric_limits<int64_t>::max)()) { return -1; }
+                ++result;
+                return 0;
+            });
+    return visit_result == 0 ? result : -1;
 }
 
 const omega_change_t *omega_session_get_last_change(const omega_session_t *session_ptr) {
@@ -264,15 +207,16 @@ const omega_change_t *omega_session_get_change(const omega_session_t *session_pt
             }
         }
     } else if (change_serial < 0) {
-        // Negative serials are retained forward changes. A materialized checkpoint model can carry both changes that
-        // have already been moved to its undo stack and positive-serial changes beyond the active checkpoint cursor.
-        for (auto iter = session_ptr->models_.crbegin(); iter != session_ptr->models_.crend(); ++iter) {
-            if (const auto *change = find_undone_change_((*iter)->changes_undone, change_serial)) { return change; }
-        }
-        for (auto iter = session_ptr->checkpoint_future_models_.crbegin();
-             iter != session_ptr->checkpoint_future_models_.crend(); ++iter) {
-            if (const auto *change = find_future_model_change_(iter->get(), change_serial)) { return change; }
-        }
+        if (change_serial == (std::numeric_limits<int64_t>::min)()) { return nullptr; }
+        const auto requested_serial = -change_serial;
+        const omega_change_t *result = nullptr;
+        omega_edit::internal::visit_retained_history_(session_ptr, false,
+                                                      [&](const omega_change_t *change, int64_t serial) {
+                                                          if (serial < requested_serial) { return 0; }
+                                                          if (serial == requested_serial) { result = change; }
+                                                          return 1;
+                                                      });
+        return result;
     }
     return nullptr;
 }
@@ -367,8 +311,20 @@ int64_t omega_session_get_num_change_transactions(const omega_session_t *session
 int64_t omega_session_get_num_undone_change_transactions(const omega_session_t *session_ptr) {
     if (!session_ptr) { return 0; }
     int64_t result = 0;
-    for (const auto &model : session_ptr->models_) { result += count_change_transactions_(model->changes_undone); }
-    return result;
+    bool have_previous = false;
+    bool previous_transaction_bit = false;
+    const auto visit_result = omega_edit::internal::visit_retained_history_(
+            session_ptr, false, [&](const omega_change_t *change, int64_t) {
+                const auto transaction_bit = omega_change_get_transaction_bit_(change);
+                if (!have_previous || transaction_bit != previous_transaction_bit) {
+                    if (result == (std::numeric_limits<int64_t>::max)()) { return -1; }
+                    ++result;
+                    previous_transaction_bit = transaction_bit;
+                    have_previous = true;
+                }
+                return 0;
+            });
+    return visit_result == 0 ? result : -1;
 }
 
 int64_t omega_session_get_num_checkpoints(const omega_session_t *session_ptr) {

--- a/core/src/lib/visit.cpp
+++ b/core/src/lib/visit.cpp
@@ -14,6 +14,7 @@
 
 #include "../include/omega_edit/visit.h"
 #include "impl_/model_def.hpp"
+#include "impl_/retained_history.hpp"
 #include "impl_/session_def.hpp"
 #include <cassert>
 
@@ -35,6 +36,30 @@ int omega_visit_changes_reverse(const omega_session_t *session_ptr, omega_sessio
         if ((rc = cbk(iter->get(), user_data)) != 0) { break; }
     }
     return rc;
+}
+
+int omega_visit_retained_history(const omega_session_t *session_ptr, int64_t first_serial, int64_t last_serial,
+                                 int reverse, omega_retained_history_visitor_cbk_t cbk, void *user_data) {
+    if (!session_ptr || !cbk || first_serial <= 0 || last_serial < first_serial) { return -1; }
+    bool range_complete = false;
+    const auto result = omega_edit::internal::visit_complete_history_(
+            session_ptr, reverse != 0, [&](const omega_change_t *change, int64_t serial) {
+                if (reverse) {
+                    if (serial > last_serial) { return 0; }
+                    if (serial < first_serial) {
+                        range_complete = true;
+                        return 1;
+                    }
+                } else {
+                    if (serial < first_serial) { return 0; }
+                    if (serial > last_serial) {
+                        range_complete = true;
+                        return 1;
+                    }
+                }
+                return cbk(change, serial, user_data);
+            });
+    return range_complete ? 0 : result;
 }
 
 struct omega_visit_change_context_struct {

--- a/core/src/tests/session_tests.cpp
+++ b/core/src/tests/session_tests.cpp
@@ -44,6 +44,20 @@ struct counting_upper_transform_state {
     int64_t calls{};
 };
 
+struct retained_history_capture {
+    std::vector<int64_t> serials;
+    std::vector<char> kinds;
+    std::vector<const omega_change_t *> changes;
+};
+
+static int capture_retained_history(const omega_change_t *change, int64_t serial, void *user_data) {
+    auto *capture = static_cast<retained_history_capture *>(user_data);
+    capture->serials.push_back(serial);
+    capture->kinds.push_back(omega_change_get_kind_as_char(change));
+    capture->changes.push_back(change);
+    return 0;
+}
+
 static omega_byte_t counting_to_upper(omega_byte_t byte, void *user_data_ptr) {
     auto *state = static_cast<counting_upper_transform_state *>(user_data_ptr);
     if (state) { ++state->calls; }
@@ -430,7 +444,12 @@ TEST_CASE("Checkpoint traversal keeps the complete forward history visible",
     for (int64_t serial = 10; serial >= 6; --serial) { REQUIRE(-serial == omega_edit_undo_last_change(session_ptr)); }
     REQUIRE(5 == omega_session_get_num_changes(session_ptr));
     REQUIRE(5 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE(5 == omega_session_get_num_undone_change_transactions(session_ptr));
     REQUIRE(1 == omega_session_get_num_future_checkpoints(session_ptr));
+    retained_history_capture transform_redo_suffix;
+    REQUIRE(0 == omega_visit_retained_history(session_ptr, 6, 10, 0, capture_retained_history, &transform_redo_suffix));
+    REQUIRE(transform_redo_suffix.serials == std::vector<int64_t>{6, 7, 8, 9, 10});
+    REQUIRE(transform_redo_suffix.kinds == std::vector<char>{'I', 'I', 'I', 'I', 'T'});
     for (int64_t serial = 6; serial <= 10; ++serial) {
         INFO("forward serial=" << serial);
         REQUIRE(omega_session_get_change(session_ptr, -serial));
@@ -453,11 +472,21 @@ TEST_CASE("Checkpoint traversal keeps the complete forward history visible",
     REQUIRE(0 == omega_edit_checkout_checkpoint(session_ptr, 0));
     REQUIRE(0 == omega_session_get_num_changes(session_ptr));
     REQUIRE(10 == omega_session_get_num_undone_changes(session_ptr));
+    REQUIRE(10 == omega_session_get_num_undone_change_transactions(session_ptr));
     REQUIRE(2 == omega_session_get_num_future_checkpoints(session_ptr));
     for (int64_t serial = 1; serial <= 10; ++serial) {
         INFO("future checkpoint serial=" << serial);
         REQUIRE(omega_session_get_change(session_ptr, -serial));
     }
+    retained_history_capture ascending;
+    REQUIRE(0 == omega_visit_retained_history(session_ptr, 1, 10, 0, capture_retained_history, &ascending));
+    REQUIRE(ascending.serials == std::vector<int64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+    REQUIRE(ascending.kinds == std::vector<char>{'I', 'I', 'I', 'I', 'I', 'I', 'I', 'I', 'I', 'T'});
+    REQUIRE(ascending.changes.size() == ascending.serials.size());
+    retained_history_capture descending;
+    REQUIRE(0 == omega_visit_retained_history(session_ptr, 3, 8, 1, capture_retained_history, &descending));
+    REQUIRE(descending.serials == std::vector<int64_t>{8, 7, 6, 5, 4, 3});
+    REQUIRE(descending.changes.size() == descending.serials.size());
     REQUIRE(0 == omega_edit_checkout_checkpoint(session_ptr, 2));
     REQUIRE(10 == omega_session_get_num_changes(session_ptr));
     REQUIRE(0 == omega_session_get_num_undone_changes(session_ptr));

--- a/dev-notes/SHORTCOMINGS.md
+++ b/dev-notes/SHORTCOMINGS.md
@@ -4,29 +4,9 @@ This is the current actionable backlog. It replaces the older historical audit,
 which had grown into a mix of fixed findings, follow-up notes, and a second
 prioritized review appended at the bottom.
 
-Items already fixed by recent work have been removed from the open list. In
-particular, the transform/change-log/checkpoint audit items that now have
-regression coverage are not repeated here. The recent VS Code extension issues
-around the initial Find toggle state, auto bytes-per-row overfitting, and the
-duplicate Ctrl-Z undo toast are also treated as fixed by the current extension
-branch/PR and are not listed as open. The redo preservation bug across
-transform undo boundaries found by the brutal-testing harness is also fixed by
-the current core test branch/PR and is no longer listed as open. The zlib
-decompression cap and C++ codec cancellation/base58 guardrail items are also
-fixed and no longer listed as open. The profile/character-count scan buffer
-issue, search read-failure reporting issue, and unbounded `replace_matches`
-materialization issue are also fixed and no longer listed as open. The utility
-string-helper issue and the fixed failure-signaling edges for unknown CLI
-options and missing session files are likewise no longer listed as open. The
-code-quality cleanup for computed-content inspection lock scope,
-descriptor-preserving temp-file writes, explicit C-string/named-options APIs, OpenSSL
-cipher key scrubbing, shared C plugin option parsing, targeted duplication
-extractions, and the replace/save failure-signaling edges is also complete and
-no longer listed as open. The in-process libmagic/CLD3 content and language
-detection RPCs have also been removed in favor of on-demand inspect/calculation
-plugins, so that item is no longer listed as open. Mutation-capable transform
-RPCs still intentionally serialize the session while a plugin runs because they
-can modify the current core model.
+Resolved items are removed rather than retained as history. Findings that were
+reviewed and determined not to be shortcomings remain at the end to avoid
+repeated audits of the same false positives.
 
 Recent core/server/plugin review findings have been folded into the priority
 list below rather than kept as a second appended review. A fresh core/server
@@ -57,10 +37,10 @@ Related execution plans:
 
 1. **Critical deployment boundary**: add optional TLS/mTLS and an authorization
    hook before making any "hardened for production" attestation.
-2. **Massive-file pressure caps**: apply a configurable segment-size cap to
-   read/classification RPCs.
-3. **Undo performance batch**: implement the remaining low-risk undo pieces
-   (transaction extents, redo batching, snapshot telemetry).
+2. **Massive-file pressure caps**: bound change-detail payload responses and
+   configure consistent gRPC message-size limits.
+3. **Redo performance batch**: batch transaction replay and coalesce repeated
+   update work.
 4. **Checkpoint caps/dedupe**: add server/API guardrails for unbounded checkpoint
    creation.
 
@@ -270,8 +250,8 @@ effectively unlimited outbound cap. Two consequences:
 - The advertised `--max-change-bytes` default of 64 MiB is unreachable — any
   `SubmitChange` above ~4 MiB is rejected at the transport layer with a
   generic gRPC error before the service's own limit or error message applies.
-- Outbound responses are unbounded, which is what makes items 4 and 5 (and
-  large `GetSegment` reads) able to produce multi-gigabyte responses.
+- Outbound responses are unbounded, which allows change-detail payloads from
+  item 2 to produce multi-gigabyte responses.
 
 Relevant code:
 - `server/cpp/src/main.cpp:556`
@@ -316,38 +296,6 @@ Suggested fix:
 ---
 
 ## P3 Low-Risk / Opportunistic Work
-
-### 23. Snapshot allocation failure silently degrades undo speed
-
-**Impact:** Low to Medium
-**Risk:** Low
-**Area:** Core undo telemetry
-
-When snapshot allocation fails, the snapshot is erased and undo performance can
-fall back to longer replay distances without any visible signal.
-
-Relevant code:
-- `core/src/lib/edit.cpp:928`
-
-Suggested fix:
-- Emit a debug/warn log or session diagnostic event when snapshot capture fails.
-- Add a test hook or allocator-failure test if the existing harness supports it.
-
-### 24. Transaction-boundary scan is linear per undo
-
-**Impact:** Low to Medium
-**Risk:** Low to Medium
-**Area:** Core undo performance
-
-Undo scans backward to find the current transaction extent each time. For very
-large transactions this is a repeated tail scan.
-
-Relevant code:
-- `core/src/lib/edit.cpp:2551`
-
-Suggested fix:
-- Store transaction extents or cached transaction change counts.
-- Reuse the same metadata for redo batching.
 
 ### 25. Redo still replays one change at a time
 
@@ -423,61 +371,8 @@ claiming production hardening:
 - Session/viewport ID validation (charset + 128-byte cap), path control-byte
   rejection, and shared-session attachment counting in the session manager are
   sound; UUIDv7 generation is mutex-guarded and monotonic.
-
----
-
-## Recently Fixed And Removed From The Open List
-
-These areas were in the old document but are no longer open backlog items:
-
-- Transform no-op/content-changed accuracy and client-side no-op undo.
-- Transform identity/history metadata in VS Code and change-log export/import.
-- Checkpoint rollback/restore naming and true restore-to-latest-checkpoint.
-- Atomic fingerprinted change-log apply with rollback compensation.
-- Change-log version enforcement, serial/group validation, completeness metadata,
-  and status-code-based missing-detail handling.
-- Former hard change-log entry/byte caps on export/import.
-- Unbounded `SearchSession` unary responses; the server now enforces a
-  configurable `max_search_matches` policy and returns `RESOURCE_EXHAUSTED`
-  instead of silently truncating when a search would exceed it.
-- Unbounded `GetSegment` allocations; the server now applies a configurable
-  read segment limit that defaults to the viewport capacity and can be disabled
-  with `0`.
-- Service-wide transform plugin execution locking; server plugin calls now
-  snapshot registry metadata under a short lock and execute under session/content
-  guards.
-- Missing explicit undo-to-baseline reset path.
-- Mixed edit API success conventions; serial-returning and status-returning core
-  APIs now have explicit success predicates.
-- Undo-based change-log rollback; AI and VS Code imports now use a native
-  restore-to-change-count primitive that discards redo.
-- Clear-changes now discards stacked checkpoint/transform models, resets change
-  serial bookkeeping to the original model, and marks viewports dirty.
-- Session creation and session/viewport subscription paths now avoid holding the
-  global session-map mutex across core session creation or per-session
-  `core_mutex` acquisition.
-- Shared file-backed session creation now reserves the file-path mapping in the
-  same critical section that observes no existing session, so concurrent authors
-  attach to one session instead of racing into adjacent reservations.
-- Session/viewport subscription lock ordering, handoff, queue closure, and
-  ordered callback delivery.
-- Desired ID/path validation and default host/port duplication.
-- Core memory ownership issues around `omega_data_t`, reverse visitor cleanup,
-  const-cast destruction, and allocation failure boundaries.
-- Transform option regex hardening.
-- Transform plugin cooperative cancellation in the core request ABI, SDK helper,
-  server gRPC/session-destroy cancellation paths, and bundled plugin polling
-  loops, with TypeScript client, AI/MCP, and VS Code webview cancellation wired
-  through to the same RPC cancellation path.
-- Large-search navigation now keeps anchor-based next/previous lookup bounded,
-  then decorates the active viewport with a separately bounded neighbor match
-  window that handles reverse navigation, overlaps, viewport boundaries, and
-  external range-map/debugger highlight overlays independently.
-- Near-`INT64_MAX` overflow coverage now exercises public C APIs and raw server
-  RPC boundaries for search, replace, segment, and viewport ranges.
-- VS Code text display encoding selection now covers ASCII, Windows-1252,
-  CP437, EBCDIC, and MacRoman across the TEXT pane, Data Inspector, Analyzer
-  labels/classification, and text search byte encoding, with both toolbar and
-  command-palette affordances.
-- Event mask signed `ALL_EVENTS` ambiguity.
-- Output collision suffix range and deprecated protobuf generator dependencies.
+- Undo's transaction-boundary discovery is two short passes over the current
+  transaction, after which those changes leave active history. Across a full
+  undo walk each active change is inspected a bounded number of times, so the
+  scan is aggregate-linear and does not justify persistent transaction-extent
+  state on its own.

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -28,8 +28,6 @@ import {
   getSegment,
   getSessionFingerprint,
   isPortAvailable,
-  getUndoCount,
-  getViewportCount,
   insert,
   listTransformPlugins as listClientTransformPlugins,
   numAscii,
@@ -1122,19 +1120,29 @@ export class OmegaEditToolkit {
   async sessionStatus(sessionId: string): Promise<SessionStatus> {
     await this.ensureServerRunning()
 
-    const [
-      computedSize,
-      changeCount,
-      undoCount,
-      viewportCount,
-      checkpointCount,
-    ] = await Promise.all([
-      getComputedFileSize(sessionId),
-      getChangeCount(sessionId),
-      getUndoCount(sessionId),
-      getViewportCount(sessionId),
-      this.getCheckpointCount(sessionId),
-    ])
+    const countKinds = [
+      CountKind.COMPUTED_FILE_SIZE,
+      CountKind.CHANGES,
+      CountKind.UNDOS,
+      CountKind.VIEWPORTS,
+      CountKind.CHECKPOINTS,
+    ]
+    const counts = await getCounts(sessionId, countKinds)
+    const countsByKind = new Map(
+      counts.map((count) => [count.getKind(), count.getCount()])
+    )
+    const requiredCount = (kind: CountKind): number => {
+      const value = countsByKind.get(kind)
+      if (value === undefined) {
+        throw new Error(`Session status count ${kind} was not returned`)
+      }
+      return value
+    }
+    const computedSize = requiredCount(CountKind.COMPUTED_FILE_SIZE)
+    const changeCount = requiredCount(CountKind.CHANGES)
+    const undoCount = requiredCount(CountKind.UNDOS)
+    const viewportCount = requiredCount(CountKind.VIEWPORTS)
+    const checkpointCount = requiredCount(CountKind.CHECKPOINTS)
 
     let lastChange: SessionStatus['lastChange'] | undefined
 

--- a/packages/client/src/action_journal.ts
+++ b/packages/client/src/action_journal.ts
@@ -18,6 +18,10 @@ import {
   ChangeLogCodecError,
   parseChangeLogNonNegativeInt64,
 } from './changeLog/codec'
+import {
+  CHANGE_LOG_KIND_TO_PROTO,
+  changeLogKindFromProto,
+} from './changeLog/proto'
 import type {
   ChangeLogEntryKind as JournalEntryKind,
   ChangeLogInt64,
@@ -136,29 +140,8 @@ function requestDecimal(value: ChangeLogInt64 | undefined): string | undefined {
     : parseChangeLogNonNegativeInt64(value, 'action-journal anchor').toString()
 }
 
-const protoKinds: Record<JournalEntryKind, ChangeLogEntryKind> = {
-  DELETE: ChangeLogEntryKind.DELETE,
-  INSERT: ChangeLogEntryKind.INSERT,
-  OVERWRITE: ChangeLogEntryKind.OVERWRITE,
-  REPLACE: ChangeLogEntryKind.REPLACE,
-  TRANSFORM: ChangeLogEntryKind.TRANSFORM,
-}
-
 function journalKind(kind: ChangeLogEntryKind): JournalEntryKind {
-  switch (kind) {
-    case ChangeLogEntryKind.DELETE:
-      return 'DELETE'
-    case ChangeLogEntryKind.INSERT:
-      return 'INSERT'
-    case ChangeLogEntryKind.OVERWRITE:
-      return 'OVERWRITE'
-    case ChangeLogEntryKind.REPLACE:
-      return 'REPLACE'
-    case ChangeLogEntryKind.TRANSFORM:
-      return 'TRANSFORM'
-    default:
-      return fail('entry kind is invalid')
-  }
+  return changeLogKindFromProto(kind) ?? fail('entry kind is invalid')
 }
 
 function payloadHint(
@@ -269,7 +252,7 @@ export async function getActionJournalViewport(
     throw new TypeError('action journal direction must be older or newer')
   }
   const kinds = options.kinds ?? []
-  if (kinds.some((kind) => protoKinds[kind] === undefined)) {
+  if (kinds.some((kind) => CHANGE_LOG_KIND_TO_PROTO[kind] === undefined)) {
     throw new TypeError('action journal kind filter is invalid')
   }
   const request: GetActionJournalViewportRequest = {
@@ -280,7 +263,7 @@ export async function getActionJournalViewport(
       direction === 'older'
         ? ActionJournalDirection.OLDER
         : ActionJournalDirection.NEWER,
-    kinds: kinds.map((kind) => protoKinds[kind]),
+    kinds: kinds.map((kind) => CHANGE_LOG_KIND_TO_PROTO[kind]),
     transactionId: options.transactionId?.trim() || undefined,
   }
   const response = options.fetch

--- a/packages/client/src/changeLog/node/index.ts
+++ b/packages/client/src/changeLog/node/index.ts
@@ -33,6 +33,7 @@ import {
   throwIfChangeLogCancelled,
 } from '../codec'
 import { scanChangeLogJson } from '../stream'
+import { changeLogKindFromProto } from '../proto'
 import type {
   ChangeLogCodecOptions,
   ChangeLogFileReadResult,
@@ -42,10 +43,7 @@ import type {
   ChangeLogWriteResult,
   NormalizedChangeLogEntry,
 } from '../types'
-import {
-  ChangeLogEntryKind,
-  type ChangeLogStreamHeader,
-} from '../../protobuf_ts/generated/omega_edit/v1/omega_edit'
+import type { ChangeLogStreamHeader } from '../../protobuf_ts/generated/omega_edit/v1/omega_edit'
 import { streamChangeLogExport, type ChangeLogRpcExportOptions } from './rpc'
 
 export * from './rpc'
@@ -123,6 +121,97 @@ async function syncParentDirectory(path: string): Promise<void> {
     // file-level fsync and atomic rename/link semantics.
   } finally {
     await handle?.close().catch(() => undefined)
+  }
+}
+
+function validateAtomicWriteOptions(
+  options: AtomicChangeLogWriteOptions
+): void {
+  if (
+    options.maxBytes !== undefined &&
+    (!Number.isSafeInteger(options.maxBytes) || options.maxBytes <= 0)
+  ) {
+    throw new ChangeLogCodecError(
+      'CHANGE_LOG_INVALID_LIMIT',
+      'maxBytes must be a positive safe integer'
+    )
+  }
+}
+
+class AtomicChangeLogOutput {
+  private readonly tempPath: string
+  private readonly stream: ReturnType<typeof createWriteStream>
+  private readonly hash = createHash('sha256')
+  private byteCount = 0
+  private committed = false
+  private streamEnded = false
+
+  constructor(
+    private readonly outputPath: string,
+    private readonly options: AtomicChangeLogWriteOptions
+  ) {
+    this.tempPath = join(
+      dirname(outputPath),
+      `.${basename(outputPath)}.${process.pid}.${randomBytes(12).toString('hex')}.tmp`
+    )
+    this.stream = createWriteStream(this.tempPath, {
+      encoding: 'utf8',
+      flags: 'wx',
+      mode: 0o600,
+    })
+  }
+
+  async writeText(text: string): Promise<void> {
+    throwIfChangeLogCancelled(this.options.signal)
+    const bytes = Buffer.byteLength(text, 'utf8')
+    if (
+      this.options.maxBytes !== undefined &&
+      this.byteCount + bytes > this.options.maxBytes
+    ) {
+      throw new ChangeLogCodecError(
+        'CHANGE_LOG_OUTPUT_LIMIT',
+        `Change log output exceeds ${this.options.maxBytes} bytes`
+      )
+    }
+    await this.options.onBytesWritten?.(this.byteCount + bytes)
+    this.hash.update(text, 'utf8')
+    this.byteCount += bytes
+    if (!this.stream.write(text)) {
+      await once(this.stream, 'drain')
+    }
+  }
+
+  async commit(): Promise<{ byteLength: number; sha256: string }> {
+    this.stream.end()
+    this.streamEnded = true
+    await finished(this.stream)
+    await syncFile(this.tempPath)
+    await this.options.beforeCommit?.()
+    throwIfChangeLogCancelled(this.options.signal)
+
+    if (this.options.overwrite) {
+      await fs.rename(this.tempPath, this.outputPath)
+      this.committed = true
+    } else {
+      await fs.link(this.tempPath, this.outputPath)
+      this.committed = true
+      await fs.rm(this.tempPath, { force: true }).catch(() => undefined)
+    }
+    await syncParentDirectory(this.outputPath)
+    return {
+      byteLength: this.byteCount,
+      sha256: this.hash.digest('hex'),
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    if (!this.streamEnded) {
+      this.stream.destroy()
+      await finished(this.stream).catch(() => undefined)
+    }
+    if (!this.committed) {
+      await fs.rm(this.tempPath, { force: true }).catch(() => undefined)
+    }
   }
 }
 
@@ -313,55 +402,15 @@ export async function writeChangeLogFileAtomic(
       `Change log changeCount exceeds ${limits.maxEntryCount}`
     )
   }
-  if (
-    options.maxBytes !== undefined &&
-    (!Number.isSafeInteger(options.maxBytes) || options.maxBytes <= 0)
-  ) {
-    throw new ChangeLogCodecError(
-      'CHANGE_LOG_INVALID_LIMIT',
-      'maxBytes must be a positive safe integer'
-    )
-  }
+  validateAtomicWriteOptions(options)
   const validatedHeader = normalizeChangeLogHeader(
     normalizedHeaderObject(header),
     expectedCount,
     limits
   )
-  const tempPath = join(
-    dirname(outputPath),
-    `.${basename(outputPath)}.${process.pid}.${randomBytes(12).toString('hex')}.tmp`
-  )
-  const stream = createWriteStream(tempPath, {
-    encoding: 'utf8',
-    flags: 'wx',
-    mode: 0o600,
-  })
-  const hash = createHash('sha256')
+  const output = new AtomicChangeLogOutput(outputPath, options)
   const sequence = new ChangeLogEntrySequenceValidator(limits)
-  let byteLength = 0
   let entryCount = 0
-  let committed = false
-  let streamEnded = false
-
-  const writeText = async (text: string): Promise<void> => {
-    throwIfChangeLogCancelled(options.signal)
-    const bytes = Buffer.byteLength(text, 'utf8')
-    if (
-      options.maxBytes !== undefined &&
-      byteLength + bytes > options.maxBytes
-    ) {
-      throw new ChangeLogCodecError(
-        'CHANGE_LOG_OUTPUT_LIMIT',
-        `Change log output exceeds ${options.maxBytes} bytes`
-      )
-    }
-    await options.onBytesWritten?.(byteLength + bytes)
-    hash.update(text, 'utf8')
-    byteLength += bytes
-    if (!stream.write(text)) {
-      await once(stream, 'drain')
-    }
-  }
 
   try {
     const metadata = normalizedHeaderObject(validatedHeader)
@@ -369,7 +418,7 @@ export async function writeChangeLogFileAtomic(
       /\n}$/,
       ',\n  "changes": ['
     )}\n`
-    await writeText(prefix)
+    await output.writeText(prefix)
     let first = true
     await writeEntries({
       writeEntry: async (entry) => {
@@ -389,7 +438,7 @@ export async function writeChangeLogFileAtomic(
           .split('\n')
           .map((line) => `    ${line}`)
           .join('\n')
-        await writeText(`${first ? '' : ',\n'}${serialized}`)
+        await output.writeText(`${first ? '' : ',\n'}${serialized}`)
         first = false
         entryCount += 1
       },
@@ -405,59 +454,15 @@ export async function writeChangeLogFileAtomic(
       entryCount,
       limits
     )
-    await writeText('\n  ]\n}\n')
-    stream.end()
-    streamEnded = true
-    await finished(stream)
-    await syncFile(tempPath)
-    await options.beforeCommit?.()
-    throwIfChangeLogCancelled(options.signal)
-
-    if (options.overwrite) {
-      await fs.rename(tempPath, outputPath)
-      committed = true
-    } else {
-      await fs.link(tempPath, outputPath)
-      committed = true
-      await fs.rm(tempPath, { force: true }).catch(() => undefined)
-    }
-    await syncParentDirectory(outputPath)
+    await output.writeText('\n  ]\n}\n')
+    const committed = await output.commit()
     return {
       path: outputPath,
-      byteLength,
-      sha256: hash.digest('hex'),
+      ...committed,
       entryCount,
     }
   } finally {
-    if (!streamEnded) {
-      stream.destroy()
-      await finished(stream).catch(() => undefined)
-    }
-    if (!committed) {
-      await fs.rm(tempPath, { force: true }).catch(() => undefined)
-    }
-  }
-}
-
-function rpcEntryKind(
-  kind: ChangeLogEntryKind
-): NormalizedChangeLogEntry['kind'] {
-  switch (kind) {
-    case ChangeLogEntryKind.DELETE:
-      return 'DELETE'
-    case ChangeLogEntryKind.INSERT:
-      return 'INSERT'
-    case ChangeLogEntryKind.OVERWRITE:
-      return 'OVERWRITE'
-    case ChangeLogEntryKind.REPLACE:
-      return 'REPLACE'
-    case ChangeLogEntryKind.TRANSFORM:
-      return 'TRANSFORM'
-    default:
-      throw new ChangeLogCodecError(
-        'CHANGE_LOG_RPC_FRAMING',
-        'RPC entry has an unspecified kind'
-      )
+    await output.cleanup()
   }
 }
 
@@ -467,52 +472,16 @@ export async function writeChangeLogRpcExportAtomic(
   rpcOptions: ChangeLogRpcExportOptions,
   options: AtomicChangeLogWriteOptions = {}
 ): Promise<ChangeLogRpcFileResult> {
-  if (
-    options.maxBytes !== undefined &&
-    (!Number.isSafeInteger(options.maxBytes) || options.maxBytes <= 0)
-  ) {
-    throw new ChangeLogCodecError(
-      'CHANGE_LOG_INVALID_LIMIT',
-      'maxBytes must be a positive safe integer'
-    )
+  const atomicOptions = {
+    ...options,
+    signal: options.signal ?? rpcOptions.signal,
   }
-  const tempPath = join(
-    dirname(outputPath),
-    `.${basename(outputPath)}.${process.pid}.${randomBytes(12).toString('hex')}.tmp`
-  )
-  const stream = createWriteStream(tempPath, {
-    encoding: 'utf8',
-    flags: 'wx',
-    mode: 0o600,
-  })
-  const hash = createHash('sha256')
-  let byteLength = 0
-  let committed = false
-  let streamEnded = false
+  validateAtomicWriteOptions(atomicOptions)
+  const output = new AtomicChangeLogOutput(outputPath, atomicOptions)
   let header: ChangeLogStreamHeader | undefined
   let entryOpen = false
   let firstEntry = true
   let entryCount = 0
-
-  const writeText = async (text: string): Promise<void> => {
-    throwIfChangeLogCancelled(options.signal ?? rpcOptions.signal)
-    const bytes = Buffer.byteLength(text, 'utf8')
-    if (
-      options.maxBytes !== undefined &&
-      byteLength + bytes > options.maxBytes
-    ) {
-      throw new ChangeLogCodecError(
-        'CHANGE_LOG_OUTPUT_LIMIT',
-        `Change log output exceeds ${options.maxBytes} bytes`
-      )
-    }
-    await options.onBytesWritten?.(byteLength + bytes)
-    hash.update(text, 'utf8')
-    byteLength += bytes
-    if (!stream.write(text)) {
-      await once(stream, 'drain')
-    }
-  }
 
   try {
     for await (const frame of streamChangeLogExport({
@@ -545,12 +514,18 @@ export async function writeChangeLogRpcExportAtomic(
           unavailableChangeCount: '0',
           unavailableChangeSerials: [],
         }
-        await writeText(
+        await output.writeText(
           `${JSON.stringify(metadata).replace(/}$/, ',"changes":[')}`
         )
       } else if (frame.type === 'entry') {
         const entry = frame.entry
-        const kind = rpcEntryKind(entry.kind)
+        const kind = changeLogKindFromProto(entry.kind)
+        if (!kind) {
+          throw new ChangeLogCodecError(
+            'CHANGE_LOG_RPC_FRAMING',
+            'RPC entry has an unspecified kind'
+          )
+        }
         const prefix = firstEntry ? '' : ','
         firstEntry = false
         if (kind === 'TRANSFORM') {
@@ -577,7 +552,7 @@ export async function writeChangeLogRpcExportAtomic(
             JSON.stringify({ transformId: transform.transformId, args }),
             'utf8'
           ).toString('hex')
-          await writeText(
+          await output.writeText(
             `${prefix}${JSON.stringify({
               kind,
               offset: entry.offsetDecimal,
@@ -587,14 +562,14 @@ export async function writeChangeLogRpcExportAtomic(
           )
           entryCount += 1
         } else {
-          await writeText(
+          await output.writeText(
             `${prefix}{"kind":${JSON.stringify(kind)},"offset":${JSON.stringify(
               entry.offsetDecimal
             )},"length":${JSON.stringify(entry.lengthDecimal)},"data":"`
           )
           entryOpen = true
           if (entry.payloadLengthDecimal === '0') {
-            await writeText('"}')
+            await output.writeText('"}')
             entryOpen = false
             entryCount += 1
           }
@@ -606,9 +581,9 @@ export async function writeChangeLogRpcExportAtomic(
             'payload arrived without an open JSON entry'
           )
         }
-        await writeText(Buffer.from(frame.payload.data).toString('hex'))
+        await output.writeText(Buffer.from(frame.payload.data).toString('hex'))
         if (frame.payload.finalChunk) {
-          await writeText('"}')
+          await output.writeText('"}')
           entryOpen = false
           entryCount += 1
         }
@@ -627,7 +602,7 @@ export async function writeChangeLogRpcExportAtomic(
             'RPC entry count changed while writing JSON'
           )
         }
-        await writeText(
+        await output.writeText(
           `],"changeCount":${JSON.stringify(
             frame.complete.emittedChangeCountDecimal
           )}}\n`
@@ -640,25 +615,10 @@ export async function writeChangeLogRpcExportAtomic(
         'RPC stream did not provide a header'
       )
     }
-    stream.end()
-    streamEnded = true
-    await finished(stream)
-    await syncFile(tempPath)
-    await options.beforeCommit?.()
-    throwIfChangeLogCancelled(options.signal ?? rpcOptions.signal)
-    if (options.overwrite) {
-      await fs.rename(tempPath, outputPath)
-      committed = true
-    } else {
-      await fs.link(tempPath, outputPath)
-      committed = true
-      await fs.rm(tempPath, { force: true }).catch(() => undefined)
-    }
-    await syncParentDirectory(outputPath)
+    const committed = await output.commit()
     return {
       path: outputPath,
-      byteLength,
-      sha256: hash.digest('hex'),
+      ...committed,
       entryCount,
       sourceChangeCount: header.sourceChangeCountDecimal,
       before: {
@@ -680,13 +640,7 @@ export async function writeChangeLogRpcExportAtomic(
       optimized: header.optimized,
     }
   } finally {
-    if (!streamEnded) {
-      stream.destroy()
-      await finished(stream).catch(() => undefined)
-    }
-    if (!committed) {
-      await fs.rm(tempPath, { force: true }).catch(() => undefined)
-    }
+    await output.cleanup()
   }
 }
 

--- a/packages/client/src/changeLog/proto.ts
+++ b/packages/client/src/changeLog/proto.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeLogEntryKind as ProtoChangeLogEntryKind } from '../protobuf_ts/generated/omega_edit/v1/omega_edit'
+import type { ChangeLogEntryKind } from './types'
+
+export const CHANGE_LOG_KIND_TO_PROTO: Readonly<
+  Record<ChangeLogEntryKind, ProtoChangeLogEntryKind>
+> = {
+  DELETE: ProtoChangeLogEntryKind.DELETE,
+  INSERT: ProtoChangeLogEntryKind.INSERT,
+  OVERWRITE: ProtoChangeLogEntryKind.OVERWRITE,
+  REPLACE: ProtoChangeLogEntryKind.REPLACE,
+  TRANSFORM: ProtoChangeLogEntryKind.TRANSFORM,
+}
+
+export function changeLogKindFromProto(
+  kind: ProtoChangeLogEntryKind
+): ChangeLogEntryKind | undefined {
+  switch (kind) {
+    case ProtoChangeLogEntryKind.DELETE:
+      return 'DELETE'
+    case ProtoChangeLogEntryKind.INSERT:
+      return 'INSERT'
+    case ProtoChangeLogEntryKind.OVERWRITE:
+      return 'OVERWRITE'
+    case ProtoChangeLogEntryKind.REPLACE:
+      return 'REPLACE'
+    case ProtoChangeLogEntryKind.TRANSFORM:
+      return 'TRANSFORM'
+    default:
+      return undefined
+  }
+}

--- a/packages/client/src/protobuf_ts/change.ts
+++ b/packages/client/src/protobuf_ts/change.ts
@@ -20,7 +20,6 @@
 import {
   ChangeKind as ProtoChangeKind,
   CountKind,
-  type GetCountResponse,
   type GetChangeDetailsResponse,
   type GetLastChangeResponse,
   type GetLastUndoResponse,
@@ -29,6 +28,7 @@ import {
 import { debugLog, getLogger } from '../logger'
 import { getClient } from '../client'
 import { callUnary, makeWrappedError } from './utils'
+import { getSingleCount } from './session'
 
 export const ChangeKind = {
   UNSPECIFIED: ProtoChangeKind.UNSPECIFIED,
@@ -66,14 +66,6 @@ export class EditStats implements IEditStats {
     this.clear_count = 0
     this.error_count = 0
   }
-}
-
-function getFirstCount(response: GetCountResponse, fn: string): number {
-  const count = response.counts[0]?.count
-  if (count === undefined) {
-    throw new Error(`${fn} failed: empty count response`)
-  }
-  return count
 }
 
 async function submitChange(
@@ -463,163 +455,29 @@ export async function getLastUndo(
 }
 
 export async function getChangeCount(sessionId: string): Promise<number> {
-  const log = getLogger()
-  const request = {
-    sessionId: sessionId,
-    kind: [CountKind.CHANGES],
-  }
-  debugLog(log, () => ({ fn: 'protobufTs.getChangeCount', rqst: request }))
-  const client = await getClient()
-
-  return new Promise<number>((resolve, reject) => {
-    callUnary(client, client.getCount, request, (err, response) => {
-      if (err) {
-        log.error({
-          fn: 'protobufTs.getChangeCount',
-          err: {
-            msg: err.message,
-            details: err.details,
-            code: err.code,
-            stack: err.stack,
-          },
-        })
-        return reject(new Error('getChangeCount failed: ' + err))
-      }
-
-      if (!response) {
-        return reject(new Error('getChangeCount failed: empty response'))
-      }
-
-      debugLog(log, () => ({
-        fn: 'protobufTs.getChangeCount',
-        resp: response,
-      }))
-      return resolve(getFirstCount(response, 'getChangeCount'))
-    })
-  })
+  return getSingleCount(sessionId, CountKind.CHANGES, 'getChangeCount')
 }
 
 export async function getUndoCount(sessionId: string): Promise<number> {
-  const log = getLogger()
-  const request = {
-    sessionId: sessionId,
-    kind: [CountKind.UNDOS],
-  }
-  debugLog(log, () => ({ fn: 'protobufTs.getUndoCount', rqst: request }))
-  const client = await getClient()
-
-  return new Promise<number>((resolve, reject) => {
-    callUnary(client, client.getCount, request, (err, response) => {
-      if (err) {
-        log.error({
-          fn: 'protobufTs.getUndoCount',
-          err: {
-            msg: err.message,
-            details: err.details,
-            code: err.code,
-            stack: err.stack,
-          },
-        })
-        return reject(new Error('getUndoCount failed: ' + err))
-      }
-
-      if (!response) {
-        return reject(new Error('getUndoCount failed: empty response'))
-      }
-
-      debugLog(log, () => ({
-        fn: 'protobufTs.getUndoCount',
-        resp: response,
-      }))
-      return resolve(getFirstCount(response, 'getUndoCount'))
-    })
-  })
+  return getSingleCount(sessionId, CountKind.UNDOS, 'getUndoCount')
 }
 
 export async function getChangeTransactionCount(
   sessionId: string
 ): Promise<number> {
-  const log = getLogger()
-  const request = {
-    sessionId: sessionId,
-    kind: [CountKind.CHANGE_TRANSACTIONS],
-  }
-  debugLog(log, () => ({
-    fn: 'protobufTs.getChangeTransactionCount',
-    rqst: request,
-  }))
-  const client = await getClient()
-
-  return new Promise<number>((resolve, reject) => {
-    callUnary(client, client.getCount, request, (err, response) => {
-      if (err) {
-        log.error({
-          fn: 'protobufTs.getChangeTransactionCount',
-          err: {
-            msg: err.message,
-            details: err.details,
-            code: err.code,
-            stack: err.stack,
-          },
-        })
-        return reject(new Error('getChangeTransactionCount failed: ' + err))
-      }
-
-      if (!response) {
-        return reject(
-          new Error('getChangeTransactionCount failed: empty response')
-        )
-      }
-
-      debugLog(log, () => ({
-        fn: 'protobufTs.getChangeTransactionCount',
-        resp: response,
-      }))
-      return resolve(getFirstCount(response, 'getChangeTransactionCount'))
-    })
-  })
+  return getSingleCount(
+    sessionId,
+    CountKind.CHANGE_TRANSACTIONS,
+    'getChangeTransactionCount'
+  )
 }
 
 export async function getUndoTransactionCount(
   sessionId: string
 ): Promise<number> {
-  const log = getLogger()
-  const request = {
-    sessionId: sessionId,
-    kind: [CountKind.UNDO_TRANSACTIONS],
-  }
-  debugLog(log, () => ({
-    fn: 'protobufTs.getUndoTransactionCount',
-    rqst: request,
-  }))
-  const client = await getClient()
-
-  return new Promise<number>((resolve, reject) => {
-    callUnary(client, client.getCount, request, (err, response) => {
-      if (err) {
-        log.error({
-          fn: 'protobufTs.getUndoTransactionCount',
-          err: {
-            msg: err.message,
-            details: err.details,
-            code: err.code,
-            stack: err.stack,
-          },
-        })
-        return reject(new Error('getUndoTransactionCount failed: ' + err))
-      }
-
-      if (!response) {
-        return reject(
-          new Error('getUndoTransactionCount failed: empty response')
-        )
-      }
-
-      debugLog(log, () => ({
-        fn: 'protobufTs.getUndoTransactionCount',
-        resp: response,
-      }))
-      return resolve(getFirstCount(response, 'getUndoTransactionCount'))
-    })
-  })
+  return getSingleCount(
+    sessionId,
+    CountKind.UNDO_TRANSACTIONS,
+    'getUndoTransactionCount'
+  )
 }

--- a/packages/client/src/protobuf_ts/session.ts
+++ b/packages/client/src/protobuf_ts/session.ts
@@ -505,23 +505,24 @@ export async function getComputedFileSize(sessionId: string): Promise<number> {
   })
 }
 
-export async function getCounts(
+async function requestCounts(
   sessionId: string,
-  kinds: number[]
+  kinds: CountKind[],
+  fn: string
 ): Promise<SingleCount[]> {
   const log = getLogger()
   const request = {
     sessionId: sessionId,
-    kind: kinds as CountKind[],
+    kind: kinds,
   }
-  debugLog(log, () => ({ fn: 'protobufTs.getCounts', rqst: request }))
+  debugLog(log, () => ({ fn: `protobufTs.${fn}`, rqst: request }))
   const client = await getClient()
 
   return new Promise<SingleCount[]>((resolve, reject) => {
     callUnary(client, client.getCount, request, (err, response) => {
       if (err) {
         log.error({
-          fn: 'protobufTs.getCounts',
+          fn: `protobufTs.${fn}`,
           rqst: request,
           err: {
             msg: err.message,
@@ -530,21 +531,41 @@ export async function getCounts(
             stack: err.stack,
           },
         })
-        return reject(makeWrappedError('getCounts', err))
+        return reject(makeWrappedError(fn, err))
       }
 
       try {
         const required = requireResponse(
           response as GetCountResponse | undefined,
-          'getCounts'
+          fn
         )
-        debugLog(log, () => ({ fn: 'protobufTs.getCounts', resp: required }))
+        debugLog(log, () => ({ fn: `protobufTs.${fn}`, resp: required }))
         return resolve(required.counts)
       } catch (error) {
-        return reject(makeWrappedError('getCounts', error))
+        return reject(makeWrappedError(fn, error))
       }
     })
   })
+}
+
+export async function getCounts(
+  sessionId: string,
+  kinds: number[]
+): Promise<SingleCount[]> {
+  return requestCounts(sessionId, kinds as CountKind[], 'getCounts')
+}
+
+export async function getSingleCount(
+  sessionId: string,
+  kind: CountKind,
+  fn: string
+): Promise<number> {
+  const counts = await requestCounts(sessionId, [kind], fn)
+  const count = counts[0]?.count
+  if (count === undefined) {
+    throw makeWrappedError(fn, 'empty count response')
+  }
+  return count
 }
 
 export async function pauseSessionChanges(sessionId: string): Promise<string> {

--- a/packages/client/src/protobuf_ts/viewport.ts
+++ b/packages/client/src/protobuf_ts/viewport.ts
@@ -21,7 +21,6 @@ import {
   CountKind,
   type CreateViewportRequest,
   type CreateViewportResponse,
-  type GetCountResponse,
   type GetViewportDataResponse,
   type ModifyViewportRequest,
 } from './generated/omega_edit/v1/omega_edit'
@@ -33,14 +32,7 @@ import {
   callUnary,
   makeWrappedError,
 } from './utils'
-
-function getFirstCount(response: GetCountResponse, fn: string): number {
-  const count = response.counts[0]?.count
-  if (count === undefined) {
-    throw new Error(`${fn} failed: empty count response`)
-  }
-  return count
-}
+import { getSingleCount } from './session'
 
 export async function createViewport(
   desiredViewportId: string | undefined,
@@ -169,41 +161,7 @@ export async function destroyViewport(viewportId: string): Promise<string> {
 }
 
 export async function getViewportCount(sessionId: string): Promise<number> {
-  const log = getLogger()
-  const request = {
-    sessionId: sessionId,
-    kind: [CountKind.VIEWPORTS],
-  }
-  debugLog(log, () => ({ fn: 'protobufTs.getViewportCount', rqst: request }))
-  const client = await getClient()
-
-  return new Promise<number>((resolve, reject) => {
-    callUnary(client, client.getCount, request, (err, response) => {
-      if (err) {
-        log.error({
-          fn: 'protobufTs.getViewportCount',
-          rqst: request,
-          err: {
-            msg: err.message,
-            details: err.details,
-            code: err.code,
-            stack: err.stack,
-          },
-        })
-        return reject(makeWrappedError('getViewportCount', err))
-      }
-
-      if (!response) {
-        return reject(makeWrappedError('getViewportCount', 'empty response'))
-      }
-
-      debugLog(log, () => ({
-        fn: 'protobufTs.getViewportCount',
-        resp: response,
-      }))
-      return resolve(getFirstCount(response, 'getViewportCount'))
-    })
-  })
+  return getSingleCount(sessionId, CountKind.VIEWPORTS, 'getViewportCount')
 }
 
 export async function getViewportData(

--- a/server/cpp/src/editor_service.cpp
+++ b/server/cpp/src/editor_service.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <limits>
 #include <optional>
@@ -2511,6 +2512,7 @@ namespace omega_edit {
                 const auto transaction_start = omega_change_get_transaction_start_serial(change);
                 return transaction_start > 0 ? "transaction:" + std::to_string(transaction_start) : std::string{};
             };
+            bool invalid_history_kind = false;
             const auto append_entry = [&](const journal_canonical_entry &canonical, const std::string &transaction_id,
                                           int64_t continuation_anchor) -> bool {
                 const auto kind_char = omega_change_get_kind_as_char(canonical.source.change);
@@ -2526,7 +2528,10 @@ namespace omega_edit {
                 } else if (kind_char == 'T') {
                     kind = ::omega_edit::v1::CHANGE_LOG_ENTRY_KIND_TRANSFORM;
                 }
-                if (kind == ::omega_edit::v1::CHANGE_LOG_ENTRY_KIND_UNSPECIFIED) { return false; }
+                if (kind == ::omega_edit::v1::CHANGE_LOG_ENTRY_KIND_UNSPECIFIED) {
+                    invalid_history_kind = true;
+                    return false;
+                }
                 if (!include_all_kinds && !included_kinds[static_cast<size_t>(kind)]) { return true; }
                 if (request->has_transaction_id() && request->transaction_id() != transaction_id) { return true; }
                 if (response->entries_size() >= static_cast<int>(request->capacity())) {
@@ -2590,39 +2595,90 @@ namespace omega_edit {
                 return true;
             };
 
-            for (int64_t serial = anchor; older ? serial >= 1 : serial <= history_tip;) {
-                if (context->IsCancelled()) {
-                    return grpc::Status(grpc::StatusCode::CANCELLED, "action journal request was cancelled");
+            struct journal_visit_context {
+                bool older{};
+                bool cancelled{};
+                bool stopped{};
+                grpc::ServerContext *rpc_context{};
+                std::optional<journal_source_entry> pending{};
+                std::function<bool(const omega_change_t *, const omega_change_t *)> is_replacement_pair;
+                std::function<bool(const journal_canonical_entry &, int64_t)> append;
+            };
+            journal_visit_context visit_context{
+                    older,
+                    false,
+                    false,
+                    context,
+                    std::nullopt,
+                    is_replacement_pair,
+                    [&](const journal_canonical_entry &canonical, int64_t continuation_anchor) {
+                        return append_entry(canonical, transaction_id_for(canonical.source.change),
+                                            continuation_anchor);
+                    }};
+            const auto visit_change = [](const omega_change_t *change, int64_t serial, void *user_data) {
+                auto &state = *static_cast<journal_visit_context *>(user_data);
+                if (state.rpc_context->IsCancelled()) {
+                    state.cancelled = true;
+                    return 1;
                 }
-                const auto *change = get_history_change(serial);
-                if (!change) {
-                    return grpc::Status(grpc::StatusCode::ABORTED,
-                                        "action journal changed while its viewport was being read");
-                }
-                const auto transaction_bit = omega_change_get_transaction_bit(change);
-                journal_canonical_entry canonical{{change, serial}, std::nullopt};
-                int64_t continuation_anchor = serial;
-                int64_t step = 1;
-                if (older && omega_change_get_kind_as_char(change) == 'I' && serial > 1) {
-                    const auto *delete_change = get_history_change(serial - 1);
-                    if (delete_change && omega_change_get_kind_as_char(delete_change) == 'D' &&
-                        omega_change_get_transaction_bit(delete_change) == transaction_bit &&
-                        omega_change_get_offset(delete_change) == omega_change_get_offset(change)) {
-                        canonical = {{delete_change, serial - 1}, journal_source_entry{change, serial}};
-                        step = 2;
+
+                const journal_source_entry current{change, serial};
+                if (state.pending) {
+                    const auto replacement = state.older
+                                                     ? state.is_replacement_pair(current.change, state.pending->change)
+                                                     : state.is_replacement_pair(state.pending->change, current.change);
+                    if (replacement) {
+                        const journal_canonical_entry canonical =
+                                state.older
+                                        ? journal_canonical_entry{current, journal_source_entry{state.pending->change,
+                                                                                                state.pending->serial}}
+                                        : journal_canonical_entry{*state.pending, current};
+                        const auto continuation_anchor = state.pending->serial;
+                        state.pending.reset();
+                        if (!state.append(canonical, continuation_anchor)) {
+                            state.stopped = true;
+                            return 1;
+                        }
+                        return 0;
                     }
-                } else if (!older && omega_change_get_kind_as_char(change) == 'D' && serial < history_tip) {
-                    const auto *insert_change = get_history_change(serial + 1);
-                    if (insert_change && omega_change_get_kind_as_char(insert_change) == 'I' &&
-                        omega_change_get_transaction_bit(insert_change) == transaction_bit &&
-                        omega_change_get_offset(insert_change) == omega_change_get_offset(change)) {
-                        canonical.replacement = journal_source_entry{insert_change, serial + 1};
-                        step = 2;
+
+                    const journal_canonical_entry pending_entry{*state.pending, std::nullopt};
+                    const auto continuation_anchor = state.pending->serial;
+                    state.pending.reset();
+                    if (!state.append(pending_entry, continuation_anchor)) {
+                        state.stopped = true;
+                        return 1;
                     }
                 }
-                const auto transaction_id = transaction_id_for(canonical.source.change);
-                if (!append_entry(canonical, transaction_id, continuation_anchor)) { break; }
-                serial += older ? -step : step;
+
+                const auto kind = omega_change_get_kind_as_char(change);
+                if ((state.older && kind == 'I') || (!state.older && kind == 'D')) {
+                    state.pending = current;
+                    return 0;
+                }
+                if (!state.append(journal_canonical_entry{current, std::nullopt}, serial)) {
+                    state.stopped = true;
+                    return 1;
+                }
+                return 0;
+            };
+
+            const auto visit_result = omega_visit_retained_history(locked_session.session(), older ? 1 : anchor,
+                                                                   older ? anchor : history_tip, older ? 1 : 0,
+                                                                   visit_change, &visit_context);
+            if (visit_context.cancelled) {
+                return grpc::Status(grpc::StatusCode::CANCELLED, "action journal request was cancelled");
+            }
+            if (invalid_history_kind || visit_result < 0) {
+                return grpc::Status(grpc::StatusCode::ABORTED, "action journal encountered invalid retained history");
+            }
+            if (!visit_context.stopped && visit_context.pending) {
+                const journal_canonical_entry pending_entry{*visit_context.pending, std::nullopt};
+                append_entry(pending_entry, transaction_id_for(pending_entry.source.change),
+                             pending_entry.source.serial);
+            }
+            if (invalid_history_kind) {
+                return grpc::Status(grpc::StatusCode::ABORTED, "action journal encountered invalid retained history");
             }
             return grpc::Status::OK;
         }

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -148,13 +148,14 @@ The example extension uses a bounded search window of `1000` matches. It probes 
 
 This mode decision is made only when the user runs an explicit search. If a replace operation changes the remaining match count across the `1000` threshold, the extension keeps the current mode until the next explicit search. For example, a search that starts in `large` mode with exactly `1001` matches stays in `large` mode after one single replacement leaves `1000` remaining matches.
 
+The bytes-per-row toolbar preference is stored in VS Code's workspace-local extension state rather than workspace settings.
+
 ## Extension Settings
 
 | Setting                 | Default | Description                                                                |
 | ----------------------- | ------- | -------------------------------------------------------------------------- |
 | `omegaEdit.serverPort`  | `9000`  | TCP gRPC server port; setting this explicitly opts out of the default macOS/Linux Unix socket transport |
 | `omegaEdit.logLevel`    | `info`  | Client log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`) |
-| `omegaEdit.bytesPerRow` | `16`    | Bytes displayed per row (8 / 16 / 32)                                      |
 | `omegaEdit.language`    | `auto`  | Svelte data editor UI language (`auto` follows VS Code; explicit options include `en` and `es`) |
 | `omegaEdit.transformPluginDirectories` | `[]` | Native transform plugin directories; local build plugin folders are auto-detected when this is empty |
 | `omegaEdit.allowExperimentalTransformPlugins` | `false` | Load experimental transform plugins from configured or bundled plugin directories |

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -57,13 +57,6 @@
           ],
           "description": "%omegaEdit.configuration.logLevel.description%"
         },
-        "omegaEdit.bytesPerRow": {
-          "type": "number",
-          "default": 16,
-          "minimum": 8,
-          "maximum": 64,
-          "description": "%omegaEdit.configuration.bytesPerRow.description%"
-        },
         "omegaEdit.language": {
           "type": "string",
           "default": "auto",

--- a/vscode-extension/package.nls.json
+++ b/vscode-extension/package.nls.json
@@ -5,7 +5,6 @@
   "omegaEdit.configuration.title": "Ωedit™ Data Editor",
   "omegaEdit.configuration.serverPort.description": "TCP port for the OmegaEdit gRPC server; explicitly setting it opts out of Unix socket transport on macOS/Linux",
   "omegaEdit.configuration.logLevel.description": "Log level for the OmegaEdit client",
-  "omegaEdit.configuration.bytesPerRow.description": "Number of bytes displayed per row in the hex view. Values must be 8 through 64.",
   "omegaEdit.configuration.language.description": "Language for the Svelte data editor UI. Use auto to follow VS Code's display language.",
   "omegaEdit.configuration.transformPluginDirectories.description": "Directories containing OmegaEdit transform plugin shared libraries",
   "omegaEdit.configuration.allowExperimentalTransformPlugins.description": "Load experimental OmegaEdit transform plugins from configured or bundled plugin directories.",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1244,9 +1244,6 @@ export async function activate(
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration('omegaEdit.bytesPerRow')) {
-        provider.refreshBytesPerRow()
-      }
       if (event.affectsConfiguration('omegaEdit.language')) {
         provider.refreshLanguage()
       }

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -139,11 +139,9 @@ import {
   type ServerHealthMetricId,
   type ServerHealthMessage,
   type WebviewToHostMessage,
-  bytesPerRowFromSetting,
   checkpointTimelineMetadataWindow,
   normalizeExternalHighlights,
   normalizeBytesPerRow,
-  normalizeBytesPerRowSetting,
   normalizeTextEncoding,
   normalizeWebviewMessage,
 } from './webviewProtocol'
@@ -167,7 +165,6 @@ interface EditorSession {
   bufferOffset: number
   visibleRows: number
   capacity: number
-  bytesPerRowSetting: number
   bytesPerRow: BytesPerRow
   filePath: string
   panel: vscode.WebviewPanel
@@ -452,6 +449,7 @@ const CONTEXT_CAN_UNDO = 'omegaEdit.canUndo'
 const CONTEXT_CAN_REDO = 'omegaEdit.canRedo'
 const CONTEXT_HAS_PENDING_CHANGES = 'omegaEdit.hasPendingChanges'
 const CONTEXT_TRANSFORM_IN_FLIGHT = 'omegaEdit.transformInFlight'
+const BYTES_PER_ROW_STORAGE_KEY = 'omegaEdit.bytesPerRow'
 const CONTEXT_ACTIVE_SESSION_RESOURCE_PATHS =
   'omegaEdit.activeSessionResourcePaths'
 const ACTION_JOURNAL_REQUEST_TIMEOUT_MS = 15_000
@@ -2102,7 +2100,11 @@ export class HexEditorProvider
   constructor(
     private readonly extensionContext?: Pick<
       vscode.ExtensionContext,
-      'extensionUri' | 'subscriptions' | 'storageUri' | 'globalStorageUri'
+      | 'extensionUri'
+      | 'subscriptions'
+      | 'storageUri'
+      | 'globalStorageUri'
+      | 'workspaceState'
     >
   ) {
     this.extensionContext?.subscriptions.push(
@@ -2181,45 +2183,19 @@ export class HexEditorProvider
     this.postEditState(session)
   }
 
-  private async updateBytesPerRowConfiguration(
-    session: EditorSession,
-    value: number
-  ): Promise<void> {
-    const resource = vscode.Uri.file(session.filePath)
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(resource)
-    const configuration = vscode.workspace.getConfiguration(
-      'omegaEdit',
-      resource
+  private storedBytesPerRow(): BytesPerRow {
+    return normalizeBytesPerRow(
+      this.extensionContext?.workspaceState?.get(BYTES_PER_ROW_STORAGE_KEY)
     )
-    const targets = workspaceFolder
-      ? [
-          vscode.ConfigurationTarget.WorkspaceFolder,
-          vscode.ConfigurationTarget.Workspace,
-          vscode.ConfigurationTarget.Global,
-        ]
-      : vscode.workspace.workspaceFolders &&
-          vscode.workspace.workspaceFolders.length > 0
-        ? [
-            vscode.ConfigurationTarget.Workspace,
-            vscode.ConfigurationTarget.Global,
-          ]
-        : [vscode.ConfigurationTarget.Global]
+  }
 
-    let lastError: unknown
-    let updated = false
-    for (const target of targets) {
-      try {
-        await configuration.update('bytesPerRow', value, target)
-        updated = true
-        break
-      } catch (err) {
-        lastError = err
-      }
-    }
-
-    if (!updated && lastError) {
-      throw lastError
-    }
+  private async persistBytesPerRow(value: BytesPerRow): Promise<void> {
+    const bytesPerRow = normalizeBytesPerRow(value)
+    await this.extensionContext?.workspaceState?.update(
+      BYTES_PER_ROW_STORAGE_KEY,
+      bytesPerRow
+    )
+    this.refreshBytesPerRow(bytesPerRow)
   }
 
   public getSessionForTesting(uri: vscode.Uri): EditorSession | undefined {
@@ -2236,7 +2212,7 @@ export class HexEditorProvider
 
   private renderWebviewHtml(
     webview: vscode.Webview,
-    bytesPerRowSetting: number
+    bytesPerRow: BytesPerRow
   ): string {
     const extensionUri = this.extensionContext?.extensionUri
     if (!extensionUri) {
@@ -2246,7 +2222,7 @@ export class HexEditorProvider
       return `<!DOCTYPE html><html><body>${message}</body></html>`
     }
 
-    return getSvelteWebviewContent(webview, extensionUri, bytesPerRowSetting)
+    return getSvelteWebviewContent(webview, extensionUri, bytesPerRow)
   }
 
   public async dispatchWebviewMessageForTesting(
@@ -2412,11 +2388,7 @@ export class HexEditorProvider
     const filePath = uri.fsPath
 
     // --- Create Ωedit™ session for this file ---
-    const config = vscode.workspace.getConfiguration('omegaEdit')
-    const bytesPerRowSetting = normalizeBytesPerRowSetting(
-      config.get('bytesPerRow')
-    )
-    const bytesPerRow = bytesPerRowFromSetting(bytesPerRowSetting)
+    const bytesPerRow = this.storedBytesPerRow()
 
     // Keep a fixed buffered viewport so resizing the editor does not need to
     // resize the server-side viewport. Only the visible row count changes.
@@ -2431,7 +2403,7 @@ export class HexEditorProvider
     }
     webviewPanel.webview.html = this.renderWebviewHtml(
       webviewPanel.webview,
-      bytesPerRowSetting
+      bytesPerRow
     )
 
     const panelDisposables: vscode.Disposable[] = []
@@ -2555,7 +2527,6 @@ export class HexEditorProvider
       bufferOffset: 0,
       visibleRows: 32,
       capacity,
-      bytesPerRowSetting,
       bytesPerRow,
       filePath,
       panel: webviewPanel,
@@ -3121,15 +3092,12 @@ export class HexEditorProvider
     return this.buildEditorState(session)
   }
 
-  /** Re-read bytesPerRow from config and refresh all open editors */
-  refreshBytesPerRow(bytesPerRowSettingOverride?: number): void {
-    const bytesPerRowSetting = normalizeBytesPerRowSetting(
-      bytesPerRowSettingOverride ??
-        vscode.workspace.getConfiguration('omegaEdit').get('bytesPerRow')
+  /** Refresh all open editors from the workspace-local preference. */
+  refreshBytesPerRow(bytesPerRowOverride?: number): void {
+    const bytesPerRow = normalizeBytesPerRow(
+      bytesPerRowOverride ?? this.storedBytesPerRow()
     )
     for (const session of this.sessions.values()) {
-      const bytesPerRow = bytesPerRowFromSetting(bytesPerRowSetting)
-      session.bytesPerRowSetting = bytesPerRowSetting
       this.postBytesPerRow(session, bytesPerRow)
       this.postTransformStatus(
         session,
@@ -3152,7 +3120,7 @@ export class HexEditorProvider
       }
       session.panel.webview.html = this.renderWebviewHtml(
         session.panel.webview,
-        session.bytesPerRowSetting
+        session.bytesPerRow
       )
       this.postTransformStatus(
         session,
@@ -7596,18 +7564,13 @@ export class HexEditorProvider
           if (msg.persist === false) {
             await this.applySessionBytesPerRow(session, msg.bytesPerRow)
           } else {
-            session.bytesPerRowSetting = msg.bytesPerRow
-            await this.updateBytesPerRowConfiguration(session, msg.bytesPerRow)
+            await this.persistBytesPerRow(msg.bytesPerRow)
           }
           break
         }
 
         case 'setBytesPerRowMode': {
-          session.bytesPerRowSetting = session.bytesPerRow
-          await this.updateBytesPerRowConfiguration(
-            session,
-            session.bytesPerRow
-          )
+          await this.persistBytesPerRow(session.bytesPerRow)
           break
         }
 

--- a/vscode-extension/src/svelteWebview.ts
+++ b/vscode-extension/src/svelteWebview.ts
@@ -14,7 +14,7 @@
 
 import * as crypto from 'node:crypto'
 import * as vscode from 'vscode'
-import { bytesPerRowFromSetting } from './webviewProtocol'
+import { normalizeBytesPerRow } from './webviewProtocol'
 
 const SVELTE_WEBVIEW_OUT_DIR = ['out', 'svelte-webview'] as const
 const AUTO_WEBVIEW_LANGUAGE = 'auto'
@@ -75,7 +75,7 @@ export function getSvelteWebviewLocalResourceRoot(
 export function getSvelteWebviewContent(
   webview: vscode.Webview,
   extensionUri: vscode.Uri,
-  bytesPerRowSetting: number
+  bytesPerRow: number
 ): string {
   const resourceRoot = getSvelteWebviewLocalResourceRoot(extensionUri)
   const scriptUri = webview.asWebviewUri(
@@ -86,7 +86,7 @@ export function getSvelteWebviewContent(
   )
   const cspSource = escapeHtmlAttribute(webview.cspSource)
   const scriptNonce = nonce()
-  const normalizedBytesPerRow = bytesPerRowFromSetting(bytesPerRowSetting)
+  const normalizedBytesPerRow = normalizeBytesPerRow(bytesPerRow)
   const bytesPerRowMode = 'fixed'
   const language = resolveWebviewLanguage()
   const escapedLanguage = escapeHtmlAttribute(language)

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -624,14 +624,6 @@ export function normalizeBytesPerRow(value: unknown): BytesPerRow {
     : DEFAULT_BYTES_PER_ROW
 }
 
-export function normalizeBytesPerRowSetting(value: unknown): number {
-  return normalizeBytesPerRow(value)
-}
-
-export function bytesPerRowFromSetting(value: unknown): BytesPerRow {
-  return normalizeBytesPerRowSetting(value)
-}
-
 export function normalizeBytesPerRowMode(value: unknown): BytesPerRowMode {
   void value
   return 'fixed'

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -129,11 +129,14 @@ test('package.json matches shared extension constants', () => {
     `${packageJson.publisher}.${packageJson.name}`,
     OMEGA_EDIT_EXTENSION_ID
   )
-  const bytesPerRowConfiguration =
-    packageJson.contributes.configuration.properties['omegaEdit.bytesPerRow']
-  assert.equal(bytesPerRowConfiguration.minimum, 8)
-  assert.equal(bytesPerRowConfiguration.maximum, 64)
-  assert.equal(bytesPerRowConfiguration.anyOf, undefined)
+  assert.equal(
+    packageJson.contributes.configuration.properties['omegaEdit.bytesPerRow'],
+    undefined
+  )
+  assert.equal(
+    packageNls['omegaEdit.configuration.bytesPerRow.description'],
+    undefined
+  )
   const historyConfiguration = packageJson.contributes.configuration.properties
   assert.equal(
     historyConfiguration['omegaEdit.checkpointHistory.maxBytesPerSession']
@@ -1137,6 +1140,14 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerJs, /reconcileExternalHighlightStaleness/)
   assert.match(providerJs, /markExternalHighlightsStale/)
   assert.match(providerJs, /postBytesPerRow/)
+  assert.match(
+    providerSource,
+    /workspaceState\?\.update\(\s*BYTES_PER_ROW_STORAGE_KEY/
+  )
+  assert.doesNotMatch(
+    providerSource,
+    /configuration\.update\(['"]bytesPerRow['"]/
+  )
   assert.doesNotMatch(providerJs, /AUTO_BYTES_PER_ROW_SETTING/)
   assert.match(providerJs, /stale:\s*true/)
   assert.match(providerJs, /notifyDocumentChanged/)

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -3251,14 +3251,30 @@ suite('OmegaEdit VS Code extension', () => {
     }
   })
 
-  test('updates bytes per row without replacing the live webview', async () => {
+  test('stores bytes per row locally without replacing the live webview', async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'omega-edit-vscode-bytes-row-')
     )
     const samplePath = path.join(tmpDir, 'bytes-row.bin')
     await fs.writeFile(samplePath, Buffer.from('bytes per row', 'utf8'))
 
-    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const workspaceValues = new Map([['omegaEdit.bytesPerRow', 32]])
+    const workspaceUpdates = []
+    const provider = new HexEditorProvider(
+      {
+        subscriptions: [],
+        workspaceState: {
+          keys: () => [...workspaceValues.keys()],
+          get: (key, fallback) =>
+            workspaceValues.has(key) ? workspaceValues.get(key) : fallback,
+          update: async (key, value) => {
+            workspaceUpdates.push([key, value])
+            workspaceValues.set(key, value)
+          },
+        },
+      },
+      testPort
+    )
     const panel = createMockWebviewPanel()
     const document = await provider.openCustomDocument(
       vscode.Uri.file(samplePath),
@@ -3279,19 +3295,23 @@ suite('OmegaEdit VS Code extension', () => {
         session,
         'Expected a live session for the bytes-per-row refresh test'
       )
-      session.bytesPerRowSetting = 0
-      session.bytesPerRow = 32
+      assert.equal(session.bytesPerRow, 32)
 
-      provider.refreshBytesPerRow(0)
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'setBytesPerRow',
+        bytesPerRow: 24,
+      })
 
       assert.equal(panel.webview.html, initialHtml)
+      assert.deepEqual(workspaceUpdates, [['omegaEdit.bytesPerRow', 24]])
+      assert.equal(workspaceValues.get('omegaEdit.bytesPerRow'), 24)
       const bytesPerRowMessage = lastMessageOfType(
         panel.messages,
         'bytesPerRow'
       )
       assert.deepEqual(bytesPerRowMessage, {
         type: 'bytesPerRow',
-        bytesPerRow: 16,
+        bytesPerRow: 24,
         bytesPerRowMode: 'fixed',
       })
     } finally {

--- a/vscode-extension/webview-ui/src/protocol.ts
+++ b/vscode-extension/webview-ui/src/protocol.ts
@@ -32,9 +32,7 @@ export {
   MIN_BYTES_PER_ROW,
   TEXT_ENCODING_OPTIONS,
   WEBVIEW_ACTION_JOURNAL_KINDS,
-  bytesPerRowFromSetting,
   normalizeBytesPerRow,
   normalizeBytesPerRowMode,
-  normalizeBytesPerRowSetting,
   normalizeTextEncoding,
 } from '../../src/webviewProtocol'


### PR DESCRIPTION
## Summary

- Persist the VS Code editor's bytes-per-row preference locally and update the live webview without replacing it.
- Add one bounded retained-history visitor covering active and redoable history, then reuse it for redo counts, serial lookup, transaction counts, and action-journal pagination.
- Eliminate repeated change-log payload-context repair and enforce output-entry limits while planning.
- Share atomic change-log output lifecycle code, proto/domain kind conversion, and singleton count request plumbing.
- Fetch AI session status counts in one coherent multi-count RPC.
- Remove obsolete write-only change-count adjustment state and report undo-snapshot allocation degradation.
- Prune resolved entries and stale cross-references from `dev-notes/SHORTCOMINGS.md`.

## Why

Recent change-log, checkpoint, and history work left parallel traversal and conversion paths. In particular, action-journal pagination repeatedly searched history from the root, redo transaction counts did not cover the same retained suffix as redo change counts, and optimized export repeatedly repaired all accumulated payload contexts. These paths could become unnecessarily expensive and could report inconsistent history depth after checkpoint navigation.

The extension's row-size preference was also represented as a synchronized configuration setting even though it is editor-local presentation state, causing avoidable webview replacement and configuration churn.

## Impact

History consumers now use one authoritative traversal, journal paging is linear in the requested retained range, redo counts remain consistent across checkpoints and transform-preserved suffixes, and change-log writers share their durability and cleanup behavior. Client status snapshots require fewer RPCs. The bytes-per-row setting stays local and updates the active editor directly.

## Validation

- `cmake --build _build -j2`
- `ctest --test-dir _build/core --output-on-failure` — 156/156 passed
- Rebuilt `server/cpp/build-linux-brutal/omega-edit-grpc-server`
- `yarn workspace @omega-edit/client build`
- `yarn workspace @omega-edit/client test:codec` — 23/23 passed
- Action-journal and undo/redo integration — 8/8 passed
- `yarn workspace @omega-edit/ai build`
- AI toolkit, MCP, and CLI tests — 23/23 passed
- Extension lint, TypeScript build, Svelte checks, and Vite build passed
- Extension unit tests — 34/34 passed
- Extension integration tests — 35 passed, 1 observation-only test pending
- ClangFormat and Biome checks passed
