### PR TITLE
Add source file size to range maps

### DIFF
--- a/images/OmegaEditLogo.omega-ranges.json
+++ b/images/OmegaEditLogo.omega-ranges.json
@@ -2,6 +2,7 @@
   "format": "omega-edit.range-map",
   "version": 1,
   "source": "images/OmegaEditLogo.png",
+  "sourceFileSize": 1572763,
   "sourceFormat": "PNG",
   "producer": "OmegaEdit experimental PNG range-map fixture",
   "selectedPath": "/png/chunks[0]/data/width",

--- a/vscode-extension/src/rangeMap.ts
+++ b/vscode-extension/src/rangeMap.ts
@@ -31,6 +31,7 @@ export interface RangeMapDocument {
   format: typeof RANGE_MAP_FORMAT
   version: typeof RANGE_MAP_VERSION
   source?: string
+  sourceFileSize?: number
   selectedPath?: string
   nodes: RangeMapNode[]
 }
@@ -301,6 +302,15 @@ export function parseRangeMapContent(content: Uint8Array): ParsedRangeMap {
     parsed.source === undefined
       ? undefined
       : safeString(parsed.source, 'Range map source')
+  const sourceFileSize =
+    parsed.sourceFileSize === undefined
+      ? undefined
+      : safeNonNegativeInteger(parsed.sourceFileSize)
+  if (parsed.sourceFileSize !== undefined && sourceFileSize === undefined) {
+    throw new Error(
+      'Range map sourceFileSize must be a non-negative safe integer'
+    )
+  }
   const selectedPath =
     parsed.selectedPath === undefined
       ? undefined
@@ -327,6 +337,7 @@ export function parseRangeMapContent(content: Uint8Array): ParsedRangeMap {
     format: RANGE_MAP_FORMAT,
     version: RANGE_MAP_VERSION,
     source,
+    sourceFileSize,
     selectedPath,
     nodes,
   }
@@ -367,6 +378,14 @@ export function assertRangeMapFitsFile(
 ): void {
   if (!Number.isSafeInteger(fileSize) || fileSize < 0) {
     throw new Error('Range map file size must be a non-negative safe integer')
+  }
+  if (
+    parsed.document.sourceFileSize !== undefined &&
+    parsed.document.sourceFileSize !== fileSize
+  ) {
+    throw new Error(
+      `Range map source file size (${parsed.document.sourceFileSize} bytes) does not match open file size (${fileSize} bytes)`
+    )
   }
 
   for (const node of flattenRangeMapNodes(parsed.document.nodes)) {

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -2561,11 +2561,13 @@ test('range map parser loads the OmegaEdit PNG logo fixture', () => {
     __dirname,
     '../../images/OmegaEditLogo.omega-ranges.json'
   )
+  const sourcePath = path.resolve(__dirname, '../../images/OmegaEditLogo.png')
   const parsed = parseRangeMapContent(fs.readFileSync(fixturePath))
 
   assert.equal(parsed.document.format, 'omega-edit.range-map')
   assert.equal(parsed.document.version, 1)
   assert.equal(parsed.document.source, 'images/OmegaEditLogo.png')
+  assert.equal(parsed.document.sourceFileSize, fs.statSync(sourcePath).size)
   assert.equal(parsed.document.selectedPath, '/png/chunks[0]/data/width')
   assert.equal(parsed.document.nodes.length, 28)
   assert.equal(parsed.nodeCount, 142)
@@ -2609,6 +2611,10 @@ test('range map parser loads the OmegaEdit PNG logo fixture', () => {
     value: '1254',
     children: [],
   })
+
+  assert.doesNotThrow(() =>
+    assertRangeMapFitsFile(parsed, fs.statSync(sourcePath).size)
+  )
 })
 
 test('range map parser rejects hostile node shapes before flattening', () => {
@@ -2711,6 +2717,39 @@ test('range map file-fit validation names the offending node', () => {
   assert.throws(
     () => assertRangeMapFitsFile(parsed, 6),
     /Range map node \/too-far \[6, 7\) is outside file bounds \(6 bytes\)/
+  )
+})
+
+test('range map validates its optional source file size', () => {
+  const parsed = parseRangeMapContent(
+    encodeRangeMap({
+      sourceFileSize: 6,
+      nodes: [
+        {
+          path: '/byte',
+          offset: 0,
+          length: 1,
+        },
+      ],
+    })
+  )
+
+  assert.equal(parsed.document.sourceFileSize, 6)
+  assert.doesNotThrow(() => assertRangeMapFitsFile(parsed, 6))
+  assert.throws(
+    () => assertRangeMapFitsFile(parsed, 7),
+    /Range map source file size \(6 bytes\) does not match open file size \(7 bytes\)/
+  )
+
+  assert.throws(
+    () =>
+      parseRangeMapContent(
+        encodeRangeMap({
+          sourceFileSize: -1,
+          nodes: [],
+        })
+      ),
+    /Range map sourceFileSize must be a non-negative safe integer/
   )
 })
 


### PR DESCRIPTION
## Summary

- add optional top-level `sourceFileSize` metadata to the unreleased v1 range-map document model
- validate the value as a non-negative safe integer and require it to match the open file size when present
- update the PNG fixture and add parser/file-fit coverage

## Why

Range bounds alone cannot reliably identify a stale or incorrect source file, especially for partial maps. Recording the generated-against file size provides an inexpensive compatibility check while preserving support for maps that omit it.

## Validation

- `npm run lint` — passed
- `npm run compile:extension` — passed
- range-map unit tests — passed, including matching, mismatched, malformed, and omitted `sourceFileSize` cases
- the broader local unit invocation passed 34/35 tests; its compiled-entrypoint assertion expected a webview bundle that was not built by the preceding extension-only compile. CI will run the comprehensive build/test workflow.
