### PR TITLE
feat: add random-access action journal navigation

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -379,7 +379,7 @@ transform state, change-log status, and the command-surface map below.
 | Transform plugins | `omegaEdit.refreshTransformPlugins` | n/a | `oe list-transform-plugins`, `oe apply-transform-plugin` / transform MCP tools |
 | Checkpoints | Checkpoint commands | `createCheckpoint`, `restoreCheckpoint`, `rollbackCheckpoint` | Checkpoint CLI / MCP tools |
 | Change logs | `omegaEdit.exportChangeLog`, `omegaEdit.applyChangeLog` | `exportChangeLog`, `applyChangeLog` | `oe export-change-log`, `oe apply-change-log` / change-log MCP tools |
-| Action journal | `omegaEdit.showActionJournal` / Live History toolbar panel | `getActionJournalViewport` | Live transaction-aware rewind/fast-forward history with checkpoint landmarks |
+| Action journal | `omegaEdit.showActionJournal` / Live History toolbar panel | `getActionJournalViewport` | Live transaction-aware history with direct change checkout, rewind/fast-forward controls, and checkpoint landmarks |
 | External highlights / range maps | Hidden annotation commands | Highlight and range-map API methods | VS Code API only |
 
 ### Daffodil Integration Notes

--- a/vscode-extension/src/hexEditorProvider.ts
+++ b/vscode-extension/src/hexEditorProvider.ts
@@ -200,6 +200,7 @@ interface ActionJournalState {
   capacity: number
   direction: 'older' | 'newer'
   requestGeneration: number
+  navigating: boolean
   refreshTask?: Promise<void>
   refreshPending: boolean
 }
@@ -2255,6 +2256,9 @@ export class HexEditorProvider
         }
         await this.performRedoOnSession(session)
         return
+      case 'navigateActionJournal':
+        await this.navigateActionJournalToChangeCount(session, msg.changeCount)
+        return
       case 'save':
       case 'saveAs': {
         const cts = new vscode.CancellationTokenSource()
@@ -2559,6 +2563,7 @@ export class HexEditorProvider
         capacity: 256,
         direction: 'older',
         requestGeneration: 0,
+        navigating: false,
         refreshPending: false,
       },
     }
@@ -4327,7 +4332,7 @@ export class HexEditorProvider
     }
   }
 
-  private async navigateToCheckpoint(
+  private async checkoutHistoryCheckpoint(
     session: EditorSession,
     targetCheckpointCount: number
   ): Promise<CheckpointTimelineResult> {
@@ -4343,15 +4348,27 @@ export class HexEditorProvider
       )
     }
 
+    const targetFingerprint =
+      targetCheckpointCount === 0
+        ? timeline.originalFingerprint
+        : timeline.entries[targetCheckpointCount - 1].interval.after
+    let resetCurrentCheckpoint = false
     if (targetCheckpointCount === timeline.cursor) {
-      return {
-        state: this.buildEditorState(session),
-        checkpointCount,
-        moved: false,
+      const currentFingerprint = await getChangeLogFingerprint(
+        session.sessionId,
+        SessionFingerprintContent.COMPUTED,
+        'sha256'
+      )
+      if (timelineFingerprintsEqual(currentFingerprint, targetFingerprint)) {
+        return {
+          state: this.buildEditorState(session),
+          checkpointCount,
+          moved: false,
+        }
       }
+      resetCurrentCheckpoint = true
     }
 
-    await this.captureCheckpointTimelineTip(session)
     await this.assertCheckpointTimelineNativeAlignment(
       session,
       'before navigation'
@@ -4369,26 +4386,30 @@ export class HexEditorProvider
     const originalCursor = timeline.cursor
     try {
       const sessionSyncVersion = session.sessionSyncVersion
+      if (resetCurrentCheckpoint) {
+        if (targetCheckpointCount <= 0) {
+          throw new Error(
+            'The original checkpoint cannot be reset while it contains uncheckpointed changes'
+          )
+        }
+        await checkoutCheckpoint(session.sessionId, targetCheckpointCount - 1)
+      }
       const response = await checkoutCheckpoint(
         session.sessionId,
         targetCheckpointCount
       )
       if (
         response.checkpointCount !== targetCheckpointCount ||
-        response.futureCheckpointCount !==
+        response.futureCheckpointCount >
           timeline.entries.length - targetCheckpointCount
       ) {
         throw new Error(
-          `Native checkpoint checkout reached ${response.checkpointCount} with ${response.futureCheckpointCount} future checkpoints; expected ${targetCheckpointCount} with ${timeline.entries.length - targetCheckpointCount} future checkpoints`
+          `Native checkpoint checkout reached ${response.checkpointCount} with ${response.futureCheckpointCount} future checkpoints; expected checkpoint ${targetCheckpointCount} with at most ${timeline.entries.length - targetCheckpointCount} future checkpoints`
         )
       }
-      const expected =
-        targetCheckpointCount === 0
-          ? timeline.originalFingerprint
-          : timeline.entries[targetCheckpointCount - 1].interval.after
       await assertCurrentSessionFingerprint(
         session.sessionId,
-        expected,
+        targetFingerprint,
         'after'
       )
       timeline.cursor = targetCheckpointCount
@@ -4621,9 +4642,164 @@ export class HexEditorProvider
     })
   }
 
+  private async nearestCheckpointForChangeCount(
+    session: EditorSession,
+    targetChangeCount: number
+  ): Promise<{ checkpoint: number; changeCount: number }> {
+    let nearest = { checkpoint: 0, changeCount: 0 }
+    let nearestDistance = Math.abs(targetChangeCount)
+    const timeline = session.checkpointTimeline
+    const nativeTimeline = await checkoutCheckpoint(
+      session.sessionId,
+      timeline.cursor
+    )
+    const logicalFutureCount = timeline.entries.length - timeline.cursor
+    if (
+      nativeTimeline.checkpointCount !== timeline.cursor ||
+      nativeTimeline.futureCheckpointCount > logicalFutureCount
+    ) {
+      throw new Error(
+        `Native checkpoint timeline is misaligned at ${nativeTimeline.checkpointCount} with ${nativeTimeline.futureCheckpointCount} future checkpoints`
+      )
+    }
+    const firstUnavailableTransformIndex =
+      nativeTimeline.futureCheckpointCount < logicalFutureCount
+        ? timeline.entries.findIndex(
+            (entry, index) =>
+              index >= timeline.cursor &&
+              entry.interval.boundaryKind === 'transform'
+          )
+        : -1
+    session.checkpointTimeline.entries.forEach((entry, index) => {
+      const checkpoint = index + 1
+      if (
+        checkpoint > timeline.cursor &&
+        nativeTimeline.futureCheckpointCount < logicalFutureCount &&
+        (firstUnavailableTransformIndex < 0 ||
+          index >= firstUnavailableTransformIndex)
+      ) {
+        // Undoing a transform removes its checkpoint model and retains the
+        // transform as redo history. A directly checked-out transform remains
+        // a materialized future model, so only avoid future ordinals when the
+        // native future count proves that the logical timeline has a gap.
+        return
+      }
+      const distance = Math.abs(entry.changeCount - targetChangeCount)
+      if (
+        distance < nearestDistance ||
+        (distance === nearestDistance &&
+          entry.changeCount < nearest.changeCount)
+      ) {
+        nearest = {
+          checkpoint,
+          changeCount: entry.changeCount,
+        }
+        nearestDistance = distance
+      }
+    })
+    return nearest
+  }
+
+  private async navigateActionJournalToChangeCount(
+    session: EditorSession,
+    targetChangeCountValue: string
+  ): Promise<void> {
+    const targetChangeCount = normalizeNonNegativeInt64ForClient(
+      targetChangeCountValue,
+      'action journal change count'
+    )
+    const state = session.actionJournal
+    if (state.navigating) {
+      return
+    }
+    if (targetChangeCount === session.changeCount) {
+      await this.postActionJournalViewport(session)
+      return
+    }
+    if (!this.ensureSessionCanMutate(session, true)) {
+      await this.postActionJournalViewport(session)
+      return
+    }
+
+    await session.historyCommandTask?.catch(() => undefined)
+    state.navigating = true
+    try {
+      const nearest = await this.nearestCheckpointForChangeCount(
+        session,
+        targetChangeCount
+      )
+      if (
+        nearest.checkpoint !== session.checkpointTimeline.cursor &&
+        nearest.changeCount !== session.changeCount
+      ) {
+        await this.checkoutHistoryCheckpoint(session, nearest.checkpoint)
+      }
+
+      session.checkpointTimeline.navigating = true
+      this.postCheckpointTimeline(session)
+      while (session.changeCount !== targetChangeCount) {
+        const before = session.changeCount
+        const direction = targetChangeCount < before ? 'undo' : 'redo'
+        const editState = session.history.getEditState()
+        if (
+          (direction === 'undo' && !editState.canUndo) ||
+          (direction === 'redo' && !editState.canRedo)
+        ) {
+          throw new Error(
+            `Change count ${targetChangeCount} is not available in retained history`
+          )
+        }
+
+        // History-card activation comes from a focused webview control. The
+        // generic VS Code undo/redo commands are focus-sensitive and may
+        // complete without invoking this custom editor, so navigate through
+        // the same session callbacks used by the registered edit events.
+        if (direction === 'undo') {
+          await this.performUndoOnSession(session)
+        } else {
+          await this.performRedoOnSession(session)
+        }
+
+        const after = session.changeCount
+        if (after === before) {
+          throw new Error(
+            `History ${direction} made no progress from change count ${before}`
+          )
+        }
+        if (
+          (direction === 'undo' && after < targetChangeCount) ||
+          (direction === 'redo' && after > targetChangeCount)
+        ) {
+          throw new Error(
+            `Change count ${targetChangeCount} is inside an atomic transaction and cannot be checked out`
+          )
+        }
+      }
+
+      state.refreshPending = false
+      await this.postActionJournalViewport(session)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.postWebviewMessage(session, {
+        type: 'actionJournalError',
+        visible: true,
+        message: omegaEditErrorMessage(message),
+      })
+      throw error
+    } finally {
+      state.navigating = false
+      session.checkpointTimeline.navigating = false
+      this.postCheckpointTimeline(session)
+    }
+  }
+
   private queueActionJournalRefresh(session: EditorSession): void {
     const state = session.actionJournal
     if (!state.visible || session.disposed || session.scope.isDisposed) {
+      return
+    }
+    if (state.navigating) {
+      state.refreshPending = true
       return
     }
     if (state.refreshTask) {
@@ -6113,35 +6289,6 @@ export class HexEditorProvider
     } finally {
       resolveTimelineOperation()
       timeline.operation = undefined
-    }
-  }
-
-  private async captureCheckpointTimelineTip(
-    session: EditorSession
-  ): Promise<void> {
-    const timeline = session.checkpointTimeline
-    if (timeline.cursor !== timeline.entries.length) return
-
-    const changeCount = await getChangeCount(session.sessionId)
-    if (changeCount === timeline.lastArchivedChangeCount) return
-
-    const historyBefore = session.history.snapshot()
-    const sessionSyncVersion = session.sessionSyncVersion
-    const count = await createCheckpoint(session.sessionId)
-    session.history.recordMilestone()
-    await this.waitForSessionSync(session, sessionSyncVersion)
-    const interval = await this.recordCheckpointTimelineEntry(
-      session,
-      count,
-      'tip'
-    )
-    if (interval?.state !== 'ready') {
-      await this.rollbackUnusableTimelineBoundary(session, count, historyBefore)
-      throw new TimelineStorageError(
-        interval?.error?.code ?? 'TIMELINE_CAPTURE_FAILED',
-        interval?.error?.message ??
-          'Latest editor history could not be archived'
-      )
     }
   }
 
@@ -7758,15 +7905,6 @@ export class HexEditorProvider
           break
         }
 
-        case 'navigateCheckpointTimeline': {
-          const timeline = session.checkpointTimeline
-          if (msg.checkpoint > timeline.entries.length || timeline.navigating) {
-            break
-          }
-          await this.navigateToCheckpoint(session, msg.checkpoint)
-          break
-        }
-
         case 'rollbackCheckpoint': {
           await this.rollbackCheckpoint({ uri: session.document.uri })
           break
@@ -7784,6 +7922,14 @@ export class HexEditorProvider
 
         case 'requestActionJournalViewport': {
           await this.postActionJournalViewport(session, msg)
+          break
+        }
+
+        case 'navigateActionJournal': {
+          await this.navigateActionJournalToChangeCount(
+            session,
+            msg.changeCount
+          )
           break
         }
 

--- a/vscode-extension/src/webviewProtocol.ts
+++ b/vscode-extension/src/webviewProtocol.ts
@@ -298,8 +298,7 @@ export type WebviewToHostMessage =
   | { type: 'createCheckpoint' }
   | { type: 'rollbackCheckpoint' }
   | { type: 'restoreCheckpoint' }
-  // Internal checkpoint-replay hook retained after retiring the standalone timeline UI.
-  | { type: 'navigateCheckpointTimeline'; checkpoint: number }
+  | { type: 'navigateActionJournal'; changeCount: string }
   | { type: 'exportChangeLog' }
   | {
       type: 'requestActionJournalViewport'
@@ -1123,10 +1122,10 @@ export function normalizeWebviewMessage(
       }
     }
 
-    case 'navigateCheckpointTimeline': {
-      const checkpoint = safeNonNegativeInteger(raw.checkpoint)
-      return checkpoint !== undefined
-        ? { type: raw.type, checkpoint }
+    case 'navigateActionJournal': {
+      const changeCount = safeActionJournalDecimal(raw.changeCount)
+      return changeCount !== undefined
+        ? { type: raw.type, changeCount }
         : undefined
     }
 

--- a/vscode-extension/tests/extension.test.js
+++ b/vscode-extension/tests/extension.test.js
@@ -877,6 +877,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(providerSource, /ACTION_JOURNAL_REQUEST_TIMEOUT_MS = 15_000/)
   assert.match(actionJournalSource, /onUndo/)
   assert.match(actionJournalSource, /onRedo/)
+  assert.match(actionJournalSource, /onNavigate/)
   assert.match(actionJournalSource, /disabled=\{!canUndo\}/)
   assert.match(actionJournalSource, /disabled=\{!canRedo\}/)
   assert.doesNotMatch(actionJournalSource, /selectedKinds|transactionFilter/)
@@ -885,7 +886,11 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(actionJournalSource, /class="checkpoint-card"/)
   assert.match(
     actionJournalSource,
-    /checkpoint\.sourceChangeCount\s*\?\?\s*String\(checkpoint\.changeCount\)/
+    /coordinate:\s*decimal\(String\(checkpoint\.changeCount\)\)/
+  )
+  assert.doesNotMatch(
+    actionJournalSource,
+    /coordinate:[\s\S]{0,100}checkpoint\.sourceChangeCount/
   )
   assert.match(actionJournalSource, /checkpointChanges\(row\.coordinate\)/)
   assert.match(
@@ -903,6 +908,11 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(actionJournalSource, /strings\.actionJournal\.currentChange/)
   assert.match(actionJournalSource, /strings\.actionJournal\.redoAvailable/)
   assert.match(actionJournalSource, /strings\.actionJournal\.originalState/)
+  assert.match(
+    actionJournalSource,
+    /strings\.actionJournal\.navigateAfterChange/
+  )
+  assert.match(actionJournalSource, /strings\.actionJournal\.navigateOriginal/)
   assert.match(
     svelteAppSource,
     /checkpoints=\{checkpointTimeline\.checkpoints\}/
@@ -2235,7 +2245,7 @@ test('compiled extension entrypoints exist after build', () => {
   assert.match(actionJournalSource, /checkpointAfter/)
   assert.doesNotMatch(actionJournalSource, /onReveal|onCopy|onFilter/)
   assert.doesNotMatch(actionJournalSource, />JSON<|>CLI<|>MCP</)
-  assert.doesNotMatch(actionJournalSource, /<button class="entry-main"/)
+  assert.match(actionJournalSource, /class="entry-main"/)
   assert.match(
     svelteAppSource,
     /message\.visible && searchPanelVisible[\s\S]+closeSearchPanel\(\)/
@@ -2836,22 +2846,13 @@ test('webview protocol normalizes editor commands and rejects invalid ranges', (
       type: 'cancelTransform',
     }
   )
-  assert.deepEqual(
+  assert.equal(
     normalizeWebviewMessage(context, {
       type: 'navigateCheckpointTimeline',
       checkpoint: 3,
     }),
-    { type: 'navigateCheckpointTimeline', checkpoint: 3 }
+    undefined
   )
-  for (const checkpoint of [-1, 1.5, Number.NaN, '2']) {
-    assert.equal(
-      normalizeWebviewMessage(context, {
-        type: 'navigateCheckpointTimeline',
-        checkpoint,
-      }),
-      undefined
-    )
-  }
   assert.equal(
     normalizeWebviewMessage(context, { type: 'hideCheckpointTimeline' }),
     undefined
@@ -3129,6 +3130,10 @@ test('action journal is the live history surface', () => {
     ),
     'utf8'
   )
+  const providerSource = fs.readFileSync(
+    path.resolve(__dirname, '../src/hexEditorProvider.ts'),
+    'utf8'
+  )
 
   assert.doesNotMatch(
     appSource,
@@ -3137,13 +3142,37 @@ test('action journal is the live history surface', () => {
   assert.doesNotMatch(appSource, /hideCheckpointTimeline/)
   assert.match(appSource, /onUndo=\{\(\) => postToHost\(\{ type: 'undo' \}\)\}/)
   assert.match(appSource, /onRedo=\{\(\) => postToHost\(\{ type: 'redo' \}\)\}/)
+  assert.match(appSource, /onNavigate=\{navigateActionJournal\}/)
   assert.match(journalSource, /strings\.actionJournal\.rewind/)
   assert.match(journalSource, /strings\.actionJournal\.fastForward/)
   assert.match(journalSource, /checkpointBefore/)
   assert.match(journalSource, /checkpointAfter/)
   assert.doesNotMatch(journalSource, /onReveal|onCopy|onFilter/)
   assert.doesNotMatch(journalSource, />JSON<|>CLI<|>MCP</)
-  assert.doesNotMatch(journalSource, /<button class="entry-main"/)
+  assert.match(journalSource, /class="entry-main"/)
+  assert.match(
+    journalSource,
+    /onclick=\{\(\) => onNavigate\(row\.entry\.changeCountAfter\)\}/
+  )
+  assert.match(journalSource, /onclick=\{\(\) => onNavigate\('0'\)\}/)
+  assert.match(
+    providerSource,
+    /if \(direction === 'undo'\) \{\s*await this\.performUndoOnSession\(session\)/
+  )
+  assert.match(
+    providerSource,
+    /else \{\s*await this\.performRedoOnSession\(session\)/
+  )
+  assert.doesNotMatch(
+    providerSource,
+    /navigateActionJournalToChangeCount[\s\S]*?executeCommand\(direction\)/
+  )
+  assert.match(
+    providerSource,
+    /checkoutHistoryCheckpoint\(session, nearest\.checkpoint\)/
+  )
+  assert.doesNotMatch(providerSource, /captureCheckpointTimelineTip/)
+  assert.doesNotMatch(providerSource, /case 'navigateCheckpointTimeline'/)
   assert.equal(
     packageJson.contributes.commands.some(
       (entry) => entry.command === 'omegaEdit.showCheckpointTimeline'
@@ -3170,10 +3199,22 @@ test('webview protocol bounds and validates action journal requests', () => {
       append: true,
     }
   )
+  assert.deepEqual(
+    normalizeWebviewMessage(context, {
+      type: 'navigateActionJournal',
+      changeCount: '9007199254740993',
+    }),
+    {
+      type: 'navigateActionJournal',
+      changeCount: '9007199254740993',
+    }
+  )
   for (const message of [
     { type: 'requestActionJournalViewport', capacity: 0 },
     { type: 'requestActionJournalViewport', capacity: 1001 },
     { type: 'requestActionJournalViewport', anchorSerial: '01' },
+    { type: 'navigateActionJournal', changeCount: '01' },
+    { type: 'navigateActionJournal', changeCount: -1 },
     { type: 'revealActionJournalEntry', offset: '1' },
     {
       type: 'copyActionJournalEntry',

--- a/vscode-extension/tests/suite/extension.integration.test.js
+++ b/vscode-extension/tests/suite/extension.integration.test.js
@@ -5,8 +5,12 @@ const os = require('node:os')
 const path = require('node:path')
 const vscode = require('vscode')
 const {
+  checkSessionModel,
+  CountKind,
+  getActionJournalViewport,
   getClient,
   getComputedFileSize,
+  getCounts,
   getSegment,
   insert,
   IOFlags,
@@ -1350,10 +1354,7 @@ suite('OmegaEdit VS Code extension', () => {
     await assertSessionText(session.sessionId, 'Xbc1')
 
     for (let cycle = 0; cycle < 3; cycle += 1) {
-      await provider.dispatchWebviewMessageForTesting(document.uri, {
-        type: 'navigateCheckpointTimeline',
-        checkpoint: 1,
-      })
+      await provider.checkoutHistoryCheckpoint(session, 1)
       await assertSessionText(session.sessionId, 'Xbc')
 
       await provider.dispatchWebviewMessageForTesting(document.uri, {
@@ -1365,22 +1366,13 @@ suite('OmegaEdit VS Code extension', () => {
       })
       await assertSessionText(session.sessionId, 'Xbc')
 
-      await provider.dispatchWebviewMessageForTesting(document.uri, {
-        type: 'navigateCheckpointTimeline',
-        checkpoint: 2,
-      })
+      await provider.checkoutHistoryCheckpoint(session, 2)
       await assertSessionText(session.sessionId, 'Xbc1')
     }
 
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 0,
-    })
+    await provider.checkoutHistoryCheckpoint(session, 0)
     await assertSessionText(session.sessionId, 'abc')
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 2,
-    })
+    await provider.checkoutHistoryCheckpoint(session, 2)
     await assertSessionText(session.sessionId, 'Xbc1')
 
     await provider.dispatchWebviewMessageForTesting(document.uri, {
@@ -1389,26 +1381,25 @@ suite('OmegaEdit VS Code extension', () => {
       data: Buffer.from('!', 'utf8').toString('hex'),
     })
     await assertSessionText(session.sessionId, 'Xbc1!')
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 0,
-    })
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      { type: 'navigateActionJournal', changeCount: '0' },
+      { propagateErrors: true }
+    )
     await assertSessionText(session.sessionId, 'abc')
-    assert.equal(session.checkpointTimeline.entries.length, 3)
+    assert.equal(session.checkpointTimeline.entries.length, 2)
     assert.equal(
       lastMessageOfType(panel.messages, 'checkpointTimeline').checkpoints
         .length,
-      3
+      2
     )
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 3,
-    })
+    await provider.dispatchWebviewMessageForTesting(
+      document.uri,
+      { type: 'navigateActionJournal', changeCount: '3' },
+      { propagateErrors: true }
+    )
     await assertSessionText(session.sessionId, 'Xbc1!')
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 2,
-    })
+    await provider.checkoutHistoryCheckpoint(session, 2)
     await assertSessionText(session.sessionId, 'Xbc1')
     await provider.dispatchWebviewMessageForTesting(document.uri, {
       type: 'overwrite',
@@ -1418,10 +1409,7 @@ suite('OmegaEdit VS Code extension', () => {
     await assertSessionText(session.sessionId, 'Xbc2')
     assert.equal(session.checkpointTimeline.entries.length, 2)
 
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 1,
-    })
+    await provider.checkoutHistoryCheckpoint(session, 1)
     assert.equal(lastMessageOfType(panel.messages, 'editState').isDirty, true)
     await provider.dispatchWebviewMessageForTesting(document.uri, {
       type: 'replace',
@@ -1429,16 +1417,10 @@ suite('OmegaEdit VS Code extension', () => {
       length: 1,
       data: Buffer.from('X', 'utf8').toString('hex'),
     })
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 2,
-    })
+    await provider.checkoutHistoryCheckpoint(session, 2)
     await assertSessionText(session.sessionId, 'Xbc1')
     assert.equal(lastMessageOfType(panel.messages, 'editState').isDirty, false)
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 1,
-    })
+    await provider.checkoutHistoryCheckpoint(session, 1)
     const abandonedArchiveFile =
       session.checkpointTimeline.entries[1].interval.archive.file
     await provider.dispatchWebviewMessageForTesting(document.uri, {
@@ -1464,14 +1446,8 @@ suite('OmegaEdit VS Code extension', () => {
     )
     await assertSessionText(session.sessionId, 'XYc')
 
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 1,
-    })
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 2,
-    })
+    await provider.checkoutHistoryCheckpoint(session, 1)
+    await provider.checkoutHistoryCheckpoint(session, 2)
     await assertSessionText(session.sessionId, 'XYc')
 
     const secondInterval = session.checkpointTimeline.entries[1].interval
@@ -1484,9 +1460,9 @@ suite('OmegaEdit VS Code extension', () => {
       ),
       'corrupt'
     )
-    await provider.navigateToCheckpoint(session, 1)
+    await provider.checkoutHistoryCheckpoint(session, 1)
     await assertSessionText(session.sessionId, 'Xbc')
-    await provider.navigateToCheckpoint(session, 2)
+    await provider.checkoutHistoryCheckpoint(session, 2)
     await assertSessionText(session.sessionId, 'XYc')
     const materializedTimeline = lastMessageOfType(
       panel.messages,
@@ -1496,7 +1472,7 @@ suite('OmegaEdit VS Code extension', () => {
     assert.equal(materializedTimeline.canRewind, true)
     assert.equal(materializedTimeline.canFastForward, false)
 
-    await provider.navigateToCheckpoint(session, 0)
+    await provider.checkoutHistoryCheckpoint(session, 0)
     await assertSessionText(session.sessionId, 'abc')
 
     await panel.fireDidDispose()
@@ -1546,10 +1522,7 @@ suite('OmegaEdit VS Code extension', () => {
     )
     await assertSessionText(session.sessionId, 'abc12')
 
-    await provider.dispatchWebviewMessageForTesting(document.uri, {
-      type: 'navigateCheckpointTimeline',
-      checkpoint: 0,
-    })
+    await provider.checkoutHistoryCheckpoint(session, 0)
     await assertSessionText(session.sessionId, 'abc')
 
     await provider.dispatchWebviewMessageForTesting(document.uri, {
@@ -1669,10 +1642,10 @@ suite('OmegaEdit VS Code extension', () => {
       'omega.example.zstd',
     ])
 
-    await provider.navigateToCheckpoint(session, 0)
+    await provider.checkoutHistoryCheckpoint(session, 0)
     await assertSessionText(session.sessionId, 'abc')
 
-    await provider.navigateToCheckpoint(session, 1)
+    await provider.checkoutHistoryCheckpoint(session, 1)
     assert.deepEqual(
       await readSessionBytes(session.sessionId),
       transformedBytes
@@ -1732,20 +1705,20 @@ suite('OmegaEdit VS Code extension', () => {
     // even if the durable audit archive is unavailable or damaged.
     const timelineStorage = session.checkpointTimeline.storage
     session.checkpointTimeline.storage = undefined
-    await provider.navigateToCheckpoint(session, 1)
+    await provider.checkoutHistoryCheckpoint(session, 1)
     await assertSessionText(session.sessionId, 'abefghij')
     assert.equal(session.checkpointTimeline.cursor, 1)
-    await provider.navigateToCheckpoint(session, 2)
+    await provider.checkoutHistoryCheckpoint(session, 2)
     await assertSessionText(session.sessionId, 'abefij')
-    await provider.navigateToCheckpoint(session, 1)
+    await provider.checkoutHistoryCheckpoint(session, 1)
     session.checkpointTimeline.storage = timelineStorage
 
     for (let cycle = 0; cycle < 3; cycle += 1) {
-      await provider.navigateToCheckpoint(session, 0)
+      await provider.checkoutHistoryCheckpoint(session, 0)
       await assertSessionText(session.sessionId, 'abcdefghij')
-      await provider.navigateToCheckpoint(session, 1)
+      await provider.checkoutHistoryCheckpoint(session, 1)
       await assertSessionText(session.sessionId, 'abefghij')
-      await provider.navigateToCheckpoint(session, 2)
+      await provider.checkoutHistoryCheckpoint(session, 2)
       await assertSessionText(session.sessionId, 'abefij')
     }
 
@@ -1851,6 +1824,226 @@ suite('OmegaEdit VS Code extension', () => {
         document?.dispose()
         await fs.rm(tmpDir, { recursive: true, force: true })
       }
+    }
+  })
+
+  test('action journal jumps to a middle delete through the nearest checkpoint', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-history-jump-')
+    )
+    const samplePath = path.join(tmpDir, 'history-jump.bin')
+    await fs.writeFile(samplePath, Buffer.from('abcdefg', 'utf8'))
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    try {
+      await provider.resolveCustomEditor(
+        document,
+        panel,
+        new vscode.CancellationTokenSource().token
+      )
+      const session = provider.getSessionForTesting(document.uri)
+      assert.ok(session)
+
+      for (const [index, offset] of [1, 2, 3, 3].entries()) {
+        await provider.dispatchWebviewMessageForTesting(document.uri, {
+          type: 'delete',
+          offset,
+          length: 1,
+        })
+        if (index === 0 || index === 2) {
+          await provider.createCheckpoint({ uri: document.uri })
+        }
+      }
+      await assertSessionText(session.sessionId, 'ace')
+
+      const assertNoImplicitCheckpoints = async (expectedCursor) => {
+        assert.equal(session.checkpointTimeline.entries.length, 2)
+        assert.equal(session.checkpointTimeline.cursor, expectedCursor)
+        const counts = await getCounts(session.sessionId, [
+          CountKind.CHECKPOINTS,
+        ])
+        assert.equal(counts[0].getCount(), expectedCursor)
+      }
+      await assertNoImplicitCheckpoints(2)
+
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        { type: 'navigateActionJournal', changeCount: '2' },
+        { propagateErrors: true }
+      )
+      await assertSessionText(session.sessionId, 'acefg')
+      await assertNoImplicitCheckpoints(1)
+      assert.equal(session.history.getEditState().canRedo, true)
+
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        { type: 'navigateActionJournal', changeCount: '4' },
+        { propagateErrors: true }
+      )
+      await assertSessionText(session.sessionId, 'ace')
+      await assertNoImplicitCheckpoints(2)
+      assert.equal(session.history.getEditState().canRedo, false)
+
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        { type: 'navigateActionJournal', changeCount: '0' },
+        { propagateErrors: true }
+      )
+      await assertSessionText(session.sessionId, 'abcdefg')
+      await assertNoImplicitCheckpoints(0)
+
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        { type: 'navigateActionJournal', changeCount: '3' },
+        { propagateErrors: true }
+      )
+      await assertSessionText(session.sessionId, 'aceg')
+      await assertNoImplicitCheckpoints(2)
+    } finally {
+      await panel.fireDidDispose()
+      document.dispose()
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('action journal repeatedly crosses an undone transform boundary', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omega-edit-vscode-transform-history-jump-')
+    )
+    const samplePath = path.join(tmpDir, 'transform-history-jump.bin')
+    const originalBytes = Buffer.from(
+      'the quick brown fox jumps over the lazy dog '.repeat(8),
+      'utf8'
+    )
+    await fs.writeFile(samplePath, originalBytes)
+
+    const provider = new HexEditorProvider({ subscriptions: [] }, testPort)
+    const panel = createMockWebviewPanel()
+    const document = await provider.openCustomDocument(
+      vscode.Uri.file(samplePath),
+      { backupId: undefined, untitledDocumentData: undefined },
+      new vscode.CancellationTokenSource().token
+    )
+
+    try {
+      await provider.resolveCustomEditor(
+        document,
+        panel,
+        new vscode.CancellationTokenSource().token
+      )
+      const session = provider.getSessionForTesting(document.uri)
+      assert.ok(session)
+
+      for (const offset of [3, 7, 11]) {
+        await provider.dispatchWebviewMessageForTesting(document.uri, {
+          type: 'delete',
+          offset,
+          length: 1,
+        })
+      }
+      await provider.createCheckpoint({ uri: document.uri })
+      for (const offset of [17, 23, 29]) {
+        await provider.dispatchWebviewMessageForTesting(document.uri, {
+          type: 'delete',
+          offset,
+          length: 1,
+        })
+      }
+      await provider.createCheckpoint({ uri: document.uri })
+      const beforeTransformBytes = await readSessionBytes(session.sessionId)
+
+      await provider.dispatchWebviewMessageForTesting(
+        document.uri,
+        {
+          type: 'applyTransform',
+          pluginId: 'omega.example.zstd',
+          offset: 0,
+          length: 0,
+          optionsJson: JSON.stringify({ action: 'compress', level: 3 }),
+        },
+        { propagateErrors: true }
+      )
+      const afterTransformBytes = await readSessionBytes(session.sessionId)
+      assert.notDeepEqual(afterTransformBytes, beforeTransformBytes)
+
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'insert',
+        offset: afterTransformBytes.length,
+        data: Buffer.from('!', 'utf8').toString('hex'),
+      })
+      await provider.dispatchWebviewMessageForTesting(document.uri, {
+        type: 'overwrite',
+        offset: 0,
+        data: Buffer.from('?', 'utf8').toString('hex'),
+      })
+      const tipBytes = await readSessionBytes(session.sessionId)
+
+      const journal = await getActionJournalViewport({
+        sessionId: session.sessionId,
+        capacity: 100,
+        direction: 'older',
+      })
+      const transformEntry = journal.entries.find(
+        (entry) => entry.kind === 'TRANSFORM'
+      )
+      assert.ok(transformEntry)
+      const targets = new Map([
+        ['0', originalBytes],
+        [transformEntry.changeCountBefore, beforeTransformBytes],
+        [transformEntry.changeCountAfter, afterTransformBytes],
+        [journal.changeCount, tipBytes],
+      ])
+      const assertAt = async (changeCount) => {
+        assert.equal(session.changeCount, Number(changeCount))
+        assert.deepEqual(
+          await readSessionBytes(session.sessionId),
+          targets.get(changeCount)
+        )
+        assert.equal((await checkSessionModel(session.sessionId)).valid, true)
+        const counts = await getCounts(session.sessionId, [
+          CountKind.CHECKPOINTS,
+        ])
+        assert.equal(counts[0].getCount(), session.checkpointTimeline.cursor)
+      }
+      const navigate = async (changeCount) => {
+        await provider.dispatchWebviewMessageForTesting(
+          document.uri,
+          { type: 'navigateActionJournal', changeCount },
+          { propagateErrors: true }
+        )
+        await assertAt(changeCount)
+      }
+
+      // Every cycle uses native undo to remove the transform checkpoint model
+      // before asking the journal to replay it. The seeded extra jump varies
+      // the surrounding checkpoint path while keeping failures reproducible.
+      let randomState = 0xc0ffee
+      const targetChangeCounts = [...targets.keys()]
+      for (let cycle = 0; cycle < 20; cycle += 1) {
+        await navigate(transformEntry.changeCountAfter)
+        await provider.dispatchWebviewMessageForTesting(
+          document.uri,
+          { type: 'undo' },
+          { propagateErrors: true }
+        )
+        await assertAt(transformEntry.changeCountBefore)
+        await navigate(transformEntry.changeCountAfter)
+        randomState = (1664525 * randomState + 1013904223) >>> 0
+        await navigate(
+          targetChangeCounts[randomState % targetChangeCounts.length]
+        )
+      }
+    } finally {
+      await panel.fireDidDispose()
+      document.dispose()
+      await fs.rm(tmpDir, { recursive: true, force: true })
     }
   })
 
@@ -3590,9 +3783,9 @@ suite('OmegaEdit VS Code extension', () => {
       savedChangeDepth: 2,
     })
 
-    await provider.navigateToCheckpoint(session, 0)
+    await provider.checkoutHistoryCheckpoint(session, 0)
     await assertSessionText(session.sessionId, original)
-    await provider.navigateToCheckpoint(session, 1)
+    await provider.checkoutHistoryCheckpoint(session, 1)
     await assertSessionText(session.sessionId, replaced)
 
     await provider.dispatchWebviewMessageForTesting(document.uri, {
@@ -3600,7 +3793,7 @@ suite('OmegaEdit VS Code extension', () => {
     })
     await assertSessionText(session.sessionId, original)
     timeline = lastMessageOfType(panel.messages, 'checkpointTimeline')
-    assert.equal(timeline.checkpointCount, 2)
+    assert.equal(timeline.checkpointCount, 1)
     assert.equal(timeline.cursor, 0)
     assert.equal(timeline.canFastForward, true)
 
@@ -3609,7 +3802,7 @@ suite('OmegaEdit VS Code extension', () => {
     })
     await assertSessionText(session.sessionId, replaced)
     timeline = lastMessageOfType(panel.messages, 'checkpointTimeline')
-    assert.equal(timeline.checkpointCount, 2)
+    assert.equal(timeline.checkpointCount, 1)
     assert.equal(timeline.cursor, 1)
     assert.equal(timeline.canRewind, true)
 

--- a/vscode-extension/webview-ui/src/App.svelte
+++ b/vscode-extension/webview-ui/src/App.svelte
@@ -1606,6 +1606,18 @@
     })
   }
 
+  function navigateActionJournal(changeCount: string): void {
+    if (
+      actionJournalLoading ||
+      actionJournalViewport?.changeCount === changeCount
+    ) {
+      return
+    }
+    actionJournalLoading = true
+    actionJournalError = ''
+    postToHost({ type: 'navigateActionJournal', changeCount })
+  }
+
   function toggleActionJournal(): void {
     if (actionJournalVisible) {
       actionJournalVisible = false
@@ -3164,6 +3176,7 @@
         canRedo={canRedo && !transformInFlight}
         onUndo={() => postToHost({ type: 'undo' })}
         onRedo={() => postToHost({ type: 'redo' })}
+        onNavigate={navigateActionJournal}
         onLoadOlder={(anchorSerial) => requestActionJournal(anchorSerial, true)}
         onClose={toggleActionJournal}
         onRetry={() => requestActionJournal()}

--- a/vscode-extension/webview-ui/src/components/ActionJournal.svelte
+++ b/vscode-extension/webview-ui/src/components/ActionJournal.svelte
@@ -16,6 +16,7 @@
     canRedo: boolean
     onUndo: () => void
     onRedo: () => void
+    onNavigate: (changeCount: string) => void
     onLoadOlder: (anchorSerial: string) => void
     onClose: () => void
     onRetry: () => void
@@ -31,6 +32,7 @@
     canRedo,
     onUndo,
     onRedo,
+    onNavigate,
     onLoadOlder,
     onClose,
     onRetry,
@@ -111,9 +113,7 @@
       ...checkpoints.map((checkpoint) => ({
         type: 'checkpoint' as const,
         key: `checkpoint:${checkpoint.checkpoint}`,
-        coordinate: decimal(
-          checkpoint.sourceChangeCount ?? String(checkpoint.changeCount)
-        ),
+        coordinate: decimal(String(checkpoint.changeCount)),
         checkpoint,
       })),
     ]
@@ -230,7 +230,13 @@
             class:future={row.position === 'future'}
             aria-current={row.position === 'current' ? 'step' : undefined}
           >
-            <div class="entry-main">
+            <button
+              type="button"
+              class="entry-main"
+              disabled={loading || row.position === 'current'}
+              aria-label={strings.actionJournal.navigateAfterChange(row.coordinate)}
+              onclick={() => onNavigate(row.entry.changeCountAfter)}
+            >
               <span class="serial">#{formatted(row.entry.firstSerial)}{row.entry.lastSerial === row.entry.firstSerial ? '' : `–${formatted(row.entry.lastSerial)}`}</span>
               <strong class:transform={row.entry.kind === 'TRANSFORM'}>{row.entry.kind}</strong>
               {#if row.position === 'current'}
@@ -246,7 +252,7 @@
               {#if row.entry.checkpointAfter !== undefined}<span class="checkpoint">{strings.actionJournal.checkpointAfter(decimal(row.entry.checkpointAfter))}</span>{/if}
               <span class="payload">{payloadHint(row.entry)}</span>
               {#if row.entry.transform}<code>{row.entry.transform.transformId}</code>{/if}
-            </div>
+            </button>
           </li>
         {/if}
       {/each}
@@ -255,6 +261,19 @@
           <span class="cursor-symbol" aria-hidden="true">●</span>
           <strong>{strings.actionJournal.originalState}</strong>
           <span>{strings.actionJournal.currentPosition}</span>
+        </li>
+      {:else if viewport && !viewport.hasMore}
+        <li class="baseline-card">
+          <button
+            type="button"
+            class="baseline-target"
+            disabled={loading}
+            aria-label={strings.actionJournal.navigateOriginal}
+            onclick={() => onNavigate('0')}
+          >
+            <span class="cursor-symbol" aria-hidden="true">○</span>
+            <strong>{strings.actionJournal.originalState}</strong>
+          </button>
         </li>
       {/if}
     </ol>
@@ -286,7 +305,9 @@
   .change-card { border-left: 3px solid transparent; }
   .change-card.current { border-left-color: var(--vscode-charts-green); background: color-mix(in srgb, var(--vscode-charts-green) 10%, transparent); }
   .change-card.future { opacity: .55; border-left-color: var(--vscode-descriptionForeground); border-left-style: dashed; background: color-mix(in srgb, var(--vscode-descriptionForeground) 6%, transparent); }
-  .entry-main { flex: 1; display: flex; flex-wrap: wrap; align-items: center; gap: .55rem; min-width: 0; padding: .38rem .5rem; text-align: left; }
+  .entry-main { flex: 1; display: flex; flex-wrap: wrap; align-items: center; gap: .55rem; min-width: 0; padding: .38rem .5rem; border: 0; background: transparent; text-align: left; }
+  .entry-main:hover:not(:disabled), .entry-main:focus-visible, .baseline-target:hover:not(:disabled), .baseline-target:focus-visible { background: var(--vscode-list-hoverBackground); }
+  .entry-main:disabled { opacity: 1; }
   .entry-main strong { color: var(--vscode-charts-blue); }
   .entry-main strong.transform { color: var(--vscode-charts-purple); }
   .checkpoint-card { gap: .6rem; padding: .48rem .55rem; border-left: 3px solid var(--vscode-charts-yellow); background: color-mix(in srgb, var(--vscode-charts-yellow) 8%, transparent); }
@@ -302,6 +323,7 @@
   .current-state { color: var(--vscode-charts-green); border-color: var(--vscode-charts-green); }
   .future-state { color: var(--vscode-descriptionForeground); }
   .baseline-card { gap: .5rem; padding: .48rem .55rem; border-left: 3px solid var(--vscode-charts-green); background: color-mix(in srgb, var(--vscode-charts-green) 10%, transparent); }
+  .baseline-target { display: flex; align-items: center; gap: .5rem; width: 100%; padding: 0; border: 0; background: transparent; text-align: left; }
   .baseline-card span { color: var(--vscode-descriptionForeground); font-size: .7rem; }
   .cursor-symbol { color: var(--vscode-charts-green) !important; }
   .serial, code, .payload, .checkpoint { font-size: .7rem; }

--- a/vscode-extension/webview-ui/src/i18n.ts
+++ b/vscode-extension/webview-ui/src/i18n.ts
@@ -573,6 +573,9 @@ const englishStrings = {
     originalState: 'Original state',
     afterChange: (change: number | bigint) =>
       `Current after change ${formatNumber(change)}`,
+    navigateAfterChange: (change: number | bigint) =>
+      `Go to state after change ${formatNumber(change)}`,
+    navigateOriginal: 'Go to original state',
     payloadNone: 'none',
     payloadInline: 'inline',
     payloadFileBacked: 'file-backed',
@@ -850,6 +853,9 @@ const localeOverrides: Record<string, LocaleStringOverrides> = {
       originalState: 'Estado original',
       afterChange: (change: number | bigint) =>
         `Actual después del cambio ${formatNumber(change)}`,
+      navigateAfterChange: (change: number | bigint) =>
+        `Ir al estado después del cambio ${formatNumber(change)}`,
+      navigateOriginal: 'Ir al estado original',
       payloadNone: 'ninguno',
       payloadInline: 'integrado',
       payloadFileBacked: 'respaldado por archivo',


### PR DESCRIPTION
## What changed

- Make retained action-journal changes and the Original state directly selectable from the History panel.
- Add a validated webview navigation request keyed by cumulative change count.
- Check out the internal checkpoint closest to the requested change count, then traverse only the remaining transaction distance with existing undo/redo machinery.
- Make History the sole navigation surface and remove the obsolete checkpoint-to-checkpoint webview protocol.
- Keep Action Journal random access read-only with respect to checkpoint storage: jumps never create implicit checkpoints.
- Preserve the separate destructive session-rollback command and its existing test coverage.
- Preserve atomic transaction boundaries, forward history, checkpoint cursor state, and history refresh behavior while navigation is in progress.
- Add English and Spanish accessible labels, documentation, protocol/source tests, and an end-to-end regression scenario covering backward, forward, Original, and exact-checkpoint-boundary jumps.

## Why

History navigation previously required users to step through every action sequentially. The retained checkpoint data already supports accelerated reconstruction, so change-level navigation can use the closest internal anchor and replay only the residual actions. Because History contains every change position, it is a strict superset of checkpoint-only navigation and avoids exposing two competing navigation models.

## User impact

Users can click or keyboard-activate any loaded history change to move directly to the state after that action, or select Original to return to the initial state. Current and future-history styling remains intact, redo history is preserved until a new edit branches it, and browsing history does not manufacture checkpoints. The destructive Roll Back Session feature remains available.

## Validation

- `npm run compile:extension`
- `npm run test:unit` (34/34 passing)
- `npm run lint`
- Added VS Code integration coverage for nearest-checkpoint random access and assertions that random jumps do not add timeline entries while native checkpoint cursor alignment is preserved. The local integration harness could not execute because this checkout has no Linux server artifact; explicitly launching the Windows artifact through WSL started the process but did not complete the client handshake. GitHub CI runs the scenario with the packaged platform server.