### PR TITLE
Promote zlib and zstd transform plugins

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -277,7 +277,7 @@ Start the server with `transformPluginDirectories` or `--transform-plugin-dir`
 before listing or applying plugins. See the
 [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins)
 for ABI, SDK, plugin package layout, and exemplar plugin details, including base64
-encode/decode, text codecs, character transcoding, zlib compress/decompress,
+encode/decode, text codecs, character transcoding, zlib and Zstandard compress/decompress,
 record/message helpers, and inspect-only digest/checksum examples.
 
 ### Logging

--- a/packages/client/tests/specs/transformPlugin.spec.ts
+++ b/packages/client/tests/specs/transformPlugin.spec.ts
@@ -136,6 +136,7 @@ describe('Transform plugin gRPC integration', () => {
         'omega.example.record_text_helpers',
         'omega.example.text_codecs',
         'omega.example.zlib',
+        'omega.example.zstd',
         'omega.example.repeat',
       ])
       const bitwisePlugin = plugins.find(
@@ -170,6 +171,16 @@ describe('Transform plugin gRPC integration', () => {
         '{"action":"compress","level":-1}'
       )
       expect(zlibPlugin?.argsSchema).to.include('"maximum":9')
+      expect(zlibPlugin?.argsSchema).to.include('"maximum":67108864')
+      const zstdPlugin = plugins.find(
+        (plugin) => plugin.id === 'omega.example.zstd'
+      )
+      expect(zstdPlugin?.help).to.include('decoder windows')
+      expect(zstdPlugin?.defaultArgs).to.equal(
+        '{"action":"compress","level":3}'
+      )
+      expect(zstdPlugin?.argsSchema).to.include('"maximum":22')
+      expect(zstdPlugin?.argsSchema).to.include('"maximum":67108864')
       const digestPlugin = plugins.find(
         (plugin) => plugin.id === 'omega.example.openssl_digests'
       )

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -178,7 +178,7 @@ test-only opt-in when used by test harnesses.
 Use the platform path-list separator (`:` on Unix-like systems, `;` on Windows).
 See the [Transform Plugins guide](https://github.com/ctc-oss/omega-edit/wiki/Transform-Plugins) for the native ABI,
 SDK helpers, plugin package layout, and exemplar plugins, including base64
-encode/decode, bitwise transforms, zlib compress/decompress, text codecs,
+encode/decode, bitwise transforms, zlib and Zstandard compress/decompress, text codecs,
 character transcoding, record/message helpers, and inspect-only digest/checksum
 examples.
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -319,7 +319,7 @@ if (BUILD_TESTS)
 
     add_executable(omega_transform_plugin_tests tests/transform_plugin_tests.cpp)
     target_link_libraries(omega_transform_plugin_tests PRIVATE omega_edit::omega_edit Catch2::Catch2WithMain
-            ${FILESYSTEM_LIB})
+            ZLIB::ZLIB ${ZSTD_TARGET} ${FILESYSTEM_LIB})
     target_include_directories(omega_transform_plugin_tests PRIVATE ${OMEGA_EDIT_TRANSFORM_PLUGIN_TEST_BINARY_DIR})
     set_target_properties(omega_transform_plugin_tests PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${OMEGA_EDIT_TRANSFORM_PLUGIN_TEST_BINARY_DIR})

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,13 +11,13 @@ default arguments, and an optional JSON Schema for validating options on both
 the client and native apply path. The bitwise exemplar exposes one action with
 an `operator` field plus a single repeated byte or repeating mask sequence, for
 example `{"operator":"xor","byte":"0x42"}` or
-`{"operator":"and","mask":["0x0F","0xF0"]}`. The zlib exemplar exposes an
+`{"operator":"and","mask":["0x0F","0xF0"]}`. The production zlib plugin exposes an
 `action` field for compression or decompression; compression accepts `level`
 values from `-1` through `9`, and decompression accepts `maxOutputBytes` with a
-64 MiB default cap.
-The zstd exemplar provides the same actions and decompression cap, with
+64 MiB default and absolute safety cap.
+The production zstd plugin provides the same actions and decompression cap, with
 compression levels from `1` (fastest) through `22` (smallest) and a default of
-`3`.
+`3`. Its decoder window is also capped at 64 MiB.
 The production detector plugins provide on-demand MIME content type detection
 (`omega.detect.content_type`) and language detection (`omega.detect.language`).
 Content type detection uses libmagic when available and falls back to built-in

--- a/plugins/src/zlib.c
+++ b/plugins/src/zlib.c
@@ -38,10 +38,11 @@ static const char ZLIB_ARGS_SCHEMA[] =
         "\"description\":\"Used when compressing: -1 uses the zlib default; 0 stores without compression; "
         "9 is smallest.\",\"default\":-1,\"minimum\":-1,\"maximum\":9},\"maxOutputBytes\":{\"type\":\"integer\","
         "\"title\":\"Maximum decompressed bytes\",\"description\":\"Used when decompressing. Expansion above this "
-        "limit fails before allocating more output memory.\",\"default\":67108864,\"minimum\":1}},"
+        "limit fails before allocating more output memory. The production safety ceiling is 64 MiB.\","
+        "\"default\":67108864,\"minimum\":1,\"maximum\":67108864}},"
         "\"additionalProperties\":false}";
 
-static const int64_t ZLIB_DEFAULT_MAX_OUTPUT_BYTES = OMEGA_MEMORY_BUFFER_LIMIT;
+static const int64_t ZLIB_MAX_OUTPUT_BYTES = OMEGA_MEMORY_BUFFER_LIMIT;
 
 static int input_length_to_ulong(int64_t input_length, uLong *input_length_out) {
     if (!input_length_out || input_length < 0 || (uint64_t) input_length > ULONG_MAX) { return -1; }
@@ -78,7 +79,7 @@ static int zlib_parse_positive_int64(const char **cursor, int64_t *value_out) {
     errno = 0;
     char *end_ptr = NULL;
     const long long parsed = strtoll(*cursor, &end_ptr, 10);
-    if (end_ptr == *cursor || errno == ERANGE || parsed < 1 || (uint64_t) parsed > INT64_MAX) { return -1; }
+    if (end_ptr == *cursor || errno == ERANGE || parsed < 1 || parsed > ZLIB_MAX_OUTPUT_BYTES) { return -1; }
     *cursor = end_ptr;
     *value_out = (int64_t) parsed;
     return 0;
@@ -88,7 +89,7 @@ static int zlib_parse_options(const char *options_json, omega_zlib_options_t *op
     if (!options_out) { return -1; }
     options_out->action = OMEGA_ZLIB_COMPRESS;
     options_out->level = Z_DEFAULT_COMPRESSION;
-    options_out->max_output_bytes = ZLIB_DEFAULT_MAX_OUTPUT_BYTES;
+    options_out->max_output_bytes = ZLIB_MAX_OUTPUT_BYTES;
     if (!options_json || !*options_json) { return 0; }
 
     const char *cursor = options_json;
@@ -228,11 +229,11 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
                       OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
     info_ptr->help = "Choose compress or decompress. Compression level uses -1 for the zlib default, "
                      "0 for no compression, 1 for fastest compression, or 9 for best compression. "
-                     "Decompression stops at maxOutputBytes, defaulting to 64 MiB.";
+                     "Decompression stops at maxOutputBytes, which defaults to and cannot exceed 64 MiB.";
     info_ptr->example = "{\"action\":\"compress\",\"level\":9}";
     info_ptr->default_args = "{\"action\":\"compress\",\"level\":-1}";
     info_ptr->args_schema = ZLIB_ARGS_SCHEMA;
-    info_ptr->support = OMEGA_TRANSFORM_PLUGIN_SUPPORT_EXPERIMENTAL;
+    info_ptr->support = OMEGA_TRANSFORM_PLUGIN_SUPPORT_PRODUCTION;
     info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }

--- a/plugins/src/zstd.c
+++ b/plugins/src/zstd.c
@@ -37,10 +37,12 @@ static const char ZSTD_ARGS_SCHEMA[] =
         "\"description\":\"Used when compressing: 1 is fastest; 22 is smallest.\",\"default\":3,"
         "\"minimum\":1,\"maximum\":22},\"maxOutputBytes\":{\"type\":\"integer\","
         "\"title\":\"Maximum decompressed bytes\",\"description\":\"Used when decompressing. Expansion above this "
-        "limit fails before allocating more output memory.\",\"default\":67108864,\"minimum\":1}},"
+        "limit fails before allocating more output memory. The production safety ceiling is 64 MiB.\","
+        "\"default\":67108864,\"minimum\":1,\"maximum\":67108864}},"
         "\"additionalProperties\":false}";
 
-static const int64_t ZSTD_DEFAULT_MAX_OUTPUT_BYTES = OMEGA_MEMORY_BUFFER_LIMIT;
+static const int64_t ZSTD_MAX_OUTPUT_BYTES = OMEGA_MEMORY_BUFFER_LIMIT;
+static const int ZSTD_MAX_WINDOW_LOG = 26;
 
 static int zstd_parse_action(const char *value, omega_zstd_action_t *action_out) {
     if (!value || !action_out) { return -1; }
@@ -70,7 +72,7 @@ static int zstd_parse_positive_int64(const char **cursor, int64_t *value_out) {
     errno = 0;
     char *end_ptr = NULL;
     const long long parsed = strtoll(*cursor, &end_ptr, 10);
-    if (end_ptr == *cursor || errno == ERANGE || parsed < 1) { return -1; }
+    if (end_ptr == *cursor || errno == ERANGE || parsed < 1 || parsed > ZSTD_MAX_OUTPUT_BYTES) { return -1; }
     *cursor = end_ptr;
     *value_out = (int64_t) parsed;
     return 0;
@@ -80,7 +82,7 @@ static int zstd_parse_options(const char *options_json, omega_zstd_options_t *op
     if (!options_out) { return -1; }
     options_out->action = OMEGA_ZSTD_COMPRESS;
     options_out->level = 3;
-    options_out->max_output_bytes = ZSTD_DEFAULT_MAX_OUTPUT_BYTES;
+    options_out->max_output_bytes = ZSTD_MAX_OUTPUT_BYTES;
     if (!options_json || !*options_json) { return 0; }
 
     const char *cursor = options_json;
@@ -168,6 +170,10 @@ static int zstd_decompress(const omega_transform_plugin_request_t *request_ptr,
     }
     ZSTD_DCtx *context = ZSTD_createDCtx();
     if (!context) { return -1; }
+    if (ZSTD_isError(ZSTD_DCtx_setParameter(context, ZSTD_d_windowLogMax, ZSTD_MAX_WINDOW_LOG))) {
+        ZSTD_freeDCtx(context);
+        return -1;
+    }
 
     omega_byte_t *output = NULL;
     size_t capacity = 0;
@@ -213,11 +219,12 @@ OMEGA_TRANSFORM_PLUGIN_EXPORT int omega_transform_plugin_get_info(omega_transfor
     info_ptr->flags = OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_EXPAND | OMEGA_TRANSFORM_PLUGIN_FLAG_MAY_SHRINK |
                       OMEGA_TRANSFORM_PLUGIN_FLAG_BINARY_SAFE;
     info_ptr->help = "Choose compress or decompress. Compression level ranges from 1 (fastest) through 22 "
-                     "(smallest), defaulting to 3. Decompression stops at maxOutputBytes, defaulting to 64 MiB.";
+                     "(smallest), defaulting to 3. Decompression stops at maxOutputBytes, which defaults to and cannot "
+                     "exceed 64 MiB; decoder windows are bounded to the same ceiling.";
     info_ptr->example = "{\"action\":\"compress\",\"level\":19}";
     info_ptr->default_args = "{\"action\":\"compress\",\"level\":3}";
     info_ptr->args_schema = ZSTD_ARGS_SCHEMA;
-    info_ptr->support = OMEGA_TRANSFORM_PLUGIN_SUPPORT_EXPERIMENTAL;
+    info_ptr->support = OMEGA_TRANSFORM_PLUGIN_SUPPORT_PRODUCTION;
     info_ptr->abi_version = OMEGA_TRANSFORM_PLUGIN_ABI_VERSION;
     return 0;
 }

--- a/plugins/tests/transform_plugin_tests.cpp
+++ b/plugins/tests/transform_plugin_tests.cpp
@@ -25,6 +25,8 @@
 #include <iterator>
 #include <string>
 #include <vector>
+#include <zlib.h>
+#include <zstd.h>
 
 namespace {
     struct cancellation_state_t {
@@ -96,7 +98,7 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(production_registry_ptr);
     REQUIRE(0 <
             omega_transform_plugin_registry_register_directory(production_registry_ptr, PLUGIN_DIR.string().c_str()));
-    REQUIRE(8 == omega_transform_plugin_registry_get_count(production_registry_ptr));
+    REQUIRE(10 == omega_transform_plugin_registry_get_count(production_registry_ptr));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(production_registry_ptr, "omega.example.base64"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(production_registry_ptr, "omega.example.bitwise"));
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(production_registry_ptr, "omega.example.case_change"));
@@ -107,6 +109,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(nullptr != omega_transform_plugin_registry_find_info(production_registry_ptr, "omega.detect.language"));
     REQUIRE(nullptr !=
             omega_transform_plugin_registry_find_info(production_registry_ptr, "omega.example.openssl_digests"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(production_registry_ptr, "omega.example.zlib"));
+    REQUIRE(nullptr != omega_transform_plugin_registry_find_info(production_registry_ptr, "omega.example.zstd"));
     REQUIRE(nullptr ==
             omega_transform_plugin_registry_find_info(production_registry_ptr, "omega.example.character_transcode"));
     REQUIRE(nullptr ==
@@ -317,6 +321,7 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                                    language_info->args_schema));
     const auto zlib_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zlib");
     REQUIRE("Zlib" == std::string(zlib_info->name));
+    REQUIRE(OMEGA_TRANSFORM_PLUGIN_SUPPORT_PRODUCTION == zlib_info->support);
     REQUIRE(std::string(zlib_info->help).find("Compression level") != std::string::npos);
     REQUIRE("{\"action\":\"compress\",\"level\":9}" == std::string(zlib_info->example));
     REQUIRE("{\"action\":\"compress\",\"level\":-1}" == std::string(zlib_info->default_args));
@@ -330,8 +335,11 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                                    zlib_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"action\":\"decompress\",\"maxOutputBytes\":0}",
                                                                    zlib_info->args_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(
+                          "{\"action\":\"decompress\",\"maxOutputBytes\":67108865}", zlib_info->args_schema));
     const auto zstd_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.zstd");
     REQUIRE("Zstandard" == std::string(zstd_info->name));
+    REQUIRE(OMEGA_TRANSFORM_PLUGIN_SUPPORT_PRODUCTION == zstd_info->support);
     REQUIRE("{\"action\":\"compress\",\"level\":3}" == std::string(zstd_info->default_args));
     REQUIRE(0 == omega_transform_plugin_options_match_args_schema("{\"action\":\"compress\",\"level\":22}",
                                                                   zstd_info->args_schema));
@@ -339,6 +347,8 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                                   zstd_info->args_schema));
     REQUIRE(-1 == omega_transform_plugin_options_match_args_schema("{\"action\":\"compress\",\"level\":23}",
                                                                    zstd_info->args_schema));
+    REQUIRE(-1 == omega_transform_plugin_options_match_args_schema(
+                          "{\"action\":\"decompress\",\"maxOutputBytes\":67108865}", zstd_info->args_schema));
     const auto cipher_info = omega_transform_plugin_registry_find_info(registry_ptr, "omega.example.openssl_ciphers");
     REQUIRE("OpenSSL Ciphers" == std::string(cipher_info->name));
     REQUIRE(std::string(cipher_info->description).find("Encrypt") != std::string::npos);
@@ -1151,12 +1161,18 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                                   0, 5, "{\"action\":\"compress\",\"level\":9}",
                                                                   &response));
     REQUIRE(0 < response.replacement_length);
-    {
-        const auto compressed = omega_session_get_segment_string(
-                codec_session_ptr, 0, omega_session_get_computed_file_size(codec_session_ptr));
-        REQUIRE(response.replacement_length == static_cast<int64_t>(compressed.size()));
-        REQUIRE(8 == (static_cast<unsigned char>(compressed[0]) & 0x0F));
-    }
+    const auto compressed_zlib_hello = omega_session_get_segment_string(
+            codec_session_ptr, 0, omega_session_get_computed_file_size(codec_session_ptr));
+    REQUIRE(response.replacement_length == static_cast<int64_t>(compressed_zlib_hello.size()));
+    REQUIRE(8 == (static_cast<unsigned char>(compressed_zlib_hello[0]) & 0x0F));
+    std::vector<omega_byte_t> external_zlib_output(5);
+    uLongf external_zlib_output_length = static_cast<uLongf>(external_zlib_output.size());
+    REQUIRE(Z_OK == uncompress(external_zlib_output.data(), &external_zlib_output_length,
+                               reinterpret_cast<const Bytef *>(compressed_zlib_hello.data()),
+                               static_cast<uLong>(compressed_zlib_hello.size())));
+    REQUIRE(5 == external_zlib_output_length);
+    REQUIRE("hello" ==
+            std::string(reinterpret_cast<const char *>(external_zlib_output.data()), external_zlib_output.size()));
     omega_transform_plugin_response_clear(&response);
 
     REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib", codec_session_ptr,
@@ -1165,6 +1181,58 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                                         omega_session_get_computed_file_size(codec_session_ptr)));
     REQUIRE(5 == response.replacement_length);
     omega_transform_plugin_response_clear(&response);
+
+    const std::string interoperability_text = "OmegaEdit interoperability vector";
+    // Frozen output from the upstream zlib implementation, independent of the plugin encode path.
+    const std::vector<omega_byte_t> known_zlib_frame = {
+            0x78, 0xda, 0xf3, 0xcf, 0x4d, 0x4d, 0x4f, 0x74, 0x4d, 0xc9, 0x2c, 0x51, 0xc8, 0xcc,
+            0x2b, 0x49, 0x2d, 0xca, 0x2f, 0x48, 0x2d, 0x4a, 0x4c, 0xca, 0xcc, 0xc9, 0x2c, 0xa9,
+            0x54, 0x28, 0x4b, 0x4d, 0x2e, 0xc9, 0x2f, 0x02, 0x00, 0xd8, 0xf0, 0x0d, 0x09,
+    };
+    const auto known_zlib_session_ptr = create_session_from_vector(known_zlib_frame);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib",
+                                                                  known_zlib_session_ptr, 0, 0,
+                                                                  "{\"action\":\"decompress\"}", &response));
+    REQUIRE(interoperability_text ==
+            omega_session_get_segment_string(known_zlib_session_ptr, 0,
+                                             omega_session_get_computed_file_size(known_zlib_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(known_zlib_session_ptr);
+
+    const std::vector<omega_byte_t> empty_zlib_frame = {0x78, 0xda, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01};
+    const auto empty_zlib_session_ptr = create_session_from_vector(empty_zlib_frame);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zlib",
+                                                                  empty_zlib_session_ptr, 0, 0,
+                                                                  "{\"action\":\"decompress\"}", &response));
+    REQUIRE(0 == omega_session_get_computed_file_size(empty_zlib_session_ptr));
+    REQUIRE(0 == response.replacement_length);
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(empty_zlib_session_ptr);
+
+    auto require_decode_failure_without_change = [&](const char *plugin_id,
+                                                     const std::vector<omega_byte_t> &input_bytes) {
+        const auto failure_session_ptr = create_session_from_vector(input_bytes);
+        const auto change_count = omega_session_get_num_changes(failure_session_ptr);
+        REQUIRE(-1 == omega_transform_plugin_registry_apply_to_session(registry_ptr, plugin_id, failure_session_ptr, 0,
+                                                                       0, "{\"action\":\"decompress\"}", &response));
+        REQUIRE(change_count == omega_session_get_num_changes(failure_session_ptr));
+        const auto unchanged_bytes = omega_session_get_segment_string(
+                failure_session_ptr, 0, omega_session_get_computed_file_size(failure_session_ptr));
+        REQUIRE(input_bytes.size() == unchanged_bytes.size());
+        REQUIRE(0 == std::memcmp(input_bytes.data(), unchanged_bytes.data(), input_bytes.size()));
+        omega_transform_plugin_response_clear(&response);
+        omega_edit_destroy_session(failure_session_ptr);
+    };
+
+    auto truncated_zlib_frame = known_zlib_frame;
+    truncated_zlib_frame.pop_back();
+    require_decode_failure_without_change("omega.example.zlib", truncated_zlib_frame);
+    auto trailing_zlib_frame = known_zlib_frame;
+    trailing_zlib_frame.push_back(0x00);
+    require_decode_failure_without_change("omega.example.zlib", trailing_zlib_frame);
+    auto corrupt_zlib_frame = known_zlib_frame;
+    corrupt_zlib_frame[corrupt_zlib_frame.size() / 2] ^= 0xff;
+    require_decode_failure_without_change("omega.example.zlib", corrupt_zlib_frame);
 
     const auto zlib_bomb_session_ptr = omega_edit_create_session(nullptr, nullptr, nullptr, NO_EVENTS, nullptr);
     REQUIRE(zlib_bomb_session_ptr);
@@ -1217,6 +1285,13 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
     REQUIRE(static_cast<unsigned char>(compressed_zstd[1]) == 0xB5);
     REQUIRE(static_cast<unsigned char>(compressed_zstd[2]) == 0x2F);
     REQUIRE(static_cast<unsigned char>(compressed_zstd[3]) == 0xFD);
+    std::vector<omega_byte_t> external_zstd_output(repeated_zstd_input.size());
+    const auto external_zstd_output_length = ZSTD_decompress(external_zstd_output.data(), external_zstd_output.size(),
+                                                             compressed_zstd.data(), compressed_zstd.size());
+    REQUIRE(!ZSTD_isError(external_zstd_output_length));
+    REQUIRE(repeated_zstd_input.size() == external_zstd_output_length);
+    REQUIRE(repeated_zstd_input ==
+            std::string(reinterpret_cast<const char *>(external_zstd_output.data()), external_zstd_output_length));
     omega_transform_plugin_response_clear(&response);
 
     const auto zstd_cap_change_count = omega_session_get_num_changes(zstd_session_ptr);
@@ -1237,6 +1312,59 @@ TEST_CASE("Packaged Transform Plugins", "[TransformPlugin]") {
                                              omega_session_get_computed_file_size(zstd_session_ptr)));
     omega_transform_plugin_response_clear(&response);
     omega_edit_destroy_session(zstd_session_ptr);
+
+    // Frozen output from the upstream Zstandard implementation, independent of the plugin encode path.
+    const std::vector<omega_byte_t> known_zstd_frame = {
+            0x28, 0xb5, 0x2f, 0xfd, 0x20, 0x21, 0x09, 0x01, 0x00, 0x4f, 0x6d, 0x65, 0x67, 0x61,
+            0x45, 0x64, 0x69, 0x74, 0x20, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6f, 0x70, 0x65, 0x72,
+            0x61, 0x62, 0x69, 0x6c, 0x69, 0x74, 0x79, 0x20, 0x76, 0x65, 0x63, 0x74, 0x6f, 0x72,
+    };
+    const auto known_zstd_session_ptr = create_session_from_vector(known_zstd_frame);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zstd",
+                                                                  known_zstd_session_ptr, 0, 0,
+                                                                  "{\"action\":\"decompress\"}", &response));
+    REQUIRE(interoperability_text ==
+            omega_session_get_segment_string(known_zstd_session_ptr, 0,
+                                             omega_session_get_computed_file_size(known_zstd_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(known_zstd_session_ptr);
+
+    const std::vector<omega_byte_t> empty_zstd_frame = {0x28, 0xb5, 0x2f, 0xfd, 0x20, 0x00, 0x01, 0x00, 0x00};
+    const auto empty_zstd_session_ptr = create_session_from_vector(empty_zstd_frame);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zstd",
+                                                                  empty_zstd_session_ptr, 0, 0,
+                                                                  "{\"action\":\"decompress\"}", &response));
+    REQUIRE(0 == omega_session_get_computed_file_size(empty_zstd_session_ptr));
+    REQUIRE(0 == response.replacement_length);
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(empty_zstd_session_ptr);
+
+    auto truncated_zstd_frame = known_zstd_frame;
+    truncated_zstd_frame.pop_back();
+    require_decode_failure_without_change("omega.example.zstd", truncated_zstd_frame);
+    auto trailing_zstd_frame = known_zstd_frame;
+    trailing_zstd_frame.push_back(0x00);
+    require_decode_failure_without_change("omega.example.zstd", trailing_zstd_frame);
+    auto corrupt_zstd_frame = known_zstd_frame;
+    corrupt_zstd_frame[0] ^= 0xff;
+    require_decode_failure_without_change("omega.example.zstd", corrupt_zstd_frame);
+
+    // This is a valid empty frame with a 128 MiB window. The production decoder ceiling is 64 MiB.
+    const std::vector<omega_byte_t> oversized_window_zstd_frame = {0x28, 0xb5, 0x2f, 0xfd, 0x00,
+                                                                   0x88, 0x01, 0x00, 0x00};
+    require_decode_failure_without_change("omega.example.zstd", oversized_window_zstd_frame);
+
+    auto concatenated_zstd_frames = known_zstd_frame;
+    concatenated_zstd_frames.insert(concatenated_zstd_frames.end(), known_zstd_frame.begin(), known_zstd_frame.end());
+    const auto concatenated_zstd_session_ptr = create_session_from_vector(concatenated_zstd_frames);
+    REQUIRE(0 == omega_transform_plugin_registry_apply_to_session(registry_ptr, "omega.example.zstd",
+                                                                  concatenated_zstd_session_ptr, 0, 0,
+                                                                  "{\"action\":\"decompress\"}", &response));
+    REQUIRE(interoperability_text + interoperability_text ==
+            omega_session_get_segment_string(concatenated_zstd_session_ptr, 0,
+                                             omega_session_get_computed_file_size(concatenated_zstd_session_ptr)));
+    omega_transform_plugin_response_clear(&response);
+    omega_edit_destroy_session(concatenated_zstd_session_ptr);
 
     REQUIRE(0 <
             omega_edit_insert_string(codec_session_ptr, omega_session_get_computed_file_size(codec_session_ptr), "!"));

--- a/scripts/verify-package-contents.js
+++ b/scripts/verify-package-contents.js
@@ -100,10 +100,16 @@ function verifyCore(packageFiles, packageSize) {
     )
   if (
     !plugins.some((entry) =>
+      /omega_transform_zlib\.(?:dll|dylib|so)$/.test(entry)
+    )
+  )
+    fail('Core package is missing the production zlib transform plugin')
+  if (
+    !plugins.some((entry) =>
       /omega_transform_zstd\.(?:dll|dylib|so)$/.test(entry)
     )
   )
-    fail('Core package is missing the zstd transform plugin')
+    fail('Core package is missing the production zstd transform plugin')
   rejectMatches(packageFiles, [
     /\/(?:src|tests|node_modules|\.venv[^/]*)\//,
     /\/(?:CMakeCache\.txt|cmake_install\.cmake)$/,

--- a/vscode-extension/scripts/verify-vsix.cjs
+++ b/vscode-extension/scripts/verify-vsix.cjs
@@ -101,8 +101,10 @@ for (const platform of packagedPlatforms) {
   )
   if (plugins.length < 17)
     fail(`VSIX contains ${plugins.length} transform plugins for ${platform}; expected at least 17`)
+  if (!plugins.some((entry) => /omega_transform_zlib\.(?:dll|dylib|so)$/.test(entry)))
+    fail(`VSIX is missing the production zlib transform plugin for ${platform}`)
   if (!plugins.some((entry) => /omega_transform_zstd\.(?:dll|dylib|so)$/.test(entry)))
-    fail(`VSIX is missing the zstd transform plugin for ${platform}`)
+    fail(`VSIX is missing the production zstd transform plugin for ${platform}`)
 }
 if (entries.length > 200) fail(`VSIX contains ${entries.length} entries; limit is 200`)
 if (size > 70 * 1024 * 1024) fail(`VSIX is ${(size / (1024 * 1024)).toFixed(1)} MiB; limit is 70 MiB`)

--- a/wiki/Transform-Plugins.md
+++ b/wiki/Transform-Plugins.md
@@ -216,6 +216,7 @@ plugins/
 |- omega_transform_record_text_helpers.dll
 |- omega_transform_text_codecs.dll
 |- omega_transform_zlib.dll
+|- omega_transform_zstd.dll
 `- omega_transform_repeat.dll
 ```
 
@@ -345,13 +346,14 @@ The repository ships small examples in `plugins/src/`:
 | `omega.example.openssl_digests` | `openssl_digests.c` | Inspect | MD5, SHA-1, SHA-2, SHA-3, and BLAKE2 digest calculation using OpenSSL 3 without changing session content. |
 | `omega.example.record_text_helpers` | `record_text_helpers.cpp` | Replace | Newline normalization, fixed-width lines, delimiter escaping, CSV quoting, XML entities, and JSON string escaping. |
 | `omega.example.text_codecs` | `text_codecs.cpp` | Replace | Hex/base16, Base64URL, Base32, Base32-Crockford, Ascii85/Base85, Z85, Base58, percent/URL, quoted-printable, uuencode, and yEnc encode/decode helpers. Base58 is capped at 64 KiB selections. |
-| `omega.example.zlib` | `zlib.c` | Replace | Zlib compression/decompression with an `action` option. Compression accepts `level` values from `-1` through `9`; decompression accepts `maxOutputBytes` with a 64 MiB default cap. |
+| `omega.example.zlib` | `zlib.c` | Replace | Production zlib compression/decompression with an `action` option. Compression accepts `level` values from `-1` through `9`; decompression accepts `maxOutputBytes` with a 64 MiB default and absolute safety cap. Exactly one zlib stream is accepted per decompression. |
+| `omega.example.zstd` | `zstd.c` | Replace | Production Zstandard compression/decompression with an `action` option. Compression accepts `level` values from `1` through `22`; decompression has a 64 MiB output and decoder-window safety ceiling and accepts concatenated Zstandard frames. |
 | `omega.example.repeat` | `repeat.c` | Replace | Expansion by replacing a range with two copies of itself. |
 
-These examples are intentionally small so they can serve as test fixtures and copyable
-developer starting points. Third-party dependencies belong to the plugin package,
-not the core ABI/loader package; the zlib and OpenSSL digest exemplars use
-`plugins/conanfile.py`.
+These plugins are intentionally small so they can serve as test fixtures and
+copyable developer starting points. Third-party dependencies belong to the
+plugin package, not the core ABI/loader package; the compression and OpenSSL
+plugins use `plugins/conanfile.py`.
 
 MD5 and SHA-1 are provided for legacy formats, interoperability checks, and
 low-security data inspection workflows. Do not use them for security-sensitive
@@ -379,6 +381,31 @@ When adding release plugins:
 3. Add native registry/harness coverage under `plugins/tests/`.
 4. Add client or AI coverage if the plugin exercises new behavior.
 5. Document the plugin ID, operation, options JSON, and result format.
+
+## Promoting Experimental Plugins
+
+Production plugins load by default, so promotion is a compatibility and
+security commitment rather than only a metadata change. A promotion pull
+request must demonstrate:
+
+1. Stable plugin ID, options schema, defaults, output, and failure behavior.
+2. Independent interoperability vectors where an external format or protocol
+   applies.
+3. Positive, boundary, empty, malformed, truncated, trailing-input,
+   cancellation, and rollback coverage appropriate to the operation.
+4. Explicit input, output, intermediate-memory, and dependency-specific
+   resource ceilings for data-amplifying or parser plugins.
+5. Passing native plugin tests on supported Windows, macOS, Linux, and ARM64
+   release targets.
+6. Production-registry discovery without the experimental opt-in and package
+   or VSIX content verification.
+7. User documentation and release notes describing the newly default plugin
+   and any security-sensitive behavior.
+
+After these gates pass, change the plugin support metadata to
+`OMEGA_TRANSFORM_PLUGIN_SUPPORT_PRODUCTION` and add an explicit production
+support assertion. Treat subsequent removal, incompatible option changes, or a
+downgrade to experimental as a breaking compatibility decision.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- promote the first-party zlib and Zstandard transform plugins from experimental to production support
- enforce a 64 MiB absolute decompression ceiling and a 64 MiB Zstandard decoder-window ceiling
- add upstream-library interoperability checks plus empty, corrupt, truncated, trailing-input, concatenated-frame, rollback, and oversized-window coverage
- verify both plugins in default production discovery and packaged core/VSIX contents
- document the production behavior and a reusable experimental-to-production promotion gate

## Why

Production plugins load without the experimental opt-in. The codecs already had round-trip and decompression-bomb coverage, but promotion needed a stable resource ceiling, Zstandard window protection, independent interoperability checks, and explicit production-registry/package assertions.

## User impact

`omega.example.zlib` and `omega.example.zstd` now load by default. `maxOutputBytes` remains configurable up to 64 MiB; values above that production safety ceiling are rejected. Zstandard decompression accepts concatenated frames while zlib decompression continues to require exactly one stream.

## Validation

- Debug native plugin build and `ctest --test-dir _build/plugins --output-on-failure`
- Clean Release native plugin build and `ctest --test-dir _build-plugin-promotion/plugins --output-on-failure`
- Biome checks for the changed TypeScript/JavaScript files
- Node syntax checks for both package-verification scripts
- `git diff --check`

Cross-platform Windows, macOS, Linux, and ARM64 coverage will run in the repository CI matrix.
